### PR TITLE
Implement null coalescing assignment ??= (PHP 7.4)

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -7689,6 +7689,51 @@ static sxi32 GenStateEmitExprCode(
 		return SXERR_ABORT;
 	}
 	iVmOp = pNode->pOp->iVmOp;
+	if( pNode->pOp->iOp == EXPR_OP_NULLC_ASSIGN ){
+		sxu32 nJmp = 0;
+		VmInstr *pInstrFix;
+		/* Null coalescing assignment requires a custom compile order: the LHS
+		 * target (pRight for prec-18 right-assoc ops) must be evaluated first
+		 * so we can short-circuit the RHS when LHS is non-null. Pass
+		 * EXPR_FLAG_LOAD_IDX_STORE so subscript LHS auto-vivifies and the
+		 * stack slot carries a writable nIdx. */
+		if( pNode->pRight ){
+			rc = GenStateEmitExprCode(&(*pGen),pNode->pRight,iFlags|EXPR_FLAG_LOAD_IDX_STORE);
+			if( rc != SXRET_OK ){
+				return rc;
+			}
+			/* Optimisation: if the outermost LHS access is a subscript, demote
+			 * its LOAD_IDX from write-context (iP2=1, eager COW separation +
+			 * insert) to peek-mode (iP2=3, separate-only-on-null/missing). On
+			 * the common "already set" path the upcoming NULLC_JMP will skip
+			 * the store, so the parent array does not need to be copied at
+			 * all. Inner levels of a nested LHS keep iP2=1 so the separation
+			 * cascade for the actual write path stays correct. */
+			pInstrFix = PH7_VmPeekInstr(pGen->pVm);
+			if( pInstrFix && pInstrFix->iOp == PH7_OP_LOAD_IDX && pInstrFix->iP2 == 1 ){
+				pInstrFix->iP2 = 3;
+			}
+		}
+		/* Short-circuit: if LHS is non-null, jump past the RHS + store. */
+		PH7_VmEmitInstr(pGen->pVm,PH7_OP_NULLC_JMP,0,0,0,&nJmp);
+		/* Compile the RHS value (pLeft for prec-18 right-assoc). */
+		if( pNode->pLeft ){
+			rc = GenStateEmitExprCode(&(*pGen),pNode->pLeft,iFlags);
+			if( rc != SXRET_OK ){
+				return rc;
+			}
+		}
+		/* Store RHS into LHS's memobj slot; leave RHS as the result on stack. */
+		PH7_VmEmitInstr(pGen->pVm,PH7_OP_NULLC_STORE,0,0,0,0);
+		/* Patch the short-circuit jump to land after the store. */
+		if( nJmp > 0 ){
+			pInstrFix = PH7_VmGetInstr(pGen->pVm,nJmp);
+			if( pInstrFix ){
+				pInstrFix->iP2 = PH7_VmInstrLength(pGen->pVm);
+			}
+		}
+		return SXRET_OK;
+	}
 	if( pNode->pOp->iOp == EXPR_OP_QUESTY ){
 		sxu32 nJz,nJmp;
 		/* Ternary operator require special handling */

--- a/src/ph7/lex.c
+++ b/src/ph7/lex.c
@@ -601,6 +601,10 @@ static sxi32 TokenizePHP(SyStream *pStream,SyToken *pToken,void *pUserData,void 
 			if( pStream->zText < pStream->zEnd && pStream->zText[0] == '?' ){
 				/* Null coalescing operator: ?? */
 				pStream->zText++;
+				if( pStream->zText < pStream->zEnd && pStream->zText[0] == '=' ){
+					/* Null coalescing assignment operator (PHP 7.4) */
+					pStream->zText++;
+				}
 			}
 			break;
 		default:

--- a/src/ph7/parse.c
+++ b/src/ph7/parse.c
@@ -235,6 +235,12 @@ static const ph7_expr_op aOpTable[] = {
 	{ {"^=",sizeof(char)*2},  EXPR_OP_XOR_ASSIGN, 18,  EXPR_OP_ASSOC_RIGHT, PH7_OP_BXOR_STORE },
 	{ {"<<=",sizeof(char)*3}, EXPR_OP_SHL_ASSIGN, 18,  EXPR_OP_ASSOC_RIGHT, PH7_OP_SHL_STORE },
 	{ {">>=",sizeof(char)*3}, EXPR_OP_SHR_ASSIGN, 18,  EXPR_OP_ASSOC_RIGHT, PH7_OP_SHR_STORE },
+	/* The escape in the literal below avoids the C trigraph for two question
+	 * marks followed by '=' (which preprocesses to '#'). Do not collapse it
+	 * back to a raw three-char literal — under -Wtrigraphs the build will
+	 * either warn or be rewritten silently. The same applies anywhere else
+	 * in this file: keep one of the question marks escaped. */
+	{ {"?\?=",sizeof(char)*3},EXPR_OP_NULLC_ASSIGN,18, EXPR_OP_ASSOC_RIGHT, PH7_OP_NULLC_STORE },
 	/* Precedence 19,left-associative */
 	{ {"and",sizeof("and")-1},   EXPR_OP_LAND, 19, EXPR_OP_ASSOC_LEFT, PH7_OP_LAND},
 	/* Precedence 20,left-associative */
@@ -1558,7 +1564,13 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 			 }
 			 if( iLeft < 0 || iRight < 0 || !NODE_ISTERM(iRight) || !NODE_ISTERM(iLeft) ){
 				 /* Syntax error */
-				 rc = PH7_GenCompileError(pGen,E_ERROR,pNode->pStart->nLine,"'%z': Missing/Invalid operand",&pNode->pOp->sOp);
+				 if( pNode->pOp->iOp == EXPR_OP_NULLC_ASSIGN ){
+					 /* PHP-compatible parse error for a malformed null coalescing assignment */
+					 rc = PH7_GenCompileError(pGen,E_PARSE,pNode->pStart->nLine,
+						 "syntax error, unexpected token \"%z\"",&pNode->pOp->sOp);
+				 }else{
+					 rc = PH7_GenCompileError(pGen,E_ERROR,pNode->pStart->nLine,"'%z': Missing/Invalid operand",&pNode->pOp->sOp);
+				 }
 				 if( rc != SXERR_ABORT ){
 					 rc = SXERR_SYNTAX;
 				 }
@@ -1568,8 +1580,14 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 				 if( pNode->pOp->iVmOp != PH7_OP_STORE ||
 					 (apNode[iLeft]->xCode != PH7_CompileList && apNode[iLeft]->xCode != PH7_CompileShortList) ){
 					 /* Left operand must be a modifiable l-value */
-					 rc = PH7_GenCompileError(pGen,E_ERROR,pNode->pStart->nLine,
-						 "'%z': Left operand must be a modifiable l-value",&pNode->pOp->sOp);
+					 if( pNode->pOp->iOp == EXPR_OP_NULLC_ASSIGN ){
+						 /* PHP-compatible parse error for a non-lvalue LHS to null coalescing assignment */
+						 rc = PH7_GenCompileError(pGen,E_PARSE,pNode->pStart->nLine,
+							 "syntax error, unexpected token \"%z\"",&pNode->pOp->sOp);
+					 }else{
+						 rc = PH7_GenCompileError(pGen,E_ERROR,pNode->pStart->nLine,
+							 "'%z': Left operand must be a modifiable l-value",&pNode->pOp->sOp);
+					 }
 					 if( rc != SXERR_ABORT ){
 						 rc = SXERR_SYNTAX;
 					 }

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -983,6 +983,8 @@ enum ph7_vm_op {
   PH7_OP_NSSWITCH,     /* Switch active namespace at runtime */
   PH7_OP_USECONST,     /* Register a use-const import at runtime */
   PH7_OP_NULLC,         /* Null coalescing ?? */
+  PH7_OP_NULLC_JMP,     /* Null coalescing assign short-circuit jump */
+  PH7_OP_NULLC_STORE,   /* Null coalescing assign store */
   PH7_OP_SPREAD         /* Mark TOS for argument unpacking (...$arr) */
 };
 /* -- END-OF INSTRUCTIONS -- */
@@ -1045,6 +1047,7 @@ enum ph7_expr_id {
 	EXPR_OP_XOR_ASSIGN, /* Combined operator: ^= */
 	EXPR_OP_SHL_ASSIGN, /* Combined operator: <<= */
 	EXPR_OP_SHR_ASSIGN, /* Combined operator: >>= */
+	EXPR_OP_NULLC_ASSIGN, /* Combined operator: null coalescing assign */
 	EXPR_OP_COMMA       /* Comma expression */
 };
 /*

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -3549,7 +3549,7 @@ case PH7_OP_LOAD_IDX: {
 		}
 		break;
 	}
-	if( pInstr->iP2 == 1 && (pTos->iFlags & MEMOBJ_HASHMAP) == 0 ){
+	if( (pInstr->iP2 == 1 || pInstr->iP2 == 3) && (pTos->iFlags & MEMOBJ_HASHMAP) == 0 ){
 		if( pTos->nIdx != SXU32_HIGH ){
 			ph7_value *pObj;
 			if( (pObj = (ph7_value *)SySetAt(&pVm->aMemObj,pTos->nIdx)) != 0 ){
@@ -3573,7 +3573,35 @@ case PH7_OP_LOAD_IDX: {
 			/* Load the desired entry */
 			rc = PH7_HashmapLookup(pMap,pIdx,&pNode);
 		}
-		if( rc != SXRET_OK && pInstr->iP2 == 1 ){
+		if( pInstr->iP2 == 3 ){
+			/* Null coalescing assign peek mode: separate only when we will
+			 * actually write back. If the looked-up value is non-null, the
+			 * caller's NULLC_JMP will short-circuit and no store happens, so
+			 * the parent can stay shared. If the value is null or the key is
+			 * missing, separate and re-lookup so the upcoming NULLC_STORE
+			 * writes into our own copy. Inner levels of a nested LHS still
+			 * use iP2 == 1 (eager separation), which keeps the cascade
+			 * correct for the outermost write. */
+			int needWrite = (rc != SXRET_OK);
+			if( !needWrite && pNode ){
+				ph7_value *pVal = (ph7_value *)SySetAt(&pVm->aMemObj,pNode->nValIdx);
+				if( pVal == 0 || (pVal->iFlags & MEMOBJ_NULL) ){
+					needWrite = 1;
+				}
+			}
+			if( needWrite ){
+				PH7_HashmapCowSeparate(&(*pVm),pTos);
+				if( pMap != (ph7_hashmap *)pTos->x.pOther ){
+					/* The map was actually copied — re-lookup so pNode points
+					 * into the new map's storage. */
+					pMap = (ph7_hashmap *)pTos->x.pOther;
+					if( pIdx ){
+						rc = PH7_HashmapLookup(pMap,pIdx,&pNode);
+					}
+				}
+			}
+		}
+		if( rc != SXRET_OK && (pInstr->iP2 == 1 || pInstr->iP2 == 3) ){
 			/* Create a new empty entry */
 			rc = PH7_HashmapInsert(pMap,pIdx,0);
 			if( rc == SXRET_OK ){
@@ -4762,6 +4790,51 @@ case PH7_OP_NULLC: {
 		/* Left is null — discard it, fall through to evaluate RHS */
 		VmPopOperand(&pTos, 1);
 	}
+	break;
+}
+/*
+ * OP_NULLC_JMP: * P2 *
+ * Null coalescing assignment short-circuit.
+ * If TOS is NOT null, jump to P2 (keeping TOS as the expression result).
+ * If TOS IS null, fall through with TOS retained — it carries the LHS's
+ * nIdx so the upcoming NULLC_STORE can write back into the variable slot.
+ */
+case PH7_OP_NULLC_JMP: {
+#ifdef UNTRUST
+	if( pTos < pStack ){
+		goto Abort;
+	}
+#endif
+	if( (pTos->iFlags & MEMOBJ_NULL) == 0 ){
+		pc = pInstr->iP2 - 1; /* Jump (will be incremented by the loop) */
+	}
+	break;
+}
+/*
+ * OP_NULLC_STORE: * * *
+ * Null coalescing assignment store.
+ * Stack: [..., LHS_null(nIdx=X), RHS_value]. Store RHS into aMemObj[X],
+ * replace pNos with the RHS value, pop pTos. Leaves the RHS value as the
+ * expression result.
+ */
+case PH7_OP_NULLC_STORE: {
+	ph7_value *pNos = &pTos[-1];
+	ph7_value *pObj;
+	sxu32 nIdx;
+#ifdef UNTRUST
+	if( pNos < pStack ){
+		goto Abort;
+	}
+#endif
+	nIdx = pNos->nIdx;
+	if( nIdx == SXU32_HIGH ){
+		PH7_VmThrowError(&(*pVm),0,PH7_CTX_ERR,
+			"Cannot perform assignment on a constant class attribute");
+	}else if( (pObj = (ph7_value *)SySetAt(&pVm->aMemObj,nIdx)) != 0 ){
+		PH7_MemObjStore(pTos,pObj);
+	}
+	PH7_MemObjStore(pTos,pNos);
+	VmPopOperand(&pTos,1);
 	break;
 }
 /*
@@ -8284,6 +8357,8 @@ static const char * VmInstrToString(sxi32 nOp)
 	case PH7_OP_SWAP:       zOp = "SWAP       "; break;
 	case PH7_OP_YIELD:      zOp = "YIELD      "; break;
 	case PH7_OP_NULLC:      zOp = "NULLC      "; break;
+	case PH7_OP_NULLC_JMP:  zOp = "NULLC_JMP  "; break;
+	case PH7_OP_NULLC_STORE:zOp = "NULLC_STORE"; break;
 	case PH7_OP_SPREAD:     zOp = "SPREAD     "; break;
 	case PH7_OP_CVT_BOOL:   zOp = "CVT_BOOL   "; break;
 	case PH7_OP_CVT_NULL:   zOp = "CVT_NULL   "; break;

--- a/tests/ph7/001-smoke/lang/null_coalescing_assign.phpt
+++ b/tests/ph7/001-smoke/lang/null_coalescing_assign.phpt
@@ -1,0 +1,151 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Null coalescing assignment operator ??=
+--DESCRIPTION--
+Object property cases (`$obj->p ??= 'v'`) are intentionally omitted: PHL has a
+pre-existing limitation with stdClass dynamic property assignment that is
+unrelated to ??=. Class constant LHS cases (`Foo::CONST ??= 1`) diverge between
+PHP (parse error) and PHL (runtime error), so they are not asserted here.
+--FILE--
+<?php
+// Null LHS gets assigned
+$a = null;
+$a ??= 'set';
+echo "1: $a\n";
+
+// Non-null LHS preserved
+$b = 'kept';
+$b ??= 'fallback';
+echo "2: $b\n";
+
+// Falsy but not null preserved
+$c = 0;
+$c ??= 99;
+echo "3: $c\n";
+
+$d = '';
+$d ??= 'nope';
+echo "4: '$d'\n";
+
+$e = false;
+$e ??= 'nope';
+echo "5: ", ($e === false ? 'false' : 'changed'), "\n";
+
+// Undefined variable treated as null
+$undef ??= 'init';
+echo "6: $undef\n";
+
+// Array element, missing key
+$arr = [];
+$arr['x'] ??= 'new';
+echo "7: {$arr['x']}\n";
+
+// Array element with explicit null
+$arr['n'] = null;
+$arr['n'] ??= 'filled';
+echo "8: {$arr['n']}\n";
+
+// Array element with existing value preserved
+$arr['k'] = 'orig';
+$arr['k'] ??= 'fallback';
+echo "9: {$arr['k']}\n";
+
+// Nested array auto-vivification
+$deep = [];
+$deep['a']['b'] ??= 'leaf';
+echo "10: {$deep['a']['b']}\n";
+
+// Short-circuit: RHS not evaluated when LHS non-null
+function side_effect() {
+    echo "called!\n";
+    return 'rhs';
+}
+$keep = 'present';
+$keep ??= side_effect();
+echo "11: $keep\n";
+
+$null_lhs = null;
+$null_lhs ??= side_effect();
+echo "12: $null_lhs\n";
+
+// Right-associative chaining: $x ??= ($y ??= 'end')
+$x = null;
+$y = null;
+$x ??= $y ??= 'end';
+echo "13: x=$x y=$y\n";
+
+// Chain stops when middle is set
+$p = null;
+$q = 'mid';
+$p ??= $q ??= 'never';
+echo "14: p=$p q=$q\n";
+
+// Result of expression is the final LHS value
+$src = null;
+$result = ($src ??= 42);
+echo "15: result=$result src=$src\n";
+
+// Reference variable: assigning through the alias updates the referent
+$base = null;
+$alias = &$base;
+$alias ??= 'via-ref';
+echo "16: base=$base alias=$alias\n";
+
+// COW: shared array, ??= on existing non-null key must not leak through
+$src = ['k' => 'orig'];
+$copy = $src;
+$copy['k'] ??= 'overwritten';
+echo "17: src=" . $src['k'] . " copy=" . $copy['k'] . "\n";
+
+// COW: shared array, ??= on null key writes only to the copy
+$src2 = ['k' => null];
+$copy2 = $src2;
+$copy2['k'] ??= 'set';
+echo "18: src2=" . ($src2['k'] === null ? 'null' : $src2['k']) . " copy2=" . $copy2['k'] . "\n";
+
+// COW: shared array, ??= on missing key writes only to the copy
+$src3 = [];
+$copy3 = $src3;
+$copy3['k'] ??= 'new';
+echo "19: src3=" . (isset($src3['k']) ? $src3['k'] : 'unset') . " copy3=" . $copy3['k'] . "\n";
+
+// COW: nested shared, ??= on existing non-null leaf must not leak
+$src4 = ['a' => ['b' => 'orig']];
+$copy4 = $src4;
+$copy4['a']['b'] ??= 'overwritten';
+echo "20: src4=" . $src4['a']['b'] . " copy4=" . $copy4['a']['b'] . "\n";
+
+// COW: nested shared, ??= on null leaf writes only to the copy
+$src5 = ['a' => ['b' => null]];
+$copy5 = $src5;
+$copy5['a']['b'] ??= 'set';
+echo "21: src5=" . ($src5['a']['b'] === null ? 'null' : $src5['a']['b']) . " copy5=" . $copy5['a']['b'] . "\n";
+?>
+--EXPECT--
+1: set
+2: kept
+3: 0
+4: ''
+5: false
+6: init
+7: new
+8: filled
+9: orig
+10: leaf
+11: present
+called!
+12: rhs
+13: x=end y=end
+14: p=mid q=mid
+15: result=42 src=42
+16: base=via-ref alias=via-ref
+17: src=orig copy=orig
+18: src2=null copy2=set
+19: src3=unset copy3=new
+20: src4=orig copy4=orig
+21: src5=null copy5=set
+--CLEAN--
+<?php
+unset($a, $b, $c, $d, $e, $undef, $arr, $deep, $keep, $null_lhs, $x, $y, $p, $q, $src, $result, $base, $alias, $src2, $src3, $src4, $src5, $copy, $copy2, $copy3, $copy4, $copy5);

--- a/tests/ph7/002-integration/parse/null_coalescing_assign_invalid_lvalue.phpt
+++ b/tests/ph7/002-integration/parse/null_coalescing_assign_invalid_lvalue.phpt
@@ -1,0 +1,13 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Null coalescing assignment to a non-lvalue is a parse error
+--FILE--
+<?php
+5 ??= 10;
+?>
+--EXPECTF--
+%s Parse error:  syntax error, unexpected token "??=" %s
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/parse/null_coalescing_assign_missing_lhs.phpt
+++ b/tests/ph7/002-integration/parse/null_coalescing_assign_missing_lhs.phpt
@@ -1,0 +1,13 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Null coalescing assignment without a left operand is a parse error
+--FILE--
+<?php
+??= 5;
+?>
+--EXPECTF--
+%s Parse error:  syntax error, unexpected token "??=%s
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/parse/null_coalescing_assign_missing_rhs.phpt
+++ b/tests/ph7/002-integration/parse/null_coalescing_assign_missing_rhs.phpt
@@ -1,0 +1,13 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Null coalescing assignment without a right operand is a parse error
+--FILE--
+<?php
+$a ??= ;
+?>
+--EXPECTF--
+%s Parse error:  syntax error, unexpected token %s
+--CLEAN--
+<?php


### PR DESCRIPTION
Add the ??= operator with true short-circuit semantics: the RHS is only evaluated when the LHS is null. The compile path mirrors the ternary operator's custom branch. LHS target is emitted first so a NULLC_JMP can skip past the RHS and store when the LHS is non-null. Two new VM opcodes (NULLC_JMP, NULLC_STORE) keep the existing NULLC pop-on-null invariant intact.
