### PR TITLE
Implement object type hint (PHP 7.2)

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -4277,6 +4277,8 @@ static sxi32 GenStateCollectFuncArgs(ph7_vm_func *pFunc,ph7_gen_state *pGen,SyTo
 					sArg.nType = MEMOBJ_STRING;
 				}else if( nKey & PH7_TKWRD_FLOAT ){
 					sArg.nType = MEMOBJ_REAL;
+				}else if( nKey & PH7_TKWRD_OBJECT ){
+					sArg.nType = MEMOBJ_OBJ;
 				}else{
 					PH7_GenCompileError(&(*pGen),E_WARNING,pGen->pIn->nLine,
 						"Invalid argument type '%z',Automatic cast will not be performed",
@@ -4363,7 +4365,9 @@ static sxi32 GenStateCollectFuncArgs(ph7_vm_func *pFunc,ph7_gen_state *pGen,SyTo
 		/* Append argument signature */
 		if( sArg.nType > 0 ){
 			if( SyStringLength(&sArg.sClass) > 0 ){
-				/* Class name */
+				/* Class name — prefix with 'o' so generic object hint is a prefix match */
+				int marker = 'o';
+				SyBlobAppend(&sSig,(const void *)&marker,sizeof(char));
 				SyBlobAppend(&sSig,SyStringData(&sArg.sClass),SyStringLength(&sArg.sClass));
 			}else{
 				int c;
@@ -4389,6 +4393,10 @@ static sxi32 GenStateCollectFuncArgs(ph7_vm_func *pFunc,ph7_gen_state *pGen,SyTo
 				case MEMOBJ_STRING:
 					/* String */
 					c = 's';
+					break;
+				case MEMOBJ_OBJ:
+					/* Object */
+					c = 'o';
 					break;
 				default:
 					break;
@@ -4550,6 +4558,8 @@ static void GenStateParseReturnType(ph7_gen_state *pGen, ph7_vm_func *pFunc)
 			pFunc->nReturnType = MEMOBJ_STRING;
 		}else if( nKey & PH7_TKWRD_FLOAT ){
 			pFunc->nReturnType = MEMOBJ_REAL;
+		}else if( nKey & PH7_TKWRD_OBJECT ){
+			pFunc->nReturnType = MEMOBJ_OBJ;
 		}else if( nKey == PH7_TKWRD_SELF || nKey == PH7_TKWRD_PARENT || nKey == PH7_TKWRD_STATIC ){
 			/* self/parent/static — store as class sentinel */
 			GenStateSetReturnClass(pGen, pFunc, pCur->sData.zString, pCur->sData.nByte);

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -649,9 +649,11 @@ static ph7_vm_func * VmOverload(
 			/* Float */
 			c = 'f';
 		}else if( aArg[j].iFlags & MEMOBJ_OBJ ){
-			/* Class instance */
+			/* Class instance — prefix with 'o' to match formal object/class signatures */
+			int marker = 'o';
 			ph7_class *pClass = ((ph7_class_instance *)aArg[j].x.pOther)->pClass;
 			SyString *pName = &pClass->sName;
+			SyBlobAppend(&sSig,(const void *)&marker,sizeof(char));
 			SyBlobAppend(&sSig,(const void *)pName->zString,pName->nByte);
 			c = -1;
 		}
@@ -2492,6 +2494,53 @@ PH7_PRIVATE sxi32 VmErrorFormat(ph7_vm *pVm,sxi32 iErr,const char *zFormat,...)
 	rc = VmThrowErrorAp(&(*pVm),0,iErr,zFormat,ap);
 	va_end(ap);
 	return rc;
+}
+/*
+ * Throw a TypeError exception from within the VM execution loop.
+ * Used for user-defined function type hint violations (e.g. object type hint).
+ */
+static sxi32 VmThrowTypeErrorForArg(ph7_vm *pVm,SyString *pFuncName,sxu32 nArg,SyString *pArgName,const char *zExpected,const char *zGiven)
+{
+	ph7_class *pClass;
+	ph7_class_instance *pThis;
+	ph7_class_method *pCons;
+	ph7_value sArg;
+	ph7_value *apArg[1];
+	SyBlob sMsg;
+	SyString sMsgStr;
+	VmFrame *pFrame;
+	sxi32 rc;
+	pClass = PH7_VmExtractClass(&(*pVm),"TypeError",sizeof("TypeError")-1,TRUE,0);
+	if( pClass == 0 ){
+		return PH7_ABORT;
+	}
+	pThis = PH7_NewClassInstance(&(*pVm),pClass);
+	if( pThis == 0 ){
+		return PH7_ABORT;
+	}
+	SyBlobInit(&sMsg,&pVm->sAllocator);
+	SyBlobFormat(&sMsg,"%z(): Argument #%u ($%z) must be of type %s, %s given",
+		pFuncName,nArg,pArgName,zExpected,zGiven);
+	pCons = PH7_ClassExtractMethod(pClass,"__construct",sizeof("__construct")-1);
+	if( pCons ){
+		SyStringInitFromBuf(&sMsgStr,(const char *)SyBlobData(&sMsg),SyBlobLength(&sMsg));
+		PH7_MemObjInitFromString(&(*pVm),&sArg,&sMsgStr);
+		apArg[0] = &sArg;
+		PH7_VmCallClassMethod(&(*pVm),pThis,pCons,0,1,apArg);
+		PH7_MemObjRelease(&sArg);
+	}
+	SyBlobRelease(&sMsg);
+	pFrame = pVm->pFrame;
+	if( pFrame ){
+		pFrame = VmSkipExceptionFrames(pFrame);
+		pFrame->iFlags |= VM_FRAME_THROW;
+	}
+	rc = VmThrowException(&(*pVm),pThis);
+	PH7_ClassInstanceUnref(pThis);
+	if( rc == SXERR_ABORT ){
+		return PH7_ABORT;
+	}
+	return PH7_EXCEPTION;
 }
 /*
  * Format and throw a run-time error and invoke the supplied VM output consumer callback.
@@ -6539,12 +6588,29 @@ case PH7_OP_CALL: {
 					{
 						ph7_hashmap *pMap = (ph7_hashmap *)pObj->x.pOther;
 						while( pArg < pTos ){
-							/* Apply type coercion to each element if the variadic has a type hint */
+							/* Apply type coercion to each element if the variadic has a type hint.
+							 * Nullable types (?type) allow null through without coercion. */
 							if( aFormalArg[n].nType > 0 && aFormalArg[n].nType != SXU32_HIGH
+								&& !((aFormalArg[n].iFlags & VM_FUNC_ARG_NULLABLE) && (pArg->iFlags & MEMOBJ_NULL))
 								&& (pArg->iFlags & aFormalArg[n].nType) == 0 ){
-								ProcMemObjCast xCast = PH7_MemObjCastMethod(aFormalArg[n].nType);
-								if( xCast ){
-									xCast(pArg);
+								if( aFormalArg[n].nType == MEMOBJ_OBJ ){
+									/* object type hint on variadic: reject non-objects with TypeError */
+									rc = VmThrowTypeErrorForArg(&(*pVm),&pVmFunc->sName,n+1,
+										&aFormalArg[n].sName,"object",ph7_type_name(pArg));
+									if( rc == PH7_ABORT ){
+										goto Abort;
+									}
+									/* Skip function body, route through normal cleanup */
+									PH7_MemObjRelease(pTos);
+									pTos = &pTos[-nCallArgs];
+									pFrameStack = 0;
+									rc = PH7_EXCEPTION;
+									goto SkipFuncBody;
+								}else{
+									ProcMemObjCast xCast = PH7_MemObjCastMethod(aFormalArg[n].nType);
+									if( xCast ){
+										xCast(pArg);
+									}
 								}
 							}
 							PH7_HashmapInsert(pMap, 0, pArg);
@@ -6597,9 +6663,24 @@ case PH7_OP_CALL: {
 							}
 						}
 					}else if( ((pArg->iFlags & aFormalArg[n].nType) == 0) ){
-						ProcMemObjCast xCast = PH7_MemObjCastMethod(aFormalArg[n].nType);
-						/* Cast to the desired type */
-						xCast(pArg);
+						if( aFormalArg[n].nType == MEMOBJ_OBJ ){
+							/* object type hint: reject non-objects with TypeError */
+							rc = VmThrowTypeErrorForArg(&(*pVm),&pVmFunc->sName,n+1,
+								&aFormalArg[n].sName,"object",ph7_type_name(pArg));
+							if( rc == PH7_ABORT ){
+								goto Abort;
+							}
+							/* Skip function body, route through normal cleanup */
+							PH7_MemObjRelease(pTos);
+							pTos = &pTos[-nCallArgs];
+							pFrameStack = 0;
+							rc = PH7_EXCEPTION;
+							goto SkipFuncBody;
+						}else{
+							ProcMemObjCast xCast = PH7_MemObjCastMethod(aFormalArg[n].nType);
+							/* Cast to the desired type */
+							xCast(pArg);
+						}
 					}
 				}
 				if( aFormalArg[n].iFlags & VM_FUNC_ARG_BY_REF ){
@@ -6699,7 +6780,8 @@ case PH7_OP_CALL: {
 					sArg.pUserData = 0;
 					SySetPut(&pFrame->sArg,(const void *)&sArg);
 					/* Make sure the default argument is of the correct type */
-					if( aFormalArg[n].nType > 0 && ((pObj->iFlags & aFormalArg[n].nType) == 0) ){
+					if( aFormalArg[n].nType > 0 && aFormalArg[n].nType != MEMOBJ_OBJ
+						&& ((pObj->iFlags & aFormalArg[n].nType) == 0) ){
 						ProcMemObjCast xCast = PH7_MemObjCastMethod(aFormalArg[n].nType);
 						/* Cast to the desired type */
 						xCast(pObj);
@@ -6724,14 +6806,17 @@ case PH7_OP_CALL: {
 			}
 			break;
 		}
+SkipFuncBody:
 		if( pSelf ){
 			/* Push class name */
 			SySetPut(&pVm->aSelf,(const void *)&pSelf);
 		}
 		/* Increment nesting level */
 		pVm->nRecursionDepth++;
-		/* Execute function body */
-		rc = VmByteCodeExec(&(*pVm),(VmInstr *)SySetBasePtr(&pVmFunc->aByteCode),pFrameStack,-1,pTos,&n,FALSE,0);
+		if( rc != PH7_EXCEPTION ){
+			/* Execute function body */
+			rc = VmByteCodeExec(&(*pVm),(VmInstr *)SySetBasePtr(&pVmFunc->aByteCode),pFrameStack,-1,pTos,&n,FALSE,0);
+		}
 		/* Decrement nesting level */
 		pVm->nRecursionDepth--;
 		if( pSelf ){
@@ -6785,8 +6870,10 @@ case PH7_OP_CALL: {
 				}
 			}
 		}
-		/* Free the operand stack */
-		SyMemBackendFree(&pVm->sAllocator,pFrameStack);
+		/* Free the operand stack (NULL when function body was skipped) */
+		if( pFrameStack ){
+			SyMemBackendFree(&pVm->sAllocator,pFrameStack);
+		}
 		/* Leave the frame */
 		VmLeaveFrame(&(*pVm));
 		if( rc == PH7_ABORT ){

--- a/tests/ph7/001-smoke/lang/object_type_hint.phpt
+++ b/tests/ph7/001-smoke/lang/object_type_hint.phpt
@@ -1,0 +1,57 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Object type hint accepts any object instance
+--FILE--
+<?php
+class ObjHintA { public $name = "ObjHintA"; }
+class ObjHintB extends ObjHintA { public $name = "ObjHintB"; }
+
+function objHintGetName(object $o): string {
+    return get_class($o);
+}
+
+echo objHintGetName(new ObjHintA()) . "\n";
+echo objHintGetName(new ObjHintB()) . "\n";
+
+function objHintIdentity(object $o): object {
+    return $o;
+}
+$objHintResult = objHintIdentity(new ObjHintA());
+echo $objHintResult->name . "\n";
+
+function objHintMaybe(?object $o): string {
+    if ($o === null) return "null";
+    return get_class($o);
+}
+echo objHintMaybe(new ObjHintA()) . "\n";
+echo objHintMaybe(null) . "\n";
+
+function objHintVariadic(object ...$objs): int {
+    return count($objs);
+}
+echo objHintVariadic(new ObjHintA(), new ObjHintB()) . "\n";
+
+function objHintNullableVariadic(?object ...$objs): string {
+    $objHintParts = [];
+    foreach ($objs as $objHintItem) {
+        $objHintParts[] = $objHintItem === null ? "null" : get_class($objHintItem);
+    }
+    return implode(",", $objHintParts);
+}
+echo objHintNullableVariadic(new ObjHintA(), null, new ObjHintB()) . "\n";
+echo objHintNullableVariadic(null, null) . "\n";
+?>
+--EXPECT--
+ObjHintA
+ObjHintB
+ObjHintA
+ObjHintA
+null
+2
+ObjHintA,null,ObjHintB
+null,null
+--CLEAN--
+<?php
+unset($objHintResult);

--- a/tests/ph7/001-smoke/lang/object_type_hint_overload.phpt
+++ b/tests/ph7/001-smoke/lang/object_type_hint_overload.phpt
@@ -1,0 +1,26 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Object type hint selects correct overload
+--SKIPIF--
+<?php if (function_exists('zend_version')) echo 'skip'; ?>
+--FILE--
+<?php
+class ObjOverA {}
+
+function objOverDispatch(object $o) { return "object"; }
+function objOverDispatch(string $s) { return "string"; }
+function objOverDispatch(int $i)    { return "int"; }
+
+echo objOverDispatch(new ObjOverA()) . "\n";
+echo objOverDispatch("hello") . "\n";
+echo objOverDispatch(42) . "\n";
+?>
+--EXPECT--
+object
+string
+int
+--CLEAN--
+<?php
+

--- a/tests/ph7/002-integration/lang/object_type_hint_reject.phpt
+++ b/tests/ph7/002-integration/lang/object_type_hint_reject.phpt
@@ -1,0 +1,41 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Object type hint rejects non-object arguments with TypeError
+--FILE--
+<?php
+function objHintTakesObject(object $o) {
+    var_dump($o);
+}
+
+function objHintShowTypeError(TypeError $e) {
+    $msg = $e->getMessage();
+    $pos = strpos($msg, ", called in");
+    if ($pos !== false) $msg = substr($msg, 0, $pos);
+    echo $msg . "\n";
+}
+
+try { objHintTakesObject("hello"); } catch (TypeError $e) { objHintShowTypeError($e); }
+try { objHintTakesObject(42); } catch (TypeError $e) { objHintShowTypeError($e); }
+try { objHintTakesObject([1,2,3]); } catch (TypeError $e) { objHintShowTypeError($e); }
+try { objHintTakesObject(null); } catch (TypeError $e) { objHintShowTypeError($e); }
+
+try {
+    objHintTakesObject("skip rest");
+    echo "FAIL: should not reach here\n";
+} catch (TypeError $e) {
+    echo "caught\n";
+}
+echo "continues after try/catch\n";
+?>
+--EXPECT--
+objHintTakesObject(): Argument #1 ($o) must be of type object, string given
+objHintTakesObject(): Argument #1 ($o) must be of type object, int given
+objHintTakesObject(): Argument #1 ($o) must be of type object, array given
+objHintTakesObject(): Argument #1 ($o) must be of type object, null given
+caught
+continues after try/catch
+--CLEAN--
+<?php
+


### PR DESCRIPTION
Add support for the generic `object` type hint in function parameters and return types. Non-objects are rejected with a TypeError rather than auto-cast to stdClass, matching PHP semantics.
