### PR TITLE
Introduce coverage for x86_64-windows-msvc builds

### DIFF
--- a/.github/actions/make-action/action.yml
+++ b/.github/actions/make-action/action.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 # SPDX-License-Identifier: BSD-3-Clause
 
-name: 'Portable Make Action'
+name: 'Make Action'
 description: 'Reusable action to run make commands for jobs'
 
 inputs:
@@ -9,31 +9,26 @@ inputs:
     description: 'The build name (e.g., x86_64-linux-gnu). Will be used to determine OS.'
     required: true
   make:
-    description: 'The make command to run (e.g., test, test-compat, or empty for build)'
-    required: false
-    default: ''
+    description: 'The make command to run (e.g., test, test-compat, or empty for build). Will be used to name artifacts.'
+    required: true
   extension:
     description: 'File extension for the binary (e.g., .exe for Windows)'
     required: false
     default: ''
-  save_job:
-    description: 'Job name to save artifact as. If set, uploads artifact with name {save_job}-{name}.'
+  artifacts_from:
+    description: 'Job name to restore artifact from. If set, downloads artifact with name {artifacts_from}-{name}.'
     required: false
-  restore_job:
-    description: 'Job name to restore artifact from. If set, downloads artifact with name {restore_job}-{name}.'
-    required: false
-
 runs:
   using: 'composite'
   steps:
-    - if: inputs.restore_job != ''
+    - if: inputs.artifacts_from != ''
       name: Download artifact
       uses: actions/download-artifact@v6
       with:
-        name: ${{ inputs.restore_job }}-${{ inputs.name }}
+        name: ${{ inputs.artifacts_from }}-${{ inputs.name }}
         path: build/${{ inputs.name }}
 
-    - if: inputs.restore_job != '' && contains(inputs.name, '-linux-')
+    - if: inputs.artifacts_from != '' && contains(inputs.name, '-linux-')
       run: chmod +x build/${{ inputs.name }}/phl${{ inputs.extension }}
       shell: bash
 
@@ -45,9 +40,8 @@ runs:
       run: build-aux/dev.bat nmake /nologo /f build-aux/nmake.mk ${{ inputs.make }}
       shell: cmd
 
-    - if: inputs.save_job != ''
-      name: Upload artifact
+    - name: Upload artifact
       uses: actions/upload-artifact@v5
       with:
-        name: ${{ inputs.save_job }}-${{ inputs.name }}
+        name: ${{ inputs.make }}-${{ inputs.name }}
         path: build/${{ inputs.name }}

--- a/.github/actions/setup-action/action.yml
+++ b/.github/actions/setup-action/action.yml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+name: 'Setup Action'
+description: 'Reusable action to run setup dependencies'
+
+runs:
+  using: 'composite'
+  steps:
+    - if: runner.os == 'Linux'
+      uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: lcov
+        version: 1.0
+    - if: runner.os == 'Windows'
+      uses: microsoft/setup-msbuild@v2
+    - if: runner.os == 'Windows'
+      uses: actions/cache@v4
+      id: cache-opencppcoverage
+      with:
+        path: OpenCppCoverageSetup-x64-*
+        key: OpenCppCoverage-${{ hashFiles('build-aux/install_opencppcoverage.bat') }}
+        restore-keys: OpenCppCoverage-
+    - if: runner.os == 'Windows'
+      shell: cmd
+      run: build-aux\install_opencppcoverage.bat

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,22 @@
 # SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 # SPDX-License-Identifier: BSD-3-Clause
 
-name: Build
+name: CI
+permissions: {}
 
 env:
   ALL_FILES_MIN_COVERAGE: 20
   CHANGED_FILES_MIN_COVERAGE: 25
 
 on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'Makefile'
+      - 'build-aux/**'
+      - '.github/workflows/build.yml'
   pull_request:
     branches: [ main, dev ]
     paths:
@@ -18,114 +27,107 @@ on:
       - '.github/workflows/build.yml'
 
 jobs:
-  # make
-  Build:
+  build:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
-          - name: x86_64-linux-gnu
+          - make: build
+            name: x86_64-linux-gnu
             os: ubuntu-latest
-          - name: x86_64-windows-msvc
+          - make: build
+            name: x86_64-windows-msvc
             os: windows-latest
             extension: .exe
     steps:
     - uses: actions/checkout@v5
-    - if: contains(matrix.name, '-windows-')
-      uses: microsoft/setup-msbuild@v2
+    - uses: ./.github/actions/setup-action
     - uses: ./.github/actions/make-action
       with:
         name: ${{ matrix.name }}
-        extension: ${{ matrix.extension }}
-        save_job: Build
-
-  # make test & test-compat
-  Test:
-    runs-on: ${{ matrix.os }}
-    needs: Build
-    strategy:
-      matrix:
-        include:
-          - make: test
-            name: x86_64-linux-gnu
-            os: ubuntu-latest
-          - make: test
-            name: x86_64-windows-msvc
-            os: windows-latest
-            extension: .exe
-          - make: test-compat
-            name: x86_64-linux-gnu
-            os: ubuntu-latest
-          - make: test-compat
-            name: x86_64-windows-msvc
-            os: windows-latest
-            extension: .exe
-    steps:
-    - uses: actions/checkout@v5
-    - uses: ./.github/actions/make-action
-      with:
         make: ${{ matrix.make }}
-        name: ${{ matrix.name }}
         extension: ${{ matrix.extension }}
-        restore_job: Build
 
-  # make coverage-html
-  Coverage:
-    runs-on: ubuntu-latest
-    needs: Build
+  qa:
+    runs-on: ${{ matrix.os }}
+    needs: build
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        make: [test, test-compat, coverage]
+        include:
+          - os: ubuntu-latest
+            name: x86_64-linux-gnu
+          - os: windows-latest
+            name: x86_64-windows-msvc
+            extension: .exe
     steps:
     - uses: actions/checkout@v5
-    - run: sudo apt-get update && sudo apt-get install -y lcov
+    - uses: ./.github/actions/setup-action
     - uses: ./.github/actions/make-action
       with:
-        make: coverage-html
-        name: x86_64-linux-gnu
-        restore_job: Build
-        save_job: Coverage
+        name: ${{ matrix.name }}
+        make: ${{ matrix.make }}
+        extension: ${{ matrix.extension }}
+        artifacts_from: build
 
-  OpenCppCoverage:
-    runs-on: windows-latest
-    needs: Build
-    steps:
-    - uses: actions/checkout@v5
-    - uses: actions/cache@v4
-      id: cache-opencppcoverage
-      with:
-        path: OpenCppCoverageSetup-x64-*
-        key: OpenCppCoverage-${{ hashFiles('build-aux/install_opencppcoverage.bat') }}
-        restore-keys: OpenCppCoverage-
-    - run: build-aux\install_opencppcoverage.bat
-    - run: build-aux\dev.bat OpenCppCoverage.exe || exit /b 0
-      shell: cmd
-
-  # Coverage reporting
-  Coverage-Report:
+  report:
     runs-on: ubuntu-latest
-    needs: Coverage
+    needs: qa
     permissions:
       contents: read
       pull-requests: write
     steps:
     - uses: actions/checkout@v5
+    - uses: ./.github/actions/setup-action
     - uses: actions/download-artifact@v6
       with:
-        name: Coverage-x86_64-linux-gnu
-        path: build/x86_64-linux-gnu
-    - name: Check for source changes
-      id: check-changes
-      uses: dorny/paths-filter@v3
+        pattern: coverage-*
+        path: artifact
+    
+    - run: |
+        mkdir -p report
+        chmod +x artifact/coverage-x86_64-linux-gnu/coverage/phl-coverage
+
+        lcov --add-tracefile artifact/coverage-x86_64-linux-gnu/coverage/coverage.info \
+             --add-tracefile artifact/coverage-x86_64-windows-msvc/coverage/coverage.info \
+             --output-file report/coverage.info
+
+        sed -i 's|SF:a/PHL/PHL/|SF:|g' report/coverage.info
+        
+        genhtml --quiet --include 'src/ph7/*'\
+          --output-directory report/html report/coverage.info
+
+        ./artifact/coverage-x86_64-linux-gnu/coverage/phl-coverage \
+          build-aux/lcov_info_to_text.php --content=all\
+            report/coverage.info > report/coverage.md
+
+        echo "### Coverage" >> report/summary.md
+        echo "" >> report/summary.md
+
+        ./artifact/coverage-x86_64-linux-gnu/coverage/phl-coverage \
+          build-aux/lcov_info_to_text.php --content=summary\
+            report/coverage.info >> report/summary.md
+
+        echo "" >> report/summary.md
+        echo "Details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> report/summary.md
+    - 
+      if: github.event_name == 'pull_request'
+      run: |
+        echo "<details><summary>Code Coverage Report</summary>" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        cat report/coverage.md >> "$GITHUB_STEP_SUMMARY"
+        echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+        gh pr comment $PR_NUMBER --edit-last --create-if-none --body-file report/summary.md
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.number }}
+
+    - uses: actions/upload-artifact@v5
       with:
-        filters: |
-          src:
-            - 'src/**'
-            - 'tests/**'
-            - 'Makefile'
-            - 'build-aux/**'
-            - '.github/workflows/build.yml'
-    - uses: jbaczuk/pr-test-coverage@v1
-      if: steps.check-changes.outputs.src == 'true'
-      with:
-        lcov-file: build/x86_64-linux-gnu/coverage.info
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        all-files-minimum-coverage: ${{ env.ALL_FILES_MIN_COVERAGE }}
-        update-comment: true
+        name: report
+        path: report

--- a/Makefile
+++ b/Makefile
@@ -8,72 +8,51 @@ CC ?= cc
 TARGET ?= $(shell CC=$(CC) ./build-aux/get_target.sh)
 
 BUILD_DIR = build/$(TARGET)
-CFLAGS = -W -Wunused -Wall -Isrc/ph7 -Ofast -DPH7_ENABLE_MATH_FUNC
-LDFLAGS = -lm
+CFLAGS = -W -Wunused -Wall -Isrc/ph7 -Ofast -DPH7_ENABLE_MATH_FUNC -DPH7_ENABLE_THREADS -D__UNIXES__
+LDFLAGS = -lm -lpthread
 
-.PHONY: all clean test test-compat coverage coverage-html
-all: $(BUILD_DIR)/phl
-clean: $(BUILD_DIR)-clean
-test: $(BUILD_DIR)-test
-test-compat: $(BUILD_DIR)-test-compat
-coverage: $(BUILD_DIR)/coverage.info
-coverage-html: $(BUILD_DIR)/coverage-html
-
-# Source file lists
-SRC_SOURCES = \
-  api.c \
-  builtin.c \
-  compile.c \
-  constant.c \
-  hashmap.c \
-  lex.c \
-  lib.c \
-  memobj.c \
-  oo.c \
-  parse.c \
-  vfs.c \
-  vm.c
+all: .ALWAYS $(BUILD_DIR)/phl
+build: .ALWAYS $(BUILD_DIR)/phl
+clean: .ALWAYS $(BUILD_DIR)-clean
+test: .ALWAYS $(BUILD_DIR)-test
+test-compat: .ALWAYS $(BUILD_DIR)-test-compat
+coverage: .ALWAYS $(BUILD_DIR)/coverage/coverage.info
+coverage-html: .ALWAYS $(BUILD_DIR)/coverage/html
+.ALWAYS: # No .PHONY to keep consistent with nmake.mk
 
 # Object files
 OBJECTS = \
-  $(BUILD_DIR)/src/ph7/api.o \
-  $(BUILD_DIR)/src/ph7/builtin.o \
-  $(BUILD_DIR)/src/ph7/compile.o \
-  $(BUILD_DIR)/src/ph7/constant.o \
-  $(BUILD_DIR)/src/ph7/hashmap.o \
-  $(BUILD_DIR)/src/ph7/lex.o \
-  $(BUILD_DIR)/src/ph7/lib.o \
-  $(BUILD_DIR)/src/ph7/memobj.o \
-  $(BUILD_DIR)/src/ph7/oo.o \
-  $(BUILD_DIR)/src/ph7/parse.o \
-  $(BUILD_DIR)/src/ph7/vfs.o \
-  $(BUILD_DIR)/src/ph7/vm.o \
-  $(BUILD_DIR)/src/phl/phl.o
-
-all: $(BUILD_DIR)/phl
+	$(BUILD_DIR)/src/ph7/api.o \
+	$(BUILD_DIR)/src/ph7/builtin.o \
+	$(BUILD_DIR)/src/ph7/compile.o \
+	$(BUILD_DIR)/src/ph7/constant.o \
+	$(BUILD_DIR)/src/ph7/hashmap.o \
+	$(BUILD_DIR)/src/ph7/lex.o \
+	$(BUILD_DIR)/src/ph7/lib.o \
+	$(BUILD_DIR)/src/ph7/memobj.o \
+	$(BUILD_DIR)/src/ph7/oo.o \
+	$(BUILD_DIR)/src/ph7/parse.o \
+	$(BUILD_DIR)/src/ph7/vfs.o \
+	$(BUILD_DIR)/src/ph7/vm.o \
+	$(BUILD_DIR)/src/phl/phl.o
 
 # Pattern rules for compilation
 $(BUILD_DIR)/src/ph7/%.o: src/ph7/%.c | $(BUILD_DIR)/src/ph7
 	$(CC) $(CFLAGS) -c $< -o $@
-
 $(BUILD_DIR)/src/phl/%.o: src/phl/%.c | $(BUILD_DIR)/src/phl
 	$(CC) $(CFLAGS) -c $< -o $@
-
-# Build target
-$(BUILD_DIR)/phl: $(OBJECTS)
-	$(CC) $(CFLAGS) -o $@ $(OBJECTS) $(LDFLAGS)
-
-# Directory creation
 $(BUILD_DIR)/src/ph7 $(BUILD_DIR)/src/phl:
 	@mkdir -p $@
+$(BUILD_DIR)/phl: $(OBJECTS)
+	$(CC) $(CFLAGS) -o $@ $(OBJECTS) $(LDFLAGS)
 
 $(BUILD_DIR)-clean:
 	@rm -rf $(BUILD_DIR)/*
 
-# TESTING AND COVERAGE TARGETS
-# ----------------------------
+# TEST TARGETS
+# ------------
 
-TEST_EXECUTABLE ?= $(BUILD_DIR)/phl -x
+TEST_EXECUTABLE ?= $(BUILD_DIR)/phl
 PHP_EXECUTABLE ?= $(shell command -v php)
 
 TEST_PHL_CMD = $(TEST_EXECUTABLE) tests/phpt.php \
@@ -81,40 +60,47 @@ TEST_PHL_CMD = $(TEST_EXECUTABLE) tests/phpt.php \
 TEST_PHP_CMD = $(PHP_EXECUTABLE) tests/phpt.php \
 	--target-dir tests
 
-$(BUILD_DIR)-test:
+$(BUILD_DIR)-test: $(BUILD_DIR)/phl
 	@$(TEST_EXECUTABLE) --version
 	$(TEST_PHL_CMD)
 
-$(BUILD_DIR)-test-compat:
-	$(eval TEST_EXECUTABLE := $(BUILD_DIR)/phl)
+$(BUILD_DIR)-test-compat: $(BUILD_DIR)/phl
 	@$(TEST_EXECUTABLE) --version
 	@$(TEST_PHL_CMD) --output-format dot
 	@$(PHP_EXECUTABLE) --version
-	$(TEST_PHP_CMD) --output-format dot
+	@$(TEST_PHP_CMD) --output-format dot
 
-COVERAGE_CFLAGS = $(CFLAGS) -fprofile-arcs -ftest-coverage
+# COVERAGE TARGETS
+# ----------------
+
+COVERAGE_CFLAGS = $(filter-out -Ofast, $(CFLAGS)) -O0 -fprofile-arcs -ftest-coverage
 COVERAGE_LDFLAGS = $(LDFLAGS) -lgcov
-COVERAGE_OBJECTS = $(OBJECTS:.o=.gcov.o)
-COVERAGE_PHL_CMD = $(BUILD_DIR)/phl-coverage -x tests/phpt.php \
+COVERAGE_OBJECTS = $(patsubst $(BUILD_DIR)/src/%,$(BUILD_DIR)/coverage/%,$(OBJECTS:.o=.gcov.o))
+
+COVERAGE_PHL_CMD = $(BUILD_DIR)/coverage/phl-coverage tests/phpt.php \
 	--target-dir tests \
 	--output-format dot
 
-$(BUILD_DIR)/src/ph7/%.gcov.o: src/ph7/%.c | $(BUILD_DIR)/src/ph7
+$(BUILD_DIR)/coverage/ph7/%.gcov.o: src/ph7/%.c | $(BUILD_DIR)/coverage/ph7
 	$(CC) $(COVERAGE_CFLAGS) -c $< -o $@
-
-$(BUILD_DIR)/src/phl/%.gcov.o: src/phl/%.c | $(BUILD_DIR)/src/phl
+$(BUILD_DIR)/coverage/phl/%.gcov.o: src/phl/%.c | $(BUILD_DIR)/coverage/phl
 	$(CC) $(COVERAGE_CFLAGS) -c $< -o $@
-
-$(BUILD_DIR)/phl-coverage: $(COVERAGE_OBJECTS)
+$(BUILD_DIR)/coverage/ph7 $(BUILD_DIR)/coverage/phl:
+	@mkdir -p $@
+$(BUILD_DIR)/coverage/phl-coverage: $(COVERAGE_OBJECTS)
 	$(CC) $(COVERAGE_CFLAGS) -o $@ $(COVERAGE_OBJECTS) $(COVERAGE_LDFLAGS)
 
-$(BUILD_DIR)/coverage.info: $(BUILD_DIR)/phl-coverage
+$(BUILD_DIR)/coverage/coverage.info: .ALWAYS $(BUILD_DIR)/coverage/phl-coverage
 	@$(COVERAGE_PHL_CMD)
-	@lcov --capture --directory $(BUILD_DIR) --include 'src/*' --output-file $(BUILD_DIR)/coverage.info
-	@./build-aux/per_file_coverage.sh $(BUILD_DIR)/coverage.info
-	@lcov --summary $(BUILD_DIR)/coverage.info
+	@lcov --capture --rc geninfo_unexecuted_blocks=1 --quiet \
+		--include 'src/ph7/*' --directory $(BUILD_DIR) \
+		--output-file $(BUILD_DIR)/coverage/coverage.info
+	@sed -i 's|SF:$(CURDIR)/|SF:|g' $(BUILD_DIR)/coverage/coverage.info
+	@$(BUILD_DIR)/coverage/phl-coverage ./build-aux/lcov_info_to_text.php $(BUILD_DIR)/coverage/coverage.info
 
-$(BUILD_DIR)/coverage-html: $(BUILD_DIR)/coverage.info
-	@genhtml --include 'src/*' $(BUILD_DIR)/coverage.info --output-directory $(BUILD_DIR)/coverage-html
-	@echo "Coverage report generated in $(BUILD_DIR)/coverage-html/index.html"
+$(BUILD_DIR)/coverage/html: .ALWAYS $(BUILD_DIR)/coverage/coverage.info
+	@genhtml \
+		--include 'src/ph7/*' $(BUILD_DIR)/coverage/coverage.info \
+		--output-directory $(BUILD_DIR)/coverage/html
+	@echo "Coverage report generated in $(BUILD_DIR)/coverage/html/index.html"
 

--- a/build-aux/cobertura_xml_to_lcov_info.php
+++ b/build-aux/cobertura_xml_to_lcov_info.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+$xml_file = isset($argv[0]) ? $argv[0] : null;
+if (!isset($xml_file)) {
+    echo "Usage: phl cobertura_xml_to_lcov_info.php <cobertura.xml> > coverage.info\n";
+    exit(1);
+}
+
+$xml = file_get_contents($xml_file);
+
+$parser = xml_parser_create();
+xml_parser_set_option($parser, XML_OPTION_CASE_FOLDING, 0);
+xml_parser_set_option($parser, XML_OPTION_SKIP_WHITE, 1);
+
+$coverage_data = array();
+$current_filename = null;
+$current_data = null;
+
+function startElement($parser, $name, $attrs) {
+    global $current_filename, $current_data;
+    if ($name == 'class') {
+        $current_filename = isset($attrs['filename']) ? $attrs['filename'] : '';
+        // Fix path
+        $current_filename = str_replace('\\', '/', $current_filename);
+        $pos = strpos($current_filename, 'PHL-build/');
+        if ($pos !== false) {
+            $current_filename = substr($current_filename, $pos + strlen('PHL-build/'));
+        }
+        $current_data = array('lines' => array(), 'functions' => array());
+    } elseif ($name == 'line' && $current_data !== null) {
+        if (isset($attrs['number']) && isset($attrs['hits'])) {
+            $current_data['lines'][] = array('number' => (int)$attrs['number'], 'hits' => (int)$attrs['hits']);
+        }
+    } elseif ($name == 'method' && $current_data !== null) {
+        if (isset($attrs['name']) && isset($attrs['line']) && isset($attrs['hits'])) {
+            $current_data['functions'][] = array('name' => $attrs['name'], 'line' => (int)$attrs['line'], 'hits' => (int)$attrs['hits']);
+        }
+    }
+}
+
+function endElement($parser, $name) {
+    global $current_filename, $current_data, $coverage_data;
+    if ($name == 'class' && $current_filename && $current_data) {
+        $coverage_data[$current_filename] = $current_data;
+        $current_data = null;
+        $current_filename = null;
+    }
+}
+
+xml_set_element_handler($parser, 'startElement', 'endElement');
+
+if (!xml_parse($parser, $xml, true)) {
+    die("XML error: " . xml_error_string(xml_get_error_code($parser)) . " at line " . xml_get_current_line_number($parser));
+}
+
+xml_parser_free($parser);
+
+// Now output lcov
+foreach ($coverage_data as $filename => $data) {
+    echo "SF:$filename\n";
+    $functions = isset($data['functions']) ? $data['functions'] : array();
+    foreach ($functions as $func) {
+        echo "FN:{$func['line']},{$func['name']}\n";
+    }
+    $fnf = count($functions);
+    $fnh = 0;
+    foreach ($functions as $func) {
+        if ($func['hits'] > 0) $fnh++;
+    }
+    echo "FNF:$fnf\n";
+    echo "FNH:$fnh\n";
+    echo "BRF:0\n";
+    echo "BRH:0\n";
+    $lines = isset($data['lines']) ? $data['lines'] : array();
+    $found = count($lines);
+    $hit = 0;
+    foreach ($lines as $line) {
+        echo "DA:{$line['number']},{$line['hits']}\n";
+        if ($line['hits'] > 0) $hit++;
+    }
+    echo "LF:$found\n";
+    echo "LH:$hit\n";
+    echo "end_of_record\n";
+}
+
+?>

--- a/build-aux/lcov_info_to_text.php
+++ b/build-aux/lcov_info_to_text.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+$usage = "Usage: lcov_info_to_text.php [--content=files|summary|all] <coverage.info>\n";
+
+$content = 'all';
+$info_file = null;
+
+foreach ($argv as $arg) {
+    if (strpos($arg, '--content=') === 0) {
+        $content = substr($arg, 10);
+    } elseif (!$info_file) {
+        $info_file = $arg;
+    } else {
+        // extra arg
+        echo $usage;
+        exit(1);
+    }
+}
+
+if ($content !== 'files' && $content !== 'summary' && $content !== 'all') {
+    echo "Invalid content option: $content\n";
+    echo $usage;
+    exit(1);
+}
+
+if (!$info_file) {
+    echo $usage;
+    exit(1);
+}
+
+$lines = file($info_file, FILE_IGNORE_NEW_LINES);
+if ($lines === false) {
+    echo "Error reading file: $info_file\n";
+    exit(1);
+}
+
+if ($content === 'files' || $content === 'all') {
+    echo "| Filename                       | Rate     | Hit/Total   |\n";
+    echo "|--------------------------------|----------|-------------|\n";
+}
+
+$file = '';
+$total = 0;
+$hit = 0;
+$total_lines_hit = 0;
+$total_lines = 0;
+$total_funcs_hit = 0;
+$total_funcs = 0;
+
+foreach ($lines as $line) {
+    if (strpos($line, 'SF:') === 0) {
+        $file = substr($line, 3);
+        $pos = strrpos($file, '/src/');
+        if ($pos !== false) {
+            $file = 'src/' . substr($file, $pos + 5);
+        }
+    } elseif (strpos($line, 'LF:') === 0) {
+        $total = (int)substr($line, 3);
+        $total_lines += $total;
+    } elseif (strpos($line, 'LH:') === 0) {
+        $hit = (int)substr($line, 3);
+        $total_lines_hit += $hit;
+        if ($total > 0) {
+            $rate = sprintf("%.2f%%", ($hit / $total) * 100);
+        } else {
+            $rate = "0.00%";
+        }
+        if ($content === 'files' || $content === 'all') {
+            echo sprintf("| %-30s | %-8s | %-11s |\n", $file, $rate, "$hit/$total");
+        }
+    } elseif (strpos($line, 'FNF:') === 0) {
+        $total_funcs += (int)substr($line, 4);
+    } elseif (strpos($line, 'FNH:') === 0) {
+        $total_funcs_hit += (int)substr($line, 4);
+    }
+}
+
+if ($total_lines > 0) {
+    $overall_rate = sprintf("%.2f%%", ($total_lines_hit / $total_lines) * 100);
+} else {
+    $overall_rate = "0.00%";
+}
+if ($total_funcs > 0) {
+    $func_rate = sprintf("%.2f%%", ($total_funcs_hit / $total_funcs) * 100);
+} else {
+    $func_rate = "0.00%";
+}
+
+if ($content === 'summary' || $content === 'all') {
+    echo "\n";
+    echo "| Total                          | Rate     | Hit/Total   |\n";
+    echo "|--------------------------------|----------|-------------|\n";
+
+    echo sprintf("| %-30s | %-8s | %-11s |\n", "Lines", $overall_rate, "$total_lines_hit/$total_lines");
+    if ($total_funcs > 0) {
+        echo sprintf("| %-30s | %-8s | %-11s |\n", "Functions", $func_rate, "$total_funcs_hit/$total_funcs");
+    }
+}
+?>

--- a/build-aux/nmake.mk
+++ b/build-aux/nmake.mk
@@ -7,69 +7,54 @@ CC = cl
 TARGET = x86_64-windows-msvc
 
 BUILD_DIR = build\$(TARGET)
-CFLAGS = /Fd$(BUILD_DIR)\ph7.pdb /I src\ph7 /W4 /Ox /DPH7_ENABLE_MATH_FUNC
-LDFLAGS = /link advapi32.lib /nologo /subsystem:console /entry:mainCRTStartup
+CFLAGS = /nologo /Fd$(BUILD_DIR)\ph7.pdb /I src /I src\ph7 /W4 /Ox /DPH7_ENABLE_MATH_FUNC /DPH7_ENABLE_THREADS
+LDFLAGS = /nologo /link advapi32.lib dbghelp.lib /subsystem:console /entry:mainCRTStartup
 
-all: $(BUILD_DIR)\phl.exe
-clean: $(BUILD_DIR)-clean
-test: $(BUILD_DIR)-test
-test-compat: $(BUILD_DIR)-test-compat
-
-# Source file lists
-SRC_SOURCES = \
-  api.c \
-  builtin.c \
-  compile.c \
-  constant.c \
-  hashmap.c \
-  lex.c \
-  lib.c \
-  memobj.c \
-  oo.c \
-  parse.c \
-  vfs.c \
-  vm.c
+all: .ALWAYS $(BUILD_DIR)\phl.exe
+build: .ALWAYS $(BUILD_DIR)\phl.exe
+clean: .ALWAYS $(BUILD_DIR)-clean
+test: .ALWAYS $(BUILD_DIR)-test
+test-compat: .ALWAYS $(BUILD_DIR)-test-compat
+coverage: .ALWAYS $(BUILD_DIR)\coverage\coverage.info
+coverage-html: .ALWAYS $(BUILD_DIR)\coverage\html
+.ALWAYS: # No .PHONY because nmake does not support it
 
 # Object files
 OBJECTS = \
-  $(BUILD_DIR)\src\ph7\api.obj \
-  $(BUILD_DIR)\src\ph7\builtin.obj \
-  $(BUILD_DIR)\src\ph7\compile.obj \
-  $(BUILD_DIR)\src\ph7\constant.obj \
-  $(BUILD_DIR)\src\ph7\hashmap.obj \
-  $(BUILD_DIR)\src\ph7\lex.obj \
-  $(BUILD_DIR)\src\ph7\lib.obj \
-  $(BUILD_DIR)\src\ph7\memobj.obj \
-  $(BUILD_DIR)\src\ph7\oo.obj \
-  $(BUILD_DIR)\src\ph7\parse.obj \
-  $(BUILD_DIR)\src\ph7\vfs.obj \
-  $(BUILD_DIR)\src\ph7\vm.obj \
-  $(BUILD_DIR)\src\phl\phl.obj
+	$(BUILD_DIR)\src\ph7\api.obj \
+	$(BUILD_DIR)\src\ph7\builtin.obj \
+	$(BUILD_DIR)\src\ph7\compile.obj \
+	$(BUILD_DIR)\src\ph7\constant.obj \
+	$(BUILD_DIR)\src\ph7\hashmap.obj \
+	$(BUILD_DIR)\src\ph7\lex.obj \
+	$(BUILD_DIR)\src\ph7\lib.obj \
+	$(BUILD_DIR)\src\ph7\memobj.obj \
+	$(BUILD_DIR)\src\ph7\oo.obj \
+	$(BUILD_DIR)\src\ph7\parse.obj \
+	$(BUILD_DIR)\src\ph7\vfs.obj \
+	$(BUILD_DIR)\src\ph7\vm.obj \
+	$(BUILD_DIR)\src\phl\phl.obj
 
-# Inference rules for compilation
+# Pattern rules for compilation
 {src\ph7}.c{$(BUILD_DIR)\src\ph7}.obj:
-  @if not exist $(BUILD_DIR)\src\ph7 mkdir $(BUILD_DIR)\src\ph7
-  $(CC) $(CFLAGS) /Fo"$@" /c $<
-
+	@if not exist $(BUILD_DIR)\src\ph7 mkdir $(BUILD_DIR)\src\ph7
+	$(CC) $(CFLAGS) /Fo"$@" /c $<
 {src\phl}.c{$(BUILD_DIR)\src\phl}.obj:
-  @if not exist $(BUILD_DIR)\src\phl mkdir $(BUILD_DIR)\src\phl
-  $(CC) $(CFLAGS) /Fo"$@" /c $<
-
-# Build target
-$(BUILD_DIR)\phl.exe: $(BUILD_DIR) $(OBJECTS)
-  $(CC) $(CFLAGS) /Fe$@ $(OBJECTS) $(LDFLAGS)
-
-# Directory creation
+	@if not exist $(BUILD_DIR)\src\phl mkdir $(BUILD_DIR)\src\phl
+	$(CC) $(CFLAGS) /Fo"$@" /c $<
 $(BUILD_DIR):
-  @if not exist $(BUILD_DIR) mkdir $(BUILD_DIR)
+	@if not exist $(BUILD_DIR) mkdir $(BUILD_DIR)
+$(BUILD_DIR)\phl.exe: $(BUILD_DIR) $(OBJECTS)
+	$(CC) $(CFLAGS) /Fe$@ $(OBJECTS) $(LDFLAGS)
 
+# Clean target
 $(BUILD_DIR)-clean:
-  @del /s /q $(BUILD_DIR)\*
+	-@del /s /q $(BUILD_DIR)\* >nul
 
-# TESTING AND COVERAGE TARGETS
-# ----------------------------
+# TEST TARGETS
+# ------------
 
-TEST_EXECUTABLE = $(BUILD_DIR)\phl.exe -x
+TEST_EXECUTABLE = $(BUILD_DIR)\phl.exe
 PHP_EXECUTABLE = php.exe
 
 TEST_PHL_CMD = $(TEST_EXECUTABLE) tests/phpt.php \
@@ -77,11 +62,52 @@ TEST_PHL_CMD = $(TEST_EXECUTABLE) tests/phpt.php \
 TEST_PHP_CMD = $(PHP_EXECUTABLE) tests/phpt.php \
 	--target-dir tests
 
-$(BUILD_DIR)-test:
-	@$(TEST_PHL_CMD)
+$(BUILD_DIR)-test: $(BUILD_DIR)\phl.exe
+	@$(TEST_EXECUTABLE) --version
+	$(TEST_PHL_CMD)
 
-$(BUILD_DIR)-test-compat:
-	@$(BUILD_DIR)\phl.exe --version
+$(BUILD_DIR)-test-compat: $(BUILD_DIR)\phl.exe
+	@$(TEST_EXECUTABLE) --version
 	@$(TEST_PHL_CMD) --output-format dot
 	@$(PHP_EXECUTABLE) --version
 	@$(TEST_PHP_CMD) --output-format dot
+
+# COVERAGE TARGETS
+# ----------------
+
+COVERAGE_CFLAGS = $(subst /Ox,/Od,$(CFLAGS)) /Fd$(BUILD_DIR)\coverage\ph7-coverage.pdb /Zi
+COVERAGE_LDFLAGS = $(LDFLAGS) /DEBUG
+COVERAGE_OBJECTS = $(OBJECTS:\src\=\coverage\)
+
+COVERAGE_PHL_CMD = $(BUILD_DIR)\coverage\phl-coverage.exe tests/phpt.php \
+	--target-dir tests \
+	--output-format dot
+
+{src\ph7}.c{$(BUILD_DIR)\coverage\ph7}.obj:
+	@if not exist $(BUILD_DIR)\coverage\ph7 mkdir $(BUILD_DIR)\coverage\ph7
+	$(CC) $(COVERAGE_CFLAGS) /Fo"$@" /c $<
+{src\phl}.c{$(BUILD_DIR)\coverage\phl}.obj:
+	@if not exist $(BUILD_DIR)\coverage\phl mkdir $(BUILD_DIR)\coverage\phl
+	$(CC) $(COVERAGE_CFLAGS) /Fo"$@" /c $<
+$(BUILD_DIR)\coverage:
+	@if not exist $(BUILD_DIR)\coverage mkdir $(BUILD_DIR)\coverage
+$(BUILD_DIR)\coverage\phl-coverage.exe: $(BUILD_DIR)\coverage $(COVERAGE_OBJECTS)
+	$(CC) $(COVERAGE_CFLAGS) /Fe$@ $(COVERAGE_OBJECTS) $(COVERAGE_LDFLAGS)
+
+$(BUILD_DIR)\coverage\coverage.info: .ALWAYS $(BUILD_DIR)\coverage\phl-coverage.exe
+	-@OpenCppCoverage.exe --quiet \
+	--sources $(MAKEDIR)\src \
+	--export_type cobertura:$(BUILD_DIR)\coverage\cobertura.xml \
+	-- $(COVERAGE_PHL_CMD)
+	@$(BUILD_DIR)\coverage\phl-coverage.exe \
+		build-aux/cobertura_xml_to_lcov_info.php \
+		$(BUILD_DIR)\coverage\cobertura.xml > $(BUILD_DIR)\coverage\coverage.info
+	@$(BUILD_DIR)\coverage\phl-coverage.exe \
+		build-aux/lcov_info_to_text.php \
+		$(BUILD_DIR)\coverage\coverage.info
+
+$(BUILD_DIR)\coverage\html: .ALWAYS $(BUILD_DIR)\coverage\phl-coverage.exe
+	-@OpenCppCoverage.exe --quiet \
+	--sources $(MAKEDIR)\src \
+	--export_type html:$(BUILD_DIR)\coverage\html \
+	-- $(COVERAGE_PHL_CMD)


### PR DESCRIPTION
 - Uses OpenCppCoverage to extract cobertura and html reports.
 - Custom cobertura_xml_to_lcov_info.php to convert between coverage data formats.
 - Custom lcov_info_to_text.php written to report coverage in an uniform style to text.
 - Overall makefile consistency (Makefile and nmake.mk made to be very similar)
 - GitHub CI configuration for the new options, new setup action, new matrix arrangement, merge lcov.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally
- [x] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
