### PR TITLE
Improve CI to ignore irrelevant files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,20 @@ name: Build
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'Makefile'
+      - 'build-aux/**'
+      - '.github/workflows/build.yml'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'Makefile'
+      - 'build-aux/**'
+      - '.github/workflows/build.yml'
 
 jobs:
   Build:

--- a/build-aux/nmake.sh
+++ b/build-aux/nmake.sh
@@ -19,14 +19,13 @@ win_temp="$(powershell.exe \
     -NoProfile -ExecutionPolicy Bypass \
     -Command 'Write-Host ${env:TEMP}')"
 wsl_temp=$(wslpath -u "$win_temp")
-tmpdir="$wsl_temp/PH7-build"
+tmpdir="$wsl_temp/PHL-build"
 
 # Create temp build directory and copy source files
 mkdir -p "$tmpdir"
-rsync -a "$workspace_dir/build-aux" "$tmpdir" &
 rsync -a "$workspace_dir/src" "$tmpdir" &
-rsync -a "$workspace_dir/examples" "$tmpdir" &
 rsync -a "$workspace_dir/tests" "$tmpdir" &
+rsync -a "$workspace_dir/build-aux" "$tmpdir" &
 wait
 
 # Run build in temp directory via PowerShell


### PR DESCRIPTION
 - Now GitHub CI will trigger only on source, test and build related changes happen.
 - Improved nmake.sh rsync to exclude the old `examples` folder which is not needed anymore to build the project.
