### PR TITLE
Implement arrow functions fn() => expr (PHP 7.4)

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -412,6 +412,9 @@ static ph7_value * GenStateInstallNumLiteral(ph7_gen_state *pGen,sxu32 *pIdx)
  */
 /* Forward declaration */
 static sxi32 GenStateCompileChunk(ph7_gen_state *pGen,sxi32 iFlags);
+static sxi32 GenStateCollectFuncArgs(ph7_vm_func *pFunc,ph7_gen_state *pGen,SyToken *pEnd);
+static void GenStateParseReturnType(ph7_gen_state *pGen, ph7_vm_func *pFunc);
+static const char * TokenTypeName(sxu32 nType);
 /*
  * Stack-scratch size for stripping PHP 7.4 numeric separators. A typical
  * literal (INT64_MAX decimal is 19 digits, binary 64-bit with per-nibble
@@ -1371,6 +1374,51 @@ static sxi32 GenStateCompileArrayBody(ph7_gen_state *pGen)
 			if( (pCur->nType & PH7_TK_ARRAY_OP) && iNest <= 0 ){
 				break;
 			}
+			/* Arrow function (PHP 7.4): 'fn(...) =>' or 'static fn(...) =>'.
+			 * The '=>' inside an arrow function is not an array key/value
+			 * separator — it introduces the expression body. Skip past the
+			 * signature so the body scan sees no false '=>'.
+			 */
+			if( iNest == 0 && (pCur->nType & PH7_TK_KEYWORD) ){
+				sxu32 nKw = (sxu32)SX_PTR_TO_INT(pCur->pUserData);
+				SyToken *pFn = pCur;
+				if( nKw == PH7_TKWRD_STATIC && &pCur[1] < pGen->pIn
+					&& (pCur[1].nType & PH7_TK_KEYWORD)
+					&& SX_PTR_TO_INT(pCur[1].pUserData) == PH7_TKWRD_FN ){
+					pFn = &pCur[1];
+					nKw = PH7_TKWRD_FN;
+				}
+				if( nKw == PH7_TKWRD_FN ){
+					pCur = pFn + 1; /* past 'fn' */
+					if( pCur < pGen->pIn && (pCur->nType & PH7_TK_AMPER) ){
+						pCur++;
+					}
+					if( pCur < pGen->pIn && (pCur->nType & PH7_TK_LPAREN) ){
+						pCur++;
+						PH7_DelimitNestedTokens(pCur,pGen->pIn,
+							PH7_TK_LPAREN,PH7_TK_RPAREN,&pCur);
+						if( pCur < pGen->pIn ){
+							pCur++;
+						}
+					}
+					if( pCur < pGen->pIn && (pCur->nType & PH7_TK_COLON) ){
+						pCur++;
+						if( pCur < pGen->pIn && (pCur->nType & PH7_TK_OP)
+							&& pCur->sData.nByte == 1
+							&& pCur->sData.zString[0] == '?' ){
+							pCur++;
+						}
+						if( pCur < pGen->pIn
+							&& (pCur->nType & (PH7_TK_KEYWORD|PH7_TK_ID)) ){
+							pCur++;
+						}
+					}
+					/* The rest of the entry is the arrow function body — no
+					 * outer key to extract. Stop the scan here. */
+					pCur = pGen->pIn;
+					break;
+				}
+			}
 			if( pCur->nType & PH7_TK_LPAREN /*'('*/ ){
 				iNest++;
 			}else if( pCur->nType & PH7_TK_RPAREN /*')'*/ ){
@@ -1724,6 +1772,513 @@ PH7_PRIVATE sxi32 PH7_CompileAnnonFunc(ph7_gen_state *pGen,sxi32 iCompileFlag)
 		PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOADC,0,nIdx,0,0);
 	}
 	/* Node successfully compiled */
+	return SXRET_OK;
+}
+/*
+ * Add a free variable to the arrow function's closure environment, unless
+ * it is 'this' (handled separately), is shadowed by a parameter at any
+ * enclosing arrow level, or has already been captured.
+ */
+static sxi32 GenStateArrowAddCapture(
+	ph7_gen_state *pGen,
+	ph7_vm_func *pFunc,
+	const char *zName,
+	sxu32 nByte,
+	SyString *aShadow,
+	sxu32 nShadow)
+{
+	ph7_vm_func_closure_env sEnv;
+	ph7_vm_func_closure_env *aEnv;
+	sxu32 n, nEnv;
+	char *zDup;
+	if( nByte == 0 ){
+		return SXRET_OK;
+	}
+	if( nByte == sizeof("this")-1
+		&& SyMemcmp(zName,"this",sizeof("this")-1) == 0 ){
+		return SXRET_OK;
+	}
+	for( n = 0 ; n < nShadow ; n++ ){
+		if( SyStringLength(&aShadow[n]) == nByte
+			&& SyMemcmp(SyStringData(&aShadow[n]),zName,nByte) == 0 ){
+			return SXRET_OK;
+		}
+	}
+	aEnv = (ph7_vm_func_closure_env *)SySetBasePtr(&pFunc->aClosureEnv);
+	nEnv = SySetUsed(&pFunc->aClosureEnv);
+	for( n = 0 ; n < nEnv ; n++ ){
+		if( SyStringLength(&aEnv[n].sName) == nByte
+			&& SyMemcmp(SyStringData(&aEnv[n].sName),zName,nByte) == 0 ){
+			return SXRET_OK;
+		}
+	}
+	zDup = SyMemBackendStrDup(&pGen->pVm->sAllocator,zName,nByte);
+	if( zDup == 0 ){
+		return SXERR_ABORT;
+	}
+	SyZero(&sEnv,sizeof(ph7_vm_func_closure_env));
+	sEnv.iFlags = 0;
+	PH7_MemObjInit(pGen->pVm,&sEnv.sValue);
+	SyStringInitFromBuf(&sEnv.sName,zDup,nByte);
+	SySetPut(&pFunc->aClosureEnv,(const void *)&sEnv);
+	return SXRET_OK;
+}
+/*
+ * Walk the raw body of a double-quoted string or heredoc, extracting every
+ * unescaped $<identifier> reference. The semantics mirror the "simple
+ * syntax" path in GenStateCompileString: `$name`, `{$name}`, `$obj->prop`,
+ * `$arr[...]`, `{$arr['k']}` all capture only the leading identifier.
+ */
+static sxi32 GenStateArrowScanInterpolatedString(
+	ph7_gen_state *pGen,
+	ph7_vm_func *pFunc,
+	const char *zIn,
+	const char *zEnd,
+	SyString *aShadow,
+	sxu32 nShadow)
+{
+	sxi32 rc;
+	while( zIn < zEnd ){
+		if( zIn[0] == '\\' ){
+			zIn++;
+			if( zIn < zEnd ){
+				zIn++;
+			}
+			continue;
+		}
+		if( zIn[0] == '$' && &zIn[1] < zEnd
+			&& ((unsigned char)zIn[1] >= 0xc0
+				|| SyisAlpha(zIn[1]) || zIn[1] == '_') ){
+			const char *zName;
+			zIn++; /* skip '$' */
+			zName = zIn;
+			while( zIn < zEnd ){
+				unsigned char c = (unsigned char)zIn[0];
+				if( c >= 0xc0 ){
+					zIn++;
+					while( zIn < zEnd
+						&& (((unsigned char)zIn[0] & 0xc0) == 0x80) ){
+						zIn++;
+					}
+					continue;
+				}
+				if( !SyisAlphaNum(zIn[0]) && zIn[0] != '_' ){
+					break;
+				}
+				zIn++;
+			}
+			if( zIn > zName ){
+				rc = GenStateArrowAddCapture(pGen,pFunc,zName,
+					(sxu32)(zIn - zName),aShadow,nShadow);
+				if( rc == SXERR_ABORT ){
+					return SXERR_ABORT;
+				}
+			}
+			continue;
+		}
+		zIn++;
+	}
+	return SXRET_OK;
+}
+/*
+ * Scan the body token range of an arrow function for free-variable
+ * references and record them in pFunc's closure environment. Handles:
+ *   - plain $<id> pairs
+ *   - variables inside "..." and heredocs (via interpolation scan)
+ *   - nested arrow functions: descends into the inner body with the inner
+ *     parameters added to the shadow list, so a variable referenced by a
+ *     nested arrow that is not the inner's parameter is captured by the
+ *     OUTER (enabling transitive capture), while the inner's own params
+ *     are never mistakenly captured.
+ */
+static sxi32 GenStateArrowCaptureScan(
+	ph7_gen_state *pGen,
+	ph7_vm_func *pFunc,
+	SyToken *pStart,
+	SyToken *pEnd,
+	SyString *aShadow,
+	sxu32 nShadow)
+{
+	SyToken *pScan = pStart;
+	sxi32 rc;
+	while( pScan < pEnd ){
+		if( pScan->nType & (PH7_TK_DSTR|PH7_TK_HEREDOC) ){
+			rc = GenStateArrowScanInterpolatedString(pGen,pFunc,
+				pScan->sData.zString,
+				pScan->sData.zString + pScan->sData.nByte,
+				aShadow,nShadow);
+			if( rc == SXERR_ABORT ){
+				return SXERR_ABORT;
+			}
+			pScan++;
+			continue;
+		}
+		if( pScan->nType & PH7_TK_KEYWORD ){
+			sxu32 nKw = (sxu32)SX_PTR_TO_INT(pScan->pUserData);
+			SyToken *pFnKw = pScan;
+			if( nKw == PH7_TKWRD_STATIC && &pScan[1] < pEnd
+				&& (pScan[1].nType & PH7_TK_KEYWORD)
+				&& SX_PTR_TO_INT(pScan[1].pUserData) == PH7_TKWRD_FN ){
+				pFnKw = &pScan[1];
+				nKw = PH7_TKWRD_FN;
+			}
+			if( nKw == PH7_TKWRD_FN ){
+				SyToken *pInnerSigStart;
+				SyToken *pInnerSigEnd;
+				SyToken *pInnerBodyEnd;
+				SyString *aInnerShadow;
+				sxu32 nInnerShadow;
+				sxu32 nInnerParamMax;
+				SyToken *p;
+				int iNestInner;
+				pScan = pFnKw + 1; /* past 'fn' */
+				if( pScan < pEnd && (pScan->nType & PH7_TK_AMPER) ){
+					pScan++;
+				}
+				if( pScan >= pEnd || (pScan->nType & PH7_TK_LPAREN) == 0 ){
+					pScan++;
+					continue;
+				}
+				pInnerSigStart = ++pScan; /* past '(' */
+				PH7_DelimitNestedTokens(pScan,pEnd,
+					PH7_TK_LPAREN,PH7_TK_RPAREN,&pInnerSigEnd);
+				if( pInnerSigEnd >= pEnd ){
+					pScan = pEnd;
+					continue;
+				}
+				/* Build an augmented shadow list: inherited + inner params */
+				nInnerParamMax = 0;
+				for( p = pInnerSigStart ; p < pInnerSigEnd ; p++ ){
+					if( p->nType & PH7_TK_DOLLAR ){
+						nInnerParamMax++;
+					}
+				}
+				aInnerShadow = (SyString *)SyMemBackendPoolAlloc(
+					&pGen->pVm->sAllocator,
+					sizeof(SyString) * (nShadow + nInnerParamMax + 1));
+				if( aInnerShadow == 0 ){
+					return SXERR_ABORT;
+				}
+				nInnerShadow = 0;
+				for( ; nInnerShadow < nShadow ; nInnerShadow++ ){
+					aInnerShadow[nInnerShadow] = aShadow[nInnerShadow];
+				}
+				for( p = pInnerSigStart ; p < pInnerSigEnd ; p++ ){
+					if( (p->nType & PH7_TK_DOLLAR) == 0 ){
+						continue;
+					}
+					if( &p[1] >= pInnerSigEnd ){
+						break;
+					}
+					if( (p[1].nType & (PH7_TK_ID|PH7_TK_KEYWORD)) == 0 ){
+						continue;
+					}
+					aInnerShadow[nInnerShadow++] = p[1].sData;
+				}
+				pScan = &pInnerSigEnd[1]; /* past ')' */
+				if( pScan < pEnd && (pScan->nType & PH7_TK_COLON) ){
+					pScan++;
+					if( pScan < pEnd && (pScan->nType & PH7_TK_OP)
+						&& pScan->sData.nByte == 1
+						&& pScan->sData.zString[0] == '?' ){
+						pScan++;
+					}
+					if( pScan < pEnd
+						&& (pScan->nType & (PH7_TK_KEYWORD|PH7_TK_ID)) ){
+						pScan++;
+					}
+				}
+				if( pScan < pEnd && (pScan->nType & PH7_TK_ARRAY_OP) ){
+					pScan++; /* past '=>' */
+				}
+				pInnerBodyEnd = pScan;
+				iNestInner = 0;
+				while( pInnerBodyEnd < pEnd ){
+					if( iNestInner == 0 && (pInnerBodyEnd->nType &
+						(PH7_TK_COMMA|PH7_TK_SEMI|PH7_TK_RPAREN
+						 |PH7_TK_CSB|PH7_TK_CCB)) ){
+						break;
+					}
+					if( pInnerBodyEnd->nType &
+						(PH7_TK_LPAREN|PH7_TK_OSB|PH7_TK_OCB) ){
+						iNestInner++;
+					}else if( pInnerBodyEnd->nType &
+						(PH7_TK_RPAREN|PH7_TK_CSB|PH7_TK_CCB) ){
+						iNestInner--;
+					}
+					pInnerBodyEnd++;
+				}
+				/* Scan the inner arrow's default-parameter VALUES as part of
+				 * the outer's body: a default value is evaluated at call time
+				 * in the outer frame, so any free variable it references is
+				 * an outer capture. We must NOT scan the parameter-name
+				 * declarations themselves (e.g. '$x' in `fn($x = 10) => ...`)
+				 * or those names leak into the outer's closure environment.
+				 *
+				 * Walk the signature argument-by-argument, splitting on
+				 * top-level commas, and for each argument scan only the token
+				 * range after the '=' sign. */
+				{
+					SyToken *pArgStart = pInnerSigStart;
+					while( pArgStart < pInnerSigEnd ){
+						SyToken *pArgEnd = pArgStart;
+						SyToken *pEq = 0;
+						int iNestArg = 0;
+						while( pArgEnd < pInnerSigEnd ){
+							if( iNestArg == 0
+								&& (pArgEnd->nType & PH7_TK_COMMA) ){
+								break;
+							}
+							if( pArgEnd->nType &
+								(PH7_TK_LPAREN|PH7_TK_OSB|PH7_TK_OCB) ){
+								iNestArg++;
+							}else if( pArgEnd->nType &
+								(PH7_TK_RPAREN|PH7_TK_CSB|PH7_TK_CCB) ){
+								iNestArg--;
+							}
+							if( pEq == 0 && iNestArg == 0
+								&& (pArgEnd->nType & PH7_TK_EQUAL) ){
+								pEq = pArgEnd;
+							}
+							pArgEnd++;
+						}
+						if( pEq && (pEq + 1) < pArgEnd ){
+							rc = GenStateArrowCaptureScan(pGen,pFunc,
+								pEq + 1,pArgEnd,aShadow,nShadow);
+							if( rc == SXERR_ABORT ){
+								return SXERR_ABORT;
+							}
+						}
+						pArgStart = pArgEnd;
+						if( pArgStart < pInnerSigEnd
+							&& (pArgStart->nType & PH7_TK_COMMA) ){
+							pArgStart++;
+						}
+					}
+				}
+				rc = GenStateArrowCaptureScan(pGen,pFunc,
+					pScan,pInnerBodyEnd,aInnerShadow,nInnerShadow);
+				if( rc == SXERR_ABORT ){
+					return SXERR_ABORT;
+				}
+				pScan = pInnerBodyEnd;
+				continue;
+			}
+		}
+		if( (pScan->nType & PH7_TK_DOLLAR) == 0 ){
+			pScan++;
+			continue;
+		}
+		{
+			/* Walk past variable-variable chains ($$x) to the base name. */
+			SyToken *pDollar = pScan;
+			while( &pDollar[1] < pEnd
+				&& (pDollar[1].nType & PH7_TK_DOLLAR) ){
+				pDollar++;
+			}
+			if( &pDollar[1] >= pEnd ){
+				break;
+			}
+			if( (pDollar[1].nType & (PH7_TK_ID|PH7_TK_KEYWORD)) == 0 ){
+				pScan = pDollar + 1;
+				continue;
+			}
+			rc = GenStateArrowAddCapture(pGen,pFunc,
+				pDollar[1].sData.zString,pDollar[1].sData.nByte,
+				aShadow,nShadow);
+			if( rc == SXERR_ABORT ){
+				return SXERR_ABORT;
+			}
+			pScan = pDollar + 2;
+		}
+	}
+	return SXRET_OK;
+}
+/*
+ * Compile a PHP 7.4 arrow function: [static] fn([params]) [: ret_type] => expr
+ * Arrow functions are always closures that auto-capture enclosing-scope
+ * variables by value. The body is a single expression that acts as an
+ * implicit return. Unless prefixed with 'static', the enclosing object's
+ * $this is also made available.
+ */
+PH7_PRIVATE sxi32 PH7_CompileArrowFunc(ph7_gen_state *pGen,sxi32 iCompileFlag)
+{
+	ph7_vm_func *pFunc;
+	ph7_vm_func_closure_env sEnv;
+	GenBlock *pBlock;
+	SySet *pInstrContainer;
+	SyToken *pSigEnd;      /* Token just past ')' of the parameter list */
+	SyToken *pBodyStart;   /* First token after '=>' */
+	SyToken *pBodyEnd;     /* Token just past the last body token */
+	SyToken *pSavedEnd;
+	ph7_vm_func_arg *aArgs;
+	char zName[512];
+	static int iCnt = 1;
+	char *zDup;
+	sxu32 nLen;
+	sxu32 nLine;
+	sxi32 iFlags = 0;
+	int bStatic = 0;
+	sxi32 rc;
+	sxu32 n;
+	SXUNUSED(iCompileFlag); /* cc warning */
+
+	nLine = pGen->pIn->nLine;
+	/* Optional 'static' prefix */
+	if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_KEYWORD)
+		&& SX_PTR_TO_INT(pGen->pIn->pUserData) == PH7_TKWRD_STATIC ){
+		bStatic = 1;
+		pGen->pIn++;
+	}
+	/* 'fn' keyword (guaranteed by ExprExtractNode's dispatch) */
+	if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_KEYWORD) == 0
+		|| SX_PTR_TO_INT(pGen->pIn->pUserData) != PH7_TKWRD_FN ){
+		PH7_GenCompileError(&(*pGen),E_ERROR,nLine,
+			"Arrow function: expected 'fn' keyword");
+		return SXERR_SYNTAX;
+	}
+	pGen->pIn++; /* Jump 'fn' */
+	/* Optional '&' — return by reference */
+	if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_AMPER) ){
+		iFlags |= VM_FUNC_REF_RETURN;
+		pGen->pIn++;
+	}
+	/* Expect '(' */
+	if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_LPAREN) == 0 ){
+		if( pGen->pIn < pGen->pEnd ){
+			PH7_GenCompileError(&(*pGen),E_PARSE,pGen->pIn->nLine,
+				"syntax error, unexpected %s \"%z\", expecting \"(\"",
+				TokenTypeName(pGen->pIn->nType),&pGen->pIn->sData);
+		}else{
+			PH7_GenCompileError(&(*pGen),E_PARSE,nLine,
+				"syntax error, unexpected end of file, expecting \"(\"");
+		}
+		return SXERR_SYNTAX;
+	}
+	pGen->pIn++; /* Jump '(' */
+	/* Delimit the parameter list */
+	PH7_DelimitNestedTokens(pGen->pIn,pGen->pEnd,PH7_TK_LPAREN,PH7_TK_RPAREN,&pSigEnd);
+	if( pSigEnd >= pGen->pEnd ){
+		PH7_GenCompileError(&(*pGen),E_PARSE,nLine,
+			"syntax error, unexpected end of file, expecting \")\"");
+		return SXERR_SYNTAX;
+	}
+	/* Allocate the function state */
+	pFunc = (ph7_vm_func *)SyMemBackendPoolAlloc(&pGen->pVm->sAllocator,sizeof(ph7_vm_func));
+	if( pFunc == 0 ){
+		PH7_GenCompileError(&(*pGen),E_ERROR,nLine,
+			"Fatal, PH7 engine is running out of memory");
+		return SXERR_ABORT;
+	}
+	/* Generate a unique lambda name */
+	nLen = SyBufferFormat(zName,sizeof(zName),"[lambda_%d]",iCnt++);
+	while( SyHashGet(&pGen->pVm->hFunction,zName,nLen) != 0 && nLen < sizeof(zName) - 2 ){
+		nLen = SyBufferFormat(zName,sizeof(zName),"[lambda_%d]",iCnt++);
+	}
+	zDup = SyMemBackendStrDup(&pGen->pVm->sAllocator,zName,nLen);
+	if( zDup == 0 ){
+		PH7_GenCompileError(&(*pGen),E_ERROR,nLine,
+			"Fatal, PH7 engine is running out of memory");
+		return SXERR_ABORT;
+	}
+	PH7_VmInitFuncState(pGen->pVm,pFunc,zDup,nLen,iFlags,0);
+	/* Collect function arguments */
+	if( pGen->pIn < pSigEnd ){
+		rc = GenStateCollectFuncArgs(pFunc,&(*pGen),pSigEnd);
+		if( rc == SXERR_ABORT ){
+			return SXERR_ABORT;
+		}
+	}
+	/* Point past ')' and parse optional return type */
+	pGen->pIn = &pSigEnd[1];
+	GenStateParseReturnType(pGen,pFunc);
+	/* Expect '=>' */
+	if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_ARRAY_OP) == 0 ){
+		if( pGen->pIn < pGen->pEnd ){
+			PH7_GenCompileError(&(*pGen),E_PARSE,pGen->pIn->nLine,
+				"syntax error, unexpected %s \"%z\", expecting \"=>\"",
+				TokenTypeName(pGen->pIn->nType),&pGen->pIn->sData);
+		}else{
+			PH7_GenCompileError(&(*pGen),E_PARSE,nLine,
+				"syntax error, unexpected end of file, expecting \"=>\"");
+		}
+		return SXERR_SYNTAX;
+	}
+	pGen->pIn++; /* Jump '=>' */
+	pBodyStart = pGen->pIn;
+	pBodyEnd = pGen->pEnd;
+	/* Build the initial shadow list from the arrow's own parameters, then
+	 * recursively collect free-variable references from the body. The scan
+	 * handles plain $<id>, interpolated strings/heredocs, and nested arrow
+	 * functions with proper parameter shadowing for transitive capture. */
+	aArgs = (ph7_vm_func_arg *)SySetBasePtr(&pFunc->aArgs);
+	{
+		SyString *aShadow = 0;
+		sxu32 nShadow = SySetUsed(&pFunc->aArgs);
+		if( nShadow > 0 ){
+			aShadow = (SyString *)SyMemBackendPoolAlloc(
+				&pGen->pVm->sAllocator,sizeof(SyString) * nShadow);
+			if( aShadow == 0 ){
+				PH7_GenCompileError(&(*pGen),E_ERROR,nLine,
+					"Fatal, PH7 engine is running out of memory");
+				return SXERR_ABORT;
+			}
+			for( n = 0 ; n < nShadow ; n++ ){
+				aShadow[n] = aArgs[n].sName;
+			}
+		}
+		rc = GenStateArrowCaptureScan(pGen,pFunc,pBodyStart,pBodyEnd,
+			aShadow,nShadow);
+		if( rc == SXERR_ABORT ){
+			return SXERR_ABORT;
+		}
+	}
+	/* Unless declared static, auto-capture $this so arrow functions used
+	 * inside methods can reference it. Flagged VM_FUNC_ARG_IGNORE so the
+	 * captured value is silently dropped when the enclosing scope has no
+	 * $this. */
+	if( !bStatic ){
+		char *zThisDup;
+		zThisDup = SyMemBackendStrDup(&pGen->pVm->sAllocator,"this",sizeof("this")-1);
+		if( zThisDup == 0 ){
+			PH7_GenCompileError(&(*pGen),E_ERROR,nLine,
+				"Fatal, PH7 engine is running out of memory");
+			return SXERR_ABORT;
+		}
+		SyZero(&sEnv,sizeof(ph7_vm_func_closure_env));
+		sEnv.iFlags = VM_FUNC_ARG_IGNORE;
+		PH7_MemObjInit(pGen->pVm,&sEnv.sValue);
+		SyStringInitFromBuf(&sEnv.sName,zThisDup,sizeof("this")-1);
+		SySetPut(&pFunc->aClosureEnv,(const void *)&sEnv);
+	}
+	/* Arrow functions are always closures */
+	pFunc->iFlags |= VM_FUNC_CLOSURE;
+	/* Compile the body expression as an implicit return */
+	rc = GenStateEnterBlock(&(*pGen),GEN_BLOCK_PROTECTED|GEN_BLOCK_FUNC,
+		PH7_VmInstrLength(pGen->pVm),pFunc,&pBlock);
+	if( rc != SXRET_OK ){
+		PH7_GenCompileError(&(*pGen),E_ERROR,nLine,
+			"PH7 engine is running out-of-memory");
+		return SXERR_ABORT;
+	}
+	pInstrContainer = PH7_VmGetByteCodeContainer(pGen->pVm);
+	PH7_VmSetByteCodeContainer(pGen->pVm,&pFunc->aByteCode);
+	pSavedEnd = pGen->pEnd;
+	pGen->pIn = pBodyStart;
+	pGen->pEnd = pBodyEnd;
+	rc = PH7_CompileExpr(&(*pGen),0,0);
+	if( rc == SXERR_ABORT ){
+		return SXERR_ABORT;
+	}
+	/* Emit implicit return: OP_DONE with p1=1 means 'value on stack' */
+	PH7_VmEmitInstr(pGen->pVm,PH7_OP_DONE,(rc != SXERR_EMPTY ? 1 : 0),0,0,0);
+	PH7_VmSetByteCodeContainer(pGen->pVm,pInstrContainer);
+	GenStateLeaveBlock(&(*pGen),0);
+	/* Restore cursors; caller will re-synchronize via the node's pEnd */
+	pGen->pIn = pBodyEnd;
+	pGen->pEnd = pSavedEnd;
+	/* Emit the load-closure instruction */
+	PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOAD_CLOSURE,0,0,pFunc,0);
 	return SXRET_OK;
 }
 /*
@@ -8410,6 +8965,12 @@ static ProcLangConstruct GenStateGetStatementHandler(
 					/* 'static' (class context),return null */
 					return 0;
 				}
+			}
+			if( nKeywordID == PH7_TKWRD_STATIC && pLookahed
+				&& (pLookahed->nType & PH7_TK_KEYWORD)
+				&& SX_PTR_TO_INT(pLookahed->pUserData) == PH7_TKWRD_FN ){
+				/* 'static fn(...)' arrow function — compile as expression */
+				return 0;
 			}
 			/* Return a pointer to the handler.
 			*/

--- a/src/ph7/lex.c
+++ b/src/ph7/lex.c
@@ -75,6 +75,14 @@ static sxi32 TokenizePHP(SyStream *pStream,SyToken *pToken,void *pUserData,void 
 		/* Record token length */
 		pStr->nByte = (sxu32)((const char *)pStream->zText-pStr->zString);
 		nKeyword = KeywordCode(pStr->zString,(int)pStr->nByte);
+		/* PHP 7.4: 'fn' is a keyword reserved for arrow functions.
+		 * The auto-generated perfect hash above doesn't know about it,
+		 * so intercept the 'fn' identifier here.
+		 */
+		if( nKeyword == PH7_TK_ID && pStr->nByte == 2
+			&& pStr->zString[0] == 'f' && pStr->zString[1] == 'n' ){
+			nKeyword = PH7_TKWRD_FN;
+		}
 		if( nKeyword != PH7_TK_ID ){
 			if( nKeyword &
 				(PH7_TKWRD_NEW|PH7_TKWRD_CLONE|PH7_TKWRD_AND|PH7_TKWRD_XOR|PH7_TKWRD_OR|PH7_TKWRD_INSTANCEOF|PH7_TKWRD_SEQ|PH7_TKWRD_SNE) ){

--- a/src/ph7/parse.c
+++ b/src/ph7/parse.c
@@ -664,6 +664,83 @@ Synchronize:
 	return rc;
 }
 /*
+ * Assemble a PHP 7.4 arrow function token range:
+ *    [static] fn [&] ( params ) [: [?] type] => expression
+ * On entry *ppCur points at 'static' or 'fn'. On exit *ppCur points just
+ * past the body expression — the body ends at the first top-level comma,
+ * semicolon, or unbalanced closing delimiter.
+ */
+static sxi32 ExprAssembleArrowFunc(ph7_gen_state *pGen,SyToken **ppCur,SyToken *pEnd)
+{
+	SyToken *pIn = *ppCur;
+	sxu32 nLine;
+	sxi32 rc;
+	int iNest;
+	nLine = pIn->nLine;
+	/* Optional 'static' prefix */
+	if( pIn < pEnd && (pIn->nType & PH7_TK_KEYWORD)
+		&& SX_PTR_TO_INT(pIn->pUserData) == PH7_TKWRD_STATIC ){
+		pIn++;
+	}
+	/* Expect 'fn' (dispatch in ExprExtractNode guarantees this) */
+	if( pIn >= pEnd || (pIn->nType & PH7_TK_KEYWORD) == 0
+		|| SX_PTR_TO_INT(pIn->pUserData) != PH7_TKWRD_FN ){
+		rc = SXERR_SYNTAX;
+		goto Synchronize;
+	}
+	pIn++; /* Jump 'fn' */
+	SXUNUSED(nLine);
+	SXUNUSED(pGen);
+	/* Optional '&' for return-by-reference */
+	if( pIn < pEnd && (pIn->nType & PH7_TK_AMPER) ){
+		pIn++;
+	}
+	/* The compile phase (PH7_CompileArrowFunc) performs the authoritative
+	 * structural validation and emits PHP-compatible parse errors. Here we
+	 * just scan token boundaries so the expression node's pEnd covers the
+	 * whole `[static] fn(...) [:T] => body` range, even if malformed. */
+	if( pIn < pEnd && (pIn->nType & PH7_TK_LPAREN) ){
+		pIn++; /* '(' */
+		PH7_DelimitNestedTokens(pIn,pEnd,PH7_TK_LPAREN,PH7_TK_RPAREN,&pIn);
+		if( pIn < pEnd ){
+			pIn++; /* ')' */
+		}
+	}
+	/* Optional return type ': [?] type' */
+	if( pIn < pEnd && (pIn->nType & PH7_TK_COLON) ){
+		pIn++;
+		if( pIn < pEnd && (pIn->nType & PH7_TK_OP)
+			&& pIn->sData.nByte == 1 && pIn->sData.zString[0] == '?' ){
+			pIn++;
+		}
+		if( pIn < pEnd && (pIn->nType & (PH7_TK_KEYWORD|PH7_TK_ID)) ){
+			pIn++;
+		}
+	}
+	/* Consume '=>' if present; the compile pass diagnoses absence */
+	if( pIn < pEnd && (pIn->nType & PH7_TK_ARRAY_OP) ){
+		pIn++;
+	}
+	/* Scan body until first top-level ',' ';' ')' ']' '}' */
+	iNest = 0;
+	while( pIn < pEnd ){
+		if( iNest == 0 && (pIn->nType &
+			(PH7_TK_COMMA|PH7_TK_SEMI|PH7_TK_RPAREN|PH7_TK_CSB|PH7_TK_CCB)) ){
+			break;
+		}
+		if( pIn->nType & (PH7_TK_LPAREN|PH7_TK_OSB|PH7_TK_OCB) ){
+			iNest++;
+		}else if( pIn->nType & (PH7_TK_RPAREN|PH7_TK_CSB|PH7_TK_CCB) ){
+			iNest--;
+		}
+		pIn++;
+	}
+	rc = SXRET_OK;
+Synchronize:
+	*ppCur = pIn;
+	return rc;
+}
+/*
  * Extract a single expression node from the input.
  * On success store the freshly extractd node in ppNode.
  * When errors,PH7 take care of generating the appropriate error message.
@@ -824,6 +901,17 @@ static sxi32 ExprExtractNode(ph7_gen_state *pGen,ph7_expr_node **ppNode,int iLas
 				 }
 				 pNode->xCode = PH7_CompileAnnonFunc;
 			  }
+		 }else if( nKeyword == PH7_TKWRD_FN
+			|| ( nKeyword == PH7_TKWRD_STATIC && &pCur[1] < pGen->pEnd
+				 && (pCur[1].nType & PH7_TK_KEYWORD)
+				 && SX_PTR_TO_INT(pCur[1].pUserData) == PH7_TKWRD_FN ) ){
+			 /* PHP 7.4 arrow function: fn(...) => expr or static fn(...) => expr */
+			 rc = ExprAssembleArrowFunc(&(*pGen),&pCur,pGen->pEnd);
+			 if( rc != SXRET_OK ){
+				 SyMemBackendPoolFree(&pGen->pVm->sAllocator,pNode);
+				 return rc;
+			 }
+			 pNode->xCode = PH7_CompileArrowFunc;
 		 }else if( PH7_IsLangConstruct(nKeyword,FALSE) == TRUE && &pCur[1] < pGen->pEnd ){
 			 /* Language constructs [i.e: print,echo,die...] require special handling */
 			 PH7_DelimitNestedTokens(pCur,pGen->pEnd,PH7_TK_LPAREN|PH7_TK_OCB|PH7_TK_OSB, PH7_TK_RPAREN|PH7_TK_CCB|PH7_TK_CSB,&pCur);

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1163,6 +1163,7 @@ enum ph7_expr_id {
 #define PH7_TKWRD_INSTEADOF    58 /* insteadof */
 #define PH7_TKWRD_FINALLY      59 /* finally */
 #define PH7_TKWRD_YIELD        60 /* yield */
+#define PH7_TKWRD_FN           61 /* fn (PHP 7.4 arrow function) */
 #define PH7_TKWRD_BOOL         0x8000  /* bool:  MUST BE A POWER OF TWO */
 #define PH7_TKWRD_INT          0x10000  /* int:   MUST BE A POWER OF TWO */
 #define PH7_TKWRD_FLOAT        0x20000  /* float:  MUST BE A POWER OF TWO */
@@ -1561,6 +1562,7 @@ PH7_PRIVATE sxi32 PH7_CompileShortArray(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileList(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileShortList(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileAnnonFunc(ph7_gen_state *pGen,sxi32 iCompileFlag);
+PH7_PRIVATE sxi32 PH7_CompileArrowFunc(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_InitCodeGenerator(ph7_vm *pVm,ProcConsumer xErr,void *pErrData);
 PH7_PRIVATE sxi32 PH7_ResetCodeGenerator(ph7_vm *pVm,ProcConsumer xErr,void *pErrData);
 PH7_PRIVATE sxi32 PH7_GenCompileError(ph7_gen_state *pGen,sxi32 nErrType,sxu32 nLine,const char *zFormat,...);

--- a/tests/ph7/001-smoke/lang/arrow_function_auto_capture.phpt
+++ b/tests/ph7/001-smoke/lang/arrow_function_auto_capture.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: auto-captures outer variables by value
+--FILE--
+<?php
+$mult = 10;
+$f = fn($x) => $x * $mult;
+echo $f(3), "\n";
+?>
+--EXPECT--
+30
+--CLEAN--
+<?php
+unset($f, $mult);

--- a/tests/ph7/001-smoke/lang/arrow_function_basic.phpt
+++ b/tests/ph7/001-smoke/lang/arrow_function_basic.phpt
@@ -1,0 +1,15 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: basic single-argument expression
+--FILE--
+<?php
+$f = fn($x) => $x * 2;
+echo $f(5), "\n";
+?>
+--EXPECT--
+10
+--CLEAN--
+<?php
+unset($f);

--- a/tests/ph7/001-smoke/lang/arrow_function_capture_by_value.phpt
+++ b/tests/ph7/001-smoke/lang/arrow_function_capture_by_value.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: capture is by value, later mutations don't leak
+--FILE--
+<?php
+$n = 1;
+$f = fn() => $n;
+$n = 99;
+echo $f(), "\n";
+?>
+--EXPECT--
+1
+--CLEAN--
+<?php
+unset($f, $n);

--- a/tests/ph7/001-smoke/lang/arrow_function_capture_in_complex_string.phpt
+++ b/tests/ph7/001-smoke/lang/arrow_function_capture_in_complex_string.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: captures variables inside curly-syntax interpolation
+--FILE--
+<?php
+$arr = ['k' => 'v'];
+$f = fn() => "value: {$arr['k']}";
+echo $f(), "\n";
+
+class AfCsObj { public $prop = "hi"; }
+$o = new AfCsObj();
+$g = fn() => "prop: {$o->prop}";
+echo $g(), "\n";
+?>
+--EXPECT--
+value: v
+prop: hi
+--CLEAN--
+<?php
+unset($arr, $f, $o, $g);

--- a/tests/ph7/001-smoke/lang/arrow_function_capture_in_dstring.phpt
+++ b/tests/ph7/001-smoke/lang/arrow_function_capture_in_dstring.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: captures variables referenced inside double-quoted strings
+--FILE--
+<?php
+$name = "world";
+$n = 42;
+$f = fn() => "hello $name, answer is $n";
+echo $f(), "\n";
+?>
+--EXPECT--
+hello world, answer is 42
+--CLEAN--
+<?php
+unset($f, $name, $n);

--- a/tests/ph7/001-smoke/lang/arrow_function_capture_in_heredoc.phpt
+++ b/tests/ph7/001-smoke/lang/arrow_function_capture_in_heredoc.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: captures variables referenced inside a heredoc
+--FILE--
+<?php
+$who = "PHL";
+$n = 7;
+$f = fn() => <<<EOT
+hello $who value=$n
+EOT;
+echo $f(), "\n";
+?>
+--EXPECT--
+hello PHL value=7
+--CLEAN--
+<?php
+unset($f, $who, $n);

--- a/tests/ph7/001-smoke/lang/arrow_function_default_param.phpt
+++ b/tests/ph7/001-smoke/lang/arrow_function_default_param.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: default parameter value
+--FILE--
+<?php
+$f = fn($x = 10) => $x * 2;
+echo $f(), "\n";
+echo $f(5), "\n";
+?>
+--EXPECT--
+20
+10
+--CLEAN--
+<?php
+unset($f);

--- a/tests/ph7/001-smoke/lang/arrow_function_immediate_invoke.phpt
+++ b/tests/ph7/001-smoke/lang/arrow_function_immediate_invoke.phpt
@@ -1,0 +1,15 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: immediately invoked expression
+--FILE--
+<?php
+echo (fn($x) => $x * 2)(5), "\n";
+echo (fn() => "hello")(), "\n";
+?>
+--EXPECT--
+10
+hello
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/arrow_function_in_array_literal.phpt
+++ b/tests/ph7/001-smoke/lang/arrow_function_in_array_literal.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: inside an array literal stops at closing bracket
+--FILE--
+<?php
+$arr = [fn($x) => $x * 2, fn($x) => $x + 1];
+echo $arr[0](5), "\n";
+echo $arr[1](5), "\n";
+?>
+--EXPECT--
+10
+6
+--CLEAN--
+<?php
+unset($arr);

--- a/tests/ph7/001-smoke/lang/arrow_function_in_array_map.phpt
+++ b/tests/ph7/001-smoke/lang/arrow_function_in_array_map.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: used as array_map callback
+--FILE--
+<?php
+$r = array_map(fn($x) => $x * 2, [1, 2, 3]);
+foreach ($r as $v) echo $v, "\n";
+?>
+--EXPECT--
+2
+4
+6
+--CLEAN--
+<?php
+unset($r);

--- a/tests/ph7/001-smoke/lang/arrow_function_inside_method.phpt
+++ b/tests/ph7/001-smoke/lang/arrow_function_inside_method.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: auto-captures $this inside a method
+--FILE--
+<?php
+class AfImBox {
+    public $value = 42;
+    public function make() {
+        return fn($x) => $this->value + $x;
+    }
+}
+$box = new AfImBox();
+$f = $box->make();
+echo $f(8), "\n";
+?>
+--EXPECT--
+50
+--CLEAN--
+<?php
+unset($box, $f);

--- a/tests/ph7/001-smoke/lang/arrow_function_multiple_capture.phpt
+++ b/tests/ph7/001-smoke/lang/arrow_function_multiple_capture.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: captures multiple outer variables
+--FILE--
+<?php
+$a = 1;
+$b = 2;
+$c = 3;
+$f = fn() => $a + $b + $c;
+echo $f(), "\n";
+?>
+--EXPECT--
+6
+--CLEAN--
+<?php
+unset($a, $b, $c, $f);

--- a/tests/ph7/001-smoke/lang/arrow_function_multiple_params.phpt
+++ b/tests/ph7/001-smoke/lang/arrow_function_multiple_params.phpt
@@ -1,0 +1,15 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: multiple parameters
+--FILE--
+<?php
+$f = fn($x, $y) => $x + $y;
+echo $f(3, 4), "\n";
+?>
+--EXPECT--
+7
+--CLEAN--
+<?php
+unset($f);

--- a/tests/ph7/001-smoke/lang/arrow_function_nested.phpt
+++ b/tests/ph7/001-smoke/lang/arrow_function_nested.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: nested, transitive capture
+--FILE--
+<?php
+$adder = fn($x) => fn($y) => $x + $y;
+$add5 = $adder(5);
+echo $add5(3), "\n";
+echo $add5(10), "\n";
+?>
+--EXPECT--
+8
+15
+--CLEAN--
+<?php
+unset($adder, $add5);

--- a/tests/ph7/001-smoke/lang/arrow_function_nested_default_capture.phpt
+++ b/tests/ph7/001-smoke/lang/arrow_function_nested_default_capture.phpt
@@ -1,0 +1,32 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: nested arrow's default values capture outer vars, param names do not leak
+--FILE--
+<?php
+// The inner arrow's $x and $y are parameter names and must NOT be captured
+// into the outer closure env. The default-value expressions, however, are
+// evaluated in the outer frame and any free variable there must be captured.
+$limit = 100;
+$outer = fn() => fn($x = 0, $y = 5) => $x + $y + $limit;
+$inner = $outer();
+echo $inner(), "\n";
+echo $inner(1, 2), "\n";
+
+// Sanity: an outer-scope $x with the same name as the nested arrow's param
+// must not affect the inner arrow's parameter binding.
+$x = 999;
+$wrap = fn() => fn($x = 10) => $x * 2;
+$ff = $wrap();
+echo $ff(), "\n";
+echo $ff(7), "\n";
+?>
+--EXPECT--
+105
+103
+20
+14
+--CLEAN--
+<?php
+unset($limit, $outer, $inner, $x, $wrap, $ff);

--- a/tests/ph7/001-smoke/lang/arrow_function_nested_shadow.phpt
+++ b/tests/ph7/001-smoke/lang/arrow_function_nested_shadow.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: nested inner parameter shadows outer-scope variable
+--FILE--
+<?php
+$y = 100;
+$f = fn($x) => fn($y) => $x + $y;
+echo $f(5)(3), "\n";
+
+$v = 999;
+$g = fn($v) => fn($v) => $v * 2;
+echo $g(1)(5), "\n";
+?>
+--EXPECT--
+8
+10
+--CLEAN--
+<?php
+unset($f, $g, $v, $y);

--- a/tests/ph7/001-smoke/lang/arrow_function_no_params.phpt
+++ b/tests/ph7/001-smoke/lang/arrow_function_no_params.phpt
@@ -1,0 +1,15 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: no parameters
+--FILE--
+<?php
+$f = fn() => 42;
+echo $f(), "\n";
+?>
+--EXPECT--
+42
+--CLEAN--
+<?php
+unset($f);

--- a/tests/ph7/001-smoke/lang/arrow_function_nullable_return_type.phpt
+++ b/tests/ph7/001-smoke/lang/arrow_function_nullable_return_type.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: nullable return type
+--FILE--
+<?php
+$f = fn($x): ?string => $x === 0 ? null : "v" . $x;
+echo (is_null($f(0)) ? "NULL" : "not"), "\n";
+echo $f(3), "\n";
+?>
+--EXPECT--
+NULL
+v3
+--CLEAN--
+<?php
+unset($f);

--- a/tests/ph7/001-smoke/lang/arrow_function_param_shadows_outer.phpt
+++ b/tests/ph7/001-smoke/lang/arrow_function_param_shadows_outer.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: parameter shadows outer variable of same name
+--FILE--
+<?php
+$x = 99;
+$f = fn($x) => $x * 2;
+echo $f(5), "\n";
+echo $x, "\n";
+?>
+--EXPECT--
+10
+99
+--CLEAN--
+<?php
+unset($x, $f);

--- a/tests/ph7/001-smoke/lang/arrow_function_return_type.phpt
+++ b/tests/ph7/001-smoke/lang/arrow_function_return_type.phpt
@@ -1,0 +1,15 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: declared return type
+--FILE--
+<?php
+$f = fn($x): int => $x * 2;
+echo $f(5), "\n";
+?>
+--EXPECT--
+10
+--CLEAN--
+<?php
+unset($f);

--- a/tests/ph7/001-smoke/lang/arrow_function_static.phpt
+++ b/tests/ph7/001-smoke/lang/arrow_function_static.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: static prefix (no $this binding)
+--FILE--
+<?php
+$f = static fn($x) => $x + 100;
+echo $f(1), "\n";
+echo $f(5), "\n";
+?>
+--EXPECT--
+101
+105
+--CLEAN--
+<?php
+unset($f);

--- a/tests/ph7/001-smoke/lang/arrow_function_string_concat.phpt
+++ b/tests/ph7/001-smoke/lang/arrow_function_string_concat.phpt
@@ -1,0 +1,15 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: string concatenation body
+--FILE--
+<?php
+$f = fn($a, $b) => $a . "-" . $b;
+echo $f("foo", "bar"), "\n";
+?>
+--EXPECT--
+foo-bar
+--CLEAN--
+<?php
+unset($f);

--- a/tests/ph7/001-smoke/lang/arrow_function_transitive_capture.phpt
+++ b/tests/ph7/001-smoke/lang/arrow_function_transitive_capture.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: inner arrow references outer scope var (transitive capture)
+--FILE--
+<?php
+$z = 7;
+$outer = fn() => fn() => $z;
+echo $outer()(), "\n";
+
+$a = 1; $b = 2; $c = 3;
+$deep = fn() => fn() => fn() => $a + $b + $c;
+echo $deep()()(), "\n";
+?>
+--EXPECT--
+7
+6
+--CLEAN--
+<?php
+unset($outer, $deep, $a, $b, $c, $z);

--- a/tests/ph7/001-smoke/lang/arrow_function_typed_param.phpt
+++ b/tests/ph7/001-smoke/lang/arrow_function_typed_param.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: typed parameter
+--FILE--
+<?php
+$f = fn(int $x): int => $x + 1;
+echo $f(5), "\n";
+echo $f(0), "\n";
+?>
+--EXPECT--
+6
+1
+--CLEAN--
+<?php
+unset($f);

--- a/tests/ph7/001-smoke/lang/arrow_function_variadic.phpt
+++ b/tests/ph7/001-smoke/lang/arrow_function_variadic.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: variadic parameters
+--FILE--
+<?php
+$sum = fn(...$args) => array_sum($args);
+echo $sum(1, 2, 3, 4), "\n";
+echo $sum(), "\n";
+?>
+--EXPECT--
+10
+0
+--CLEAN--
+<?php
+unset($sum);

--- a/tests/ph7/002-integration/lang/arrow_function_missing_arrow.phpt
+++ b/tests/ph7/002-integration/lang/arrow_function_missing_arrow.phpt
@@ -1,0 +1,13 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: missing '=>' between signature and body
+--FILE--
+<?php
+$f = fn($x) $x * 2;
+?>
+--EXPECTF--
+%A Parse error:%Asyntax error, unexpected %A, expecting "=>"%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/arrow_function_missing_paren.phpt
+++ b/tests/ph7/002-integration/lang/arrow_function_missing_paren.phpt
@@ -1,0 +1,13 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: missing '(' after 'fn' keyword
+--FILE--
+<?php
+$f = fn $x => $x;
+?>
+--EXPECTF--
+%A Parse error:%Asyntax error, unexpected %A, expecting "("%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/arrow_function_unclosed_paren.phpt
+++ b/tests/ph7/002-integration/lang/arrow_function_unclosed_paren.phpt
@@ -1,0 +1,13 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Arrow function: unclosed parameter list
+--FILE--
+<?php
+$f = fn($x => $x;
+?>
+--EXPECTF--
+%A Parse error:%Asyntax error, unexpected %A, expecting ")"%A
+--CLEAN--
+<?php

--- a/tests/phpt.php
+++ b/tests/phpt.php
@@ -184,7 +184,8 @@ function handle_error($errno, $errstr, $errfile, $errline) {
 }
 
 function match_expectf_pattern($phpt_pattern, $phpt_output) {
-    // Handle %d (digits) and %s (non-whitespace strings) without regex
+    // Handle %d (digits), %s (non-whitespace), %f (floats), %A (any chars
+    // including empty, lazy) and %% (literal percent) without regex.
     $phpt_pattern_len = strlen($phpt_pattern);
     $phpt_output_len = strlen($phpt_output);
     $phpt_p = 0; // pattern position
@@ -195,6 +196,20 @@ function match_expectf_pattern($phpt_pattern, $phpt_output) {
             $phpt_p++; // move past %
             if ($phpt_p >= $phpt_pattern_len) {
                 return false; // incomplete % sequence
+            }
+
+            if ($phpt_pattern[$phpt_p] === 'A') {
+                // Match any characters (possibly empty) lazily: try the
+                // shortest advance of the output cursor for which the rest
+                // of the pattern matches the rest of the output.
+                $phpt_p++; // move past 'A'
+                $phpt_rest_pattern = substr($phpt_pattern, $phpt_p);
+                for ($phpt_i = $phpt_o; $phpt_i <= $phpt_output_len; $phpt_i++) {
+                    if (match_expectf_pattern($phpt_rest_pattern, substr($phpt_output, $phpt_i))) {
+                        return true;
+                    }
+                }
+                return false;
             }
 
             if ($phpt_pattern[$phpt_p] === 'd') {


### PR DESCRIPTION
Add the short-closure syntax with auto-capture by value. A new PH7_TKWRD_FN token is injected post-hash in the lexer; parse.c routes fn(...) and static fn(...) nodes through ExprAssembleArrowFunc, which delimits the signature and scans the body up to the first top-level delimiter. compile.c's PH7_CompileArrowFunc reuses GenStateCollectFuncArgs and GenStateParseReturnType for the signature, then runs a recursive capture scan that threads a parameter shadow list through nested arrows — so transitive captures work and an inner parameter shadows a same-named outer variable. The scan also walks embedded variables inside double-quoted strings and heredocs, matching PHP semantics. The body is compiled as an implicit return into the function's bytecode container, then loaded via the existing PH7_OP_LOAD_CLOSURE opcode, so no VM changes are required. Non-static arrows auto-capture \$this with VM_FUNC_ARG_IGNORE.

Also teaches GenStateCompileArrayBody to skip past an arrow function's signature when scanning for a key/value '=>' separator, so arrow functions work inside array literals.

Covered by 24 smoke tests (basic, multi-param, auto-capture, capture-by-value, nested, nested-shadow, transitive, default/typed/ variadic params, return types incl. nullable, static, \$this in methods, array literal, array_map, immediate invoke, string/heredoc/complex-string interpolation) and 3 error tests for missing '=>', missing '(', and unclosed parameter list.
