### PR TITLE
Implement trailing comma support in function calls (PHP 7.3)

### DIFF
--- a/src/ph7/parse.c
+++ b/src/ph7/parse.c
@@ -1008,15 +1008,18 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 				/* Put a pointer to the root of the tree in the arguments set */
 				SySetPut(&pOp->aNodeArgs,(const void *)&apNode[iNode]);
 			}else{
-				/* Empty function argument */
-				rc = PH7_GenCompileError(&(*pGen),E_ERROR,pOp->pStart->nLine,"Empty function argument");
+				/* No expression before comma */
+				rc = PH7_GenCompileError(&(*pGen),E_PARSE,
+					(iCur < nToken && apNode[iCur]) ? apNode[iCur]->pStart->nLine : pOp->pStart->nLine,
+					"syntax error, unexpected token \",\"");
 				if( rc != SXERR_ABORT ){
 					rc = SXERR_SYNTAX;
 				}
 				return rc;
 			}
 		}else{
-			rc = PH7_GenCompileError(&(*pGen),E_ERROR,pOp->pStart->nLine,"Missing function argument");
+			/* Comma with no preceding argument */
+			rc = PH7_GenCompileError(&(*pGen),E_PARSE,apNode[iCur]->pStart->nLine,"syntax error, unexpected token \",\"");
 			if( rc != SXERR_ABORT ){
 				rc = SXERR_SYNTAX;
 			}
@@ -1026,12 +1029,8 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 		if( iCur < nToken && apNode[iCur] && (apNode[iCur]->pStart->nType & PH7_TK_COMMA) ){
 			iCur++;
 			if( iCur >= nToken ){
-				/* missing function argument */
-				rc = PH7_GenCompileError(&(*pGen),E_ERROR,pOp->pStart->nLine,"Missing function argument");
-				if( rc != SXERR_ABORT ){
-					rc = SXERR_SYNTAX;
-				}
-				return rc;
+				/* Trailing comma after last argument */
+				break;
 			}
 		}
 	}

--- a/tests/ph7/001-smoke/lang/trailing_comma_closure_use.phpt
+++ b/tests/ph7/001-smoke/lang/trailing_comma_closure_use.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Trailing comma in closure use list
+--FILE--
+<?php
+$x = 10;
+$y = 20;
+$f = function() use ($x, $y,) { return $x + $y; };
+echo $f() . "\n";
+?>
+--EXPECT--
+30
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/trailing_comma_constructor_call.phpt
+++ b/tests/ph7/001-smoke/lang/trailing_comma_constructor_call.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Trailing comma in constructor call
+--FILE--
+<?php
+class TcCcPoint {
+    public $x;
+    public $y;
+    function __construct($x, $y) { $this->x = $x; $this->y = $y; }
+}
+$p = new TcCcPoint(1, 2,);
+echo $p->x . "\n";
+echo $p->y . "\n";
+?>
+--EXPECT--
+1
+2
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/trailing_comma_function_call.phpt
+++ b/tests/ph7/001-smoke/lang/trailing_comma_function_call.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Trailing comma in function call arguments
+--FILE--
+<?php
+function tcFcAdd($a, $b, $c) { return $a + $b + $c; }
+echo tcFcAdd(1, 2, 3,) . "\n";
+echo tcFcAdd(10, 20, 30,) . "\n";
+?>
+--EXPECT--
+6
+60
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/trailing_comma_isset_call.phpt
+++ b/tests/ph7/001-smoke/lang/trailing_comma_isset_call.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Trailing comma in isset() and unset() calls
+--FILE--
+<?php
+$a = 1;
+echo isset($a,) ? "yes" : "no";
+echo "\n";
+unset($a,);
+echo isset($a) ? "yes" : "no";
+echo "\n";
+?>
+--EXPECT--
+yes
+no
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/trailing_comma_method_call.phpt
+++ b/tests/ph7/001-smoke/lang/trailing_comma_method_call.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Trailing comma in method and static method calls
+--FILE--
+<?php
+class TcMcCalc {
+    public function sum($a, $b) { return $a + $b; }
+    public static function mul($a, $b) { return $a * $b; }
+}
+$c = new TcMcCalc();
+echo $c->sum(3, 4,) . "\n";
+echo TcMcCalc::mul(5, 6,) . "\n";
+?>
+--EXPECT--
+7
+30
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/trailing_comma_param_declaration.phpt
+++ b/tests/ph7/001-smoke/lang/trailing_comma_param_declaration.phpt
@@ -2,12 +2,16 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-Missing function argument
+Trailing comma in function parameter declaration
 --FILE--
 <?php
-function foo($a,) { }
+function tcPdFoo($a,) { echo $a . "\n"; }
+tcPdFoo(1);
+function tcPdBar($a, $b,) { echo ($a + $b) . "\n"; }
+tcPdBar(2, 3);
 ?>
 --EXPECT--
+1
+5
 --CLEAN--
 <?php
-

--- a/tests/ph7/001-smoke/lang/trailing_comma_single_arg_call.phpt
+++ b/tests/ph7/001-smoke/lang/trailing_comma_single_arg_call.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Trailing comma in single-argument function call
+--FILE--
+<?php
+function tcSaIdentity($x) { return $x; }
+echo tcSaIdentity(42,) . "\n";
+?>
+--EXPECT--
+42
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/error/empty_function_argument.phpt
+++ b/tests/ph7/002-integration/error/empty_function_argument.phpt
@@ -3,14 +3,11 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Syntax error: Empty function argument
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 func(, 2);
 ?>
 --EXPECTF--
-%s Fatal error:  Missing function argument %s
+%s Parse error:  syntax error, unexpected token ","
 --CLEAN--
 <?php
-

--- a/tests/ph7/002-integration/lang/trailing_comma_call_double.phpt
+++ b/tests/ph7/002-integration/lang/trailing_comma_call_double.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Double comma in function call is a parse error
+--FILE--
+<?php
+function tcCdFoo($a, $b) { }
+tcCdFoo(1,,);
+?>
+--EXPECTF--
+%s Parse error:  syntax error, unexpected token ","
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/trailing_comma_call_leading.phpt
+++ b/tests/ph7/002-integration/lang/trailing_comma_call_leading.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Leading comma in function call is a parse error
+--FILE--
+<?php
+function tcClFoo($a) { }
+tcClFoo(,);
+?>
+--EXPECTF--
+%s Parse error:  syntax error, unexpected token ","
+--CLEAN--
+<?php


### PR DESCRIPTION
Allow trailing commas in function/method call argument lists by replacing the error at the end of ExprProcessFuncArguments() with a loop break. Invalid cases (leading comma, double comma) are still caught by earlier error paths. Also aligns error messages for invalid comma usage to PHP's "syntax error, unexpected token" format using E_PARSE, removing SKIPIF from the existing empty_function_argument test.
