### PR TITLE
Added PHL-compatible phpt runner, build improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,5 @@
 *.yaml text eol=lf
 *.md text eol=lf
 *.php text eol=lf
-*.phpt text eol=lf
+*.phpt text eol=lf linguist-language=PHP
+*.diag text eol=lf linguist-language=PHP

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       with:
         name: ${{ matrix.name }}-phl${{ matrix.extension }}
         path: build/${{ matrix.name }}
-  Report:
+  Test:
     runs-on: ${{ matrix.os }}
     needs: Build
     strategy:
@@ -56,18 +56,14 @@ jobs:
         include:
           - name: x86_64-linux-gnu
             os: ubuntu-latest
-            run_cmd: make test || true
+            run_cmd: make test-compat
           - name: x86_64-windows-msvc
             os: windows-latest
             extension: .exe
-            run_cmd: wsl -e sh -c 'sh tests/phpt.sh --target-executable build/x86_64-windows-msvc/phl.exe --target-dir vendor/php-src/tests || true'
+            run_cmd: >
+              build-aux/nmake.bat /nologo /f build-aux/nmake.mk test-compat
     steps:
     - uses: actions/checkout@v5
-      with:
-        submodules: true
-        
-    - if: matrix.os == 'windows-latest'
-      uses: Vampire/setup-wsl@v6
 
     - name: Artifact
       uses: actions/download-artifact@v6

--- a/build-aux/get_target.sh
+++ b/build-aux/get_target.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+# TODO: Improve target detection logic
+echo "x86_64-linux-gnu"

--- a/src/phl/phl.c
+++ b/src/phl/phl.c
@@ -29,6 +29,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 /* Make sure this header file is available.*/
 #include "ph7.h"
 /* 
@@ -47,10 +48,21 @@ static void Fatal(const char *zMsg)
  */
 static void Help(void)
 {
-	puts("phl [-h|-b|-x] path/to/php_file [script args]");
+	puts("phl [-h|--help|-b|-x|-v|--version] path/to/php_file [script args]");
 	puts("\t-b: Dump PH7 byte-code instructions");
 	puts("\t-x: Report run-time errors");
-	puts("\t-h: Display this message and exit");
+	puts("\t-v, --version: Display version information and exit");
+	puts("\t-h, --help: Display this message and exit");
+	/* Exit immediately */
+	exit(0);
+}
+/*
+ * Display version information and exit.
+ */
+static void Version(void)
+{
+	puts("PHL " PH7_VERSION " (cli) (built " __DATE__ " " __TIME__ ")");
+	puts("Copyright (c) 2011-2014 Symisc Systems, 2025 Alexandre Gomes Gaigalas");
 	/* Exit immediately */
 	exit(0);
 }
@@ -114,6 +126,18 @@ int main(int argc,char **argv)
 			/* No more interpreter arguments */
 			break;
 		}
+		/* Check for long options */
+		if( argv[n][1] == '-' ){
+			if( strcmp(argv[n], "--version") == 0 ){
+				Version();
+			}else if( strcmp(argv[n], "--help") == 0 ){
+				Help();
+			}else{
+				/* Unknown long option */
+				Help();
+			}
+			continue;
+		}
 		c = argv[n][1];
 		if( c == 'b' ){
 			/* Dump byte-code instructions */
@@ -121,6 +145,9 @@ int main(int argc,char **argv)
 		}else if( c == 'x' ){
 			/* Report run-time errors */
 			err_report = 1;
+		}else if( c == 'v' ){
+			/* Display version */
+			Version();
 		}else{
 			/* Display a help message and exit */
 			Help();

--- a/tests/ph7/phptrunner/001-pass_test.diag
+++ b/tests/ph7/phptrunner/001-pass_test.diag
@@ -1,0 +1,8 @@
+--TEST--
+Passing test example
+--FILE--
+<?php
+echo "Expected output";
+?>
+--EXPECT--
+Expected output

--- a/tests/ph7/phptrunner/002-fail_test.diag
+++ b/tests/ph7/phptrunner/002-fail_test.diag
@@ -1,0 +1,8 @@
+--TEST--
+Failing test example
+--FILE--
+<?php
+echo "Wrong output";
+?>
+--EXPECT--
+Expected output

--- a/tests/ph7/phptrunner/003-skip_test.diag
+++ b/tests/ph7/phptrunner/003-skip_test.diag
@@ -1,0 +1,10 @@
+--TEST--
+Skip test example
+--SKIPIF--
+<?php echo "skip this test"; ?>
+--FILE--
+<?php
+echo "This should not run";
+?>
+--EXPECT--
+This should not run

--- a/tests/ph7/phptrunner/004-unimplemented_test.diag
+++ b/tests/ph7/phptrunner/004-unimplemented_test.diag
@@ -1,0 +1,10 @@
+--TEST--
+Unimplemented test example
+--GET--
+some get data
+--FILE--
+<?php
+echo "This uses unimplemented feature";
+?>
+--EXPECT--
+This uses unimplemented feature

--- a/tests/ph7/phptrunner/005-clean_test.diag
+++ b/tests/ph7/phptrunner/005-clean_test.diag
@@ -1,0 +1,13 @@
+--TEST--
+Clean test example
+--FILE--
+<?php
+echo "Hello from clean test";
+?>
+--EXPECT--
+Hello from clean test
+--CLEAN--
+<?php
+// Some cleanup code
+echo "Cleaning up\n";
+?>

--- a/tests/ph7/phptrunner/README.md
+++ b/tests/ph7/phptrunner/README.md
@@ -1,0 +1,10 @@
+# phpt.php diagnostics tests
+
+These are not part of the PHL test suite, and only exist to diagnose
+the `phpt.php` test runner. As so, they are marked as disabled.
+
+You can run those diagnostics using:
+
+```sh
+phl -x tests/phpt.php --target-dir tests/ph7/phptrunner --file-extension disabled
+```

--- a/tests/ph7/smoke/001-hello_world.phpt
+++ b/tests/ph7/smoke/001-hello_world.phpt
@@ -1,0 +1,8 @@
+--TEST--
+Hello World
+--FILE--
+<?php
+echo "Hello, World!";
+?>
+--EXPECT--
+Hello, World!

--- a/tests/ph7/smoke/002-variable_test.phpt
+++ b/tests/ph7/smoke/002-variable_test.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Variable assignment and echo
+--FILE--
+<?php
+$a = 42;
+echo $a;
+?>
+--EXPECT--
+42

--- a/tests/ph7/smoke/003-function_test.phpt
+++ b/tests/ph7/smoke/003-function_test.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Simple function call
+--FILE--
+<?php
+function add($x, $y) {
+    return $x + $y;
+}
+echo add(3, 4);
+?>
+--EXPECT--
+7

--- a/tests/phpt.php
+++ b/tests/phpt.php
@@ -1,0 +1,320 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+/**
+ * PHP test runner and TAP producer, compatible with PHP and PHL
+ */
+
+// Valid section types
+$valid_sections = array('test', 'description', 'credits', 'skipif', 'file', 'expect', 'expectf', 'expectregex', 'clean', 'post', 'post_raw', 'get', 'cookie', 'stdin', 'ini', 'args', 'env');
+
+// Unimplemented section types
+$not_implemented = array('post', 'post_raw', 'get', 'cookie', 'stdin', 'ini', 'args', 'env', 'expectf', 'expectregex');
+
+// Default values
+$target_executable = "";
+$target_timeout = 1;
+$target_dir = dirname(__FILE__);
+$file_extension = "phpt";
+$filter = "";
+$output_format = "tap";
+
+// Parse arguments
+if (count($argv) > 0 && strpos($argv[0], '--') !== 0) {
+    $args = array_slice($argv, 1);
+    $script_name = $argv[0];
+} else {
+    $args = $argv;
+    $script_name = 'phpt.php';
+}
+while (!empty($args)) {
+    $arg = array_shift($args);
+    switch ($arg) {
+        case '--target-executable':
+            $target_executable = array_shift($args);
+            if ($target_executable === null) {
+                echo "Error: --target-executable requires a value\n";
+                exit(1);
+            }
+            break;
+        case '--target-timeout':
+            $target_timeout = array_shift($args);
+            if ($target_timeout === null) {
+                echo "Error: --target-timeout requires a value\n";
+                exit(1);
+            }
+            break;
+        case '--target-dir':
+            $target_dir = array_shift($args);
+            if ($target_dir === null) {
+                echo "Error: --target-dir requires a value\n";
+                exit(1);
+            }
+            break;
+        case '--file-extension':
+            $file_extension = array_shift($args);
+            if ($file_extension === null) {
+                echo "Error: --file-extension requires a value\n";
+                exit(1);
+            }
+            break;
+        case '--filter':
+            $filter = array_shift($args);
+            if ($filter === null) {
+                echo "Error: --filter requires a value\n";
+                exit(1);
+            }
+            break;
+        case '--output-format':
+            $output_format = array_shift($args);
+            if ($output_format === null) {
+                echo "Error: --output-format requires a value\n";
+                exit(1);
+            }
+            break;
+        case '--help':
+            echo "Usage: " . $script_name . " [options]\n";
+            echo "\n";
+            echo "Options:\n";
+            echo "  --target-executable <exe>  Path to the executable being tested (mandatory)\n";
+            echo "  --target-timeout <sec>     Timeout for each test in seconds (default: 1)\n";
+            echo "  --target-dir <dir>         Directory containing test files (default: directory of this script)\n";
+            echo "  --file-extension <ext>     File extension for test files (default: phpt)\n";
+            echo "  --filter <pattern>         Filter test files by prefix (optional, runs all if not specified)\n";
+            echo "  --output-format <format>   Output format: tap (default) or dot\n";
+            echo "  --help                     Show this help message\n";
+            echo "\n";
+            exit(0);
+        default:
+            echo "Unknown option: $arg\n";
+            exit(1);
+    }
+}
+
+// Argument parsing complete
+
+// Validate arguments
+if (!is_numeric($target_timeout) || $target_timeout != (int)$target_timeout) {
+    echo "1..0 # Target timeout '$target_timeout' is not a valid integer.\n";
+    exit(1);
+}
+if (!is_dir($target_dir)) {
+    echo "1..0 # Target directory '$target_dir' not found.\n";
+    exit(1);
+}
+if ($output_format != "tap" && $output_format != "dot") {
+    echo "1..0 # Invalid output format '$output_format'. Must be 'tap' or 'dot'.\n";
+    exit(1);
+}
+
+// TAP header
+if ($output_format == "tap") {
+    echo "Tap Version 13\n";
+}
+
+function parse_phpt_sections($path, $valid_sections) {
+    // Read file and normalize line endings to LF
+    $content = file_get_contents($path);
+    $content = str_replace("\r\n", "\n", $content);
+    $content = str_replace("\r", "\n", $content);
+    $lines = explode("\n", $content);
+    
+    $sections = array();
+    $current_section = null;
+    $content_lines = array();
+    
+    foreach ($lines as $line) {
+        if (substr($line, 0, 2) === '--' && substr($line, -2) === '--') {
+            // Save previous section
+            if ($current_section !== null) {
+                $sections[$current_section] = implode("\n", $content_lines);
+            }
+            $section_name = strtolower(substr($line, 2, -2));
+            if (in_array($section_name, $valid_sections)) {
+                $current_section = $section_name;
+            } else {
+                $current_section = null;
+            }
+            $content_lines = array();
+        } else {
+            if ($current_section !== null) {
+                $content_lines[] = $line;
+            }
+        }
+    }
+    
+    // Save last section
+    if ($current_section !== null) {
+        $sections[$current_section] = implode("\n", $content_lines);
+    }
+    
+    return $sections;
+}
+
+function find_files($dir, $extension, $filter = '') {
+    $files = array();
+    if (!is_dir($dir)) {
+        return $files;
+    }
+    $handle = opendir($dir);
+    while (($entry = readdir($handle)) !== false) {
+        if ($entry == '.' || $entry == '..') continue;
+        $path = $dir . '/' . $entry;
+        if (is_dir($path)) {
+            $files = array_merge($files, find_files($path, $extension, $filter));
+        } elseif (is_file($path) && pathinfo($path, PATHINFO_EXTENSION) === $extension) {
+            $basename = pathinfo($path, PATHINFO_FILENAME);
+            if (empty($filter) || strpos($basename, $filter) === 0) {
+                $files[] = $path;
+            }
+        }
+    }
+    closedir($handle);
+    return $files;
+}
+
+// Find test files
+$files = find_files($target_dir, $file_extension, $filter);
+sort($files);
+
+$total = count($files);
+if ($output_format == "tap") {
+    echo "1..$total\n";
+}
+
+$passed = 0;
+$failed = 0;
+$skipped = 0;
+$nimp = 0;
+$count = 1;
+
+foreach ($files as $file) {
+    $sections = parse_phpt_sections($file, $valid_sections);
+    
+    // Write sections to disk
+    if (isset($sections['file'])) {
+        $file_path = $file . '.file';
+        file_put_contents($file_path, $sections['file']);
+    }
+    if (isset($sections['skipif'])) {
+        $skipif_path = $file . '.skipif';
+        file_put_contents($skipif_path, $sections['skipif']);
+    }
+    if (isset($sections['clean'])) {
+        $clean_path = $file . '.clean';
+        file_put_contents($clean_path, $sections['clean']);
+    }
+
+    $test_name = $file;
+    
+    // SKIPIF check
+    $skip = false;
+    if (isset($sections['skipif'])) {
+        $skipif_path = $file . '.skipif';
+        ob_start();
+        @include($skipif_path);
+        $skip_output = ob_get_clean();
+        $skip_output = trim($skip_output);
+        if (!empty($skip_output)) {
+            $skip = true;
+        }
+    }
+    
+    if ($skip) {
+        if ($output_format == "tap") {
+            echo "ok $count - $test_name # skip\n";
+        } else {
+            echo "S";
+        }
+        $skipped++;
+    } else {
+        // Check for unimplemented sections
+        $has_unimplemented = false;
+        foreach ($not_implemented as $section) {
+            if (isset($sections[$section]) && !empty(trim($sections[$section]))) {
+                $has_unimplemented = true;
+                break;
+            }
+        }
+        
+        if ($has_unimplemented) {
+            if ($output_format == "tap") {
+                echo "not ok $count - $test_name # TODO no runner support\n";
+            } else {
+                echo "F";
+            }
+            $nimp++;
+        } else {
+            // Test execution
+            $file_path = $file . '.file';
+            ob_start();
+            @include($file_path);
+            $output = ob_get_clean();
+            $output = trim($output);
+            
+            $expected = isset($sections['expect']) ? trim($sections['expect']) : '';
+            
+            if ($output === $expected) {
+                if ($output_format == "tap") {
+                    echo "ok $count - $test_name\n";
+                } else {
+                    echo ".";
+                }
+                $passed++;
+            } else {
+                if ($output_format == "tap") {
+                    echo "not ok $count - $test_name\n";
+                } else {
+                    echo "F";
+                }
+                $failed++;
+            }
+        }
+    }
+    
+    // CLEAN execution
+    if (isset($sections['clean'])) {
+        $clean_path = $file . '.clean';
+        ob_start();
+        @include($clean_path);
+        ob_end_clean();
+    }
+    
+    $count++;
+    
+    // Clean up temp files
+    @unlink($file . '.file');
+    @unlink($file . '.skipif');
+    @unlink($file . '.clean');
+    @unlink($file . '.output');
+    @unlink($file . '.expect');
+}
+
+if ($output_format == "tap") {
+    echo "# Incomplete Tests\n";
+    echo "# ----------------\n";
+    echo "#     ok: $skipped\t(# skip)\n";
+    echo "# not ok: $nimp\t(# TODO)\n";
+    echo "# ----------------\n";
+    echo "#  Total: " . ($skipped + $nimp) . " incomplete\n";
+    echo "\n";
+    echo "# Test Summary\n";
+    echo "# ----------------\n";
+    echo "#     ok: " . ($passed + $skipped) . "\n";
+    echo "# not ok: " . ($failed + $nimp) . "\n";
+    echo "# ----------------\n";
+    echo "#  Total: $total tests\n";
+} else {
+    echo " (" . ($passed + $skipped) . "/$total)\n";
+}
+
+if ($total != ($passed + $failed + $skipped + $nimp)) {
+    echo "# WARNING: Test count mismatch in directory '$target_dir'.\n";
+    exit(1);
+}
+
+if ($failed > 0) {
+    exit(1);
+}


### PR DESCRIPTION
 - Do not depend on WSL for testing anymore. We implemented a PHL-compatible test runner that works on Windows, thanks to PHL being portable.
 - Allow passing a `TARGET=` with a triplet-like identifier to the build. This will be useful later for more elaborate cross compiler builds.
 - Introduce a homebrew test suite and a Makefile target that runs it both against PHP and PHL, ensuring both of them pass. This will be crucial for continuous testing of compatibility until we can pass PHP's own test suite.
 - Added `--version` and `--help` to the phl interpreter. The version is used on the CI before running comparative tests.
 - Introduced a short one-line format for the test runner. 

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally
- [x] Any dependent changes have been merged and published
- [x] I have updated the documentation accordingly
