### PR TITLE
Fix unsigned subtraction vulnerability in XML parser and add tests

### DIFF
--- a/src/ph7/lib.c
+++ b/src/ph7/lib.c
@@ -3987,7 +3987,7 @@ static sxi32  ProcessXML(SyXMLParser *pParse,SySet *pTagStack,SySet *pWorker)
 			int isXML = 0;
 			/* Extract the target and data */
 			XMLExtactPI(pToken,&sTarget,&sData,&isXML);
-			if( isXML && SySetCursor(pTokenSet) - 1 > 0 ){
+			if( isXML && SySetCursor(pTokenSet) > 1 ){
 				if( pParse->xError ){
 					rc = pParse->xError("Unexpected XML declaration. The XML declaration must be the first node in the document",
 						SXML_ERROR_MISPLACED_XML_PI,pToken,pParse->pUserData);

--- a/tests/ph7/002-engine/builtin/xml/xml_declaration_middle.phpt
+++ b/tests/ph7/002-engine/builtin/xml/xml_declaration_middle.phpt
@@ -1,0 +1,43 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+XML Declaration In Middle Of Document Test
+--DESCRIPTION--
+Test that XML declarations are rejected when placed in the middle of XML documents.
+--SKIPIF--
+<?php
+if (function_exists('zend_version')) {
+    echo "skip Test requires PH7 XML parser, not PHP's XML extension";
+}
+?>
+--FILE--
+<?php
+$parser = xml_parser_create();
+xml_set_element_handler($parser, 'start_element', 'end_element');
+xml_set_character_data_handler($parser, 'character_data');
+$xml = '<root><child><' . '?xml version="1.0"?' . '></child></root>';
+$result = xml_parse($parser, $xml, true);
+$error_code = xml_get_error_code($parser);
+$error_string = xml_error_string($error_code);
+xml_parser_free($parser);
+echo "Parse result: $result, error code: $error_code ($error_string)\n";
+
+function start_element($parser, $name, $attrs) {
+    echo "Start: $name\n";
+}
+
+function end_element($parser, $name) {
+    echo "End: $name\n";
+}
+
+function character_data($parser, $data) {
+    if (trim($data)) {
+        echo "Data: $data\n";
+    }
+}
+?>
+--EXPECT--
+Start: root
+Start: child
+Parse result: 0, error code: 18 (Misplaced processing instruction)

--- a/tests/ph7/002-engine/builtin/xml/xml_declaration_misplaced.phpt
+++ b/tests/ph7/002-engine/builtin/xml/xml_declaration_misplaced.phpt
@@ -1,0 +1,44 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+XML Declaration Misplaced Security Fix Test
+--DESCRIPTION--
+Test for the unsigned subtraction security vulnerability fix in XML parser.
+Ensures XML declarations are rejected when placed after the first element.
+Reference: https://github.com/alganet/PHL/security/code-scanning/5
+--SKIPIF--
+<?php
+if (function_exists('zend_version')) {
+    echo "skip Test requires PH7 XML parser, not PHP's XML extension";
+}
+?>
+--FILE--
+<?php
+$parser = xml_parser_create();
+xml_set_element_handler($parser, 'start_element', 'end_element');
+xml_set_character_data_handler($parser, 'character_data');
+$xml = '<root><' . '?xml version="1.0"?' . '><child>test</child></root>';
+$result = xml_parse($parser, $xml, true);
+$error_code = xml_get_error_code($parser);
+$error_string = xml_error_string($error_code);
+xml_parser_free($parser);
+echo "Parse result: $result, error code: $error_code ($error_string)\n";
+
+function start_element($parser, $name, $attrs) {
+    echo "Start: $name\n";
+}
+
+function end_element($parser, $name) {
+    echo "End: $name\n";
+}
+
+function character_data($parser, $data) {
+    if (trim($data)) {
+        echo "Data: $data\n";
+    }
+}
+?>
+--EXPECT--
+Start: root
+Parse result: 0, error code: 18 (Misplaced processing instruction)

--- a/tests/ph7/002-engine/builtin/xml/xml_declaration_valid.phpt
+++ b/tests/ph7/002-engine/builtin/xml/xml_declaration_valid.phpt
@@ -1,0 +1,44 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+XML Declaration Valid Position Test
+--DESCRIPTION--
+Test that XML declarations are allowed as the first element in valid XML.
+--SKIPIF--
+<?php
+if (function_exists('zend_version')) {
+    echo "skip Test requires PH7 XML parser, not PHP's XML extension";
+}
+?>
+--FILE--
+<?php
+$parser = xml_parser_create();
+xml_set_element_handler($parser, 'start_element', 'end_element');
+xml_set_character_data_handler($parser, 'character_data');
+$xml = '<' . '?xml version="1.0" encoding="UTF-8"?' . '><root><child>test</child></root>';
+$result = xml_parse($parser, $xml, true);
+xml_parser_free($parser);
+echo "Parse result: $result\n";
+
+function start_element($parser, $name, $attrs) {
+    echo "Start: $name\n";
+}
+
+function end_element($parser, $name) {
+    echo "End: $name\n";
+}
+
+function character_data($parser, $data) {
+    if (trim($data)) {
+        echo "Data: $data\n";
+    }
+}
+?>
+--EXPECT--
+Start: root
+Start: child
+Data: test
+End: child
+End: root
+Parse result: 1

--- a/tests/ph7/002-engine/builtin/xml/xml_declaration_whitespace.phpt
+++ b/tests/ph7/002-engine/builtin/xml/xml_declaration_whitespace.phpt
@@ -1,0 +1,44 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+XML Declaration After Whitespace Test
+--DESCRIPTION--
+Test that XML declarations are allowed when preceded only by whitespace.
+--SKIPIF--
+<?php
+if (function_exists('zend_version')) {
+    echo "skip Test requires PH7 XML parser, not PHP's XML extension";
+}
+?>
+--FILE--
+<?php
+$parser = xml_parser_create();
+xml_set_element_handler($parser, 'start_element', 'end_element');
+xml_set_character_data_handler($parser, 'character_data');
+$xml = '   <' . '?xml version="1.0"?' . '><root><child>test</child></root>';
+$result = xml_parse($parser, $xml, true);
+xml_parser_free($parser);
+echo "Parse result: $result\n";
+
+function start_element($parser, $name, $attrs) {
+    echo "Start: $name\n";
+}
+
+function end_element($parser, $name) {
+    echo "End: $name\n";
+}
+
+function character_data($parser, $data) {
+    if (trim($data)) {
+        echo "Data: $data\n";
+    }
+}
+?>
+--EXPECT--
+Start: root
+Start: child
+Data: test
+End: child
+End: root
+Parse result: 1


### PR DESCRIPTION
Prevent unsigned integer wraparound in XML declaration validation by changing the condition from 'SySetCursor(pTokenSet) - 1 > 0' to 'SySetCursor(pTokenSet) > 1' in ProcessXML function.

Add comprehensive phpt tests covering:
- Valid XML declaration positioning
- Misplaced XML declarations (security fix validation)
- XML declarations after whitespace
- XML declarations in middle of documents

Reference:
https://github.com/alganet/PHL/security/code-scanning/5

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally
- [x] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
