### PR TITLE
Make all src folder available to HTML coverage report on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
              --ignore-errors format \
              --output-file report/coverage.info
 
-        genhtml --quiet --include 'src/ph7/*'\
+        genhtml --quiet --include 'src/*'\
           --output-directory report/html report/coverage.info
 
         ./artifact/coverage-x86_64-linux-gnu/coverage/phl-coverage \


### PR DESCRIPTION
Our current coverage tracks all the `src` folder, as seen in the `coverage` branch:

https://github.com/alganet/PHL/blob/coverage/coverage.md

However, when generating the `report.zip`, we were limiting the report to only include `src/ph7` files.

This commit fixes that, allowing the report to include information for all files.

This change does not affect coverage tresholds or the historical coverage branch, which were independent of this report.