### PR TITLE
Re-enable --target-executable for phpt.php runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,12 @@ OBJECTS = \
 
 # Test and Coverage Logic
 TEST_PHL_CMD = "$(PHL_BIN)" "tests/phpt.php" \
+	--target-executable "./$(PHL_BIN)" \
 	--target-dir tests
 TEST_PHP_CMD = "$(PHP_BIN)" "tests/phpt.php" \
 	--target-dir tests
 COVERAGE_PHL_CMD = "$(COVERAGE_BIN)" "tests/phpt.php" \
+	--target-executable "./$(COVERAGE_BIN)" \
 	--target-dir tests \
 	--output-format dot
 

--- a/src/ph7/vfs.c
+++ b/src/ph7/vfs.c
@@ -7993,7 +7993,47 @@ static pipe_private * PipeOpen(ph7_vm *pVm, const char *zCommand, const char *zM
 	}
 	/* Open the pipe using system popen */
 #ifdef __WINNT__
-	pFile = _popen(zCommand, zMode);
+	{
+		const char *zShellPrefix = "cmd.exe /s /c \""; /* will form: cmd.exe /s /c "<command>" */
+		const char *zShellSuffix = "\"";
+		size_t nPrefix = strlen(zShellPrefix);
+		size_t nSuffix = strlen(zShellSuffix);
+		size_t nCmd = strlen(zCommand);
+		size_t nQuotes = 0;
+		for (size_t i = 0; i < nCmd; ++i) {
+			if (zCommand[i] == '"') nQuotes++;
+		}
+		size_t nCmdEsc = nCmd + nQuotes; /* each quote gets one extra '^' */
+		char *zCmdEsc = (char *)SyMemBackendAlloc(&pVm->sAllocator, (sxu32)(nCmdEsc + 1));
+		if (zCmdEsc == NULL) {
+			return 0;
+		}
+		/* Fill escaped buffer */
+		size_t j = 0;
+		for (size_t i = 0; i < nCmd; ++i) {
+			char ch = zCommand[i];
+			if (ch == '"') {
+				zCmdEsc[j++] = '^';
+				zCmdEsc[j++] = '"';
+			} else {
+				zCmdEsc[j++] = ch;
+			}
+		}
+		zCmdEsc[j] = '\0';
+		size_t nTotal = nPrefix + nCmdEsc + nSuffix + 1;
+		char *zWinCmd = (char *)SyMemBackendAlloc(&pVm->sAllocator, (sxu32)nTotal);
+		if (zWinCmd == NULL) {
+			SyMemBackendFree(&pVm->sAllocator, zCmdEsc);
+			return 0;
+		}
+		memcpy(zWinCmd, zShellPrefix, nPrefix);
+		memcpy(zWinCmd + nPrefix, zCmdEsc, nCmdEsc);
+		memcpy(zWinCmd + nPrefix + nCmdEsc, zShellSuffix, nSuffix);
+		zWinCmd[nTotal - 1] = '\0';
+		pFile = _popen(zWinCmd, zMode);
+		SyMemBackendFree(&pVm->sAllocator, zCmdEsc);
+		SyMemBackendFree(&pVm->sAllocator, zWinCmd);
+	}
 #else
 	pFile = popen(zCommand, zMode);
 #endif

--- a/tests/phpt.php
+++ b/tests/phpt.php
@@ -234,6 +234,25 @@ function match_expectf_pattern($phpt_pattern, $phpt_output) {
     return true;
 }
 
+// Run a PHPT section file through an external target executable
+// Returns the combined stdout/stderr output as string, or false if popen() failed
+function run_file_with_target($phpt_target_executable, $phpt_file) {
+    $cmd = '"' . $phpt_target_executable . '" "' . $phpt_file . '" 2>&1';
+    $fp = popen($cmd, 'r');
+    if ($fp === false) {
+        // piped execution failed
+        return false;
+    }
+    $output = '';
+    while (!feof($fp)) {
+        $chunk = fgets($fp);
+        if ($chunk === false) break;
+        $output .= $chunk;
+    }
+    pclose($fp);
+    return $output;
+}
+
 // Find test files
 $phpt_files = find_files($phpt_target_dir, $phpt_file_extension, $phpt_filter);
 sort($phpt_files);
@@ -272,9 +291,17 @@ foreach ($phpt_files as $phpt_file) {
     $phpt_skip = false;
     if (isset($phpt_sections['skipif'])) {
         $phpt_skipif_path = $phpt_file . '.skipif';
-        ob_start();
-        include($phpt_skipif_path);
-        $phpt_skip_output = ob_get_clean();
+        if (!empty($phpt_target_executable)) {
+            $phpt_skip_output = run_file_with_target($phpt_target_executable, $phpt_skipif_path);
+            if ($phpt_skip_output === false) {
+                echo "# ERROR: Failed to spawn skipif for $phpt_skipif_path\n";
+                $phpt_skip_output = '';
+            }
+        } else {
+            ob_start();
+            include($phpt_skipif_path);
+            $phpt_skip_output = ob_get_clean();
+        }
         chdir($phpt_curdir);
         $phpt_skip_output = trim($phpt_skip_output);
         if (!empty($phpt_skip_output)) {
@@ -309,11 +336,19 @@ foreach ($phpt_files as $phpt_file) {
         } else {
             // Test execution
             $phpt_file_path = $phpt_file . '.file';
-            ob_start();
-            set_error_handler('handle_error');
-            include($phpt_file_path);
-            set_error_handler(null);
-            $phpt_output = ob_get_clean();
+            if (!empty($phpt_target_executable)) {
+                $phpt_output = run_file_with_target($phpt_target_executable, $phpt_file_path);
+                if ($phpt_output === false) {
+                    echo "# ERROR: Failed to spawn test for $phpt_file_path\n";
+                    $phpt_output = "";
+                }
+            } else {
+                ob_start();
+                set_error_handler('handle_error');
+                include($phpt_file_path);
+                set_error_handler(null);
+                $phpt_output = ob_get_clean();
+            }
             $phpt_output = str_replace("\r\n", "\n", $phpt_output);
             $phpt_output = str_replace("\r", "", $phpt_output);
             chdir($phpt_curdir);
@@ -363,9 +398,16 @@ foreach ($phpt_files as $phpt_file) {
     // CLEAN execution
     if (isset($phpt_sections['clean']) && $phpt_skip === false) {
         $phpt_clean_path = $phpt_file . '.clean';
-        ob_start();
-        include($phpt_clean_path);
-        ob_end_clean();
+        if (!empty($phpt_target_executable)) {
+            $phpt_clean_output = run_file_with_target($phpt_target_executable, $phpt_clean_path);
+            if ($phpt_clean_output === false) {
+                echo "# ERROR: Failed to spawn clean for $phpt_clean_path\n";
+            }
+        } else {
+            ob_start();
+            include($phpt_clean_path);
+            ob_end_clean();
+        }
         chdir($phpt_curdir);
     }
 


### PR DESCRIPTION
This commit changes the popen function on WINNT to always use cmd.exe, making it even closer to official PHP behavior.

We also re-enabled the `--target-executable` option for the phpt.php runner, which allows us to run each test in a separate proccess. This will be necessary to create tests that verify behavior for fatal and syntax errors, among other unrecoverable types of tests in the future.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally
- [x] Any dependent changes have been merged and published
- [x] I have updated the documentation accordingly
