### PR TITLE
Implement multi-catch exception handling (PHP 7.1)

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -6842,6 +6842,7 @@ static sxi32 PH7_CompileCatch(ph7_gen_state *pGen,ph7_exception *pException)
 	sxu32 nLine = pGen->pIn->nLine;
 	ph7_exception_block sCatch;
 	SySet *pInstrContainer;
+	SyString sClassName;
 	GenBlock *pCatch;
 	SyToken *pToken;
 	SyString *pName;
@@ -6851,31 +6852,93 @@ static sxi32 PH7_CompileCatch(ph7_gen_state *pGen,ph7_exception *pException)
 	/* Zero the structure */
 	SyZero(&sCatch,sizeof(ph7_exception_block));
 	/* Initialize fields */
+	SySetInit(&sCatch.aClasses,&pException->pVm->sAllocator,sizeof(SyString));
 	SySetInit(&sCatch.sByteCode,&pException->pVm->sAllocator,sizeof(VmInstr));
-	if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_LPAREN) == 0 /*(*/ ||
-		&pGen->pIn[1] >= pGen->pEnd || (pGen->pIn[1].nType & (PH7_TK_ID|PH7_TK_KEYWORD)) == 0 ){
+	if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_LPAREN) == 0 /*(*/ ){
 			/* Unexpected token,break immediately */
 			pToken = pGen->pIn;
 			if( pToken >= pGen->pEnd ){
 				pToken--;
 			}
-			rc = PH7_GenCompileError(pGen,E_ERROR,pToken->nLine,
-				"Catch: Unexpected token '%z',excpecting class name",&pToken->sData);
+			rc = PH7_GenCompileError(pGen,E_PARSE,pToken->nLine,
+				"syntax error, unexpected %s \"%z\"",
+				TokenTypeName(pToken->nType),&pToken->sData);
 			if( rc == SXERR_ABORT ){
 				return SXERR_ABORT;
 			}
 			return SXERR_INVALID;
 	}
-	/* Extract the exception class */
+	/* Extract the exception class(es) — supports multi-catch: catch (A | B $e) */
 	pGen->pIn++; /* Jump the left parenthesis '(' */
-	/* Duplicate class name */
-	pName = &pGen->pIn->sData;
-	zDup = SyMemBackendStrDup(&pGen->pVm->sAllocator,pName->zString,pName->nByte);
-	if( zDup == 0 ){
-		goto Mem;
+	for(;;){
+		int isAbsolute = 0;
+		SyBlob sName;
+		SyBlobInit(&sName,&pGen->pVm->sAllocator);
+		/* Accept optional leading '\' for fully-qualified names */
+		if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_NSSEP) ){
+			isAbsolute = 1;
+			pGen->pIn++;
+		}
+		if( pGen->pIn >= pGen->pEnd ||
+			(pGen->pIn->nType & (PH7_TK_ID|PH7_TK_KEYWORD)) == 0 ){
+			SyBlobRelease(&sName);
+			pToken = pGen->pIn;
+			if( pToken >= pGen->pEnd ){
+				pToken--;
+			}
+			rc = PH7_GenCompileError(pGen,E_PARSE,pToken->nLine,
+				"syntax error, unexpected %s \"%z\"",
+				TokenTypeName(pToken->nType),&pToken->sData);
+			if( rc == SXERR_ABORT ){
+				return SXERR_ABORT;
+			}
+			return SXERR_INVALID;
+		}
+		/* Collect namespace-qualified name: ID [\ ID]* */
+		SyBlobAppend(&sName,pGen->pIn->sData.zString,pGen->pIn->sData.nByte);
+		pGen->pIn++;
+		while( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_NSSEP) &&
+			&pGen->pIn[1] < pGen->pEnd && (pGen->pIn[1].nType & (PH7_TK_ID|PH7_TK_KEYWORD)) ){
+			SyBlobAppend(&sName,"\\",1);
+			pGen->pIn++; /* Skip '\' separator */
+			SyBlobAppend(&sName,pGen->pIn->sData.zString,pGen->pIn->sData.nByte);
+			pGen->pIn++;
+		}
+		/* Resolve through namespace/imports for non-absolute names */
+		if( !isAbsolute ){
+			SyString sRaw;
+			SyBlob sResolved;
+			SyStringInitFromBuf(&sRaw,(const char *)SyBlobData(&sName),SyBlobLength(&sName));
+			SyBlobInit(&sResolved,&pGen->pVm->sAllocator);
+			GenStateResolveName(pGen,&sRaw,&sResolved);
+			zDup = SyMemBackendStrDup(&pGen->pVm->sAllocator,
+				(const char *)SyBlobData(&sResolved),SyBlobLength(&sResolved));
+			SyStringInitFromBuf(&sClassName,zDup,SyBlobLength(&sResolved));
+			SyBlobRelease(&sResolved);
+		}else{
+			/* Absolute name: use as-is without namespace prefix */
+			zDup = SyMemBackendStrDup(&pGen->pVm->sAllocator,
+				(const char *)SyBlobData(&sName),SyBlobLength(&sName));
+			SyStringInitFromBuf(&sClassName,zDup,SyBlobLength(&sName));
+		}
+		SyBlobRelease(&sName);
+		if( zDup == 0 ){
+			goto Mem;
+		}
+		rc = SySetPut(&sCatch.aClasses,(const void *)&sClassName);
+		if( rc != SXRET_OK ){
+			goto Mem;
+		}
+		/* Check for '|' (multi-catch separator) */
+		if( pGen->pIn < pGen->pEnd &&
+			(pGen->pIn->nType & PH7_TK_OP) &&
+			pGen->pIn->sData.nByte == 1 &&
+			pGen->pIn->sData.zString[0] == '|' ){
+			pGen->pIn++; /* Consume the '|' */
+			continue;
+		}
+		break;
 	}
-	SyStringInitFromBuf(&sCatch.sClass,zDup,pName->nByte);
-	pGen->pIn++;
 	if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_DOLLAR) == 0 /*$*/ ||
 		&pGen->pIn[1] >= pGen->pEnd || (pGen->pIn[1].nType & (PH7_TK_ID|PH7_TK_KEYWORD)) == 0 ){
 			/* Unexpected token,break immediately */
@@ -6883,8 +6946,9 @@ static sxi32 PH7_CompileCatch(ph7_gen_state *pGen,ph7_exception *pException)
 			if( pToken >= pGen->pEnd ){
 				pToken--;
 			}
-			rc = PH7_GenCompileError(pGen,E_ERROR,pToken->nLine,
-				"Catch: Unexpected token '%z',expecting variable name",&pToken->sData);
+			rc = PH7_GenCompileError(pGen,E_PARSE,pToken->nLine,
+				"syntax error, unexpected %s \"%z\"",
+				TokenTypeName(pToken->nType),&pToken->sData);
 			if( rc == SXERR_ABORT ){
 				return SXERR_ABORT;
 			}
@@ -6905,8 +6969,9 @@ static sxi32 PH7_CompileCatch(ph7_gen_state *pGen,ph7_exception *pException)
 		if( pToken >= pGen->pEnd ){
 			pToken--;
 		}
-		rc = PH7_GenCompileError(pGen,E_ERROR,pToken->nLine,
-			"Catch: Unexpected token '%z',expecting right parenthesis ')'",&pToken->sData);
+		rc = PH7_GenCompileError(pGen,E_PARSE,pToken->nLine,
+			"syntax error, unexpected %s \"%z\"",
+			TokenTypeName(pToken->nType),&pToken->sData);
 		if( rc == SXERR_ABORT ){
 			return SXERR_ABORT;
 		}

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -704,7 +704,7 @@ typedef struct ph7_exception_block ph7_exception_block;
 typedef struct ph7_exception ph7_exception;
 struct ph7_exception_block
 {
-	SyString sClass; /* Exception class name [i.e: Exception,MyException...] */
+	SySet aClasses;  /* Exception class names (SyString instances) for multi-catch */
 	SyString sThis;  /* Instance name [i.e: $e..] */
 	SySet sByteCode; /* Block compiled instructions */
 };

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -10588,21 +10588,33 @@ static sxi32 VmThrowException(
 	if( SySetUsed(&pVm->aException) > 0 ){
 		ph7_exception_block *aCatch;
 		ph7_class *pClass;
-		sxu32 j;
+		SyString *aNames;
+		sxu32 nNames;
+		int matched;
+		sxu32 j,k;
 		/* Locate the appropriate block to execute */
 		pException = apException[SySetUsed(&pVm->aException) - 1];
 		(void)SySetPop(&pVm->aException);
 		aCatch = (ph7_exception_block *)SySetBasePtr(&pException->sEntry);
 		for( j = 0 ; j < SySetUsed(&pException->sEntry) ; ++j ){
-			SyString *pName = &aCatch[j].sClass;
-			/* Extract the target class */
-			pClass = PH7_VmExtractClass(&(*pVm),pName->zString,pName->nByte,TRUE,0);
-			if( pClass == 0 ){
-				/* No such class */
-				continue;
+			/* Iterate over all class names in this catch block (multi-catch support) */
+			aNames = (SyString *)SySetBasePtr(&aCatch[j].aClasses);
+			nNames = SySetUsed(&aCatch[j].aClasses);
+			matched = 0;
+			for( k = 0 ; k < nNames ; ++k ){
+				/* Extract the target class */
+				pClass = PH7_VmExtractClass(&(*pVm),aNames[k].zString,aNames[k].nByte,TRUE,0);
+				if( pClass == 0 ){
+					/* No such class */
+					continue;
+				}
+				if( PH7_VmInstanceOf(pThis->pClass,pClass) ){
+					matched = 1;
+					break;
+				}
 			}
-			if( PH7_VmInstanceOf(pThis->pClass,pClass) ){
-				/* Catch block found,break immeditaley */
+			if( matched ){
+				/* Catch block found,break immediately */
 				pCatch = &aCatch[j];
 				break;
 			}

--- a/tests/ph7/001-smoke/lang/multi_catch_basic.phpt
+++ b/tests/ph7/001-smoke/lang/multi_catch_basic.phpt
@@ -1,0 +1,27 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Multi-catch basic: catch (A | B $e) catches first and second type
+--FILE--
+<?php
+class McBasicA extends Exception {}
+class McBasicB extends Exception {}
+
+try {
+    throw new McBasicA("first");
+} catch (McBasicA | McBasicB $e) {
+    echo $e->getMessage() . "\n";
+}
+
+try {
+    throw new McBasicB("second");
+} catch (McBasicA | McBasicB $e) {
+    echo $e->getMessage() . "\n";
+}
+?>
+--EXPECT--
+first
+second
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/multi_catch_fallthrough.phpt
+++ b/tests/ph7/001-smoke/lang/multi_catch_fallthrough.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Multi-catch: no match falls through to next catch block
+--FILE--
+<?php
+class McFallA extends Exception {}
+class McFallB extends Exception {}
+class McFallC extends Exception {}
+
+try {
+    throw new McFallC("from C");
+} catch (McFallA | McFallB $e) {
+    echo "AB: " . $e->getMessage() . "\n";
+} catch (McFallC $e) {
+    echo "C: " . $e->getMessage() . "\n";
+}
+?>
+--EXPECT--
+C: from C
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/multi_catch_finally.phpt
+++ b/tests/ph7/001-smoke/lang/multi_catch_finally.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Multi-catch: works with finally block
+--FILE--
+<?php
+class McFinA extends Exception {}
+
+try {
+    throw new McFinA("test");
+} catch (McFinA | Exception $e) {
+    echo "caught: " . $e->getMessage() . "\n";
+} finally {
+    echo "finally\n";
+}
+?>
+--EXPECT--
+caught: test
+finally
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/multi_catch_first_block_wins.phpt
+++ b/tests/ph7/001-smoke/lang/multi_catch_first_block_wins.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Multi-catch: first matching catch block wins
+--FILE--
+<?php
+class McFirstA extends Exception {}
+class McFirstB extends Exception {}
+
+try {
+    throw new McFirstA("from A");
+} catch (McFirstA | McFirstB $e) {
+    echo "multi: " . $e->getMessage() . "\n";
+} catch (McFirstA $e) {
+    echo "single: " . $e->getMessage() . "\n";
+}
+?>
+--EXPECT--
+multi: from A
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/multi_catch_inheritance.phpt
+++ b/tests/ph7/001-smoke/lang/multi_catch_inheritance.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Multi-catch: subclass matches parent listed in multi-catch
+--FILE--
+<?php
+class McInhA extends Exception {}
+class McInhB extends McInhA {}
+
+try {
+    throw new McInhB("child");
+} catch (McInhA | Exception $e) {
+    echo $e->getMessage() . "\n";
+}
+?>
+--EXPECT--
+child
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/multi_catch_namespace.phpt
+++ b/tests/ph7/001-smoke/lang/multi_catch_namespace.phpt
@@ -1,0 +1,38 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Multi-catch with namespace-qualified and fully-qualified types
+--FILE--
+<?php
+namespace McNs;
+
+use Exception;
+
+class McExOne extends Exception {}
+class McExTwo extends Exception {}
+
+try {
+    throw new McExOne("namespaced");
+} catch (McExOne | McExTwo $e) {
+    echo $e->getMessage() . "\n";
+}
+
+try {
+    throw new McExTwo("fqn");
+} catch (\McNs\McExOne | \McNs\McExTwo $e) {
+    echo $e->getMessage() . "\n";
+}
+
+try {
+    throw new McExOne("backslash");
+} catch (\Exception $e) {
+    echo $e->getMessage() . "\n";
+}
+?>
+--EXPECT--
+namespaced
+fqn
+backslash
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/multi_catch_rethrow.phpt
+++ b/tests/ph7/001-smoke/lang/multi_catch_rethrow.phpt
@@ -1,0 +1,29 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Multi-catch: rethrow from multi-catch with finally
+--FILE--
+<?php
+class McRethrowA extends Exception {}
+class McRethrowB extends Exception {}
+
+try {
+    try {
+        throw new McRethrowB("rethrown");
+    } catch (McRethrowA | McRethrowB $e) {
+        echo "inner: " . $e->getMessage() . "\n";
+        throw $e;
+    } finally {
+        echo "finally\n";
+    }
+} catch (McRethrowB $e) {
+    echo "outer: " . $e->getMessage() . "\n";
+}
+?>
+--EXPECT--
+inner: rethrown
+finally
+outer: rethrown
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/multi_catch_three_types.phpt
+++ b/tests/ph7/001-smoke/lang/multi_catch_three_types.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Multi-catch: three exception types
+--FILE--
+<?php
+class McThreeA extends Exception {}
+class McThreeB extends Exception {}
+class McThreeC extends Exception {}
+
+try {
+    throw new McThreeC("three");
+} catch (McThreeA | McThreeB | McThreeC $e) {
+    echo $e->getMessage() . "\n";
+}
+?>
+--EXPECT--
+three
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/multi_catch_empty.phpt
+++ b/tests/ph7/002-integration/lang/multi_catch_empty.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Empty catch clause is a parse error
+--FILE--
+<?php
+try {
+    throw new Exception("test");
+} catch () {
+    echo "should not reach here\n";
+}
+?>
+--EXPECTF--
+%s Parse error:  syntax error, unexpected %s %s
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/multi_catch_trailing_pipe.phpt
+++ b/tests/ph7/002-integration/lang/multi_catch_trailing_pipe.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Multi-catch trailing pipe is a parse error
+--FILE--
+<?php
+class McTrailA extends Exception {}
+try {
+    throw new McTrailA("test");
+} catch (McTrailA | $e) {
+    echo "should not reach here\n";
+}
+?>
+--EXPECTF--
+%s Parse error:  syntax error, unexpected %s %s
+--CLEAN--
+<?php


### PR DESCRIPTION
Support catch (ExceptionA | ExceptionB $e) syntax with pipe-separated exception types in a single catch clause.

- Replace SyString sClass with SySet aClasses in ph7_exception_block to store multiple class names
- Parser loops on '|' to collect class names, with PHP-compatible E_PARSE error messages
- VM iterates aClasses per catch block for matching
