### PR TITLE
Fix use-after-free, introduce crash handler, fix nmake.mk

### DIFF
--- a/build-aux/nmake.mk
+++ b/build-aux/nmake.mk
@@ -9,9 +9,9 @@ BIN_SUFFIX = .exe
 
 CC = cl
 TARGET = x86_64-windows-msvc
-CFLAGS = /nologo /Fd$(BUILD_DIR:/=\)\ph7.pdb /I src /I src/ph7 /W4 /Ox $(PH7_DEFINES)
-LDFLAGS = /nologo /link advapi32.lib dbghelp.lib /subsystem:console /entry:mainCRTStartup
-COVERAGE_CFLAGS = /nologo /Fd$(BUILD_DIR:/=\)\coverage\ph7-coverage.pdb /I src /I src/ph7 /W4 /Od /Zi $(PH7_DEFINES)
+CFLAGS = /nologo /Fd$(BUILD_DIR:/=\)\ph7.pdb /I src /I src/ph7 /W4 /Ox $(PH7_DEFINES:-=/)
+LDFLAGS = /nologo /link advapi32.lib /subsystem:console /entry:mainCRTStartup
+COVERAGE_CFLAGS = /nologo /Fd$(BUILD_DIR:/=\)\coverage\ph7-coverage.pdb /I src /I src/ph7 /W4 /Od /Zi $(PH7_DEFINES:-=/) /DPH7_DEBUG
 
 PHP_BIN = php$(BIN_SUFFIX)
 
@@ -24,14 +24,14 @@ $(BUILD_DIR)-clean:
 # COVERAGE
 # --------
 
-COVERAGE_LDFLAGS = $(LDFLAGS) /DEBUG
+COVERAGE_LDFLAGS = /nologo /link advapi32.lib dbghelp.lib /subsystem:console /entry:mainCRTStartup
 COVERAGE_OBJECTS = $(OBJECTS:/src/=/coverage/src/)
 
 $(COVERAGE_BIN): $(BUILD_DIR)/coverage $(COVERAGE_OBJECTS)
 	$(CC) $(COVERAGE_CFLAGS) /Fe$@ $(COVERAGE_OBJECTS) $(COVERAGE_LDFLAGS)
 
 $(BUILD_DIR)/coverage/coverage.info: .ALWAYS $(COVERAGE_BIN)
-	-@OpenCppCoverage.exe --quiet \
+	@OpenCppCoverage.exe --quiet \
 	--sources "$(MAKEDIR)\src" \
 	--export_type cobertura:$(BUILD_DIR)/coverage/cobertura.xml \
 	-- $(COVERAGE_PHL_CMD)

--- a/src/minidump.h
+++ b/src/minidump.h
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2020 OpenCppCoverage
+// SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef MINIDUMP_H
+#define MINIDUMP_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void CreateMiniDumpOnUnHandledException();
+
+#ifdef __cplusplus
+}
+#endif
+
+// Implementation
+#ifdef MINIDUMP_IMPLEMENTATION
+
+#include <Windows.h>
+#include <stdio.h>
+
+#pragma warning(push)
+#pragma warning(disable: 4091) // 'typedef ': ignored on left of '' when no variable is declared
+#include <DbgHelp.h>
+#pragma warning(pop)
+
+// Define MiniDumpWithSystemInfo if not available (for older DbgHelp versions)
+#ifndef MiniDumpWithSystemInfo
+#define MiniDumpWithSystemInfo ((MINIDUMP_TYPE)0x800)
+#endif
+
+//-----------------------------------------------------------------------------
+void GetTimestampedFilename(wchar_t* buffer, size_t bufferSize)
+{
+    SYSTEMTIME st;
+    GetLocalTime(&st);
+    swprintf(buffer, bufferSize / sizeof(wchar_t), L"PHL-%04d-%02d-%02d-%02d-%02d-%02d.dmp",
+             st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);
+}
+
+//-----------------------------------------------------------------------------
+MINIDUMP_TYPE GetMiniDumpDefaultType()
+{
+	return (MINIDUMP_TYPE)(MiniDumpWithDataSegs |
+		MiniDumpWithPrivateReadWriteMemory |
+		MiniDumpWithFullMemoryInfo |
+		MiniDumpWithThreadInfo |
+		MiniDumpWithSystemInfo);
+}
+
+//-----------------------------------------------------------------------------
+void CreateMiniDump(
+	MINIDUMP_EXCEPTION_INFORMATION* minidumpInfo,
+	HANDLE hFile,
+	const wchar_t* dmpFilename)
+{
+	MINIDUMP_TYPE miniDumpType = GetMiniDumpDefaultType();
+
+	fwprintf(stderr, L"\tTrying to create memory dump...\n");
+	if (MiniDumpWriteDump(
+		GetCurrentProcess(),
+		GetCurrentProcessId(),
+		hFile,
+		miniDumpType,
+		minidumpInfo,
+		NULL,
+		NULL))
+	{
+		fwprintf(stderr, L"\tMemory dump created successfully: %s\n", dmpFilename);
+		fwprintf(stderr, L"\tPlease create a new issue on ");
+		fwprintf(stderr, L"https://github.com/alganet/PHL/issues and attach the memory dump ");
+		fwprintf(stderr, L"%s\n", dmpFilename);
+	}
+	else
+		fwprintf(stderr, L"\tFailed to create memory dump.\n");
+}
+
+//-----------------------------------------------------------------------------
+LONG CALLBACK VectoredHandler(PEXCEPTION_POINTERS ExceptionInfo)
+{
+	if (ExceptionInfo->ExceptionRecord->ExceptionCode == EXCEPTION_ACCESS_VIOLATION)
+	{
+		MINIDUMP_EXCEPTION_INFORMATION minidumpInfo;
+		wchar_t dmpFilename[256];
+
+		fwprintf(stderr, L"Unexpected error occurred.\n");
+
+		minidumpInfo.ThreadId = GetCurrentThreadId();
+		minidumpInfo.ExceptionPointers = ExceptionInfo;
+		minidumpInfo.ClientPointers = FALSE;
+
+		GetTimestampedFilename(dmpFilename, sizeof(dmpFilename));
+		HANDLE hFile = CreateFileW(dmpFilename, GENERIC_WRITE, 0, NULL,
+			CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+
+		if (hFile != INVALID_HANDLE_VALUE)
+		{
+			CreateMiniDump(&minidumpInfo, hFile, dmpFilename);
+			CloseHandle(hFile);
+		}
+		// Do not abort, let PHL handle it
+	}
+	return EXCEPTION_CONTINUE_SEARCH;
+}
+
+//-------------------------------------------------------------------------
+void CreateMiniDumpOnUnHandledException()
+{
+	PVOID handler = AddVectoredExceptionHandler(1, VectoredHandler);
+	if (handler == NULL) {
+		fwprintf(stderr, L"Warning: Failed to register vectored exception handler\n");
+	}
+}
+
+#endif // MINIDUMP_IMPLEMENTATION
+
+#endif // MINIDUMP_H

--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -1035,6 +1035,41 @@ PH7_PRIVATE sxi32 PH7_HashmapCmp(
 	return 0; /* Hashmaps are equals */
 }
 /*
+ * Duplicate a hashmap node.
+ * This function is used by HashmapMerge, HashmapOverwrite and PH7_HashmapDup.
+ */
+static sxi32 HashmapDuplicateNode(
+	ph7_hashmap *pDest,
+	ph7_hashmap_node *pEntry,
+	ph7_value *pVal,
+	int iAction /* 0: Merge, 1: Overwrite, 2: Dup */
+	)
+{
+	ph7_value sSafeVal = *pVal;
+	ph7_value sKey;
+	sxi32 rc;
+
+	if( pEntry->iType == HASHMAP_BLOB_NODE ){
+		/* Blob key insertion */
+		PH7_MemObjInitFromString(pDest->pVm,&sKey,0);
+		PH7_MemObjStringAppend(&sKey,(const char *)SyBlobData(&pEntry->xKey.sKey),SyBlobLength(&pEntry->xKey.sKey));
+		rc = PH7_HashmapInsert(pDest,&sKey,&sSafeVal);
+		PH7_MemObjRelease(&sKey);
+	}else{
+		/* Int key */
+		if( iAction == 0 ){ /* Merge */
+			rc = HashmapInsert(pDest,0/* Automatic index assign */,&sSafeVal);
+		}else if( iAction == 1 ){ /* Overwrite */
+			PH7_MemObjInitFromInt(pDest->pVm,&sKey,pEntry->xKey.iKey);
+			rc = PH7_HashmapInsert(pDest,&sKey,&sSafeVal);
+			PH7_MemObjRelease(&sKey);
+		}else{ /* Dup */
+			rc = HashmapInsertIntKey(pDest,pEntry->xKey.iKey,&sSafeVal,0,FALSE);
+		}
+	}
+	return rc;
+}
+/*
  * Merge two hashmaps.
  * Note on the merge process
  * According to the PHP language reference manual.
@@ -1049,7 +1084,7 @@ PH7_PRIVATE sxi32 PH7_HashmapCmp(
 static sxi32 HashmapMerge(ph7_hashmap *pSrc,ph7_hashmap *pDest)
 {
 	ph7_hashmap_node *pEntry;
-	ph7_value sKey,*pVal;
+	ph7_value *pVal;
 	sxi32 rc;
 	sxu32 n;
 	if( pSrc == pDest ){
@@ -1064,14 +1099,15 @@ static sxi32 HashmapMerge(ph7_hashmap *pSrc,ph7_hashmap *pDest)
 	for( n = 0 ; n < pSrc->nEntry ; ++n ){
 		/* Extract the node value */
 		pVal = HashmapExtractNodeValue(pEntry);
-		if( pEntry->iType == HASHMAP_BLOB_NODE ){
-			/* Blob key insertion */
-			PH7_MemObjInitFromString(pDest->pVm,&sKey,0);
-			PH7_MemObjStringAppend(&sKey,(const char *)SyBlobData(&pEntry->xKey.sKey),SyBlobLength(&pEntry->xKey.sKey));
-			rc = PH7_HashmapInsert(&(*pDest),&sKey,pVal);
-			PH7_MemObjRelease(&sKey);
+		if( pVal ){
+			/* Make a local copy of the value.
+			 * The insertion call below may trigger a memory pool reallocation
+			 * which will invalidate the 'pVal' pointer since it points
+			 * to the old pool.
+			 */
+			rc = HashmapDuplicateNode(pDest,pEntry,pVal,0);
 		}else{
-			rc = HashmapInsert(&(*pDest),0/* Automatic index assign */,pVal);
+			rc = SXRET_OK;
 		}
 		if( rc != SXRET_OK ){
 			return rc;
@@ -1098,7 +1134,7 @@ static sxi32 HashmapMerge(ph7_hashmap *pSrc,ph7_hashmap *pDest)
 static sxi32 HashmapOverwrite(ph7_hashmap *pSrc,ph7_hashmap *pDest)
 {
 	ph7_hashmap_node *pEntry;
-	ph7_value sKey,*pVal;
+	ph7_value *pVal;
 	sxi32 rc;
 	sxu32 n;
 	if( pSrc == pDest ){
@@ -1113,16 +1149,11 @@ static sxi32 HashmapOverwrite(ph7_hashmap *pSrc,ph7_hashmap *pDest)
 	for( n = 0 ; n < pSrc->nEntry ; ++n ){
 		/* Extract the node value */
 		pVal = HashmapExtractNodeValue(pEntry);
-		if( pEntry->iType == HASHMAP_BLOB_NODE ){
-			/* Blob key insertion */
-			PH7_MemObjInitFromString(pDest->pVm,&sKey,0);
-			PH7_MemObjStringAppend(&sKey,(const char *)SyBlobData(&pEntry->xKey.sKey),SyBlobLength(&pEntry->xKey.sKey));
+		if( pVal ){
+			rc = HashmapDuplicateNode(pDest,pEntry,pVal,1);
 		}else{
-			/* Int key insertion */
-			PH7_MemObjInitFromInt(pDest->pVm,&sKey,pEntry->xKey.iKey);
+			rc = SXRET_OK;
 		}
-		rc = PH7_HashmapInsert(&(*pDest),&sKey,pVal);
-		PH7_MemObjRelease(&sKey);
 		if( rc != SXRET_OK ){
 			return rc;
 		}
@@ -1138,7 +1169,7 @@ static sxi32 HashmapOverwrite(ph7_hashmap *pSrc,ph7_hashmap *pDest)
 PH7_PRIVATE sxi32 PH7_HashmapDup(ph7_hashmap *pSrc,ph7_hashmap *pDest)
 {
 	ph7_hashmap_node *pEntry;
-	ph7_value sKey,*pVal;
+	ph7_value *pVal;
 	sxi32 rc;
 	sxu32 n;
 	if( pSrc == pDest ){
@@ -1153,15 +1184,10 @@ PH7_PRIVATE sxi32 PH7_HashmapDup(ph7_hashmap *pSrc,ph7_hashmap *pDest)
 	for( n = 0 ; n < pSrc->nEntry ; ++n ){
 		/* Extract the node value */
 		pVal = HashmapExtractNodeValue(pEntry);
-		if( pEntry->iType == HASHMAP_BLOB_NODE ){
-			/* Blob key insertion */
-			PH7_MemObjInitFromString(pDest->pVm,&sKey,0);
-			PH7_MemObjStringAppend(&sKey,(const char *)SyBlobData(&pEntry->xKey.sKey),SyBlobLength(&pEntry->xKey.sKey));
-			rc = PH7_HashmapInsert(&(*pDest),&sKey,pVal);
-			PH7_MemObjRelease(&sKey);
+		if( pVal ){
+			rc = HashmapDuplicateNode(pDest,pEntry,pVal,2);
 		}else{
-			/* Int key insertion */
-			rc = HashmapInsertIntKey(&(*pDest),pEntry->xKey.iKey,pVal,0,FALSE);
+			rc = SXRET_OK;
 		}
 		if( rc != SXRET_OK ){
 			return rc;
@@ -1226,13 +1252,14 @@ PH7_PRIVATE sxi32 PH7_HashmapUnion(ph7_hashmap *pLeft,ph7_hashmap *pRight)
 		/* Make sure the given key does not exists in the left array */
 		if( pEntry->iType == HASHMAP_BLOB_NODE ){
 			/* BLOB key */
-			if( SXRET_OK != 
+			if( SXRET_OK !=
 				HashmapLookupBlobKey(&(*pLeft),SyBlobData(&pEntry->xKey.sKey),SyBlobLength(&pEntry->xKey.sKey),0) ){
 					pObj = HashmapExtractNodeValue(pEntry);
 					if( pObj ){
+						ph7_value sSafeVal = *pObj;
 						/* Perform the insertion */
 						rc = HashmapInsertBlobKey(&(*pLeft),SyBlobData(&pEntry->xKey.sKey),SyBlobLength(&pEntry->xKey.sKey),
-							pObj,0,FALSE);
+							&sSafeVal,0,FALSE);
 						if( rc != SXRET_OK ){
 							return rc;
 						}
@@ -1243,8 +1270,9 @@ PH7_PRIVATE sxi32 PH7_HashmapUnion(ph7_hashmap *pLeft,ph7_hashmap *pRight)
 			if( SXRET_OK != HashmapLookupIntKey(&(*pLeft),pEntry->xKey.iKey,0) ){
 				pObj = HashmapExtractNodeValue(pEntry);
 				if( pObj ){
+					ph7_value sSafeVal = *pObj;
 					/* Perform the insertion */
-					rc = HashmapInsertIntKey(&(*pLeft),pEntry->xKey.iKey,pObj,0,FALSE);
+					rc = HashmapInsertIntKey(&(*pLeft),pEntry->xKey.iKey,&sSafeVal,0,FALSE);
 					if( rc != SXRET_OK ){
 						return rc;
 					}

--- a/src/ph7/memobj.c
+++ b/src/ph7/memobj.c
@@ -476,6 +476,7 @@ PH7_PRIVATE sxi32 PH7_MemObjToHashmap(ph7_value *pObj)
 			SyBlobRelease(&pObj->sBlob);
 		}
 		/* Invalidate any prior representation */
+		PH7_MemObjRelease(pObj);
 		MemObjSetType(pObj,MEMOBJ_HASHMAP);
 		pObj->x.pOther = pMap;
 	}

--- a/src/phl/phl.c
+++ b/src/phl/phl.c
@@ -5,7 +5,7 @@
  */
 /*
  * The PHL interpreter is a simple stand-alone PHP interpreter that allows
- * the user to enter and execute PHP files against a PH7 engine. 
+ * the user to enter and execute PHP files against a PH7 engine.
  * To start the phl program, just type "phl" followed by the name of the PHP file
  * to compile and execute. That is, the first argument is to the interpreter, the rest
  * are scripts arguments, press "Enter" and the PHP code will be executed.
@@ -22,7 +22,7 @@
  *   -h: Display this help message
  *
  * The PHL interpreter package includes more than 70 PHP scripts to test ranging from
- * simple hello world programs to XML processing, ZIP archive extracting, MP3 tag extracting, 
+ * simple hello world programs to XML processing, ZIP archive extracting, MP3 tag extracting,
  * UUID generation, JSON encoding/decoding, INI processing, Base32 encoding/decoding and many
  * more. These scripts are available in the scripts directory from the zip archive.
  */
@@ -31,7 +31,11 @@
 #include <string.h>
 /* Make sure this header file is available.*/
 #include "ph7.h"
-/* 
+#if defined(__WINNT__) && defined(PH7_DEBUG)
+#define MINIDUMP_IMPLEMENTATION
+#include "minidump.h"
+#endif
+/*
  * Display an error message and exit.
  */
 static void Fatal(const char *zMsg)
@@ -107,7 +111,7 @@ static int Output_Consumer(const void *pOutput,unsigned int nOutputLen,void *pUs
 	return PH7_OK;
 }
 /*
- * Main program: Compile and execute the PHP file. 
+ * Main program: Compile and execute the PHP file.
  */
 int main(int argc,char **argv)
 {
@@ -151,6 +155,11 @@ int main(int argc,char **argv)
 		puts("Missing PHP file to compile");
 		Help();
 	}
+
+#if defined(__WINNT__) && defined(PH7_DEBUG)
+	/* Install an unhandled exception minidump handler for Windows debug builds */
+	CreateMiniDumpOnUnHandledException();
+#endif
 	/* Allocate a new PH7 engine instance */
 	rc = ph7_init(&pEngine);
 	if( rc != PH7_OK ){


### PR DESCRIPTION
 - Fixes an use-after-free issue related to pool reallocation.
 - Adds minidump.h, based on minidump.c from the OpenCppCoverage
   source.
 - Includes minidump.h when building with `/DPH7_DEBUG` on Windows.
 - Fixes an issue where we were passing `-D` flags instead of `/D`
   flags to MSVC.
 - Fixes an issue where we were linking against dbghelp.lib on non
   instrumented builds.
 - Fixes an issue where OpenCppCoverage failures were not making
   the CI build fail.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally
- [x] Any dependent changes have been merged and published
- [x] I have updated the documentation accordingly
