### PR TITLE
Increase coverage for invalid argc cases

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -21,7 +21,6 @@ tests/
 ```
 
 Conventions & style
-- Tests are PHPT-format files with sections such as `--TEST--`, `--FILE--`, `--EXPECT--`/`--EXPECTF--` and (optionally) `--CLEAN--`.
 - All test files must include the `--CREDITS--` section at the top for SPDX compliance.
 - Prefer focused tests: each PHPT should exercise one behavior of one function or feature. Avoid huge grouped tests asserting many unrelated behaviors.
 - All test files end with a single trailing new line.
@@ -31,12 +30,15 @@ Conventions & style
   - Individual functions may require one or more specialized PHPT files; place them in the function's folder (for example, `function/addslashes/addslashes.phpt` and `function/addslashes/addslashes_multibyte.phpt`).
 
 How to add a test
-1. Create a directory under the correct scope: `tests/ph7/002-engine/function/<function>/`.
-2. Add a single PHPT file named `<function>.phpt` with the minimal `--TEST--`, `--FILE--` and `--EXPECT--` sections.
+1. Create a directory under the correct scope. For example, `tests/ph7/002-engine/function/<function>/` if the target is a function.
+2. Add a single PHPT file named `<function>.phpt` with the minimal `--CREDITS--`, `--TEST--`, `--FILE--` and `--EXPECT--` sections.
 3. Run compatibility and coverage checks (see below).
 
 Minimal PHPT example
 ```
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 addslashes escapes single quote
 --FILE--
@@ -56,16 +58,17 @@ Running & verifying tests
 
 Notes and tips
 - Keep tests minimal: one core behavior per test file. Prefer many focused tests to a few large ones.
-- When you move or rename tests, update expected outputs that depend on basename (for example, `basename($errfile)` used by error handler tests).
+- Keep happy paths separate from error or invalid scenarios. Example: `acos.phpt` (happy path), `acos_invalid.phpt` (invalid argument).
 - If a test must differ per runtime, prefer to create a complementary test under the same function dir and mark differences with `--EXPECTF--` patterns.
+- PHL and PHP error output differs drastically, use `--SKIPIF--` with `<?php if (function_exists('zend_version')) echo 'skip'; ?>` to skip testing on Zend PHP.
+- Avoid using `var_dump`, `var_export`, `json_encode` and similar value-printing functions, since they differ between PHL and PHP. Check the values and print verification messages instead.
 
 Best Practices
 - Use `--CREDITS--` on new PHPT files with SPDX metadata.
-- Add a `--CLEAN--` section to unset variables, close resources and remove temporary files so tests do not pollute the runner context.
-- Use `--SKIPIF--` to skip tests that depend on features not available in the current runtime (e.g. PH7-only constants or functions).
-- Prefer `--EXPECTF--` or numeric formatting (e.g., `sprintf`) when runtime differences (precision, platform behavior) may cause failures.
+- Add a `--CLEAN--` section to close resources and remove temporary files.
 - Use `tempnam(sys_get_temp_dir(), 'ph7_')` for temporary files and clean them in `--CLEAN--`.
 - For Windows vs Unix differences, use `PHP_OS` to branch or skip.
+- Use `--EXPECTF--` with the `%d` (digits) and `%s` (string) placeholder for tests that could fail due to dynamic output (file names, different precision values, etc).
 
 Maintainers
 - If you’re not sure where to put a test — ask in the project's issue tracker or reach out to the maintainers.

--- a/tests/ph7/002-engine/function/abs/abs_invalid.phpt
+++ b/tests/ph7/002-engine/function/abs/abs_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: abs missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (abs() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/acos/acos.phpt
+++ b/tests/ph7/002-engine/function/acos/acos.phpt
@@ -1,0 +1,42 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: acos basic functionality
+--FILE--
+<?php
+// Test basic acos functionality
+$result1 = acos(1);
+echo abs($result1 - 0.0) < 0.0001 ? "ONE_OK\n" : "ONE_FAIL: $result1\n";
+
+// Test acos(0) = π/2
+$result2 = acos(0);
+$pi_half = 3.141592653589793 / 2;
+echo abs($result2 - $pi_half) < 0.0001 ? "ZERO_OK\n" : "ZERO_FAIL: $result2\n";
+
+// Test acos(-1) = π
+$result3 = acos(-1);
+$pi = 3.141592653589793;
+echo abs($result3 - $pi) < 0.0001 ? "NEG_ONE_OK\n" : "NEG_ONE_FAIL: $result3\n";
+
+// Test acos(0.5) ≈ π/3
+$result4 = acos(0.5);
+$pi_third = 3.141592653589793 / 3;
+echo abs($result4 - $pi_third) < 0.0001 ? "HALF_OK\n" : "HALF_FAIL: $result4\n";
+
+// Test acos(-0.5) ≈ 2π/3
+$result5 = acos(-0.5);
+$two_pi_third = 2 * 3.141592653589793 / 3;
+echo abs($result5 - $two_pi_third) < 0.0001 ? "NEG_HALF_OK\n" : "NEG_HALF_FAIL: $result5\n";
+
+// Test return type
+$result6 = acos(0.3);
+echo is_float($result6) ? "TYPE_OK\n" : "TYPE_FAIL\n";
+?>
+--EXPECT--
+ONE_OK
+ZERO_OK
+NEG_ONE_OK
+HALF_OK
+NEG_HALF_OK
+TYPE_OK

--- a/tests/ph7/002-engine/function/acos/acos_invalid.phpt
+++ b/tests/ph7/002-engine/function/acos/acos_invalid.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: acos missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+// Calling acos with no arguments should return integer 0
+if (acos() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/addcslashes/addcslashes_invalid.phpt
+++ b/tests/ph7/002-engine/function/addcslashes/addcslashes_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: addcslashes missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (addcslashes() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/addslashes/addslashes_invalid.phpt
+++ b/tests/ph7/002-engine/function/addslashes/addslashes_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: addslashes missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (addslashes() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/asin/asin_invalid.phpt
+++ b/tests/ph7/002-engine/function/asin/asin_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: asin missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (asin() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/atan/atan_invalid.phpt
+++ b/tests/ph7/002-engine/function/atan/atan_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: atan missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (atan() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/atan2/atan2_invalid.phpt
+++ b/tests/ph7/002-engine/function/atan2/atan2_invalid.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: atan2 missing arguments returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+// Calling atan2 with no arguments should return integer 0
+if (atan2() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/base64_decode/base64_decode_invalid.phpt
+++ b/tests/ph7/002-engine/function/base64_decode/base64_decode_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: base64_decode missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (base64_decode() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/base64_encode/base64_encode_invalid.phpt
+++ b/tests/ph7/002-engine/function/base64_encode/base64_encode_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: base64_encode missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (base64_encode() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/base_convert/base_convert_invalid.phpt
+++ b/tests/ph7/002-engine/function/base_convert/base_convert_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: base_convert missing arguments returns empty string
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (base_convert() == "") {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/bin2hex/bin2hex_invalid.phpt
+++ b/tests/ph7/002-engine/function/bin2hex/bin2hex_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: bin2hex missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (bin2hex() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/bindec/bindec_invalid.phpt
+++ b/tests/ph7/002-engine/function/bindec/bindec_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: bindec missing argument returns -1
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (bindec() === -1) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/ceil/ceil_invalid.phpt
+++ b/tests/ph7/002-engine/function/ceil/ceil_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: ceil missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (ceil() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/chr/chr_invalid.phpt
+++ b/tests/ph7/002-engine/function/chr/chr_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: chr missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (chr() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/cos/cos_invalid.phpt
+++ b/tests/ph7/002-engine/function/cos/cos_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: cos missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (cos() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/cosh/cosh_invalid.phpt
+++ b/tests/ph7/002-engine/function/cosh/cosh_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: cosh missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (cosh() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/crc32/crc32_invalid.phpt
+++ b/tests/ph7/002-engine/function/crc32/crc32_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: crc32 missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (crc32() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/ctype_alnum/ctype_alnum_invalid.phpt
+++ b/tests/ph7/002-engine/function/ctype_alnum/ctype_alnum_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: ctype_alnum missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (ctype_alnum() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/ctype_alpha/ctype_alpha_invalid.phpt
+++ b/tests/ph7/002-engine/function/ctype_alpha/ctype_alpha_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: ctype_alpha missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (ctype_alpha() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/ctype_cntrl/ctype_cntrl_invalid.phpt
+++ b/tests/ph7/002-engine/function/ctype_cntrl/ctype_cntrl_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: ctype_cntrl missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (ctype_cntrl() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/ctype_digit/ctype_digit_invalid.phpt
+++ b/tests/ph7/002-engine/function/ctype_digit/ctype_digit_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: ctype_digit missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (ctype_digit() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/ctype_graph/ctype_graph_invalid.phpt
+++ b/tests/ph7/002-engine/function/ctype_graph/ctype_graph_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: ctype_graph missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (ctype_graph() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/ctype_lower/ctype_lower_invalid.phpt
+++ b/tests/ph7/002-engine/function/ctype_lower/ctype_lower_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: ctype_lower missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (ctype_lower() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/ctype_print/ctype_print_invalid.phpt
+++ b/tests/ph7/002-engine/function/ctype_print/ctype_print_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: ctype_print missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (ctype_print() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/ctype_punct/ctype_punct_invalid.phpt
+++ b/tests/ph7/002-engine/function/ctype_punct/ctype_punct_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: ctype_punct missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (ctype_punct() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/ctype_space/ctype_space_invalid.phpt
+++ b/tests/ph7/002-engine/function/ctype_space/ctype_space_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: ctype_space missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (ctype_space() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/ctype_upper/ctype_upper_invalid.phpt
+++ b/tests/ph7/002-engine/function/ctype_upper/ctype_upper_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: ctype_upper missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (ctype_upper() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/ctype_xdigit/ctype_xdigit_invalid.phpt
+++ b/tests/ph7/002-engine/function/ctype_xdigit/ctype_xdigit_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: ctype_xdigit missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (ctype_xdigit() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/date/date_invalid.phpt
+++ b/tests/ph7/002-engine/function/date/date_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: date missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (date() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/decbin/decbin_invalid.phpt
+++ b/tests/ph7/002-engine/function/decbin/decbin_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: decbin missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (decbin() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/dechex/dechex_invalid.phpt
+++ b/tests/ph7/002-engine/function/dechex/dechex_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: dechex missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (dechex() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/decoct/decoct_invalid.phpt
+++ b/tests/ph7/002-engine/function/decoct/decoct_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: decoct missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (decoct() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/exp/exp_invalid.phpt
+++ b/tests/ph7/002-engine/function/exp/exp_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: exp missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (exp() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/explode/explode_invalid.phpt
+++ b/tests/ph7/002-engine/function/explode/explode_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: explode missing arguments returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (explode() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/floor/floor_invalid.phpt
+++ b/tests/ph7/002-engine/function/floor/floor_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: floor missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (floor() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/fmod/fmod_invalid.phpt
+++ b/tests/ph7/002-engine/function/fmod/fmod_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: fmod missing arguments returns float 0.0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (is_float(fmod()) && fmod() == 0.0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/gmdate/gmdate_invalid.phpt
+++ b/tests/ph7/002-engine/function/gmdate/gmdate_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: gmdate missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (gmdate() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/hexdec/hexdec_invalid.phpt
+++ b/tests/ph7/002-engine/function/hexdec/hexdec_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: hexdec missing argument returns -1
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (hexdec() === -1) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/html_entity_decode/html_entity_decode_invalid.phpt
+++ b/tests/ph7/002-engine/function/html_entity_decode/html_entity_decode_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: html_entity_decode missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (html_entity_decode() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/htmlentities/htmlentities_invalid.phpt
+++ b/tests/ph7/002-engine/function/htmlentities/htmlentities_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: htmlentities missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (htmlentities() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/htmlspecialchars/htmlspecialchars_invalid.phpt
+++ b/tests/ph7/002-engine/function/htmlspecialchars/htmlspecialchars_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: htmlspecialchars missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (htmlspecialchars() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/htmlspecialchars_decode/htmlspecialchars_decode_invalid.phpt
+++ b/tests/ph7/002-engine/function/htmlspecialchars_decode/htmlspecialchars_decode_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: htmlspecialchars_decode missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (htmlspecialchars_decode() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/hypot/hypot_invalid.phpt
+++ b/tests/ph7/002-engine/function/hypot/hypot_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: hypot missing arguments returns float 0.0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (is_float(hypot()) && hypot() == 0.0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/idate/idate_invalid.phpt
+++ b/tests/ph7/002-engine/function/idate/idate_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: idate missing argument returns integer -1
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (idate() === -1) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/implode/implode_invalid.phpt
+++ b/tests/ph7/002-engine/function/implode/implode_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: implode missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (implode() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/implode_recursive/implode_recursive_invalid.phpt
+++ b/tests/ph7/002-engine/function/implode_recursive/implode_recursive_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: implode_recursive missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (implode_recursive() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/intval/intval_invalid.phpt
+++ b/tests/ph7/002-engine/function/intval/intval_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: intval missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (intval() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/lcfirst/lcfirst_invalid.phpt
+++ b/tests/ph7/002-engine/function/lcfirst/lcfirst_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: lcfirst missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (lcfirst() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/log/log_invalid.phpt
+++ b/tests/ph7/002-engine/function/log/log_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: log missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (log() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/log10/log10_invalid.phpt
+++ b/tests/ph7/002-engine/function/log10/log10_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: log10 missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (log10() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/ltrim/ltrim_invalid.phpt
+++ b/tests/ph7/002-engine/function/ltrim/ltrim_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: ltrim missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (ltrim() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/md5/md5_invalid.phpt
+++ b/tests/ph7/002-engine/function/md5/md5_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: md5 missing argument returns empty string
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (md5() == "") {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/nl2br/nl2br_invalid.phpt
+++ b/tests/ph7/002-engine/function/nl2br/nl2br_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: nl2br missing argument returns empty string
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (nl2br() == "") {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/octdec/octdec_invalid.phpt
+++ b/tests/ph7/002-engine/function/octdec/octdec_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: octdec missing argument returns integer -1
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (octdec() === -1) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/ord/ord_invalid.phpt
+++ b/tests/ph7/002-engine/function/ord/ord_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: ord missing argument returns -1
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (ord() === -1) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/pow/pow_invalid.phpt
+++ b/tests/ph7/002-engine/function/pow/pow_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: pow missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (pow() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/printf/printf_invalid.phpt
+++ b/tests/ph7/002-engine/function/printf/printf_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: printf missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (printf() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/quotemeta/quotemeta_invalid.phpt
+++ b/tests/ph7/002-engine/function/quotemeta/quotemeta_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: quotemeta missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (quotemeta() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/round/round_invalid.phpt
+++ b/tests/ph7/002-engine/function/round/round_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: round missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (round() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/rtrim/rtrim_invalid.phpt
+++ b/tests/ph7/002-engine/function/rtrim/rtrim_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: rtrim missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (rtrim() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/sha1/sha1_invalid.phpt
+++ b/tests/ph7/002-engine/function/sha1/sha1_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: sha1 missing argument returns empty string
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (sha1() == "") {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/sin/sin_invalid.phpt
+++ b/tests/ph7/002-engine/function/sin/sin_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: sin missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (sin() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/sinh/sinh_invalid.phpt
+++ b/tests/ph7/002-engine/function/sinh/sinh_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: sinh missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (sinh() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/size_format/size_format_invalid.phpt
+++ b/tests/ph7/002-engine/function/size_format/size_format_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: size_format missing argument returns empty string
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (size_format() == "") {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/sqrt/sqrt_invalid.phpt
+++ b/tests/ph7/002-engine/function/sqrt/sqrt_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: sqrt missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (sqrt() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/str_getcsv/str_getcsv_invalid.phpt
+++ b/tests/ph7/002-engine/function/str_getcsv/str_getcsv_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: str_getcsv missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (str_getcsv() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/str_pad/str_pad_invalid.phpt
+++ b/tests/ph7/002-engine/function/str_pad/str_pad_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: str_pad missing argument returns empty string
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (str_pad() == "") {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/str_repeat/str_repeat_invalid.phpt
+++ b/tests/ph7/002-engine/function/str_repeat/str_repeat_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: str_repeat missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (str_repeat() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/str_replace/str_replace_invalid.phpt
+++ b/tests/ph7/002-engine/function/str_replace/str_replace_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: str_replace missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (str_replace() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/str_shuffle/str_shuffle_invalid.phpt
+++ b/tests/ph7/002-engine/function/str_shuffle/str_shuffle_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: str_shuffle missing argument returns empty string
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (str_shuffle() == "") {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/str_split/str_split_invalid.phpt
+++ b/tests/ph7/002-engine/function/str_split/str_split_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: str_split missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (str_split() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/strcasecmp/strcasecmp_invalid.phpt
+++ b/tests/ph7/002-engine/function/strcasecmp/strcasecmp_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: strcasecmp missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (strcasecmp() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/strcmp/strcmp_invalid.phpt
+++ b/tests/ph7/002-engine/function/strcmp/strcmp_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: strcmp missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (strcmp() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/strcspn/strcspn_invalid.phpt
+++ b/tests/ph7/002-engine/function/strcspn/strcspn_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: strcspn missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (strcspn() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/strftime/strftime_invalid.phpt
+++ b/tests/ph7/002-engine/function/strftime/strftime_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: strftime missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (strftime() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/strip_tags/strip_tags_invalid.phpt
+++ b/tests/ph7/002-engine/function/strip_tags/strip_tags_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: strip_tags missing argument returns empty string
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (strip_tags() == "") {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/stripos/stripos_invalid.phpt
+++ b/tests/ph7/002-engine/function/stripos/stripos_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: stripos missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (stripos() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/stripslashes/stripslashes_invalid.phpt
+++ b/tests/ph7/002-engine/function/stripslashes/stripslashes_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: stripslashes missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (stripslashes() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/stristr/stristr_invalid.phpt
+++ b/tests/ph7/002-engine/function/stristr/stristr_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: stristr missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (stristr() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/strncasecmp/strncasecmp_invalid.phpt
+++ b/tests/ph7/002-engine/function/strncasecmp/strncasecmp_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: strncasecmp missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (strncasecmp() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/strpbrk/strpbrk_invalid.phpt
+++ b/tests/ph7/002-engine/function/strpbrk/strpbrk_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: strpbrk missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (strpbrk() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/strpos/strpos_invalid.phpt
+++ b/tests/ph7/002-engine/function/strpos/strpos_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: strpos missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (strpos() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/strrchr/strrchr_invalid.phpt
+++ b/tests/ph7/002-engine/function/strrchr/strrchr_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: strrchr missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (strrchr() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/strrev/strrev_invalid.phpt
+++ b/tests/ph7/002-engine/function/strrev/strrev_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: strrev missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (strrev() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/strripos/strripos_invalid.phpt
+++ b/tests/ph7/002-engine/function/strripos/strripos_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: strripos missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (strripos() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/strrpos/strrpos_invalid.phpt
+++ b/tests/ph7/002-engine/function/strrpos/strrpos_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: strrpos missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (strrpos() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/strspn/strspn_invalid.phpt
+++ b/tests/ph7/002-engine/function/strspn/strspn_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: strspn missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (strspn() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/strstr/strstr_invalid.phpt
+++ b/tests/ph7/002-engine/function/strstr/strstr_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: strstr missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (strstr() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/strtolower/strtolower_invalid.phpt
+++ b/tests/ph7/002-engine/function/strtolower/strtolower_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: strtolower missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (strtolower() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/strtoupper/strtoupper_invalid.phpt
+++ b/tests/ph7/002-engine/function/strtoupper/strtoupper_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: strtoupper missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (strtoupper() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/strtr/strtr_invalid.phpt
+++ b/tests/ph7/002-engine/function/strtr/strtr_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: strtr missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (strtr() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/strval/strval_invalid.phpt
+++ b/tests/ph7/002-engine/function/strval/strval_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: strval missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (strval() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/substr_compare/substr_compare_invalid.phpt
+++ b/tests/ph7/002-engine/function/substr_compare/substr_compare_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: substr_compare missing arguments returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (substr_compare() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/tan/tan_invalid.phpt
+++ b/tests/ph7/002-engine/function/tan/tan_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: tan missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (tan() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/tanh/tanh_invalid.phpt
+++ b/tests/ph7/002-engine/function/tanh/tanh_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: tanh missing argument returns integer 0
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (tanh() === 0) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/trim/trim_invalid.phpt
+++ b/tests/ph7/002-engine/function/trim/trim_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: trim missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (trim() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/ucfirst/ucfirst_invalid.phpt
+++ b/tests/ph7/002-engine/function/ucfirst/ucfirst_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: ucfirst missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (ucfirst() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/ucwords/ucwords_invalid.phpt
+++ b/tests/ph7/002-engine/function/ucwords/ucwords_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: ucwords missing argument returns NULL
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (ucwords() === null) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/urldecode/urldecode_invalid.phpt
+++ b/tests/ph7/002-engine/function/urldecode/urldecode_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: urldecode missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (urldecode() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/urlencode/urlencode_invalid.phpt
+++ b/tests/ph7/002-engine/function/urlencode/urlencode_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: urlencode missing argument returns FALSE
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (urlencode() === false) {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/vsprintf/vsprintf_invalid.phpt
+++ b/tests/ph7/002-engine/function/vsprintf/vsprintf_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: vsprintf missing arguments returns empty string
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (vsprintf() == "") {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true

--- a/tests/ph7/002-engine/function/wordwrap/wordwrap_invalid.phpt
+++ b/tests/ph7/002-engine/function/wordwrap/wordwrap_invalid.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7: wordwrap missing argument returns empty string
+--SKIPIF--
+<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+--FILE--
+<?php
+if (wordwrap() == "") {
+    echo "true";
+} else {
+    echo "false";
+}
+?>
+--EXPECT--
+true


### PR DESCRIPTION
The PH7 engine accepts an invalid number of arguments for functions in many cases where PHP doesn't, often returning a default value for such situations.

We're including dedicated test files for those scenarios, and skipping the test on Zend PHP.

This will help map out better differences between the engines to be later fixed.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
