### PR TITLE
Add set_error_handler implementation

### DIFF
--- a/tests/ph7/002-engine/builtin/file/file_put_contents.phpt
+++ b/tests/ph7/002-engine/builtin/file/file_put_contents.phpt
@@ -2,11 +2,12 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-Test file_put_contents with empty data and locked file
+Test file_put_contents()
 --SKIPIF--
 <?php
-if (function_exists('zend_version')) {
-    echo "Zend PHP on Windows handles locks differently";
+
+if (PHP_OS === 'WINNT' && function_exists('zend_version')) {
+    echo "skip: platform";
 }
 if (!function_exists('file_put_contents') || !function_exists('flock') || !function_exists('fopen')) {
     echo 'skip: file functions not available';

--- a/tests/ph7/002-engine/builtin/file/file_put_contents_zend_win.phpt
+++ b/tests/ph7/002-engine/builtin/file/file_put_contents_zend_win.phpt
@@ -2,16 +2,13 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-Test file_put_contents with empty data and locked file
+Test file_put_contents()
+Compatibility test with Zend PHP on Windows
 --SKIPIF--
 <?php
 
-// !!!!
-echo "skip, not working on CI for some reason, remove this to enable the test locally";
-// !!!!
-
-if (!function_exists('zend_version') || PHP_OS === 'Linux') {
-    echo "Zend PHP on Windows handles locks differently";
+if (PHP_OS === 'Linux' || !function_exists('zend_version')) {
+    echo "skip: platform";
 }
 if (!function_exists('file_put_contents') || !function_exists('flock') || !function_exists('fopen')) {
     echo 'skip: file functions not available';
@@ -19,6 +16,11 @@ if (!function_exists('file_put_contents') || !function_exists('flock') || !funct
 ?>
 --FILE--
 <?php
+
+$restore_error_handler = set_error_handler(function ($code, $msg) {
+    echo "CAUGHT: $msg" . PHP_EOL;
+    return true;
+});
 
 // Test 2: Try writing to a locked file (advisory lock, may not fail on all systems)
 $lockFile = tempnam(sys_get_temp_dir(), 'ph7_lock_test');
@@ -39,10 +41,11 @@ if ($fp && flock($fp, LOCK_EX)) {
 
 // Clean up
 unlink($lockFile);
+set_error_handler($restore_error_handler);
 
 ?>
---EXPECTF--
-Notice: file_put_contents(): Write of 4 bytes failed with errno=13 Permission denied in %s on line 8
+--EXPECT--
+CAUGHT: file_put_contents(): Write of 4 bytes failed with errno=13 Permission denied
 Writing to locked file failed as expected
 --CLEAN--
 <?php

--- a/tests/ph7/002-engine/error/set_error_handler_suppress.phpt
+++ b/tests/ph7/002-engine/error/set_error_handler_suppress.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+set_error_handler with suppress (return true)
+--FILE--
+<?php
+$restore_error_handler = set_error_handler(function($errno, $errstr, $errfile, $errline) {
+    $fname = basename($errfile);
+    echo "Handler called: $errno, $errstr, $fname, $errline" . PHP_EOL;
+    return true; // Suppress normal error reporting
+});
+trigger_error("Test error suppressed", E_USER_NOTICE);
+set_error_handler($restore_error_handler);
+echo "After error\n";
+?>
+--EXPECTF--
+Handler called: %d, Test error suppressed, set_error_handler_suppress.phpt.file, %d
+After error


### PR DESCRIPTION
This commit makes the first steps into more elaborate error handling for the ph7 engine by enabling the incomplete set_error_handler() implementation and finishing its handler.

The original idea seems to be able to expose error handling to the ph7 embedding API, however, this is not explored in this stage.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally
- [x] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
