### PR TITLE
Implement symmetric array destructuring [$a, $b] = ... (PHP 7.1)

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -1239,13 +1239,19 @@ static sxi32 GenStateListNodeValidator(ph7_gen_state *pGen,ph7_expr_node *pRoot)
  *  Return Values
  *   The assigned array.
  */
-/* Nested list entry recorded during first pass of PH7_CompileList */
+/* Nested list entry recorded during first pass of list body compilation */
 struct NestedListEntry {
 	sxi32 nIndex;        /* Position in the outer list (0-based) */
-	SyToken *pStart;     /* Token range: 'list' keyword */
-	SyToken *pEnd;       /* Token range: past closing ')' */
+	SyToken *pStart;     /* Token range: start of nested construct */
+	SyToken *pEnd;       /* Token range: past closing delimiter */
+	sxi32 isShort;       /* 1 if [...] form, 0 if list(...) form */
 };
-PH7_PRIVATE sxi32 PH7_CompileList(ph7_gen_state *pGen,sxi32 iCompileFlag)
+/*
+ * Shared body for list() and short list [...] compilation.
+ * Assumes pGen->pIn and pGen->pEnd are already positioned past
+ * the opening delimiter and before the closing delimiter.
+ */
+static sxi32 GenStateCompileListBody(ph7_gen_state *pGen)
 {
 	SySet sNested; /* Dynamically-sized container of NestedListEntry */
 	SyToken *pNext;
@@ -1253,10 +1259,6 @@ PH7_PRIVATE sxi32 PH7_CompileList(ph7_gen_state *pGen,sxi32 iCompileFlag)
 	sxi32 rc;
 	nExpr = 0;
 	SySetInit(&sNested,&pGen->pVm->sAllocator,sizeof(struct NestedListEntry));
-	/* Jump the 'list' keyword,the leading left parenthesis and the trailing parenthesis */
-	pGen->pIn += 2;
-	pGen->pEnd--;
-	SXUNUSED(iCompileFlag); /* cc warning */
 	while( SXRET_OK == PH7_GetNextExpr(pGen->pIn,pGen->pEnd,&pNext) ){
 		if( pGen->pIn < pNext ){
 			/* Check for nested list() */
@@ -1272,6 +1274,21 @@ PH7_PRIVATE sxi32 PH7_CompileList(ph7_gen_state *pGen,sxi32 iCompileFlag)
 					sEntry.nIndex = nExpr;
 					sEntry.pStart = pGen->pIn;
 					sEntry.pEnd = pListEnd + 1;
+					sEntry.isShort = 0;
+					SySetPut(&sNested,(const void *)&sEntry);
+				}
+				/* Emit NULL placeholder — outer LOAD_LIST will skip this index */
+				PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOADC,0,0,0,0);
+			}else if( pGen->pIn->nType & PH7_TK_OSB ){
+				/* Nested short destructuring [...] */
+				SyToken *pBracketEnd = 0;
+				PH7_DelimitNestedTokens(pGen->pIn+1,pNext,PH7_TK_OSB,PH7_TK_CSB,&pBracketEnd);
+				if( pBracketEnd ){
+					struct NestedListEntry sEntry;
+					sEntry.nIndex = nExpr;
+					sEntry.pStart = pGen->pIn;
+					sEntry.pEnd = pBracketEnd + 1;
+					sEntry.isShort = 1;
 					SySetPut(&sNested,(const void *)&sEntry);
 				}
 				/* Emit NULL placeholder — outer LOAD_LIST will skip this index */
@@ -1280,6 +1297,7 @@ PH7_PRIVATE sxi32 PH7_CompileList(ph7_gen_state *pGen,sxi32 iCompileFlag)
 				/* Compile the expression holding the variable */
 				rc = GenStateCompileArrayEntry(&(*pGen),pGen->pIn,pNext,EXPR_FLAG_LOAD_IDX_STORE,GenStateListNodeValidator);
 				if( rc != SXRET_OK ){
+					SySetRelease(&sNested);
 					return SXRET_OK;
 				}
 			}
@@ -1294,7 +1312,7 @@ PH7_PRIVATE sxi32 PH7_CompileList(ph7_gen_state *pGen,sxi32 iCompileFlag)
 	/* Emit the LOAD_LIST instruction */
 	PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOAD_LIST,nExpr,0,0,0);
 	/* After LOAD_LIST, the source array is still on the stack top.
-	 * For each nested list() entry, emit code to extract the sub-array
+	 * For each nested entry, emit code to extract the sub-array
 	 * at the corresponding index and recursively destructure it.
 	 */
 	if( SySetUsed(&sNested) > 0 ){
@@ -1316,12 +1334,19 @@ PH7_PRIVATE sxi32 PH7_CompileList(ph7_gen_state *pGen,sxi32 iCompileFlag)
 			}
 			PH7_MemObjInitFromInt(pGen->pVm,pIdx,(sxi64)apNested[i].nIndex);
 			PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOADC,0,nConstIdx,0,0);
-			/* LOAD_IDX: pop index, replace DUP'd source with source[index] */
-			PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOAD_IDX,1,0,0,0);
-			/* Recursively compile the inner list() */
+			/* LOAD_IDX: pop index, replace DUP'd source with source[index].
+			 * iP2=2 signals the VM to emit an "Undefined array key" warning
+			 * when the key is missing (PHP-compatible list destructuring).
+			 */
+			PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOAD_IDX,1,2,0,0);
+			/* Recursively compile the inner list */
 			pGen->pIn = apNested[i].pStart;
 			pGen->pEnd = apNested[i].pEnd;
-			rc = PH7_CompileList(&(*pGen),0);
+			if( apNested[i].isShort ){
+				rc = PH7_CompileShortList(&(*pGen),0);
+			}else{
+				rc = PH7_CompileList(&(*pGen),0);
+			}
 			pGen->pIn = pSavedIn;
 			pGen->pEnd = pSavedEnd;
 			if( rc == SXERR_ABORT ){
@@ -1335,6 +1360,22 @@ PH7_PRIVATE sxi32 PH7_CompileList(ph7_gen_state *pGen,sxi32 iCompileFlag)
 	SySetRelease(&sNested);
 	/* Node successfully compiled */
 	return SXRET_OK;
+}
+PH7_PRIVATE sxi32 PH7_CompileList(ph7_gen_state *pGen,sxi32 iCompileFlag)
+{
+	/* Jump the 'list' keyword, the leading '(' and exclude trailing ')' */
+	pGen->pIn += 2;
+	pGen->pEnd--;
+	SXUNUSED(iCompileFlag);
+	return GenStateCompileListBody(pGen);
+}
+PH7_PRIVATE sxi32 PH7_CompileShortList(ph7_gen_state *pGen,sxi32 iCompileFlag)
+{
+	/* Jump the leading '[', exclude trailing ']'. */
+	pGen->pIn++;
+	pGen->pEnd--;
+	SXUNUSED(iCompileFlag);
+	return GenStateCompileListBody(pGen);
 }
 /* Forward declarations */
 static sxi32 GenStateCompileFunc(ph7_gen_state *pGen,SyString *pName,sxi32 iFlags,int bHandleClosure,ph7_vm_func **ppFunc);
@@ -3008,6 +3049,37 @@ static sxi32 PH7_CompileForeach(ph7_gen_state *pGen)
 		pGen->pIn = &pListEnd[1]; /* Past ')' */
 		pListEnd = pGen->pIn;
 		pInfo->iFlags |= PH7_4EACH_STEP_LIST;
+	}else if( pGen->pIn->nType & PH7_TK_OSB ){
+		/* foreach ($arr as [$a, $b]) — short list unpacking.
+		 * Save the [...] token range; we'll compile it after FOREACH_STEP.
+		 */
+		static int iForeachShortListCnt = 0;
+		char zTmp[128];
+		sxu32 nLen;
+		char *zDup;
+		nLen = (sxu32)SyBufferFormat(zTmp,sizeof(zTmp),"[__foreach_slist_%d__]",iForeachShortListCnt++);
+		zDup = SyMemBackendStrDup(&pGen->pVm->sAllocator,zTmp,nLen);
+		if( zDup == 0 ){
+			PH7_GenCompileError(&(*pGen),E_ERROR,nLine,"Fatal, PH7 engine is running out of memory");
+			return SXERR_ABORT;
+		}
+		SyStringInitFromBuf(&pInfo->sValue,zDup,nLen);
+		/* Save [...] token boundaries */
+		pListStart = pGen->pIn;
+		/* Advance past [...] */
+		pGen->pIn++; /* Jump '[' */
+		PH7_DelimitNestedTokens(pGen->pIn,pEnd,PH7_TK_OSB,PH7_TK_CSB,&pListEnd);
+		if( pListEnd >= pEnd ){
+			rc = PH7_GenCompileError(pGen,E_ERROR,nLine,
+				"foreach: Missing closing ']' after short list");
+			if( rc == SXERR_ABORT ){
+				return SXERR_ABORT;
+			}
+			goto Synchronize;
+		}
+		pGen->pIn = &pListEnd[1]; /* Past ']' */
+		pListEnd = pGen->pIn;
+		pInfo->iFlags |= PH7_4EACH_STEP_LIST;
 	}else{
 		/* Compile the expression holding the value name */
 		rc = PH7_CompileExpr(&(*pGen),0,GenStateForEachNodeValidator);
@@ -3038,15 +3110,19 @@ static sxi32 PH7_CompileForeach(ph7_gen_state *pGen)
 		 * The LOAD_LIST handler expects the array below the variable entries.
 		 */
 		PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOAD,0,0,(void *)SyStringData(&pInfo->sValue),0);
-		/* Compile list(...) body directly — this pushes variables and emits LOAD_LIST.
-		 * We position the tokens at the list keyword so PH7_CompileList picks up
-		 * the opening '(' and the variable names inside.
+		/* Compile list/short-list body directly — this pushes variables and emits LOAD_LIST.
+		 * We position the tokens at the construct start so the appropriate compiler
+		 * picks up the delimiter and the variable names inside.
 		 */
 		pSavedIn = pGen->pIn;
 		pSavedEnd = pGen->pEnd;
 		pGen->pIn = pListStart;
 		pGen->pEnd = pListEnd;
-		rc = PH7_CompileList(&(*pGen),0);
+		if( pListStart->nType & PH7_TK_OSB ){
+			rc = PH7_CompileShortList(&(*pGen),0);
+		}else{
+			rc = PH7_CompileList(&(*pGen),0);
+		}
 		pGen->pIn = pSavedIn;
 		pGen->pEnd = pSavedEnd;
 		if( rc == SXERR_ABORT ){
@@ -7510,12 +7586,17 @@ static sxi32 GenStateEmitExprCode(
 		}
 		rc = GenStateEmitExprCode(&(*pGen),pNode->pRight,iFlags);
 		if( iVmOp == PH7_OP_STORE ){
-			pInstr = PH7_VmPeekInstr(pGen->pVm);
-			if( pInstr ){
-				if( pInstr->iOp == PH7_OP_LOAD_LIST ){
-					/* Hide the STORE instruction */
-					iVmOp = 0;
-				}else if(pInstr->iOp == PH7_OP_MEMBER ){
+			if( pNode->pRight && (pNode->pRight->xCode == PH7_CompileList ||
+				pNode->pRight->xCode == PH7_CompileShortList) ){
+				/* list()/[] destructuring handles assignment internally via LOAD_LIST;
+				 * suppress the STORE instruction entirely.  This check uses the node's
+				 * compile handler rather than peeking at the last opcode, because nested
+				 * list entries emit extra instructions (DUP, LOAD_IDX, POP) after the
+				 * outer LOAD_LIST, which would fool an opcode-based check.
+				 */
+				iVmOp = 0;
+			}else if( (pInstr = PH7_VmPeekInstr(pGen->pVm)) != 0 ){
+				if(pInstr->iOp == PH7_OP_MEMBER ){
 					/* Perform a member store operation [i.e: $this->x = 50] */
 					iP2 = 1;
 				}else{

--- a/src/ph7/parse.c
+++ b/src/ph7/parse.c
@@ -368,8 +368,8 @@ static sxi32 ExprVerifyNodes(ph7_gen_state *pGen,ph7_expr_node **apNode,sxi32 nN
 	}
 	iParen = iSquare = iQuesty = iBraces = 0;
 	for( i = 0 ; i < nNode ; ++i ){
-		if( apNode[i]->xCode == PH7_CompileShortArray ){
-			/* Short array literal: brackets are self-contained, skip */
+		if( apNode[i]->xCode == PH7_CompileShortArray || apNode[i]->xCode == PH7_CompileShortList ){
+			/* Short array/list literal: brackets are self-contained, skip */
 			continue;
 		}
 		if( apNode[i]->pStart->nType & PH7_TK_LPAREN /*'('*/){
@@ -714,7 +714,19 @@ static sxi32 ExprExtractNode(ph7_gen_state *pGen,ph7_expr_node **ppNode,int iLas
 			SyMemBackendPoolFree(&pGen->pVm->sAllocator,pNode);
 			return rc;
 		}
-		pNode->xCode = PH7_CompileShortArray;
+		/* Check if ']' is followed by '=' — if so, this is symmetric array
+		 * destructuring (PHP 7.1 short list syntax), not an array literal.
+		 */
+		if( pCur < pGen->pEnd && (pCur->nType & PH7_TK_OP) ){
+			ph7_expr_op *pOp = (ph7_expr_op *)pCur->pUserData;
+			if( pOp && pOp->iVmOp == PH7_OP_STORE ){
+				pNode->xCode = PH7_CompileShortList;
+			}else{
+				pNode->xCode = PH7_CompileShortArray;
+			}
+		}else{
+			pNode->xCode = PH7_CompileShortArray;
+		}
 	}else if( pCur->nType & PH7_TK_OP ){
 		/* Point to the instance that describe this operator */
 		pNode->pOp = (const ph7_expr_op *)pCur->pUserData;
@@ -1554,7 +1566,8 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 				 return rc;
 			 }
 			 if( ExprIsModifiableValue(apNode[iLeft],FALSE) == FALSE ){
-				 if( pNode->pOp->iVmOp != PH7_OP_STORE || apNode[iLeft]->xCode != PH7_CompileList ){
+				 if( pNode->pOp->iVmOp != PH7_OP_STORE ||
+					 (apNode[iLeft]->xCode != PH7_CompileList && apNode[iLeft]->xCode != PH7_CompileShortList) ){
 					 /* Left operand must be a modifiable l-value */
 					 rc = PH7_GenCompileError(pGen,E_ERROR,pNode->pStart->nLine,
 						 "'%z': Left operand must be a modifiable l-value",&pNode->pOp->sOp);

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1554,6 +1554,7 @@ PH7_PRIVATE sxi32 PH7_CompileString(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileArray(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileShortArray(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileList(ph7_gen_state *pGen,sxi32 iCompileFlag);
+PH7_PRIVATE sxi32 PH7_CompileShortList(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileAnnonFunc(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_InitCodeGenerator(ph7_vm *pVm,ProcConsumer xErr,void *pErrData);
 PH7_PRIVATE sxi32 PH7_ResetCodeGenerator(ph7_vm *pVm,ProcConsumer xErr,void *pErrData);

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -3397,13 +3397,46 @@ case PH7_OP_LOAD_LIST: {
 						/* Store node value */
 						PH7_HashmapExtractNodeValue(pNode,pObj,TRUE);
 					}else{
-						/* Nullify the variable */
+						/* Undefined array key */
+						char zMsg[128];
+						SyBufferFormat(zMsg,sizeof(zMsg),"Undefined array key %d",(int)sKey.x.iVal);
+						PH7_VmThrowError(&(*pVm),0,PH7_CTX_WARNING,zMsg);
 						PH7_MemObjRelease(pObj);
 					}
 				}
 			}
 			sKey.x.iVal++; /* Next numeric index */
 			pEntry++;
+		}
+	}else{
+		/* Source is not an array */
+		ph7_value *pObj;
+		while( pEntry <= pTos ){
+			if( pEntry->nIdx != SXU32_HIGH ){
+				if( (pObj = (ph7_value *)SySetAt(&pVm->aMemObj,pEntry->nIdx)) != 0 ){
+					PH7_MemObjRelease(pObj);
+				}
+			}
+			pEntry++;
+		}
+		if( (pTos[-pInstr->iP1].iFlags & (MEMOBJ_NULL|MEMOBJ_BOOL)) == 0 ){
+			/* Emit PHP-compatible warning with type name */
+			const char *zType = "unknown";
+			sxi32 iFlags = pTos[-pInstr->iP1].iFlags;
+			char zMsg[256];
+			if( iFlags & MEMOBJ_STRING ){
+				zType = "string";
+			}else if( iFlags & MEMOBJ_INT ){
+				zType = "int";
+			}else if( iFlags & MEMOBJ_REAL ){
+				zType = "float";
+			}else if( iFlags & MEMOBJ_OBJ ){
+				zType = "object";
+			}else if( iFlags & MEMOBJ_RES ){
+				zType = "resource";
+			}
+			SyBufferFormat(zMsg,sizeof(zMsg),"Cannot use %s as array",zType);
+			PH7_VmThrowError(&(*pVm),0,PH7_CTX_WARNING,zMsg);
 		}
 	}
 	VmPopOperand(&pTos,pInstr->iP1);
@@ -3467,7 +3500,7 @@ case PH7_OP_LOAD_IDX: {
 		}
 		break;
 	}
-	if( pInstr->iP2 && (pTos->iFlags & MEMOBJ_HASHMAP) == 0 ){
+	if( pInstr->iP2 == 1 && (pTos->iFlags & MEMOBJ_HASHMAP) == 0 ){
 		if( pTos->nIdx != SXU32_HIGH ){
 			ph7_value *pObj;
 			if( (pObj = (ph7_value *)SySetAt(&pVm->aMemObj,pTos->nIdx)) != 0 ){
@@ -3478,7 +3511,7 @@ case PH7_OP_LOAD_IDX: {
 	}
 	rc = SXERR_NOTFOUND; /* Assume the index is invalid */
 	if( pTos->iFlags & MEMOBJ_HASHMAP ){
-		if( pInstr->iP2 ){
+		if( pInstr->iP2 == 1 ){
 			/* Write-context access (iP2 = create-if-missing).  COW-separate
 			 * the parent so nested writes like $b[0][0] = 99 don't leak
 			 * through shared outer arrays.  Read-only loads (iP2 == 0) must
@@ -3491,7 +3524,7 @@ case PH7_OP_LOAD_IDX: {
 			/* Load the desired entry */
 			rc = PH7_HashmapLookup(pMap,pIdx,&pNode);
 		}
-		if( rc != SXRET_OK && pInstr->iP2 ){
+		if( rc != SXRET_OK && pInstr->iP2 == 1 ){
 			/* Create a new empty entry */
 			rc = PH7_HashmapInsert(pMap,pIdx,0);
 			if( rc == SXRET_OK ){
@@ -3499,6 +3532,15 @@ case PH7_OP_LOAD_IDX: {
 				pNode = pMap->pLast;
 			}
 		}
+	}
+	if( rc != SXRET_OK && pInstr->iP2 == 2 && pIdx ){
+		/* List destructuring context: emit PHP-compatible warning for missing key */
+		char zMsg[128];
+		if( (pIdx->iFlags & MEMOBJ_INT) == 0 ){
+			PH7_MemObjToInteger(pIdx);
+		}
+		SyBufferFormat(zMsg,sizeof(zMsg),"Undefined array key %d",(int)pIdx->x.iVal);
+		PH7_VmThrowError(&(*pVm),0,PH7_CTX_WARNING,zMsg);
 	}
 	if( pIdx ){
 		PH7_MemObjRelease(pIdx);

--- a/tests/ph7/001-smoke/lang/foreach_short_list.phpt
+++ b/tests/ph7/001-smoke/lang/foreach_short_list.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+foreach with symmetric array destructuring
+--FILE--
+<?php
+$rows = [[1, 2], [3, 4], [5, 6]];
+foreach ($rows as [$a, $b]) {
+    echo "$a $b\n";
+}
+?>
+--EXPECT--
+1 2
+3 4
+5 6
+--CLEAN--
+<?php
+unset($rows, $a, $b);

--- a/tests/ph7/001-smoke/lang/short_list_basic.phpt
+++ b/tests/ph7/001-smoke/lang/short_list_basic.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Symmetric array destructuring basic assignment
+--FILE--
+<?php
+[$a, $b] = [1, 2];
+echo "$a $b\n";
+
+[$x, $y, $z] = [10, 20, 30];
+echo "$x $y $z\n";
+
+$arr = [100, 200, 300];
+[$p, $q, $r] = $arr;
+echo "$p $q $r\n";
+?>
+--EXPECT--
+1 2
+10 20 30
+100 200 300
+--CLEAN--
+<?php
+unset($a, $b, $x, $y, $z, $arr, $p, $q, $r);

--- a/tests/ph7/001-smoke/lang/short_list_fewer.phpt
+++ b/tests/ph7/001-smoke/lang/short_list_fewer.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Symmetric array destructuring with fewer variables than values
+--FILE--
+<?php
+[$a] = [1, 2, 3];
+echo "$a\n";
+
+[$x, $y] = [10, 20, 30];
+echo "$x $y\n";
+?>
+--EXPECT--
+1
+10 20
+--CLEAN--
+<?php
+unset($a, $x, $y);

--- a/tests/ph7/001-smoke/lang/short_list_mixed_nesting.phpt
+++ b/tests/ph7/001-smoke/lang/short_list_mixed_nesting.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Deeply nested symmetric array destructuring
+--FILE--
+<?php
+[[$a, $b], [$c, $d]] = [[1, 2], [3, 4]];
+echo "$a $b $c $d\n";
+
+[$x, [[$y], $z]] = [10, [[20], 30]];
+echo "$x $y $z\n";
+?>
+--EXPECT--
+1 2 3 4
+10 20 30
+--CLEAN--
+<?php
+unset($a, $b, $c, $d, $x, $y, $z);

--- a/tests/ph7/001-smoke/lang/short_list_nested.phpt
+++ b/tests/ph7/001-smoke/lang/short_list_nested.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nested symmetric array destructuring
+--FILE--
+<?php
+[[$a, $b], $c] = [[1, 2], 3];
+echo "$a $b $c\n";
+
+[$x, [$y, $z]] = [10, [20, 30]];
+echo "$x $y $z\n";
+?>
+--EXPECT--
+1 2 3
+10 20 30
+--CLEAN--
+<?php
+unset($a, $b, $c, $x, $y, $z);

--- a/tests/ph7/001-smoke/lang/short_list_skip.phpt
+++ b/tests/ph7/001-smoke/lang/short_list_skip.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Symmetric array destructuring with skipped elements
+--FILE--
+<?php
+[, $b] = [1, 2];
+echo "$b\n";
+
+[$a, , $c] = [1, 2, 3];
+echo "$a $c\n";
+
+[, , $third] = [10, 20, 30];
+echo "$third\n";
+?>
+--EXPECT--
+2
+1 3
+30
+--CLEAN--
+<?php
+unset($a, $b, $c, $third);

--- a/tests/ph7/002-integration/error/short_list_invalid_expression.phpt
+++ b/tests/ph7/002-integration/error/short_list_invalid_expression.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Symmetric array destructuring with invalid expression is fatal error
+--FILE--
+<?php
+[1] = array(1);
+echo "should not reach here";
+?>
+--EXPECTF--
+PHP Fatal error:  %s
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/error/short_list_non_array.phpt
+++ b/tests/ph7/002-integration/error/short_list_non_array.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Symmetric array destructuring from non-array source emits warning
+--SKIPIF--
+<?php if (function_exists('zend_version') && version_compare(PHP_VERSION, '8.5.0', '<')) echo 'skip'; ?>
+--FILE--
+<?php
+[$a] = "string";
+echo isset($a) ? "set" : "not set";
+?>
+--EXPECTF--
+%s Warning:  Cannot use string as array
+--CLEAN--
+<?php
+unset($a);


### PR DESCRIPTION
Add short list syntax as syntactic sugar for list(), reusing the existing LOAD_LIST bytecode. The parser disambiguates [...]= from array literals, the compiler delegates to a shared GenStateCompileListBody, and foreach ($arr as [$a, $b]) is supported. The VM now emits PHP-compatible warnings for non-array sources and undefined keys.
