### PR TITLE
Improve windows build coverage output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,8 +109,6 @@ jobs:
              --ignore-errors format \
              --output-file report/coverage.info
 
-        sed -i 's|SF:a/PHL/PHL/|SF:|g' report/coverage.info
-
         genhtml --quiet --include 'src/ph7/*'\
           --output-directory report/html report/coverage.info
 

--- a/build-aux/cobertura_xml_to_lcov_info.php
+++ b/build-aux/cobertura_xml_to_lcov_info.php
@@ -26,9 +26,9 @@ function startElement($parser, $name, $attrs) {
         $current_filename = isset($attrs['filename']) ? $attrs['filename'] : '';
         // Fix path
         $current_filename = str_replace('\\', '/', $current_filename);
-        $pos = strpos($current_filename, 'PHL-build/');
+        $pos = strpos($current_filename, 'src/');
         if ($pos !== false) {
-            $current_filename = substr($current_filename, $pos + strlen('PHL-build/'));
+            $current_filename = substr($current_filename, $pos);
         }
         $current_data = array('lines' => array(), 'functions' => array());
     } elseif ($name == 'line' && $current_data !== null) {


### PR DESCRIPTION
The `cobertura_xml_to_lcov_info.php` file was relying on the implied structure used by `dev.sh` (WSL wrapper), and thus, not fully doing its job on pure windows builds (such as the CI), leaving coverage files with absolute paths.

There was a hack in the GitHub workflow to fix this using sed, but it was being applied in the wrong place, generating some duplication in some reports.

This commit fixes the script and removes the hack, hopefully improving the list of covered files to not feature duplicates.

It's likely that this won't affect final coverage metrics, because lcov and genhtml were working around the duplication anyways. However, this makes our builds cleaner, and some artifacts (such as comments in build summaries) better.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
