### PR TITLE
Implement numeric literal separators (PHP 7.4)

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -413,6 +413,152 @@ static ph7_value * GenStateInstallNumLiteral(ph7_gen_state *pGen,sxu32 *pIdx)
 /* Forward declaration */
 static sxi32 GenStateCompileChunk(ph7_gen_state *pGen,sxi32 iFlags);
 /*
+ * Stack-scratch size for stripping PHP 7.4 numeric separators. A typical
+ * literal (INT64_MAX decimal is 19 digits, binary 64-bit with per-nibble
+ * separators is ~80 chars) fits comfortably, so the fast path never touches
+ * the heap. The language itself imposes no upper bound on the length of a
+ * well-formed literal — the stripper falls back to a VM-allocator buffer
+ * for anything larger, so correctness is preserved even for pathological
+ * inputs like a thousand-digit number.
+ */
+#define GEN_NUM_SCRATCH 128
+/*
+ * Return TRUE if c is a valid digit for the given numeric base.
+ *   base 16 => SyisHex (0-9, a-f, A-F)
+ *   base  2 => 0 or 1
+ *   base 10 => SyisDigit (0-9, also used for octal literals which share the
+ *              decimal scan in the lexer)
+ */
+static int GenStateIsBaseDigit(int c, int base)
+{
+	if( base == 16 ){ return SyisHex(c); }
+	if( base == 2 ){ return c == '0' || c == '1'; }
+	return SyisDigit(c);
+}
+/*
+ * Given the raw text of a numeric literal token, locate a misplaced PHP 7.4
+ * underscore separator so the caller can report the malformed portion with
+ * the exact wording PHP uses:
+ *
+ *   syntax error, unexpected identifier "X"
+ *
+ * The lexer guarantees that every underscore it consumed as a separator is
+ * surrounded by valid base digits; anything else sits in the trailing run
+ * absorbed by the lexer specifically to let this validator see and report
+ * it. That invariant means the malformed span is exactly [bad .. nByte) —
+ * no forward rescan needed.
+ *
+ * Returns 1 and fills pBadStart / pBadLen when the literal is malformed;
+ * returns 0 when it is well-formed.
+ */
+static int GenStateFindBadNumericSeparator(
+	const SyString *pRaw, const char **pBadStart, sxu32 *pBadLen)
+{
+	const char *z = pRaw->zString;
+	sxu32 n = pRaw->nByte;
+	int base = 10;
+	sxu32 i, start;
+	if( n < 2 ) return 0;
+	if( z[0] == '0' && (z[1] == 'x' || z[1] == 'X') ){
+		base = 16;
+	}else if( z[0] == '0' && (z[1] == 'b' || z[1] == 'B') ){
+		base = 2;
+	}
+	for( i = 0; i < n; ++i ){
+		if( z[i] != '_' ) continue;
+		if( i > 0 && i + 1 < n
+			&& GenStateIsBaseDigit((unsigned char)z[i-1], base)
+			&& GenStateIsBaseDigit((unsigned char)z[i+1], base) ){
+			continue; /* well-placed separator */
+		}
+		/* First misplaced underscore — the lexer already absorbed the full
+		 * malformed tail, so it runs from here to the end of the token. */
+		start = i;
+		if( start > 0 && (z[start-1] == 'x' || z[start-1] == 'X'
+			|| z[start-1] == 'b' || z[start-1] == 'B') ){
+			start--; /* include the base letter for 0x_... / 0b_... */
+		}
+		*pBadStart = &z[start];
+		*pBadLen = n - start;
+		return 1;
+	}
+	return 0;
+}
+/*
+ * Emit the shared "syntax error, unexpected identifier" parse error when a
+ * numeric-literal token contains a misplaced PHP 7.4 separator. Returns
+ * SXRET_OK when the token is well-formed; on error propagates whatever
+ * PH7_GenCompileError returned (SXERR_ABORT when the error count is
+ * exhausted, otherwise the error is reported and SXERR_SYNTAX is returned
+ * so callers can bail from the current construct).
+ */
+static sxi32 GenStateValidateNumericSeparator(ph7_gen_state *pGen, SyToken *pToken)
+{
+	const char *zBad = 0;
+	sxu32 nBad = 0;
+	SyString sBad;
+	sxi32 rc;
+	if( !GenStateFindBadNumericSeparator(&pToken->sData, &zBad, &nBad) ){
+		return SXRET_OK;
+	}
+	SyStringInitFromBuf(&sBad, zBad, nBad);
+	rc = PH7_GenCompileError(pGen, E_PARSE, pToken->nLine,
+		"syntax error, unexpected identifier \"%z\"", &sBad);
+	if( rc == SXERR_ABORT ){
+		return SXERR_ABORT;
+	}
+	return SXERR_SYNTAX;
+}
+/*
+ * Strip PHP 7.4 numeric literal separators (underscores between digits) from
+ * a numeric token's text and yield a SyString suitable for the low-level
+ * converters (SyStrToInt64 / SyStrToReal / etc.).
+ *
+ * Fast path: if the token contains no '_', *pOut aliases pToken with no copy
+ * and *pzAlloc is set to NULL.
+ * Stack path: if the cleaned bytes fit in zScratch, they are written there
+ * and *pzAlloc is set to NULL.
+ * Heap path: for literals larger than the scratch buffer, a fresh buffer is
+ * allocated from pAlloc, returned via *pzAlloc, and must be released by the
+ * caller with SyMemBackendFree once the converter is done.
+ *
+ * Returns SXRET_OK on success, SXERR_ABORT on allocator failure (in which
+ * case *pOut is left untouched and the caller must not read it).
+ */
+static sxi32 GenStateStripNumericSeparators(
+	SyMemBackend *pAlloc,
+	const SyString *pToken,
+	char *zScratch, sxu32 nScratch,
+	SyString *pOut, char **pzAlloc)
+{
+	sxu32 i, j;
+	int hasUnderscore = 0;
+	char *zBuf;
+	*pzAlloc = 0;
+	for( i = 0; i < pToken->nByte; ++i ){
+		if( pToken->zString[i] == '_' ){ hasUnderscore = 1; break; }
+	}
+	if( !hasUnderscore ){
+		SyStringDupPtr(pOut, pToken);
+		return SXRET_OK;
+	}
+	if( pToken->nByte <= nScratch ){
+		zBuf = zScratch;
+	}else{
+		zBuf = (char *)SyMemBackendAlloc(pAlloc, pToken->nByte);
+		if( zBuf == 0 ){
+			return SXERR_ABORT;
+		}
+		*pzAlloc = zBuf;
+	}
+	j = 0;
+	for( i = 0; i < pToken->nByte; ++i ){
+		if( pToken->zString[i] != '_' ){ zBuf[j++] = pToken->zString[i]; }
+	}
+	SyStringInitFromBuf(pOut, zBuf, j);
+	return SXRET_OK;
+}
+/*
  * Compile a numeric [i.e: integer or real] literal.
  * Notes on the integer type.
  *  According to the PHP language reference manual
@@ -432,13 +578,27 @@ static sxi32 PH7_CompileNumLiteral(ph7_gen_state *pGen,sxi32 iCompileFlag)
 {
 	SyToken *pToken = pGen->pIn; /* Raw token */
 	sxu32 nIdx = 0;
+	char zScratch[GEN_NUM_SCRATCH];
+	char *zAlloc = 0;
+	SyString sNum;
+	sxi32 rc;
+	SXUNUSED(iCompileFlag); /* cc warning */
+	rc = GenStateValidateNumericSeparator(pGen, pToken);
+	if( rc != SXRET_OK ){
+		return rc;
+	}
+	rc = GenStateStripNumericSeparators(&pGen->pVm->sAllocator, &pToken->sData,
+		zScratch, sizeof(zScratch), &sNum, &zAlloc);
+	if( rc != SXRET_OK ){
+		return SXERR_ABORT;
+	}
 	if( pToken->nType & PH7_TK_INTEGER ){
 		ph7_value *pObj;
 		sxi64 iValue;
-		iValue = PH7_TokenValueToInt64(&pToken->sData);
+		iValue = PH7_TokenValueToInt64(&sNum);
 		pObj = GenStateInstallNumLiteral(&(*pGen),&nIdx);
 		if( pObj == 0 ){
-			SXUNUSED(iCompileFlag); /* cc warning */
+			if( zAlloc ){ SyMemBackendFree(&pGen->pVm->sAllocator, zAlloc); }
 			return SXERR_ABORT;
 		}
 		PH7_MemObjInitFromInt(pGen->pVm,pObj,iValue);
@@ -449,11 +609,13 @@ static sxi32 PH7_CompileNumLiteral(ph7_gen_state *pGen,sxi32 iCompileFlag)
 		pObj = PH7_ReserveConstObj(pGen->pVm,&nIdx);
 		if( pObj == 0 ){
 			PH7_GenCompileError(&(*pGen),E_ERROR,1,"PH7 engine is running out of memory");
+			if( zAlloc ){ SyMemBackendFree(&pGen->pVm->sAllocator, zAlloc); }
 			return SXERR_ABORT;
 		}
-		PH7_MemObjInitFromString(pGen->pVm,pObj,&pToken->sData);
+		PH7_MemObjInitFromString(pGen->pVm,pObj,&sNum);
 		PH7_MemObjToReal(pObj);
 	}
+	if( zAlloc ){ SyMemBackendFree(&pGen->pVm->sAllocator, zAlloc); }
 	/* Emit the load constant instruction */
 	PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOADC,0,nIdx,0,0);
 	/* Node successfully compiled */
@@ -2018,7 +2180,22 @@ static sxi32 PH7_CompileContinue(ph7_gen_state *pGen)
 		/* optional numeric argument which tells us how many levels
 		 * of enclosing loops we should skip to the end of.
 		 */
-		iLevel = (sxi32)PH7_TokenValueToInt64(&pGen->pIn->sData);
+		char zScratch[GEN_NUM_SCRATCH];
+		char *zAlloc = 0;
+		SyString sNum;
+		rc = GenStateValidateNumericSeparator(pGen, pGen->pIn);
+		if( rc == SXERR_ABORT ){
+			return SXERR_ABORT;
+		}
+		if( rc == SXRET_OK ){
+			rc = GenStateStripNumericSeparators(&pGen->pVm->sAllocator,
+				&pGen->pIn->sData, zScratch, sizeof(zScratch), &sNum, &zAlloc);
+			if( rc != SXRET_OK ){
+				return SXERR_ABORT;
+			}
+			iLevel = (sxi32)PH7_TokenValueToInt64(&sNum);
+			if( zAlloc ){ SyMemBackendFree(&pGen->pVm->sAllocator, zAlloc); }
+		}
 		if( iLevel < 2 ){
 			iLevel = 0;
 		}
@@ -2086,7 +2263,22 @@ static sxi32 PH7_CompileBreak(ph7_gen_state *pGen)
 		/* optional numeric argument which tells us how many levels
 		 * of enclosing loops we should skip to the end of.
 		 */
-		iLevel = (sxi32)PH7_TokenValueToInt64(&pGen->pIn->sData);
+		char zScratch[GEN_NUM_SCRATCH];
+		char *zAlloc = 0;
+		SyString sNum;
+		rc = GenStateValidateNumericSeparator(pGen, pGen->pIn);
+		if( rc == SXERR_ABORT ){
+			return SXERR_ABORT;
+		}
+		if( rc == SXRET_OK ){
+			rc = GenStateStripNumericSeparators(&pGen->pVm->sAllocator,
+				&pGen->pIn->sData, zScratch, sizeof(zScratch), &sNum, &zAlloc);
+			if( rc != SXRET_OK ){
+				return SXERR_ABORT;
+			}
+			iLevel = (sxi32)PH7_TokenValueToInt64(&sNum);
+			if( zAlloc ){ SyMemBackendFree(&pGen->pVm->sAllocator, zAlloc); }
+		}
 		if( iLevel < 2 ){
 			iLevel = 0;
 		}

--- a/src/ph7/lex.c
+++ b/src/ph7/lex.c
@@ -122,19 +122,43 @@ static sxi32 TokenizePHP(SyStream *pStream,SyToken *pToken,void *pUserData,void 
 			return SXERR_CONTINUE;
 		}else if( SyisDigit(pStream->zText[0]) ){
 			pStream->zText++;
-			/* Decimal digit stream */
+			/* PHP 7.4: handle underscore separator immediately following the first digit.
+			 * Check pStream->zText < pStream->zEnd BEFORE forming pStream->zText + 1 so
+			 * we never compute a pointer past one-past-end. */
+			if( pStream->zText < pStream->zEnd
+				&& pStream->zText[0] == '_'
+				&& pStream->zText + 1 < pStream->zEnd
+				&& pStream->zText[1] < 0xc0
+				&& SyisDigit(pStream->zText[1]) ){
+				pStream->zText++; /* swallow underscore between two digits */
+			}
+			/* Decimal digit stream (PHP 7.4: underscore separator allowed between two digits) */
 			while( pStream->zText < pStream->zEnd && pStream->zText[0] < 0xc0 && SyisDigit(pStream->zText[0]) ){
 				pStream->zText++;
+				if( pStream->zText < pStream->zEnd
+					&& pStream->zText[0] == '_'
+					&& pStream->zText + 1 < pStream->zEnd
+					&& pStream->zText[1] < 0xc0
+					&& SyisDigit(pStream->zText[1]) ){
+					pStream->zText++; /* swallow underscore between two digits */
+				}
 			}
 			/* Mark the token as integer until we encounter a real number */
 			pToken->nType = PH7_TK_INTEGER;
 			if( pStream->zText < pStream->zEnd ){
 				c = pStream->zText[0];
 				if( c == '.' ){
-					/* Real number */
+					/* Real number (PHP 7.4: underscore separator allowed between two digits) */
 					pStream->zText++;
 					while( pStream->zText < pStream->zEnd && pStream->zText[0] < 0xc0 && SyisDigit(pStream->zText[0]) ){
 						pStream->zText++;
+						if( pStream->zText < pStream->zEnd
+							&& pStream->zText[0] == '_'
+							&& pStream->zText + 1 < pStream->zEnd
+							&& pStream->zText[1] < 0xc0
+							&& SyisDigit(pStream->zText[1]) ){
+							pStream->zText++;
+						}
 					}
 					if( pStream->zText < pStream->zEnd ){
 						c = pStream->zText[0];
@@ -148,6 +172,13 @@ static sxi32 TokenizePHP(SyStream *pStream,SyToken *pToken,void *pUserData,void 
 								}
 								while( pStream->zText < pStream->zEnd && pStream->zText[0] < 0xc0 && SyisDigit(pStream->zText[0]) ){
 									pStream->zText++;
+									if( pStream->zText < pStream->zEnd
+										&& pStream->zText[0] == '_'
+										&& pStream->zText + 1 < pStream->zEnd
+										&& pStream->zText[1] < 0xc0
+										&& SyisDigit(pStream->zText[1]) ){
+										pStream->zText++;
+									}
 								}
 							}
 						}
@@ -165,21 +196,53 @@ static sxi32 TokenizePHP(SyStream *pStream,SyToken *pToken,void *pUserData,void 
 						}
 						while( pStream->zText < pStream->zEnd && pStream->zText[0] < 0xc0 && SyisDigit(pStream->zText[0]) ){
 							pStream->zText++;
+							if( pStream->zText < pStream->zEnd
+								&& pStream->zText[0] == '_'
+								&& pStream->zText + 1 < pStream->zEnd
+								&& pStream->zText[1] < 0xc0
+								&& SyisDigit(pStream->zText[1]) ){
+								pStream->zText++;
+							}
 						}
 					}
 					pToken->nType = PH7_TK_REAL;
 				}else if( c == 'x' || c == 'X' ){
-					/* Hex digit stream */
+					/* Hex digit stream (PHP 7.4: underscore separator allowed between two digits) */
 					pStream->zText++;
 					while( pStream->zText < pStream->zEnd && pStream->zText[0] < 0xc0 && SyisHex(pStream->zText[0]) ){
 						pStream->zText++;
+						if( pStream->zText < pStream->zEnd
+							&& pStream->zText[0] == '_'
+							&& pStream->zText + 1 < pStream->zEnd
+							&& pStream->zText[1] < 0xc0
+							&& SyisHex(pStream->zText[1]) ){
+							pStream->zText++;
+						}
 					}
 				}else if(c  == 'b' || c == 'B' ){
-					/* Binary digit stream */
+					/* Binary digit stream (PHP 7.4: underscore separator allowed between two digits) */
 					pStream->zText++;
 					while( pStream->zText < pStream->zEnd && (pStream->zText[0] == '0' || pStream->zText[0] == '1') ){
 						pStream->zText++;
+						if( pStream->zText < pStream->zEnd
+							&& pStream->zText[0] == '_'
+							&& pStream->zText + 1 < pStream->zEnd
+							&& (pStream->zText[1] == '0' || pStream->zText[1] == '1') ){
+							pStream->zText++;
+						}
 					}
+				}
+			}
+			/* PHP 7.4: absorb a trailing malformed underscore run into the
+			 * numeric token so the compile phase can emit a PHP-compatible
+			 * "syntax error, unexpected identifier" parse error. Valid
+			 * separators were already consumed by the per-loop peek logic
+			 * above, so an underscore here is always misplaced. */
+			if( pStream->zText < pStream->zEnd && pStream->zText[0] == '_' ){
+				pStream->zText++;
+				while( pStream->zText < pStream->zEnd && pStream->zText[0] < 0xc0
+					&& (SyisAlphaNum(pStream->zText[0]) || pStream->zText[0] == '_') ){
+					pStream->zText++;
 				}
 			}
 			/* Record token length */

--- a/tests/ph7/001-smoke/lang/numeric_separator_arithmetic.phpt
+++ b/tests/ph7/001-smoke/lang/numeric_separator_arithmetic.phpt
@@ -1,0 +1,32 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Numeric literal separator arithmetic operations
+--FILE--
+<?php
+echo 1_000 + 2_000 . "\n";
+echo 5_000 - 1_000 . "\n";
+echo 1_000 * 3 . "\n";
+echo 10_000 / 2_5 . "\n";
+echo 1_0 % 3 . "\n";
+echo 0xFF_FF + 1 . "\n";
+echo 0b1_0 * 0b1_0 . "\n";
+echo -1_000 . "\n";
+echo +1_000 . "\n";
+echo 1_000.5 + 0.5 . "\n";
+?>
+--EXPECT--
+3000
+4000
+3000
+400
+1
+65536
+4
+-1000
+1000
+1001
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/lang/numeric_separator_array.phpt
+++ b/tests/ph7/001-smoke/lang/numeric_separator_array.phpt
@@ -1,0 +1,33 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Numeric literal separator in array literals
+--FILE--
+<?php
+$arr = [1_000, 2_000, 3_000];
+echo $arr[0] . "\n";
+echo $arr[1] . "\n";
+echo $arr[2] . "\n";
+$keyed = [1_000 => 'a', 2_000 => 'b', 0xFF_FF => 'c'];
+echo $keyed[1000] . "\n";
+echo $keyed[2000] . "\n";
+echo $keyed[65535] . "\n";
+$mixed = [0b1_0 => 'two', 0_755 => 'octal', 0xCAFE_F00D => 'cafe'];
+echo $mixed[2] . "\n";
+echo $mixed[493] . "\n";
+echo $mixed[3405705229] . "\n";
+?>
+--EXPECT--
+1000
+2000
+3000
+a
+b
+c
+two
+octal
+cafe
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/lang/numeric_separator_assignment.phpt
+++ b/tests/ph7/001-smoke/lang/numeric_separator_assignment.phpt
@@ -1,0 +1,36 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Numeric literal separator in assignment expressions
+--FILE--
+<?php
+$a = 1_000;
+echo $a . "\n";
+$a += 2_000;
+echo $a . "\n";
+$a -= 1_500;
+echo $a . "\n";
+$a *= 1_0;
+echo $a . "\n";
+$a /= 5_0;
+echo $a . "\n";
+$b = 0xFF_FF;
+echo $b . "\n";
+$c = 0b1010_1010;
+echo $c . "\n";
+$d = 1_234.567;
+echo $d . "\n";
+?>
+--EXPECT--
+1000
+3000
+1500
+15000
+300
+65535
+170
+1234.567
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/lang/numeric_separator_basic.phpt
+++ b/tests/ph7/001-smoke/lang/numeric_separator_basic.phpt
@@ -1,0 +1,30 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Numeric literal separator basic values
+--FILE--
+<?php
+echo 1_000 . "\n";
+echo 1_000_000 . "\n";
+echo 1_2_3 . "\n";
+echo 100_000_000 . "\n";
+echo 1_2 . "\n";
+echo 999_999_999 . "\n";
+echo (int)(1_000 === 1000) . "\n";
+echo (int)(1_000_000 === 1000000) . "\n";
+echo (int)(1_2_3 === 123) . "\n";
+?>
+--EXPECT--
+1000
+1000000
+123
+100000000
+12
+999999999
+1
+1
+1
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/lang/numeric_separator_binary.phpt
+++ b/tests/ph7/001-smoke/lang/numeric_separator_binary.phpt
@@ -1,0 +1,28 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Numeric literal separator in binary literals
+--FILE--
+<?php
+echo 0b1010_1010 . "\n";
+echo 0b1_1_1_1 . "\n";
+echo 0b1111_0000 . "\n";
+echo 0b1111_1111_1111_1111 . "\n";
+echo 0B1010_0101 . "\n";
+echo (int)(0b1010_1010 === 0b10101010) . "\n";
+echo (int)(0b1_1_1_1 === 0b1111) . "\n";
+echo (int)(0b1111_0000 === 0b11110000) . "\n";
+?>
+--EXPECT--
+170
+15
+240
+65535
+165
+1
+1
+1
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/lang/numeric_separator_comparison.phpt
+++ b/tests/ph7/001-smoke/lang/numeric_separator_comparison.phpt
@@ -1,0 +1,32 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Numeric literal separator comparison operators
+--FILE--
+<?php
+echo (int)(1_000 === 1000) . "\n";
+echo (int)(1_000 == 1000) . "\n";
+echo (int)(1_000 !== 999) . "\n";
+echo (int)(0xFF_FF === 0xFFFF) . "\n";
+echo (int)(0b1_0 === 2) . "\n";
+echo (int)(0_755 === 493) . "\n";
+echo (int)(1_000 < 2_000) . "\n";
+echo (int)(2_000 > 1_000) . "\n";
+echo (int)(1_000 <= 1_000) . "\n";
+echo (int)(1_000.5 == 1000.5) . "\n";
+?>
+--EXPECT--
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/lang/numeric_separator_exponent.phpt
+++ b/tests/ph7/001-smoke/lang/numeric_separator_exponent.phpt
@@ -1,0 +1,28 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Numeric literal separator in exponent notation
+--FILE--
+<?php
+echo 1e1_0 . "\n";
+echo 1_0e5 . "\n";
+echo 1.5e1_0 . "\n";
+echo 2.5_5e+1_0 . "\n";
+echo 1_000e-3 . "\n";
+echo (int)(1e1_0 === 1e10) . "\n";
+echo (int)(1_0e5 === 10e5) . "\n";
+echo (int)(1.5e1_0 === 1.5e10) . "\n";
+?>
+--EXPECT--
+10000000000
+1000000
+15000000000
+25500000000
+1
+1
+1
+1
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/lang/numeric_separator_float.phpt
+++ b/tests/ph7/001-smoke/lang/numeric_separator_float.phpt
@@ -1,0 +1,28 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Numeric literal separator in float literals
+--FILE--
+<?php
+echo 1_000.50 . "\n";
+echo 3.141_59 . "\n";
+echo 1_234.567_89 . "\n";
+echo 0.123_456 . "\n";
+echo 1_000.0 . "\n";
+echo (int)(1_000.50 === 1000.50) . "\n";
+echo (int)(3.141_59 === 3.14159) . "\n";
+echo (int)(1_234.567_89 === 1234.56789) . "\n";
+?>
+--EXPECT--
+1000.5
+3.14159
+1234.56789
+0.123456
+1000
+1
+1
+1
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/lang/numeric_separator_function.phpt
+++ b/tests/ph7/001-smoke/lang/numeric_separator_function.phpt
@@ -1,0 +1,39 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Numeric literal separator in function arguments and return values
+--FILE--
+<?php
+function withDefault($x = 1_000) {
+    return $x;
+}
+echo withDefault() . "\n";
+echo withDefault(2_500) . "\n";
+
+function double($n) {
+    return $n * 2;
+}
+echo double(1_000) . "\n";
+echo double(0xFF_FF) . "\n";
+
+function returnsLarge() {
+    return 1_000_000;
+}
+echo returnsLarge() . "\n";
+
+function sumThree($a, $b, $c) {
+    return $a + $b + $c;
+}
+echo sumThree(1_000, 2_000, 3_000) . "\n";
+?>
+--EXPECT--
+1000
+2500
+2000
+131070
+1000000
+6000
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/lang/numeric_separator_hex.phpt
+++ b/tests/ph7/001-smoke/lang/numeric_separator_hex.phpt
@@ -1,0 +1,28 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Numeric literal separator in hexadecimal literals
+--FILE--
+<?php
+echo 0xCAFE_F00D . "\n";
+echo 0xFF_FF . "\n";
+echo 0x1_2_3_4 . "\n";
+echo 0xDEAD_BEEF . "\n";
+echo 0X00_FF . "\n";
+echo (int)(0xFF_FF === 0xFFFF) . "\n";
+echo (int)(0xCAFE_F00D === 0xCAFEF00D) . "\n";
+echo (int)(0x1_2_3_4 === 0x1234) . "\n";
+?>
+--EXPECT--
+3405705229
+65535
+4660
+3735928559
+255
+1
+1
+1
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/lang/numeric_separator_large_values.phpt
+++ b/tests/ph7/001-smoke/lang/numeric_separator_large_values.phpt
@@ -1,0 +1,37 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Numeric literal separator with large values
+--FILE--
+<?php
+echo 9_223_372_036_854_775_807 . "\n";
+echo 1_000_000_000_000 . "\n";
+echo 0x7FFF_FFFF_FFFF_FFFF . "\n";
+echo 0b1111_1111_1111_1111_1111_1111_1111_1111 . "\n";
+echo (int)(9_223_372_036_854_775_807 === PHP_INT_MAX) . "\n";
+echo (int)(1_000_000_000_000 === 1000000000000) . "\n";
+// 63-bit binary literal with every-3-bit separator is ~85 chars, inside the
+// compile-time stripper's 128-byte stack scratch.
+echo 0b111_111_111_111_111_111_111_111_111_111_111_111_111_111_111_111_111_111_111_111_111 . "\n";
+echo (int)(0b111_111_111_111_111_111_111_111_111_111_111_111_111_111_111_111_111_111_111_111_111 === PHP_INT_MAX) . "\n";
+// 200-digit decimal literal with separators overflows the 128-byte stack
+// scratch and exercises the stripper's heap-allocation fallback path. The
+// int64 parser saturates at the representable range, which is fine — we
+// only care that the long literal is accepted and stripped without crashing
+// or silently dropping the underscore-rejected low bits.
+echo (int)(1_234_567_890_123_456_789_012_345_678_901_234_567_890_123_456_789_012_345_678_901_234_567_890_123_456_789_012_345_678_901_234_567_890_123_456_789_012_345_678_901_234_567_890_123_456_789_012_345_678_901_234_567_890 > 0) . "\n";
+?>
+--EXPECT--
+9223372036854775807
+1000000000000
+9223372036854775807
+4294967295
+1
+1
+9223372036854775807
+1
+1
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/lang/numeric_separator_loop_levels.phpt
+++ b/tests/ph7/001-smoke/lang/numeric_separator_loop_levels.phpt
@@ -1,0 +1,26 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Numeric literal separator in break/continue level arguments
+--FILE--
+<?php
+// Underscored level argument on break/continue
+for ($i = 0; $i < 3; $i++) {
+    for ($j = 0; $j < 3; $j++) {
+        if ($j === 1) {
+            continue 0_2;
+        }
+        if ($i === 2 && $j === 0) {
+            break 0_2;
+        }
+        echo "$i,$j\n";
+    }
+}
+?>
+--EXPECT--
+0,0
+1,0
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/lang/numeric_separator_octal.phpt
+++ b/tests/ph7/001-smoke/lang/numeric_separator_octal.phpt
@@ -1,0 +1,26 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Numeric literal separator in octal literals
+--FILE--
+<?php
+echo 0_755 . "\n";
+echo 07_55 . "\n";
+echo 0_1_2_3 . "\n";
+echo 0_777 . "\n";
+echo (int)(0_755 === 0755) . "\n";
+echo (int)(07_55 === 0755) . "\n";
+echo (int)(0_1_2_3 === 0123) . "\n";
+?>
+--EXPECT--
+493
+493
+83
+511
+1
+1
+1
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/lang/numeric_separator_switch.phpt
+++ b/tests/ph7/001-smoke/lang/numeric_separator_switch.phpt
@@ -1,0 +1,36 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Numeric literal separator in switch case labels
+--FILE--
+<?php
+function classify($n) {
+    switch ($n) {
+        case 1_000:
+            return "thousand";
+        case 1_000_000:
+            return "million";
+        case 0xFF_FF:
+            return "max16";
+        case 0b1010_1010:
+            return "pattern";
+        default:
+            return "other";
+    }
+}
+echo classify(1000) . "\n";
+echo classify(1_000_000) . "\n";
+echo classify(0xFFFF) . "\n";
+echo classify(170) . "\n";
+echo classify(42) . "\n";
+?>
+--EXPECT--
+thousand
+million
+max16
+pattern
+other
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/lang/numeric_separator_type.phpt
+++ b/tests/ph7/001-smoke/lang/numeric_separator_type.phpt
@@ -1,0 +1,32 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Numeric literal separator type checks
+--FILE--
+<?php
+echo (int)is_int(1_000) . "\n";
+echo (int)is_int(0xFF_FF) . "\n";
+echo (int)is_int(0b1_0) . "\n";
+echo (int)is_int(0_755) . "\n";
+echo (int)is_float(1_000.5) . "\n";
+echo (int)is_float(1.5e1_0) . "\n";
+echo (int)is_numeric(1_000) . "\n";
+echo (int)is_numeric(1_000.5) . "\n";
+echo (int)is_numeric(0xFF_FF) . "\n";
+echo (int)is_numeric(0b1010_1010) . "\n";
+?>
+--EXPECT--
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+--CLEAN--
+<?php
+

--- a/tests/ph7/002-integration/parse/numeric_separator_adjacent_dot.phpt
+++ b/tests/ph7/002-integration/parse/numeric_separator_adjacent_dot.phpt
@@ -1,0 +1,13 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Numeric literal underscore adjacent to decimal point is a parse error
+--FILE--
+<?php
+$x = 1_.5;
+?>
+--EXPECTF--
+%s Parse error:  syntax error, unexpected identifier "_" %s
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/parse/numeric_separator_break_level.phpt
+++ b/tests/ph7/002-integration/parse/numeric_separator_break_level.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Malformed numeric separator in 'break' level is a parse error
+--FILE--
+<?php
+for ($i = 0; $i < 3; $i++) {
+    for ($j = 0; $j < 3; $j++) {
+        break 1_;
+    }
+}
+?>
+--EXPECTF--
+%s Parse error:  syntax error, unexpected identifier "_"
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/parse/numeric_separator_continue_level.phpt
+++ b/tests/ph7/002-integration/parse/numeric_separator_continue_level.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Malformed numeric separator in 'continue' level is a parse error
+--FILE--
+<?php
+for ($i = 0; $i < 3; $i++) {
+    for ($j = 0; $j < 3; $j++) {
+        continue 1__2;
+    }
+}
+?>
+--EXPECTF--
+%s Parse error:  syntax error, unexpected identifier "__2"
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/parse/numeric_separator_double_underscore.phpt
+++ b/tests/ph7/002-integration/parse/numeric_separator_double_underscore.phpt
@@ -1,0 +1,13 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Numeric literal with consecutive underscores is a parse error
+--FILE--
+<?php
+$x = 1__2;
+?>
+--EXPECTF--
+%s Parse error:  syntax error, unexpected identifier "__2" %s
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/parse/numeric_separator_leading_bin_separator.phpt
+++ b/tests/ph7/002-integration/parse/numeric_separator_leading_bin_separator.phpt
@@ -1,0 +1,13 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Binary literal with underscore immediately after prefix is a parse error
+--FILE--
+<?php
+$x = 0b_10;
+?>
+--EXPECTF--
+%s Parse error:  syntax error, unexpected identifier "b_10" %s
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/parse/numeric_separator_leading_hex_separator.phpt
+++ b/tests/ph7/002-integration/parse/numeric_separator_leading_hex_separator.phpt
@@ -1,0 +1,13 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Hexadecimal literal with underscore immediately after prefix is a parse error
+--FILE--
+<?php
+$x = 0x_1F;
+?>
+--EXPECTF--
+%s Parse error:  syntax error, unexpected identifier "x_1F" %s
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/parse/numeric_separator_trailing_underscore.phpt
+++ b/tests/ph7/002-integration/parse/numeric_separator_trailing_underscore.phpt
@@ -1,0 +1,13 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Numeric literal with trailing underscore is a parse error
+--FILE--
+<?php
+$x = 1_;
+?>
+--EXPECTF--
+%s Parse error:  syntax error, unexpected identifier "_" %s
+--CLEAN--
+<?php


### PR DESCRIPTION
Lets source literals use '_' as a visual separator between digits (1_000_000, 0xCAFE_F00D, 0b1010_1010, 0_755, 1_000.50, 1.5e1_0) while leaving runtime string-to-number coercion untouched so intval("1_000") still returns 1. Malformed placements emit the same "syntax error, unexpected identifier" wording PHP uses.
