### PR TITLE
Increase vm.c coverage

### DIFF
--- a/tests/ph7/002-engine/function/class_alias/class_alias.phpt
+++ b/tests/ph7/002-engine/function/class_alias/class_alias.phpt
@@ -1,0 +1,13 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+class_alias creates an alias for a class
+--FILE--
+<?php
+class ClassAlias_Test_2025 {}
+class_alias('ClassAlias_Test_2025', 'ClassAlias_Alias_2025');
+echo (class_exists('ClassAlias_Alias_2025') ? "ok\n" : "fail\n");
+?>
+--EXPECT--
+ok

--- a/tests/ph7/002-engine/function/compact/compact.phpt
+++ b/tests/ph7/002-engine/function/compact/compact.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+compact returns an associative array of variable names and values
+--FILE--
+<?php
+$a = 'first';
+$b = 'second';
+$c = compact('a','b');
+echo $c['a'] . "\n";
+echo $c['b'] . "\n";
+?>
+--EXPECT--
+first
+second
+
+--CLEAN--
+<?php
+unset($a, $b, $c);
+?>

--- a/tests/ph7/002-engine/function/debug_print_backtrace/debug_print_backtrace.phpt
+++ b/tests/ph7/002-engine/function/debug_print_backtrace/debug_print_backtrace.phpt
@@ -1,0 +1,28 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+debug_print_backtrace prints a string describing the backtrace
+--SKIPIF--
+<?php
+if (!function_exists('debug_print_backtrace')) {
+    echo "skip";
+}
+?>
+--FILE--
+<?php
+function b1(){
+    ob_start();
+    debug_print_backtrace();
+    $o = ob_get_clean();
+    if (strpos($o, 'b1') !== false) echo "OK\n"; else echo "FAIL\n";
+}
+b1();
+?>
+--EXPECT--
+OK
+
+--CLEAN--
+<?php
+unset($o);
+?>

--- a/tests/ph7/002-engine/function/debug_string_backtrace/debug_string_backtrace.phpt
+++ b/tests/ph7/002-engine/function/debug_string_backtrace/debug_string_backtrace.phpt
@@ -1,0 +1,27 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+debug_string_backtrace returns a string describing the backtrace
+--SKIPIF--
+<?php
+if (!function_exists('debug_string_backtrace')) {
+    echo "skip";
+}
+?>
+--FILE--
+<?php
+function foo(){
+    return debug_string_backtrace();
+}
+$s = foo();
+// It must contain the symbol 'foo' from the stack trace
+if (strpos($s, 'foo') !== false) echo "OK\n"; else echo "FAIL\n";
+?>
+--EXPECT--
+OK
+
+--CLEAN--
+<?php
+unset($s);
+?>

--- a/tests/ph7/002-engine/function/extract/extract.phpt
+++ b/tests/ph7/002-engine/function/extract/extract.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+extract imports variables into the current symbol table
+--FILE--
+<?php
+$arr = array('k' => 'v');
+extract($arr);
+echo $k . "\n";
+?>
+--EXPECT--
+v
+--CLEAN--
+<?php
+unset($arr, $k);
+?>

--- a/tests/ph7/002-engine/function/forward_static_call/forward_static_call.phpt
+++ b/tests/ph7/002-engine/function/forward_static_call/forward_static_call.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+forward_static_call forwards call to a static method
+--SKIPIF--
+<?php
+if (!function_exists('forward_static_call')) {
+    echo "skip";
+}
+?>
+--FILE--
+<?php
+class X { public static function v($x){ return $x*2; } }
+class CallProxy{ public static function f(){ return forward_static_call(array('X','v'), 10); } }
+echo CallProxy::f() . "\n";
+?>
+--EXPECT--
+20
+
+--CLEAN--
+<?php
+// nothing to cleanup
+?>

--- a/tests/ph7/002-engine/function/forward_static_call/forward_static_call_array.phpt
+++ b/tests/ph7/002-engine/function/forward_static_call/forward_static_call_array.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+forward_static_call_array forwards call to static method using an array of args
+--SKIPIF--
+<?php
+if (!function_exists('forward_static_call_array')) {
+    echo "skip";
+}
+?>
+--FILE--
+<?php
+class Y { public static function v($a,$b){ return $a+$b; } }
+class CallProxy2{ public static function f(){ return forward_static_call_array(array('Y','v'), array(3,7)); } }
+echo CallProxy2::f() . "\n";
+?>
+--EXPECT--
+10
+
+--CLEAN--
+<?php
+// nothing to cleanup
+?>

--- a/tests/ph7/002-engine/function/func_get_arg/func_get_arg.phpt
+++ b/tests/ph7/002-engine/function/func_get_arg/func_get_arg.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+func_get_arg retrieves a single argument by index
+--FILE--
+<?php
+function f1_get_arg($a, $b, $c){
+    echo func_get_arg(0) . "\n";
+    echo func_get_arg(2) . "\n";
+}
+
+f1_get_arg('first','second','third');
+?>
+--EXPECT--
+first
+third

--- a/tests/ph7/002-engine/function/func_get_args/func_get_args.phpt
+++ b/tests/ph7/002-engine/function/func_get_args/func_get_args.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+func_get_args returns the list of arguments as an array
+--FILE--
+<?php
+function f1_get_args($a, $b){
+    $args = func_get_args();
+    echo count($args) . "\n";
+    echo $args[1] . "\n";
+}
+
+f1_get_args('one', 'two');
+?>
+--EXPECT--
+2
+two
+

--- a/tests/ph7/002-engine/function/func_get_args_byref/func_get_args_byref.phpt
+++ b/tests/ph7/002-engine/function/func_get_args_byref/func_get_args_byref.phpt
@@ -1,0 +1,29 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+func_get_args_byref returns arguments by reference
+--SKIPIF--
+<?php
+if (function_exists('zend_version')) {
+    echo "skip";
+}
+?>
+--FILE--
+<?php
+function inc(&$v){ $v += 1; }
+function wrapper(&$a){
+    $args = func_get_args_byref();
+    $args[0] += 1; // modify via reference
+}
+
+$a = 10;
+wrapper($a);
+echo $a . "\n";
+?>
+--EXPECT--
+11
+--CLEAN--
+<?php
+unset($a);
+?>

--- a/tests/ph7/002-engine/function/func_num_args/func_num_args.phpt
+++ b/tests/ph7/002-engine/function/func_num_args/func_num_args.phpt
@@ -1,0 +1,15 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+func_num_args returns the number of args passed to the current function
+--FILE--
+<?php
+function f1_num_args($a, $b, $c){
+    echo func_num_args() . "\n";
+}
+
+f1_num_args(1,2,3);
+?>
+--EXPECT--
+3

--- a/tests/ph7/002-engine/function/get_declared_interfaces/get_declared_interfaces.phpt
+++ b/tests/ph7/002-engine/function/get_declared_interfaces/get_declared_interfaces.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+get_declared_interfaces returns declared interfaces
+--FILE--
+<?php
+interface ITest {}
+$list = get_declared_interfaces();
+if (is_array($list) && in_array('ITest', $list, true)) echo "OK\n"; else echo "FAIL\n";
+?>
+--EXPECT--
+OK
+
+--CLEAN--
+<?php
+unset($list);
+?>

--- a/tests/ph7/002-engine/function/get_defined_vars/get_defined_vars.phpt
+++ b/tests/ph7/002-engine/function/get_defined_vars/get_defined_vars.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+get_defined_vars returns variables in current scope
+--FILE--
+<?php
+$foo = 'bar';
+$vars = get_defined_vars();
+if (isset($vars['foo']) && $vars['foo'] === 'bar') echo "OK\n"; else echo "FAIL\n";
+?>
+--EXPECT--
+OK
+
+--CLEAN--
+<?php
+unset($foo, $vars);
+?>

--- a/tests/ph7/002-engine/function/get_included_files/get_included_files.phpt
+++ b/tests/ph7/002-engine/function/get_included_files/get_included_files.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+get_included_files returns an array
+--FILE--
+<?php
+// Create a helper file inside the test directory and include it, to ensure the
+// runtime has something to register. The test harness runs tests in a fresh
+// environment, so create the file at runtime.
+$path = __DIR__ . '/inc_me.php';
+file_put_contents($path, "<?php\n// Helper included by get_included_files test\n?>");
+include $path;
+// The entries vary depending on runtime so assert an array is returned.
+echo is_array(get_included_files()) ? "ok\n" : "fail\n";
+?>
+--EXPECT--
+ok
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/inc_me.php');
+unset($path);
+?>

--- a/tests/ph7/002-engine/function/get_object_vars/get_object_vars.phpt
+++ b/tests/ph7/002-engine/function/get_object_vars/get_object_vars.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+get_object_vars returns public properties of an object
+--FILE--
+<?php
+class C { public $a = 1; protected $b = 2; private $c = 3; }
+$o = new C();
+$vars = get_object_vars($o);
+if (array_key_exists('a', $vars) && !array_key_exists('b', $vars) && !array_key_exists('c', $vars)) echo "OK\n"; else echo "FAIL\n";
+?>
+--EXPECT--
+OK
+
+--CLEAN--
+<?php
+unset($o, $vars);
+?>

--- a/tests/ph7/002-engine/function/get_resource_type/get_resource_type.phpt
+++ b/tests/ph7/002-engine/function/get_resource_type/get_resource_type.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+get_resource_type returns a well-formed resource id string
+--SKIPIF--
+<?php
+if (function_exists('zend_version')) {
+	echo "skip";
+}
+?>
+--FILE--
+<?php
+$f = fopen(__FILE__, 'r');
+$t = get_resource_type($f);
+if (strpos($t, 'resID_') === 0) echo "ok\n"; else echo "fail\n";
+fclose($f);
+?>
+--EXPECT--
+ok
+--CLEAN--
+<?php
+unset($f, $t);
+?>

--- a/tests/ph7/002-engine/function/get_resource_type/get_resource_type_zend.phpt
+++ b/tests/ph7/002-engine/function/get_resource_type/get_resource_type_zend.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+get_resource_type returns a well-formed resource id string
+--SKIPIF--
+<?php
+if (!function_exists('zend_version')) {
+	echo "skip";
+}
+?>
+--FILE--
+<?php
+$f = fopen(__FILE__, 'r');
+$t = get_resource_type($f);
+if ($t == 'stream') echo "ok\n"; else echo "fail\n";
+fclose($f);
+?>
+--EXPECT--
+ok
+--CLEAN--
+<?php
+unset($f, $t);
+?>

--- a/tests/ph7/002-engine/function/getrandmax/getrandmax.phpt
+++ b/tests/ph7/002-engine/function/getrandmax/getrandmax.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+getrandmax returns an integer greater than 0
+--FILE--
+<?php
+$r = getrandmax();
+if (is_int($r) && $r > 0) echo "ok\n"; else echo "fail\n";
+?>
+--EXPECT--
+ok
+--CLEAN--
+<?php
+unset($r);
+?>

--- a/tests/ph7/002-engine/function/include_once/include_once.phpt
+++ b/tests/ph7/002-engine/function/include_once/include_once.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+include_once should include file only once
+--FILE--
+<?php
+$tmp = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ph7_include_once_test.php';
+file_put_contents($tmp, '<?php echo "INCL";');
+include_once $tmp; // prints INCL
+include_once $tmp; // should not print again
+?>
+--EXPECT--
+INCL
+
+--CLEAN--
+<?php
+@unlink($tmp);
+unset($tmp);
+?>

--- a/tests/ph7/002-engine/function/is_a/is_a.phpt
+++ b/tests/ph7/002-engine/function/is_a/is_a.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+is_a returns true for instance of class
+--FILE--
+<?php
+class IsA_Test_2025 {}
+$o = new IsA_Test_2025();
+echo (is_a($o, 'IsA_Test_2025') ? "ok\n" : "fail\n");
+?>
+--EXPECT--
+ok
+--CLEAN--
+<?php
+unset($o);
+?>

--- a/tests/ph7/002-engine/function/is_callable/is_callable.phpt
+++ b/tests/ph7/002-engine/function/is_callable/is_callable.phpt
@@ -1,0 +1,12 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+is_callable detects named function
+--FILE--
+<?php
+function is_callable_test_fn(){}
+echo (is_callable('is_callable_test_fn') ? "ok\n" : "fail\n");
+?>
+--EXPECT--
+ok

--- a/tests/ph7/002-engine/function/json_last_error/json_last_error.phpt
+++ b/tests/ph7/002-engine/function/json_last_error/json_last_error.phpt
@@ -1,0 +1,12 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+json_last_error returns a non-zero error after invalid JSON
+--FILE--
+<?php
+json_decode('invalid json');
+echo (json_last_error() !== JSON_ERROR_NONE) ? "ok\n" : "fail\n";
+?>
+--EXPECT--
+ok

--- a/tests/ph7/002-engine/function/mt_rand/mt_rand.phpt
+++ b/tests/ph7/002-engine/function/mt_rand/mt_rand.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+mt_rand returns an integer within mt_getrandmax
+--FILE--
+<?php
+$m = mt_getrandmax();
+$r = mt_rand();
+if (is_int($r) && $r >= 0 && $r <= $m) echo "OK\n"; else echo "FAIL\n";
+?>
+--EXPECT--
+OK
+
+--CLEAN--
+<?php
+unset($m, $r);
+?>

--- a/tests/ph7/002-engine/function/ph7credits/ph7credits.phpt
+++ b/tests/ph7/002-engine/function/ph7credits/ph7credits.phpt
@@ -1,0 +1,25 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+ph7credits returns TRUE and prints credits (printed content is ignored via ob buffering)
+--SKIPIF--
+<?php
+if (function_exists('zend_version')) {
+    echo "skip";
+}
+?>
+--FILE--
+<?php
+ob_start();
+ph7credits();
+$s = ob_get_clean();
+// Ensure we got something resembling the PH7 credits HTML: look for the "PH7"
+echo (strpos($s, 'PH7') !== false) ? "ok\n" : "fail\n";
+?>
+--EXPECT--
+ok
+--CLEAN--
+<?php
+unset($s);
+?>

--- a/tests/ph7/002-engine/function/ph7version/ph7version.phpt
+++ b/tests/ph7/002-engine/function/ph7version/ph7version.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+ph7version returns the PH7_VERSION value
+--SKIPIF--
+<?php
+if (function_exists('zend_version')) {
+    echo "skip";
+}
+?>
+--FILE--
+<?php
+// Compare constant PH7_VERSION to the return value of ph7version
+if (defined('PH7_VERSION')) {
+    // ph7version() is expected to be a substring of PH7_VERSION (e.g. "2.1.4" vs "PH7/2.1.4")
+    echo (strpos(PH7_VERSION, ph7version()) !== false) ? "ok\n" : "fail\n";
+} else {
+    echo "no_const\n";
+}
+?>
+--EXPECT--
+ok

--- a/tests/ph7/002-engine/function/rand_str/rand_str.phpt
+++ b/tests/ph7/002-engine/function/rand_str/rand_str.phpt
@@ -1,0 +1,27 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+rand_str returns a string with requested length and default length on invalid argument
+--SKIPIF--
+<?php
+if (function_exists('zend_version')) {
+    echo "skip";
+}
+?>
+--FILE--
+<?php
+// test explicit length
+$s = rand_str(8);
+if (strlen($s) !== 8) echo "len8_fail\n"; else echo "len8_ok\n";
+// test default length on invalid input (e.g. -1)
+$s2 = rand_str(-1);
+if (strlen($s2) === 0) echo "len_default_fail\n"; else echo "len_default_ok\n";
+?>
+--EXPECT--
+len8_ok
+len_default_ok
+--CLEAN--
+<?php
+unset($s, $s2);
+?>

--- a/tests/ph7/002-engine/function/require_once/require_once.phpt
+++ b/tests/ph7/002-engine/function/require_once/require_once.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+require_once should include file only once
+--FILE--
+<?php
+$tmp = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ph7_require_once_test.php';
+file_put_contents($tmp, '<?php echo "REQ";');
+require_once $tmp; // prints REQ
+require_once $tmp; // should not print again
+?>
+--EXPECT--
+REQ
+
+--CLEAN--
+<?php
+@unlink($tmp);
+unset($tmp);
+?>

--- a/tests/ph7/002-engine/function/uniqid/uniqid.phpt
+++ b/tests/ph7/002-engine/function/uniqid/uniqid.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+uniqid returns a non-empty string
+--FILE--
+<?php
+$s = uniqid();
+echo (is_string($s) && strlen($s) > 0) ? "ok\n" : "fail\n";
+?>
+--EXPECT--
+ok
+--CLEAN--
+<?php
+unset($s);
+?>

--- a/tests/ph7/002-engine/function/utf8_decode/utf8_decode.phpt
+++ b/tests/ph7/002-engine/function/utf8_decode/utf8_decode.phpt
@@ -1,0 +1,26 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+utf8_decode decodes UTF-8 to ISO-8859-1
+--SKIPIF--
+<?php
+if (defined('PHP_VERSION_ID') && PHP_VERSION_ID >= 80300) {
+	echo "skip";
+}
+?>
+--FILE--
+<?php
+$old = error_reporting();
+error_reporting($old & ~E_DEPRECATED);
+$utf8 = "\xC3\xA9"; // 'é'
+$latin = @utf8_decode($utf8);
+echo ($latin === "\xE9") ? "ok\n" : "fail\n";
+error_reporting($old);
+?>
+--EXPECT--
+ok
+--CLEAN--
+<?php
+unset($old, $utf8, $latin);
+?>

--- a/tests/ph7/002-engine/function/utf8_encode/utf8_encode.phpt
+++ b/tests/ph7/002-engine/function/utf8_encode/utf8_encode.phpt
@@ -1,0 +1,27 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+utf8_encode encodes ISO-8859-1 to UTF-8
+--SKIPIF--
+<?php
+if (defined('PHP_VERSION_ID') && PHP_VERSION_ID >= 80300) {
+	echo "skip";
+}
+?>
+--FILE--
+<?php
+// Latin-1 char: 0xE9 (é)
+$latin = "\xE9";
+$utf8 = utf8_encode($latin);
+// Expected UTF-8 sequence for 'é' is 0xC3 0xA9
+$expected = "\xC3\xA9";
+echo ($utf8 === $expected) ? "ok\n" : "fail\n";
+?>
+--EXPECT--
+ok
+--CLEAN--
+<?php
+unset($latin, $utf8, $expected);
+?>
+

--- a/tests/ph7/002-engine/function/var_export/var_export.phpt
+++ b/tests/ph7/002-engine/function/var_export/var_export.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+var_export with return parameter produces a string representation
+--FILE--
+<?php
+$a = array('x' => 1, 'y' => 2);
+$s = var_export($a, true);
+if ((stripos($s, 'array') !== false || stripos($s, 'Array') !== false) && stripos($s, 'x') !== false) echo "OK\n"; else echo "FAIL\n";
+?>
+--EXPECT--
+OK
+
+--CLEAN--
+<?php
+unset($a, $s);
+?>

--- a/tests/ph7/002-engine/lang/load_store_ref_array_element_ref.phpt
+++ b/tests/ph7/002-engine/lang/load_store_ref_array_element_ref.phpt
@@ -7,8 +7,8 @@ Return a reference to an array element from a function and change it.
 <?php
 function &ref_elem(&$arr, $k){ return $arr[$k]; }
 $a = array('k' => 1);
-$b =& ref_elem($a, 'k');
-$b = 10;
+$b_ref =& ref_elem($a, 'k');
+$b_ref = 10;
 echo $a['k'] . "\n"; // 10 now
 
 // Store reference to array element into another array index
@@ -25,5 +25,5 @@ echo $arr2['x'] . "\n";
 
 --CLEAN--
 <?php
-unset($a, $b, $arr2);
+unset($a, $b_ref, $arr2);
 ?>


### PR DESCRIPTION
 - Tests for core PHP functions that live in `vm.c`.
 - Some functions don't exist on Zend PHP, so they're skipped.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
