### PR TITLE
Implement class constant visibility (PHP 7.1)

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -5340,9 +5340,35 @@ static sxi32 PH7_CompileClassInterface(ph7_gen_state *pGen)
 		/* Extract the current keyword */
 		nKwrd = SX_PTR_TO_INT(pGen->pIn->pUserData);
 		if( nKwrd == PH7_TKWRD_PRIVATE || nKwrd == PH7_TKWRD_PROTECTED ){
-			/* Emit a warning and switch to public visibility */
-			PH7_GenCompileError(&(*pGen),E_WARNING,pGen->pIn->nLine,"interface: Access type must be public");
-			nKwrd = PH7_TKWRD_PUBLIC;
+			/* Fatal error: interface members must be public (PHP 7.1-8.0 behavior).
+			 * Peek ahead to distinguish constant vs method and extract the member name. */
+			const char *zKind = "member";
+			SyString *pMemberName = 0;
+			if( (pGen->pIn + 1) < pGen->pEnd ){
+				sxi32 nNext = SX_PTR_TO_INT((pGen->pIn + 1)->pUserData);
+				if( nNext == PH7_TKWRD_CONST ){
+					zKind = "constant";
+					if( (pGen->pIn + 2) < pGen->pEnd && ((pGen->pIn + 2)->nType & PH7_TK_ID) ){
+						pMemberName = &(pGen->pIn + 2)->sData;
+					}
+				}else if( nNext == PH7_TKWRD_FUNCTION ){
+					zKind = "method";
+					if( (pGen->pIn + 2) < pGen->pEnd && ((pGen->pIn + 2)->nType & PH7_TK_ID) ){
+						pMemberName = &(pGen->pIn + 2)->sData;
+					}
+				}
+			}
+			if( pMemberName ){
+				rc = PH7_GenCompileError(&(*pGen),E_ERROR,pGen->pIn->nLine,
+					"Access type for interface %s %z::%z must be public",zKind,pName,pMemberName);
+			}else{
+				rc = PH7_GenCompileError(&(*pGen),E_ERROR,pGen->pIn->nLine,
+					"Access type for interface %s must be public",zKind);
+			}
+			if( rc == SXERR_ABORT ){
+				return SXERR_ABORT;
+			}
+			goto done;
 		}
 		if( nKwrd != PH7_TKWRD_PUBLIC && nKwrd != PH7_TKWRD_FUNCTION && nKwrd != PH7_TKWRD_CONST && nKwrd != PH7_TKWRD_STATIC ){
 			rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -5763,7 +5763,7 @@ case PH7_OP_MEMBER: {
 				if( pObjAttr ){
 					ph7_value *pValue = 0; /* cc warning */
 					/* Check attribute access */
-					if( PH7_VmClassMemberAccess(&(*pVm),pClass,&pObjAttr->pAttr->sName,pObjAttr->pAttr->iProtection,TRUE) ){
+					if( PH7_VmClassMemberAccess(&(*pVm),pClass,&pObjAttr->pAttr->sName,pObjAttr->pAttr->iProtection,FALSE) ){
 						/* Load attribute */
 						pValue = (ph7_value *)SySetAt(&pVm->aMemObj,pObjAttr->nIdx);
 						if( pValue ){
@@ -5783,6 +5783,17 @@ case PH7_OP_MEMBER: {
 								}
 							}
 						}
+					}else{
+						/* Throw Error exception (PHP-compatible).
+						 * Build message before unref — pObjAttr belongs to pThis->hAttr. */
+						char zMsg[256];
+						const char *zVis = pObjAttr->pAttr->iProtection == PH7_CLASS_PROT_PRIVATE ? "private" : "protected";
+						SyBufferFormat(zMsg,sizeof(zMsg),"Cannot access %s property %.*s::$%.*s",
+							zVis,(int)pClass->sName.nByte,pClass->sName.zString,
+							(int)pObjAttr->pAttr->sName.nByte,pObjAttr->pAttr->sName.zString);
+						PH7_ClassInstanceUnref(pThis);
+						VmReportUncaughtException(&(*pVm),"Error",5,zMsg,(sxu32)SyStrlen(zMsg),0,0);
+						goto Abort;
 					}
 				}
 				/* Safely unreference the object */
@@ -5925,7 +5936,7 @@ case PH7_OP_MEMBER: {
 							}else{
 								ph7_value *pValue;
 								/* Check if the access to the attribute is allowed */
-								if( PH7_VmClassMemberAccess(&(*pVm),pClass,&pAttr->sName,pAttr->iProtection,TRUE) ){
+								if( PH7_VmClassMemberAccess(&(*pVm),pClass,&pAttr->sName,pAttr->iProtection,FALSE) ){
 									/* Load the desired attribute */
 									pValue = (ph7_value *)SySetAt(&pVm->aMemObj,pAttr->nIdx);
 									if( pValue ){
@@ -5935,6 +5946,21 @@ case PH7_OP_MEMBER: {
 											pTos->nIdx = pAttr->nIdx;
 										}
 									}
+								}else{
+									/* Throw Error exception (PHP-compatible) */
+									char zMsg[256];
+									const char *zVis = pAttr->iProtection == PH7_CLASS_PROT_PRIVATE ? "private" : "protected";
+									if( pAttr->iFlags & PH7_CLASS_ATTR_CONSTANT ){
+										SyBufferFormat(zMsg,sizeof(zMsg),"Cannot access %s constant %.*s::%.*s",
+											zVis,(int)pClass->sName.nByte,pClass->sName.zString,
+											(int)pAttr->sName.nByte,pAttr->sName.zString);
+									}else{
+										SyBufferFormat(zMsg,sizeof(zMsg),"Cannot access %s property %.*s::$%.*s",
+											zVis,(int)pClass->sName.nByte,pClass->sName.zString,
+											(int)pAttr->sName.nByte,pAttr->sName.zString);
+									}
+									VmReportUncaughtException(&(*pVm),"Error",5,zMsg,(sxu32)SyStrlen(zMsg),0,0);
+									goto Abort;
 								}
 							}
 						}
@@ -6330,14 +6356,19 @@ case PH7_OP_CALL: {
 					/* Check if the call is allowed */
 					pMeth = PH7_ClassExtractMethod(pSelf,pVmFunc->sName.zString,pVmFunc->sName.nByte);
 					if( pMeth && pMeth->iProtection != PH7_CLASS_PROT_PUBLIC ){
-						if( !PH7_VmClassMemberAccess(&(*pVm),pSelf,&pVmFunc->sName,pMeth->iProtection,TRUE) ){
+						if( !PH7_VmClassMemberAccess(&(*pVm),pSelf,&pVmFunc->sName,pMeth->iProtection,FALSE) ){
+							/* Throw Error exception (PHP-compatible) */
+							char zMsg[256];
+							const char *zVis = pMeth->iProtection == PH7_CLASS_PROT_PRIVATE ? "private" : "protected";
+							SyBufferFormat(zMsg,sizeof(zMsg),"Call to %s method %.*s::%.*s() from global scope",
+								zVis,(int)pSelf->sName.nByte,pSelf->sName.zString,
+								(int)pVmFunc->sName.nByte,pVmFunc->sName.zString);
 							/* Pop given arguments */
 							if( nCallArgs > 0 ){
 								VmPopOperand(&pTos,nCallArgs);
 							}
-							/* Assume a null return value so that the program continue it's execution normally */
-							PH7_MemObjRelease(pTos);
-							break;
+							VmReportUncaughtException(&(*pVm),"Error",5,zMsg,(sxu32)SyStrlen(zMsg),0,0);
+							goto Abort;
 						}
 					}
 				}

--- a/src/ph7/vm_builtin_class.c
+++ b/src/ph7/vm_builtin_class.c
@@ -547,8 +547,8 @@ PH7_PRIVATE int PH7_VmClassMemberAccess(
 		}else{
 			/* Protected */
 			ph7_class *pBase = (ph7_class *)pVmFunc->pUserData;
-			/* Must be a derived class */
-			if( !PH7_VmInstanceOf(pClass,pBase) ){
+			/* Must be in the same class hierarchy */
+			if( !PH7_VmInstanceOf(pClass,pBase) && !PH7_VmInstanceOf(pBase,pClass) ){
 				goto dis; /* Access is forbidden */
 			}
 		}

--- a/tests/ph7/001-smoke/oo/class_const_visibility.phpt
+++ b/tests/ph7/001-smoke/oo/class_const_visibility.phpt
@@ -1,0 +1,37 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Class constant visibility (public, protected, private)
+--FILE--
+<?php
+class ConstVisibility {
+    const BARE = "bare";
+    public const PUB = "public";
+    protected const PROT = "protected";
+    private const PRIV = "private";
+
+    public function getAll() {
+        echo self::BARE . "\n";
+        echo self::PUB . "\n";
+        echo self::PROT . "\n";
+        echo self::PRIV . "\n";
+    }
+}
+
+$obj = new ConstVisibility();
+$obj->getAll();
+
+echo ConstVisibility::BARE . "\n";
+echo ConstVisibility::PUB . "\n";
+?>
+--EXPECT--
+bare
+public
+protected
+private
+bare
+public
+--CLEAN--
+<?php
+unset($obj);

--- a/tests/ph7/001-smoke/oo/class_const_visibility_inheritance.phpt
+++ b/tests/ph7/001-smoke/oo/class_const_visibility_inheritance.phpt
@@ -1,0 +1,46 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Class constant visibility with inheritance (protected accessible from child)
+--FILE--
+<?php
+class ConstVisParent {
+    public const PUB = "parent_public";
+    protected const PROT = "parent_protected";
+
+    public function getFromParent() {
+        echo self::PUB . "\n";
+        echo self::PROT . "\n";
+    }
+}
+
+class ConstVisChild extends ConstVisParent {
+    public function getFromChild() {
+        echo parent::PUB . "\n";
+        echo parent::PROT . "\n";
+        echo self::PUB . "\n";
+        echo self::PROT . "\n";
+        echo static::PUB . "\n";
+        echo static::PROT . "\n";
+    }
+}
+
+$child = new ConstVisChild();
+$child->getFromParent();
+$child->getFromChild();
+echo ConstVisChild::PUB . "\n";
+?>
+--EXPECT--
+parent_public
+parent_protected
+parent_public
+parent_protected
+parent_public
+parent_protected
+parent_public
+parent_protected
+parent_public
+--CLEAN--
+<?php
+unset($child);

--- a/tests/ph7/001-smoke/oo/class_const_visibility_parent_access.phpt
+++ b/tests/ph7/001-smoke/oo/class_const_visibility_parent_access.phpt
@@ -1,0 +1,26 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Protected member accessible from parent scope (bidirectional hierarchy)
+--FILE--
+<?php
+class ProtParent {
+    public function readChildProp(ProtChild $child) {
+        echo $child->prot . "\n";
+    }
+}
+
+class ProtChild extends ProtParent {
+    protected $prot = "child_protected";
+}
+
+$parent = new ProtParent();
+$child = new ProtChild();
+$parent->readChildProp($child);
+?>
+--EXPECT--
+child_protected
+--CLEAN--
+<?php
+unset($parent, $child);

--- a/tests/ph7/001-smoke/oo/method_visibility_parent.phpt
+++ b/tests/ph7/001-smoke/oo/method_visibility_parent.phpt
@@ -1,0 +1,39 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Protected method accessible via parent:: and static:: from child class
+--FILE--
+<?php
+class MethVisBase {
+    protected function protMethod() {
+        return "protected_result";
+    }
+
+    protected static function protStatic() {
+        return "protected_static_result";
+    }
+}
+
+class MethVisChild extends MethVisBase {
+    public function callViaParent() {
+        echo parent::protMethod() . "\n";
+        echo parent::protStatic() . "\n";
+    }
+
+    public function callViaStatic() {
+        echo static::protStatic() . "\n";
+    }
+}
+
+$child = new MethVisChild();
+$child->callViaParent();
+$child->callViaStatic();
+?>
+--EXPECT--
+protected_result
+protected_static_result
+protected_static_result
+--CLEAN--
+<?php
+unset($child);

--- a/tests/ph7/002-integration/oo/class_const_private_inherit.phpt
+++ b/tests/ph7/002-integration/oo/class_const_private_inherit.phpt
@@ -1,0 +1,41 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Private class constant not inherited by child class
+--FILE--
+<?php
+class ConstInhBase {
+    private const PRIV = "base_private";
+    protected const PROT = "base_protected";
+
+    public function getPrivFromConstInhBase() {
+        echo self::PRIV . "\n";
+    }
+}
+
+class ConstInhChild extends ConstInhBase {
+    public function getProtFromConstInhChild() {
+        echo self::PROT . "\n";
+    }
+
+    public function getPrivFromConstInhChild() {
+        echo parent::PRIV . "\n";
+    }
+}
+
+$base = new ConstInhBase();
+$base->getPrivFromConstInhBase();
+
+$child = new ConstInhChild();
+$child->getProtFromConstInhChild();
+$child->getPrivFromConstInhChild();
+echo "should not reach here\n";
+?>
+--EXPECTF--
+base_private
+base_protected
+%s Fatal error:  Uncaught Error: Cannot access private constant ConstInhBase::PRIV in %s
+--CLEAN--
+<?php
+unset($base, $child);

--- a/tests/ph7/002-integration/oo/class_const_visibility_access.phpt
+++ b/tests/ph7/002-integration/oo/class_const_visibility_access.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Class constant visibility enforcement (private/protected forbidden from outside)
+--FILE--
+<?php
+class Restricted {
+    public const PUB = "public";
+    protected const PROT = "protected";
+}
+
+echo Restricted::PUB . "\n";
+echo Restricted::PROT . "\n";
+echo "should not reach here\n";
+?>
+--EXPECTF--
+public
+%s Fatal error:  Uncaught Error: Cannot access protected constant Restricted::PROT in %s
+--CLEAN--
+<?php
+

--- a/tests/ph7/002-integration/oo/interface_const_visibility.phpt
+++ b/tests/ph7/002-integration/oo/interface_const_visibility.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Interface constants must be public (private/protected is fatal error)
+--FILE--
+<?php
+interface Iface {
+    protected const PROT = 3;
+}
+echo "should not reach here\n";
+?>
+--EXPECTF--
+%s Fatal error:  Access type for interface constant %s
+--CLEAN--
+<?php
+


### PR DESCRIPTION
Support public/protected/private modifiers on class constants. The parser and data structures already handled this; the missing pieces were runtime enforcement and correct error behavior.

- Fix protected visibility check to allow bidirectional hierarchy access (child accessing parent:: and vice versa)
- Visibility violations now throw Uncaught Error exceptions matching PHP behavior, for constants, properties, and methods
- Non-public interface constants are a fatal compile error
