### PR TITLE
Implement flexible heredoc/nowdoc syntax (PHP 7.3)

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -705,6 +705,103 @@ PH7_PRIVATE sxi32 PH7_CompileSimpleString(ph7_gen_state *pGen,sxi32 iCompileFlag
 	return SXRET_OK;
 }
 /*
+ * PHP 7.3 flexible heredoc/nowdoc closing-marker indent stripping.
+ *
+ * When the lexer matched the closing marker with leading whitespace on its
+ * own line, it stored the indent count in pGen->pIn->pUserData. The marker's
+ * indent prefix bytes sit immediately after the stripped body (at
+ * pIn->sData.zString + pIn->sData.nByte + 1 for LF, +2 for CRLF) in the
+ * original source buffer — the buffer is stable through compilation.
+ *
+ * For each body line, we remove exactly `nIndent` leading bytes that must
+ * byte-for-byte match the marker's prefix. Empty lines (0 bytes or bare \r)
+ * bypass validation. Mismatches raise the exact PHP 7.3+ parse errors:
+ *   - "Invalid body indentation level (expecting an indentation level of
+ *     at least N)" — line too short, or first differing byte is not
+ *     whitespace.
+ *   - "Invalid indentation - tabs and spaces cannot be mixed" — first
+ *     differing byte is whitespace but differs from the marker prefix.
+ */
+static sxi32 GenStateStripHeredocIndent(ph7_gen_state *pGen, SyString *pOut)
+{
+	SyString *pIn = &pGen->pIn->sData;
+	sxu32 nIndent = (sxu32)SX_PTR_TO_INT(pGen->pIn->pUserData);
+	const char *zPrefix;
+	const char *z, *zEnd;
+	char *zBuf, *zDst;
+	if( nIndent == 0 ){
+		/* Legacy column-0 marker: zero-copy fast path */
+		*pOut = *pIn;
+		return SXRET_OK;
+	}
+	/* Recover the marker indent prefix from the original source buffer.
+	 * Skip the terminator the lexer stripped: one '\n' plus an optional
+	 * preceding '\r'. Note: when the body is empty (pIn->nByte == 0) the
+	 * lexer stripped nothing, so this offset is one byte past the true
+	 * marker-indent start. That is harmless — the strip loop below never
+	 * runs (z == zEnd), and zPrefix is never dereferenced. */
+	zPrefix = pIn->zString + pIn->nByte;
+	if( zPrefix[0] == '\r' && zPrefix[1] == '\n' ){
+		zPrefix += 2;
+	}else{
+		zPrefix += 1;
+	}
+	/* Allocate scratch buffer sized to the original body (always enough). */
+	zBuf = (char *)SyMemBackendAlloc(&pGen->pVm->sAllocator, pIn->nByte + 1);
+	if( zBuf == 0 ){
+		PH7_GenCompileError(&(*pGen),E_ERROR,pGen->pIn->nLine,"PH7 engine is running out of memory");
+		return SXERR_ABORT;
+	}
+	zDst = zBuf;
+	z = pIn->zString;
+	zEnd = z + pIn->nByte;
+	while( z < zEnd ){
+		const char *zLine = z;
+		sxu32 nLine;
+		int bEmpty;
+		while( z < zEnd && z[0] != '\n' ){
+			z++;
+		}
+		nLine = (sxu32)(z - zLine);
+		bEmpty = (nLine == 0) || (nLine == 1 && zLine[0] == '\r');
+		if( !bEmpty ){
+			sxu32 i;
+			if( nLine < nIndent ){
+				PH7_GenCompileError(&(*pGen),E_ERROR,pGen->pIn->nLine,
+					"Invalid body indentation level (expecting an indentation level of at least %u)",
+					nIndent);
+				return SXERR_ABORT;
+			}
+			for( i = 0; i < nIndent; i++ ){
+				if( zLine[i] != zPrefix[i] ){
+					unsigned char c = (unsigned char)zLine[i];
+					if( c == ' ' || c == '\t' ){
+						PH7_GenCompileError(&(*pGen),E_ERROR,pGen->pIn->nLine,
+							"Invalid indentation - tabs and spaces cannot be mixed");
+					}else{
+						PH7_GenCompileError(&(*pGen),E_ERROR,pGen->pIn->nLine,
+							"Invalid body indentation level (expecting an indentation level of at least %u)",
+							nIndent);
+					}
+					return SXERR_ABORT;
+				}
+			}
+			SyMemcpy((const void *)(zLine + nIndent), (void *)zDst, nLine - nIndent);
+			zDst += nLine - nIndent;
+		}else if( nLine == 1 ){
+			/* Preserve the stray '\r' on an otherwise empty line */
+			*zDst++ = '\r';
+		}
+		if( z < zEnd ){
+			*zDst++ = '\n';
+			z++;
+		}
+	}
+	pOut->zString = zBuf;
+	pOut->nByte = (sxu32)(zDst - zBuf);
+	return SXRET_OK;
+}
+/*
  * Compile a nowdoc string.
  * According to the PHP language reference manual:
  *
@@ -718,11 +815,18 @@ PH7_PRIVATE sxi32 PH7_CompileSimpleString(ph7_gen_state *pGen,sxi32 iCompileFlag
  *  identifiers also apply to nowdoc identifiers, especially those regarding the appearance
  *  of the closing identifier.
  */
-static sxi32 PH7_CompileNowDoc(ph7_gen_state *pGen,sxi32 iCompileFlag)
+PH7_PRIVATE sxi32 PH7_CompileNowDoc(ph7_gen_state *pGen,sxi32 iCompileFlag)
 {
-	SyString *pStr = &pGen->pIn->sData; /* Constant string literal */
+	SyString sStripped;
+	SyString *pStr;
 	ph7_value *pObj;
 	sxu32 nIdx;
+	sxi32 rc;
+	rc = GenStateStripHeredocIndent(&(*pGen), &sStripped);
+	if( rc != SXRET_OK ){
+		return rc;
+	}
+	pStr = &sStripped;
 	nIdx = 0; /* Prevent compiler warning */
 	if( pStr->nByte <= 0 ){
 		/* Empty string,load NULL */
@@ -1145,12 +1249,24 @@ PH7_PRIVATE sxi32 PH7_CompileString(ph7_gen_state *pGen,sxi32 iCompileFlag)
  * Compile a Heredoc string.
  *  See the block-comment above for more information.
  */
-static sxi32 PH7_CompileHereDoc(ph7_gen_state *pGen,sxi32 iCompileFlag)
+PH7_PRIVATE sxi32 PH7_CompileHereDoc(ph7_gen_state *pGen,sxi32 iCompileFlag)
 {
-	GenStateCompileString(&(*pGen));
+	SyString sOrig, sStripped;
+	sxi32 rc;
+	rc = GenStateStripHeredocIndent(&(*pGen), &sStripped);
+	if( rc != SXRET_OK ){
+		return rc;
+	}
+	/* Temporarily swap in the dedented body so GenStateCompileString
+	 * (which reads pGen->pIn->sData directly) sees the stripped content.
+	 * Restore before returning so downstream code that references pIn is
+	 * unaffected, including on the error path. */
+	sOrig = pGen->pIn->sData;
+	pGen->pIn->sData = sStripped;
+	rc = GenStateCompileString(&(*pGen));
+	pGen->pIn->sData = sOrig;
 	SXUNUSED(iCompileFlag); /* cc warning */
-	/* Compilation result */
-	return SXRET_OK;
+	return rc;
 }
 /*
  * Compile an array entry whether it is a key or a value.

--- a/src/ph7/lex.c
+++ b/src/ph7/lex.c
@@ -935,56 +935,69 @@ static sxi32 LexExtractHeredoc(SyStream *pStream,SyToken *pToken)
 	zIn++;
 	/* Isolate the delimited string */
 	sStr.zString = (const char *)zIn;
-	/* Go and found the closing delimiter */
-	for(;;){
-		/* Synchronize with the next line */
-		while( zIn < zEnd && zIn[0] != '\n' ){
-			zIn++;
-		}
-		if( zIn >= zEnd ){
-			/* End of the input reached, break immediately */
-			pStream->zText = pStream->zEnd;
-			break;
-		}
-		pStream->nLine++; /* Increment line counter */
-		zIn++;
-		if( (sxu32)(zEnd - zIn) >= sDelim.nByte && SyMemcmp((const void *)sDelim.zString,(const void *)zIn,sDelim.nByte) == 0 ){
-			zPtr = &zIn[sDelim.nByte];
-			while( zPtr < zEnd && zPtr[0] < 0xc0 && SyisSpace(zPtr[0]) && zPtr[0] != '\n' ){
-				zPtr++;
+	/* PHP 7.3 flexible heredoc/nowdoc: the closing marker may be preceded
+	 * by whitespace (spaces/tabs), and may be followed by any non-identifier
+	 * character. The indent count is recorded in pToken->pUserData and the
+	 * compile phase strips it from each body line. */
+	{
+		const unsigned char *zMarkerLine = zIn; /* Start of marker's line (set on match) */
+		sxu32 nIndent = 0;
+		for(;;){
+			const unsigned char *zLineStart = zIn;
+			/* Skip leading space/tab on this line */
+			while( zIn < zEnd && (zIn[0] == ' ' || zIn[0] == '\t') ){
+				zIn++;
 			}
-			if( zPtr >= zEnd ){
-				/* End of input */
-				pStream->zText = zPtr;
-				break;
-			}
-			if( zPtr[0] == ';' ){
-				const unsigned char *zCur = zPtr;
-				zPtr++;
-				while( zPtr < zEnd && zPtr[0] < 0xc0 && SyisSpace(zPtr[0]) && zPtr[0] != '\n' ){
-					zPtr++;
+			if( (sxu32)(zEnd - zIn) >= sDelim.nByte
+				&& SyMemcmp((const void *)sDelim.zString,(const void *)zIn,sDelim.nByte) == 0 ){
+				int bIdentCont;
+				zPtr = &zIn[sDelim.nByte];
+				/* Disambiguate: next byte must not continue an identifier.
+				 * A leading byte >= 0xc0 starts a multi-byte UTF-8 sequence,
+				 * which PHP identifiers may contain, so treat it as ident. */
+				if( zPtr >= zEnd ){
+					bIdentCont = 0;
+				}else if( zPtr[0] >= 0xc0 ){
+					bIdentCont = 1;
+				}else{
+					bIdentCont = (SyisAlphaNum(zPtr[0]) || zPtr[0] == '_');
 				}
-				if( zPtr >= zEnd || zPtr[0] == '\n' ){
-					/* Closing delimiter found,break immediately */
-					pStream->zText = zCur; /* Keep the semi-colon */
+				if( !bIdentCont ){
+					/* Closing marker found */
+					nIndent = (sxu32)(zIn - zLineStart);
+					zMarkerLine = zLineStart;
+					pStream->zText = zPtr; /* Cursor right after identifier */
 					break;
 				}
-			}else if( zPtr[0] == '\n' ){
-				/* Closing delimiter found,break immediately */
-				pStream->zText = zPtr; /* Synchronize with the stream cursor */
+			}
+			/* Not the closing marker on this line; walk to next newline */
+			while( zIn < zEnd && zIn[0] != '\n' ){
+				zIn++;
+			}
+			if( zIn >= zEnd ){
+				/* End of input without finding the closing marker */
+				pStream->zText = pStream->zEnd;
+				zMarkerLine = zIn;
 				break;
 			}
-			/* Synchronize pointers and continue searching */
-			zIn = zPtr;
+			pStream->nLine++;
+			zIn++;
 		}
-	} /* For(;;) */
-	/* Get the delimited string length */
-	sStr.nByte = (sxu32)((const char *)zIn-sStr.zString);
-	/* Record token type and length */
-	pToken->nType = bNowDoc ? PH7_TK_NOWDOC : PH7_TK_HEREDOC;
-	SyStringDupPtr(&pToken->sData,&sStr);
-	/* Remove trailing white spaces */
-	SyStringRightTrim(&pToken->sData);
+		/* Body runs from sStr.zString up to just before the marker line */
+		sStr.nByte = (sxu32)((const char *)zMarkerLine - sStr.zString);
+		pToken->nType = bNowDoc ? PH7_TK_NOWDOC : PH7_TK_HEREDOC;
+		SyStringDupPtr(&pToken->sData,&sStr);
+		/* Strip exactly one line terminator that precedes the marker's line. */
+		if( pToken->sData.nByte > 0
+			&& pToken->sData.zString[pToken->sData.nByte - 1] == '\n' ){
+			pToken->sData.nByte--;
+			if( pToken->sData.nByte > 0
+				&& pToken->sData.zString[pToken->sData.nByte - 1] == '\r' ){
+				pToken->sData.nByte--;
+			}
+		}
+		pToken->pUserData = SX_INT_TO_PTR(nIndent);
+	}
 	/* All done */
 	return SXRET_OK;
 }

--- a/src/ph7/memobj.c
+++ b/src/ph7/memobj.c
@@ -1310,20 +1310,22 @@ PH7_PRIVATE sxi32 PH7_MemObjDump(
 			if((pObj->iFlags & MEMOBJ_STRING) == 0 ){
 				MemObjStringValue(&(*pOut),&(*pObj),FALSE);
 			}else{
-				/* Append length first */
+				/* PHP format: string(N) "content" */
 				if( ShowType ){
-					SyBlobFormat(&(*pOut),"%u '",SyBlobLength(&pObj->sBlob));
+					SyBlobFormat(&(*pOut),"%u) \"",SyBlobLength(&pObj->sBlob));
 				}
 				if( SyBlobLength(pContents) > 0 ){
 					SyBlobAppend(&(*pOut),SyBlobData(pContents),SyBlobLength(pContents));
 				}
 				if( ShowType ){
-					SyBlobAppend(&(*pOut),"'",sizeof(char));
+					SyBlobAppend(&(*pOut),"\"",sizeof(char));
 				}
 			}
 		}
 		if( ShowType ){
-			if( (pObj->iFlags & (MEMOBJ_HASHMAP|MEMOBJ_OBJ)) == 0 ){
+			/* Strings already emitted their own ')' as part of the
+			 * "N) \"content\"" format above. */
+			if( (pObj->iFlags & (MEMOBJ_HASHMAP|MEMOBJ_OBJ|MEMOBJ_STRING)) == 0 ){
 				SyBlobAppend(&(*pOut),")",sizeof(char));
 			}
 		}

--- a/src/ph7/parse.c
+++ b/src/ph7/parse.c
@@ -1199,6 +1199,7 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 				 sxi32 iNest = 1;
 				 if(  iLeft < 0 || apNode[iLeft] == 0 || (apNode[iLeft]->pOp == 0 && (apNode[iLeft]->xCode != PH7_CompileVariable &&
 					 apNode[iLeft]->xCode != PH7_CompileSimpleString && apNode[iLeft]->xCode != PH7_CompileString &&
+					 apNode[iLeft]->xCode != PH7_CompileHereDoc && apNode[iLeft]->xCode != PH7_CompileNowDoc &&
 					 apNode[iLeft]->xCode != PH7_CompileArray && apNode[iLeft]->xCode != PH7_CompileShortArray ) ) ||
 					 ( apNode[iLeft]->pOp && apNode[iLeft]->pOp->iPrec != 2 /* postfix */) ){
 						 /* Syntax error */

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1554,6 +1554,8 @@ PH7_PRIVATE sxi32 PH7_CompileVariable(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileLiteral(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileSimpleString(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileString(ph7_gen_state *pGen,sxi32 iCompileFlag);
+PH7_PRIVATE sxi32 PH7_CompileHereDoc(ph7_gen_state *pGen,sxi32 iCompileFlag);
+PH7_PRIVATE sxi32 PH7_CompileNowDoc(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileArray(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileShortArray(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileList(ph7_gen_state *pGen,sxi32 iCompileFlag);

--- a/tests/ph7/001-smoke/function/base_convert/base_convert_insufficient_args.phpt
+++ b/tests/ph7/001-smoke/function/base_convert/base_convert_insufficient_args.phpt
@@ -16,9 +16,9 @@ $result3 = base_convert();
 var_dump($result3);
 ?>
 --EXPECT--
-string(0 '')
-string(0 '')
-string(0 '')
+string(0) ""
+string(0) ""
+string(0) ""
 --CLEAN--
 <?php
 unset($result, $result2, $result3);

--- a/tests/ph7/001-smoke/function/base_convert/base_convert_invalid_input.phpt
+++ b/tests/ph7/001-smoke/function/base_convert/base_convert_invalid_input.phpt
@@ -12,7 +12,7 @@ $result = base_convert('G', 16, 10);
 var_dump($result);
 ?>
 --EXPECT--
-string(1 '0')
+string(1) "0"
 --CLEAN--
 <?php
 unset($result);

--- a/tests/ph7/001-smoke/function/sprintf/sprintf_left_justify.phpt
+++ b/tests/ph7/001-smoke/function/sprintf/sprintf_left_justify.phpt
@@ -16,7 +16,7 @@ $ret = sprintf("%-10s", "Hi");
 var_dump($ret);
 ?>
 --EXPECTF--
-string(10 'Hi        ')
+string(10) "Hi        "
 --CLEAN--
 <?php
 unset($ret);

--- a/tests/ph7/001-smoke/function/str_pad/str_pad_insufficient_args.phpt
+++ b/tests/ph7/001-smoke/function/str_pad/str_pad_insufficient_args.phpt
@@ -11,7 +11,7 @@ $result = str_pad("hello");
 var_dump($result);
 ?>
 --EXPECT--
-string(0 '')
+string(0) ""
 --CLEAN--
 <?php
 unset($result);

--- a/tests/ph7/001-smoke/function/str_repeat/str_repeat_negative.phpt
+++ b/tests/ph7/001-smoke/function/str_repeat/str_repeat_negative.phpt
@@ -11,7 +11,7 @@ $result = str_repeat("a", -1);
 var_dump($result);
 ?>
 --EXPECT--
-string(0 '')
+string(0) ""
 --CLEAN--
 <?php
 unset($result);

--- a/tests/ph7/001-smoke/function/str_replace/str_replace_empty_key.phpt
+++ b/tests/ph7/001-smoke/function/str_replace/str_replace_empty_key.phpt
@@ -12,7 +12,7 @@ $result = str_replace(array('', 'l'), array('x', 'L'), 'hello');
 var_dump($result);
 ?>
 --EXPECT--
-string(5 'hexxo')
+string(5) "hexxo"
 --CLEAN--
 <?php
 unset($result);

--- a/tests/ph7/001-smoke/function/strtr/strtr_empty_key.phpt
+++ b/tests/ph7/001-smoke/function/strtr/strtr_empty_key.phpt
@@ -12,7 +12,7 @@ $result = strtr('hello', array('' => 'x', 'l' => 'L'));
 var_dump($result);
 ?>
 --EXPECT--
-string(5 'heLlo')
+string(5) "heLlo"
 --CLEAN--
 <?php
 unset($result);

--- a/tests/ph7/001-smoke/lang/empty_nowdoc.phpt
+++ b/tests/ph7/001-smoke/lang/empty_nowdoc.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Empty nowdoc strings
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 $empty = <<<'EOD'
@@ -14,6 +12,9 @@ echo "Length: " . strlen($empty) . "\n";
 echo "Done\n";
 ?>
 --EXPECT--
+Empty nowdoc: ''
+Length: 0
+Done
 --CLEAN--
 <?php
 unset($empty);

--- a/tests/ph7/001-smoke/lang/expression_edge_cases.phpt
+++ b/tests/ph7/001-smoke/lang/expression_edge_cases.phpt
@@ -44,7 +44,7 @@ var_dump($func_result);
 double(4.5)
 int(-2)
 int(3)
-string(15 'hello world 223')
+string(15) "hello world 223"
 int(5)
 int(10)
 --CLEAN--

--- a/tests/ph7/001-smoke/lang/heredoc_flex_backcompat.phpt
+++ b/tests/ph7/001-smoke/lang/heredoc_flex_backcompat.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PHP 7.3 flexible heredoc keeps legacy column-0 closing marker working
+--FILE--
+<?php
+$x = <<<EOT
+line1
+line2
+EOT;
+echo "[$x]\n";
+
+$y = <<<'EOT'
+raw $var
+EOT;
+echo "[$y]\n";
+--EXPECT--
+[line1
+line2]
+[raw $var]
+--CLEAN--
+<?php
+unset($x, $y);

--- a/tests/ph7/001-smoke/lang/heredoc_flex_close_paren.phpt
+++ b/tests/ph7/001-smoke/lang/heredoc_flex_close_paren.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PHP 7.3 heredoc as last argument followed by closing parenthesis
+--FILE--
+<?php
+echo strlen(<<<EOT
+    measure me
+    EOT) . "\n";
+
+echo str_repeat(<<<EOT
+    ab
+    EOT, 3) . "\n";
+--EXPECT--
+10
+ababab
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/lang/heredoc_flex_concat.phpt
+++ b/tests/ph7/001-smoke/lang/heredoc_flex_concat.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PHP 7.3 heredoc closing marker followed by concatenation operator
+--FILE--
+<?php
+$x = <<<EOT
+    concat
+    EOT . "!";
+echo "[$x]\n";
+
+$y = "prefix-" . <<<EOT
+    middle
+    EOT . "-suffix";
+echo "[$y]\n";
+--EXPECT--
+[concat!]
+[prefix-middle-suffix]
+--CLEAN--
+<?php
+unset($x, $y);

--- a/tests/ph7/001-smoke/lang/heredoc_flex_empty_lines.phpt
+++ b/tests/ph7/001-smoke/lang/heredoc_flex_empty_lines.phpt
@@ -1,0 +1,26 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PHP 7.3 indented heredoc preserves blank body lines
+--FILE--
+<?php
+$x = <<<EOT
+    first
+
+    third
+
+    fifth
+    EOT;
+echo "[$x]\n";
+echo strlen($x) . "\n";
+--EXPECT--
+[first
+
+third
+
+fifth]
+19
+--CLEAN--
+<?php
+unset($x);

--- a/tests/ph7/001-smoke/lang/heredoc_flex_in_arg.phpt
+++ b/tests/ph7/001-smoke/lang/heredoc_flex_in_arg.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PHP 7.3 heredoc as function argument followed by comma
+--FILE--
+<?php
+function join3($a, $b, $c) {
+    return $a . '|' . $b . '|' . $c;
+}
+
+echo join3(<<<EOT
+    first
+    EOT, "second", "third") . "\n";
+
+echo join3("alpha", <<<EOT
+    beta
+    EOT, "gamma") . "\n";
+--EXPECT--
+first|second|third
+alpha|beta|gamma
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/lang/heredoc_flex_indent_basic.phpt
+++ b/tests/ph7/001-smoke/lang/heredoc_flex_indent_basic.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PHP 7.3 heredoc with indented closing marker
+--FILE--
+<?php
+$x = <<<EOT
+    hello
+    world
+    EOT;
+echo "[$x]\n";
+echo strlen($x) . "\n";
+--EXPECT--
+[hello
+world]
+11
+--CLEAN--
+<?php
+unset($x);

--- a/tests/ph7/001-smoke/lang/heredoc_flex_indent_body_deeper.phpt
+++ b/tests/ph7/001-smoke/lang/heredoc_flex_indent_body_deeper.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PHP 7.3 heredoc body indented deeper than closing marker
+--FILE--
+<?php
+$x = <<<EOT
+  first
+      deeper
+  last
+  EOT;
+echo "[$x]\n";
+--EXPECT--
+[first
+    deeper
+last]
+--CLEAN--
+<?php
+unset($x);

--- a/tests/ph7/001-smoke/lang/heredoc_flex_indent_tabs.phpt
+++ b/tests/ph7/001-smoke/lang/heredoc_flex_indent_tabs.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PHP 7.3 heredoc with tab-indented closing marker
+--FILE--
+<?php
+$x = <<<EOT
+	alpha
+	beta
+	gamma
+	EOT;
+echo "[$x]\n";
+echo strlen($x) . "\n";
+--EXPECT--
+[alpha
+beta
+gamma]
+16
+--CLEAN--
+<?php
+unset($x);

--- a/tests/ph7/001-smoke/lang/heredoc_flex_interpolation.phpt
+++ b/tests/ph7/001-smoke/lang/heredoc_flex_interpolation.phpt
@@ -1,0 +1,30 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PHP 7.3 indented heredoc with variable interpolation
+--FILE--
+<?php
+$name = "World";
+$n = 42;
+$x = <<<EOT
+    Hello, $name!
+    n = $n
+    EOT;
+echo "[$x]\n";
+
+class Box {
+    public $label = "hi";
+}
+$b = new Box();
+$y = <<<EOT
+    label={$b->label}
+    EOT;
+echo "[$y]\n";
+--EXPECT--
+[Hello, World!
+n = 42]
+[label=hi]
+--CLEAN--
+<?php
+unset($name, $n, $x, $b, $y);

--- a/tests/ph7/001-smoke/lang/heredoc_flex_semicolon_same_line.phpt
+++ b/tests/ph7/001-smoke/lang/heredoc_flex_semicolon_same_line.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PHP 7.3 indented heredoc closing marker followed by semicolon
+--FILE--
+<?php
+$x = <<<EOT
+    one
+    two
+    EOT;
+$y = "next";
+echo "[$x][$y]\n";
+--EXPECT--
+[one
+two][next]
+--CLEAN--
+<?php
+unset($x, $y);

--- a/tests/ph7/001-smoke/lang/heredoc_flex_subscript.phpt
+++ b/tests/ph7/001-smoke/lang/heredoc_flex_subscript.phpt
@@ -1,0 +1,28 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PHP 7.3 heredoc and nowdoc directly subscripted with [N]
+--FILE--
+<?php
+$c = (<<<EOT
+    abcdef
+    EOT)[2];
+echo "[$c]\n";
+
+$d = (<<<EOT
+    zyxwv
+    EOT)[0];
+echo "[$d]\n";
+
+$e = (<<<'EOT'
+    raw $var literal
+    EOT)[4];
+echo "[$e]\n";
+--EXPECT--
+[c]
+[z]
+[$]
+--CLEAN--
+<?php
+unset($c, $d, $e);

--- a/tests/ph7/001-smoke/lang/nowdoc_flex_in_arg.phpt
+++ b/tests/ph7/001-smoke/lang/nowdoc_flex_in_arg.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PHP 7.3 indented nowdoc as function argument
+--FILE--
+<?php
+function pair($a, $b) {
+    return "[$a][$b]";
+}
+echo pair(<<<'EOT'
+    raw $var text
+    EOT, "second") . "\n";
+--EXPECT--
+[raw $var text][second]
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/lang/nowdoc_flex_indent_basic.phpt
+++ b/tests/ph7/001-smoke/lang/nowdoc_flex_indent_basic.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PHP 7.3 nowdoc with indented closing marker
+--FILE--
+<?php
+$name = "ignored";
+$x = <<<'EOT'
+    $name is literal
+    no interpolation
+    EOT;
+echo "[$x]\n";
+echo strlen($x) . "\n";
+--EXPECT--
+[$name is literal
+no interpolation]
+33
+--CLEAN--
+<?php
+unset($name, $x);

--- a/tests/ph7/001-smoke/oo/object_cast_to_array.phpt
+++ b/tests/ph7/001-smoke/oo/object_cast_to_array.phpt
@@ -20,11 +20,11 @@ var_dump($array);
 --EXPECT--
 array(3) {
  [publicVar] =>
-  string(6 'public')
+  string(6) "public"
  [privateVar] =>
-  string(7 'private')
+  string(7) "private"
  [protectedVar] =>
-  string(9 'protected')
+  string(9) "protected"
  }
 --CLEAN--
 <?php

--- a/tests/ph7/001-smoke/oo/object_var_dump.phpt
+++ b/tests/ph7/001-smoke/oo/object_var_dump.phpt
@@ -21,7 +21,7 @@ echo $output;
 --EXPECTF--
 object(TestClass) {
  ['public_attr'] =>
-  string(4 'test')
+  string(4) "test"
  ['private_attr'] =>
   int(42)
  }

--- a/tests/ph7/001-smoke/parse/complex_operator_precedence.phpt
+++ b/tests/ph7/001-smoke/parse/complex_operator_precedence.phpt
@@ -43,7 +43,7 @@ var_dump($result6); // int(13) - (10 + ((5 % 3) * 2) - 1)
 --EXPECT--
 bool(TRUE)
 int(7)
-string(9 'Value: 17')
+string(9) "Value: 17"
 int(12)
 int(14)
 int(13)

--- a/tests/ph7/002-integration/array/array_invalid_key.phpt
+++ b/tests/ph7/002-integration/array/array_invalid_key.phpt
@@ -16,7 +16,7 @@ var_dump($arr);
 %s Notice:  Missing constructor argument 1($v) for class 'stdClass'
 array(1) {
  [Object] =>
-  string(5 'value')
+  string(5) "value"
  }
 --CLEAN--
 <?php

--- a/tests/ph7/002-integration/lang/heredoc_flex_err_tab_space_mix.phpt
+++ b/tests/ph7/002-integration/lang/heredoc_flex_err_tab_space_mix.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PHP 7.3 heredoc mixing tabs and spaces in the indent prefix is a parse error
+--FILE--
+<?php
+$x = <<<EOT
+	tab-prefixed body
+    EOT;
+--EXPECTF--
+PHP %s error:  Invalid indentation - tabs and spaces cannot be mixed in %s on line %d
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/heredoc_flex_err_under_indent.phpt
+++ b/tests/ph7/002-integration/lang/heredoc_flex_err_under_indent.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PHP 7.3 heredoc body indented less than closing marker is a parse error
+--FILE--
+<?php
+$x = <<<EOT
+  too shallow
+    EOT;
+--EXPECTF--
+PHP %s error:  Invalid body indentation level (expecting an indentation level of at least 4) in %s on line %d
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/nowdoc_flex_err_tab_space_mix.phpt
+++ b/tests/ph7/002-integration/lang/nowdoc_flex_err_tab_space_mix.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PHP 7.3 nowdoc mixing tabs and spaces in the indent prefix is a parse error
+--FILE--
+<?php
+$x = <<<'EOT'
+	tab-prefixed body
+    EOT;
+--EXPECTF--
+PHP %s error:  Invalid indentation - tabs and spaces cannot be mixed in %s on line %d
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/nowdoc_flex_err_under_indent.phpt
+++ b/tests/ph7/002-integration/lang/nowdoc_flex_err_under_indent.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PHP 7.3 nowdoc body indented less than closing marker is a parse error
+--FILE--
+<?php
+$x = <<<'EOT'
+  too shallow
+      EOT;
+--EXPECTF--
+PHP %s error:  Invalid body indentation level (expecting an indentation level of at least 6) in %s on line %d
+--CLEAN--
+<?php


### PR DESCRIPTION
Allow closing markers to be indented (stripped from body lines) and followed by any non-identifier character (. , ) [ ; etc). The lexer records the marker's indent width in the token's user-data slot; the compile phase allocates a dedented scratch buffer from the VM allocator and validates each body line's prefix, emitting the exact PHP wording for under-indent and tab/space-mixing errors.

Also allows heredoc and nowdoc as array-subscript bases so `(<<<EOT ... EOT)[0]` parses, and fixes var_dump string output to emit `string(N) "content"` instead of the legacy `string(N 'content')`. Promotes PH7_CompileHereDoc and PH7_CompileNowDoc from static to PH7_PRIVATE so parse.c can reference them in the l-value allow-list. Updates 12 existing test fixtures that asserted on the old var_dump format.
