### PR TITLE
Implement typed class properties (PHP 7.4)

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -5846,15 +5846,253 @@ Synchronize:
  *   Refer to the official documentation for more information on the powerful extension
  *   introduced by the PH7 engine to the OO subsystem.
  */
+/*
+ * Lookahead: return TRUE if the tokens starting at pStart look like a typed
+ * property declaration — i.e. an optional '?', optional '\', one or more
+ * ID/keyword tokens (possibly separated by '\' for namespace paths), followed
+ * by a '$'. This is used by the class-body dispatcher to decide whether to
+ * route into the typed-attribute path vs. fall through to method/const/etc.
+ */
+static int GenStateLooksLikeTypedProperty(SyToken *pStart,SyToken *pEnd)
+{
+	SyToken *p = pStart;
+	if( p >= pEnd ) return 0;
+	if( (p->nType & PH7_TK_OP) && p->sData.nByte == 1 && p->sData.zString[0] == '?' ){
+		p++;
+		if( p >= pEnd ) return 0;
+	}
+	if( p->nType & PH7_TK_NSSEP ){
+		p++;
+		if( p >= pEnd ) return 0;
+	}
+	if( (p->nType & (PH7_TK_ID|PH7_TK_KEYWORD)) == 0 ){
+		return 0;
+	}
+	/* Reject class-body modifier keywords that aren't types. Visibility
+	 * (public/private/protected) has already been consumed by the caller,
+	 * but static/final/abstract may still appear here for the initial
+	 * dispatch site. */
+	if( p->nType & PH7_TK_KEYWORD ){
+		sxu32 k = (sxu32)(SX_PTR_TO_INT(p->pUserData));
+		if( k == PH7_TKWRD_FUNCTION || k == PH7_TKWRD_VAR || k == PH7_TKWRD_CONST
+		 || k == PH7_TKWRD_STATIC || k == PH7_TKWRD_FINAL || k == PH7_TKWRD_ABSTRACT ){
+			return 0;
+		}
+	}
+	p++;
+	/* Consume optional namespace path */
+	while( p + 1 < pEnd && (p->nType & PH7_TK_NSSEP) && (p[1].nType & (PH7_TK_ID|PH7_TK_KEYWORD)) ){
+		p += 2;
+	}
+	if( p >= pEnd ) return 0;
+	return (p->nType & PH7_TK_DOLLAR) ? 1 : 0;
+}
+
+/*
+ * Parse an optional property type hint starting at pGen->pIn. On return,
+ * pGen->pIn points at the '$' token if a type was present (or is unchanged
+ * if not). Recognized forms:
+ *   ?Type, array, bool, int, float, string, object,
+ *   self, parent, \Ns\ClassName, ClassName
+ * The 'iterable' pseudo-type is not yet supported and is rejected earlier
+ * by GenStateCompileClassAttr along with void/never/mixed/callable.
+ * Returns SXRET_OK on successful parse (type or no type), SXERR_SYNTAX
+ * on unrecoverable error.
+ *
+ * When a type is parsed:
+ *   *pnType is set to MEMOBJ_* (or SXU32_HIGH for class types)
+ *   *pClass is set to the class name (for class types)
+ *   *piTypeFlags receives PH7_CLASS_ATTR_TYPED and optionally NULLABLE
+ *   *pTypeText is set to the original text span of the type
+ * Otherwise they are left unchanged (so multi-decl reuse works).
+ */
+static sxi32 GenStateParsePropertyType(
+	ph7_gen_state *pGen,
+	sxu32 *pnType,
+	SyString *pClass,
+	sxi32 *piTypeFlags,
+	SyString *pTypeText
+){
+	SyToken *pIn = pGen->pIn;
+	SyToken *pTypeStart = pIn;
+	int bNullable = 0;
+	sxu32 nType = 0;
+	SyString sClassName;
+	int bHaveClass = 0;
+	SyStringInitFromBuf(&sClassName,0,0);
+	if( pIn >= pGen->pEnd ){
+		return SXRET_OK;
+	}
+	/* If the first token is '$', there's no type */
+	if( pIn->nType & PH7_TK_DOLLAR ){
+		return SXRET_OK;
+	}
+	/* Optional nullable prefix '?' */
+	if( (pIn->nType & PH7_TK_OP) && pIn->sData.nByte == 1 && pIn->sData.zString[0] == '?' ){
+		bNullable = 1;
+		pIn++;
+		if( pIn >= pGen->pEnd ){
+			return SXERR_SYNTAX;
+		}
+	}
+	/* Skip leading namespace separator '\' */
+	if( pIn < pGen->pEnd && (pIn->nType & PH7_TK_NSSEP) ){
+		pIn++;
+	}
+	if( pIn >= pGen->pEnd || (pIn->nType & (PH7_TK_ID|PH7_TK_KEYWORD)) == 0 ){
+		return SXERR_SYNTAX;
+	}
+	if( pIn->nType & PH7_TK_KEYWORD ){
+		sxu32 nKey = (sxu32)(SX_PTR_TO_INT(pIn->pUserData));
+		if( nKey & PH7_TKWRD_ARRAY ){
+			nType = MEMOBJ_HASHMAP;
+		}else if( nKey & PH7_TKWRD_BOOL ){
+			nType = MEMOBJ_BOOL;
+		}else if( nKey & PH7_TKWRD_INT ){
+			nType = MEMOBJ_INT;
+		}else if( nKey & PH7_TKWRD_STRING ){
+			nType = MEMOBJ_STRING;
+		}else if( nKey & PH7_TKWRD_FLOAT ){
+			nType = MEMOBJ_REAL;
+		}else if( nKey & PH7_TKWRD_OBJECT ){
+			nType = MEMOBJ_OBJ;
+		}else if( nKey == PH7_TKWRD_SELF || nKey == PH7_TKWRD_PARENT ){
+			/* self/parent — treat as class type with that literal name */
+			nType = SXU32_HIGH;
+			sClassName = pIn->sData;
+			bHaveClass = 1;
+		}else{
+			/* Unknown keyword as type — treat as syntax error for properties */
+			return SXERR_SYNTAX;
+		}
+		pIn++;
+	}else{
+		/* Class / interface name (identifier). Consume namespace path a\b\c
+		 * and grow sClassName to span the full qualified name rather than
+		 * only the first segment. */
+		SyToken *pFirst = pIn;
+		SyToken *pLast = pIn;
+		sClassName = pIn->sData;
+		nType = SXU32_HIGH;
+		bHaveClass = 1;
+		pIn++;
+		while( pIn + 1 < pGen->pEnd && (pIn->nType & PH7_TK_NSSEP) && (pIn[1].nType & PH7_TK_ID) ){
+			pLast = &pIn[1];
+			pIn += 2;
+		}
+		if( pLast != pFirst ){
+			const char *zFirst = pFirst->sData.zString;
+			const char *zEnd = pLast->sData.zString + pLast->sData.nByte;
+			sClassName.zString = zFirst;
+			sClassName.nByte = (sxu32)(zEnd - zFirst);
+		}
+	}
+	/* Verify the next token is '$' — otherwise this wasn't a property type */
+	if( pIn >= pGen->pEnd || (pIn->nType & PH7_TK_DOLLAR) == 0 ){
+		return SXERR_SYNTAX;
+	}
+	/* Commit */
+	*pnType = nType;
+	*piTypeFlags = PH7_CLASS_ATTR_TYPED;
+	if( bNullable ){
+		*piTypeFlags |= PH7_CLASS_ATTR_NULLABLE;
+	}
+	if( bHaveClass ){
+		char *zDup = SyMemBackendStrDup(&pGen->pVm->sAllocator,sClassName.zString,sClassName.nByte);
+		if( zDup == 0 ){
+			return SXERR_ABORT;
+		}
+		SyStringInitFromBuf(pClass,zDup,sClassName.nByte);
+	}
+	if( pTypeText ){
+		const char *zStart = pTypeStart->sData.zString;
+		const char *zEnd = pIn->sData.zString; /* points at '$' */
+		sxu32 nLen;
+		char *zDupTxt;
+		if( zEnd > zStart ){
+			nLen = (sxu32)(zEnd - zStart);
+			/* Strip trailing whitespace that may separate the type from '$' */
+			while( nLen > 0 && (zStart[nLen-1] == ' ' || zStart[nLen-1] == '\t'
+				|| zStart[nLen-1] == '\n' || zStart[nLen-1] == '\r') ){
+				nLen--;
+			}
+		}else{
+			nLen = pTypeStart->sData.nByte;
+		}
+		zDupTxt = SyMemBackendStrDup(&pGen->pVm->sAllocator,zStart,nLen);
+		if( zDupTxt ){
+			SyStringInitFromBuf(pTypeText,zDupTxt,nLen);
+		}else{
+			SyStringInitFromBuf(pTypeText,0,0);
+		}
+	}
+	pGen->pIn = pIn;
+	return SXRET_OK;
+}
+
 static sxi32 GenStateCompileClassAttr(ph7_gen_state *pGen,sxi32 iProtection,sxi32 iFlags,ph7_class *pClass)
 {
 	sxu32 nLine = pGen->pIn->nLine;
 	ph7_class_attr *pAttr;
 	SyString *pName;
 	sxi32 rc;
+	sxu32 nType = 0;
+	SyString sTypeClass;
+	SyString sTypeText;
+	sxi32 iTypeFlags = 0;
+	SyStringInitFromBuf(&sTypeClass,0,0);
+	SyStringInitFromBuf(&sTypeText,0,0);
 	/* Extract visibility level */
 	iProtection = GetProtectionLevel(iProtection);
+	/* Parse optional type hint (typed properties, PHP 7.4+) */
+	if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_DOLLAR) == 0 ){
+		SyToken *pTypeTok = pGen->pIn;
+		/* A leading '?' is part of the type, look past it when sniffing the
+		 * type keyword for the disallowed list. */
+		if( (pTypeTok->nType & PH7_TK_OP) && pTypeTok->sData.nByte == 1
+		 && pTypeTok->sData.zString[0] == '?' && pTypeTok + 1 < pGen->pEnd ){
+			pTypeTok = pTypeTok + 1;
+		}
+		/* Reject disallowed property types up front: void, callable, never,
+		 * mixed, and iterable (the last is not yet implemented in PHL — we
+		 * reject explicitly rather than silently fall through to a class
+		 * name lookup that would resolve to NULL). */
+		if( pTypeTok->nType & PH7_TK_ID ){
+			SyString *pT = &pTypeTok->sData;
+			if( (pT->nByte == 4 && SyMemcmpNoCase(pT->zString,"void",4) == 0)
+			 || (pT->nByte == 5 && SyMemcmpNoCase(pT->zString,"never",5) == 0)
+			 || (pT->nByte == 5 && SyMemcmpNoCase(pT->zString,"mixed",5) == 0)
+			 || (pT->nByte == 8 && SyMemcmpNoCase(pT->zString,"callable",8) == 0)
+			 || (pT->nByte == 8 && SyMemcmpNoCase(pT->zString,"iterable",8) == 0) ){
+				rc = PH7_GenCompileError(pGen,E_ERROR,nLine,
+					"Property cannot have type %z",pT);
+				if( rc == SXERR_ABORT ){
+					return SXERR_ABORT;
+				}
+				goto Synchronize;
+			}
+		}
+		rc = GenStateParsePropertyType(pGen,&nType,&sTypeClass,&iTypeFlags,&sTypeText);
+		if( rc == SXERR_SYNTAX ){
+			rc = PH7_GenCompileError(pGen,E_ERROR,nLine,
+				"Invalid property type or declaration near '%z'",
+				&pGen->pIn->sData);
+			if( rc == SXERR_ABORT ){
+				return SXERR_ABORT;
+			}
+			goto Synchronize;
+		}else if( rc == SXERR_ABORT ){
+			return SXERR_ABORT;
+		}
+	}
 loop:
+	if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_DOLLAR) == 0 ){
+		rc = PH7_GenCompileError(pGen,E_ERROR,nLine,"Expected '$' at start of property name");
+		if( rc == SXERR_ABORT ){
+			return SXERR_ABORT;
+		}
+		goto Synchronize;
+	}
 	pGen->pIn++; /* Jump the dollar sign */
 	if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & (PH7_TK_KEYWORD|PH7_TK_ID)) == 0 ){
 		/* Invalid attribute name */
@@ -5879,10 +6117,15 @@ loop:
 		goto Synchronize;
 	}
 	/* Allocate a new class attribute */
-	pAttr = PH7_NewClassAttr(pGen->pVm,pName,nLine,iProtection,iFlags);
+	pAttr = PH7_NewClassAttr(pGen->pVm,pName,nLine,iProtection,iFlags|iTypeFlags);
 	if( pAttr == 0 ){
 		PH7_GenCompileError(pGen,E_ERROR,nLine,"Fatal, PH7 engine is running out of memory");
 		return SXERR_ABORT;
+	}
+	if( iTypeFlags & PH7_CLASS_ATTR_TYPED ){
+		pAttr->nType = nType;
+		pAttr->sClass = sTypeClass;
+		pAttr->sTypeName = sTypeText;
 	}
 	if( pGen->pIn->nType & PH7_TK_EQUAL /*'='*/ ){
 		SySet *pInstrContainer;
@@ -6864,7 +7107,8 @@ static sxi32 GenStateCompileClass(ph7_gen_state *pGen,sxi32 iFlags)
 			if( nKwrd == PH7_TKWRD_PUBLIC || nKwrd == PH7_TKWRD_PRIVATE || nKwrd == PH7_TKWRD_PROTECTED ){
 				iProtection = nKwrd;
 				pGen->pIn++; /* Jump the visibility token */
-				if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & (PH7_TK_KEYWORD|PH7_TK_DOLLAR)) == 0 ){
+				if( pGen->pIn >= pGen->pEnd
+					|| (pGen->pIn->nType & (PH7_TK_KEYWORD|PH7_TK_DOLLAR|PH7_TK_ID|PH7_TK_OP|PH7_TK_NSSEP)) == 0 ){
 					rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,
 						"Unexpected token '%z'. Expecting attribute declaration inside class '%z'",
 						&pGen->pIn->sData,pName);
@@ -6875,7 +7119,18 @@ static sxi32 GenStateCompileClass(ph7_gen_state *pGen,sxi32 iFlags)
 					goto done;
 				}
 				if( pGen->pIn->nType & PH7_TK_DOLLAR ){
-					/* Attribute declaration */
+					/* Attribute declaration (untyped) */
+					rc = GenStateCompileClassAttr(&(*pGen),iProtection,iAttrflags,pClass);
+					if( rc != SXRET_OK ){
+						if( rc == SXERR_ABORT ){
+							return SXERR_ABORT;
+						}
+						goto done;
+					}
+					continue;
+				}
+				if( GenStateLooksLikeTypedProperty(pGen->pIn,pGen->pEnd) ){
+					/* Typed attribute declaration (PHP 7.4+) */
 					rc = GenStateCompileClassAttr(&(*pGen),iProtection,iAttrflags,pClass);
 					if( rc != SXRET_OK ){
 						if( rc == SXERR_ABORT ){
@@ -6910,7 +7165,8 @@ static sxi32 GenStateCompileClass(ph7_gen_state *pGen,sxi32 iFlags)
 							pGen->pIn++; /* Jump the visibility token */
 						}
 					}
-					if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & (PH7_TK_KEYWORD|PH7_TK_DOLLAR)) == 0 ){
+					if( pGen->pIn >= pGen->pEnd
+						|| (pGen->pIn->nType & (PH7_TK_KEYWORD|PH7_TK_DOLLAR|PH7_TK_ID|PH7_TK_OP|PH7_TK_NSSEP)) == 0 ){
 						rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,
 							"Unexpected token '%z',Expecting method,attribute or constant declaration inside class '%z'",
 							&pGen->pIn->sData,pName);
@@ -6922,6 +7178,17 @@ static sxi32 GenStateCompileClass(ph7_gen_state *pGen,sxi32 iFlags)
 					}
 					if( pGen->pIn->nType & PH7_TK_DOLLAR ){
 						/* Attribute declaration */
+						rc = GenStateCompileClassAttr(&(*pGen),iProtection,iAttrflags,pClass);
+						if( rc != SXRET_OK ){
+							if( rc == SXERR_ABORT ){
+								return SXERR_ABORT;
+							}
+							goto done;
+						}
+						continue;
+					}
+					if( GenStateLooksLikeTypedProperty(pGen->pIn,pGen->pEnd) ){
+						/* Typed static attribute declaration */
 						rc = GenStateCompileClassAttr(&(*pGen),iProtection,iAttrflags,pClass);
 						if( rc != SXRET_OK ){
 							if( rc == SXERR_ABORT ){
@@ -7476,7 +7743,8 @@ static sxi32 PH7_CompileTrait(ph7_gen_state *pGen)
 			if( nKwrd == PH7_TKWRD_PUBLIC || nKwrd == PH7_TKWRD_PRIVATE || nKwrd == PH7_TKWRD_PROTECTED ){
 				iProtection = nKwrd;
 				pGen->pIn++;
-				if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & (PH7_TK_KEYWORD|PH7_TK_DOLLAR)) == 0 ){
+				if( pGen->pIn >= pGen->pEnd
+					|| (pGen->pIn->nType & (PH7_TK_KEYWORD|PH7_TK_DOLLAR|PH7_TK_ID|PH7_TK_OP|PH7_TK_NSSEP)) == 0 ){
 					rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,
 						"Unexpected token '%z'. Expecting attribute declaration inside trait '%z'",
 						&pGen->pIn->sData,pName);
@@ -7486,6 +7754,16 @@ static sxi32 PH7_CompileTrait(ph7_gen_state *pGen)
 					goto done;
 				}
 				if( pGen->pIn->nType & PH7_TK_DOLLAR ){
+					rc = GenStateCompileClassAttr(&(*pGen),iProtection,iAttrflags,pClass);
+					if( rc != SXRET_OK ){
+						if( rc == SXERR_ABORT ){
+							return SXERR_ABORT;
+						}
+						goto done;
+					}
+					continue;
+				}
+				if( GenStateLooksLikeTypedProperty(pGen->pIn,pGen->pEnd) ){
 					rc = GenStateCompileClassAttr(&(*pGen),iProtection,iAttrflags,pClass);
 					if( rc != SXRET_OK ){
 						if( rc == SXERR_ABORT ){
@@ -7515,7 +7793,8 @@ static sxi32 PH7_CompileTrait(ph7_gen_state *pGen)
 							pGen->pIn++;
 						}
 					}
-					if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & (PH7_TK_KEYWORD|PH7_TK_DOLLAR)) == 0 ){
+					if( pGen->pIn >= pGen->pEnd
+						|| (pGen->pIn->nType & (PH7_TK_KEYWORD|PH7_TK_DOLLAR|PH7_TK_ID|PH7_TK_OP|PH7_TK_NSSEP)) == 0 ){
 						rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,
 							"Unexpected token '%z',Expecting method or attribute declaration inside trait '%z'",
 							&pGen->pIn->sData,pName);
@@ -7525,6 +7804,16 @@ static sxi32 PH7_CompileTrait(ph7_gen_state *pGen)
 						goto done;
 					}
 					if( pGen->pIn->nType & PH7_TK_DOLLAR ){
+						rc = GenStateCompileClassAttr(&(*pGen),iProtection,iAttrflags,pClass);
+						if( rc != SXRET_OK ){
+							if( rc == SXERR_ABORT ){
+								return SXERR_ABORT;
+							}
+							goto done;
+						}
+						continue;
+					}
+					if( GenStateLooksLikeTypedProperty(pGen->pIn,pGen->pEnd) ){
 						rc = GenStateCompileClassAttr(&(*pGen),iProtection,iAttrflags,pClass);
 						if( rc != SXRET_OK ){
 							if( rc == SXERR_ABORT ){

--- a/src/ph7/oo.c
+++ b/src/ph7/oo.c
@@ -169,6 +169,12 @@ PH7_PRIVATE sxi32 PH7_ClassInstallAttr(ph7_class *pClass,ph7_class_attr *pAttr)
 {
 	SyString *pName = &pAttr->sName;
 	sxi32 rc;
+	/* Remember where this attribute was originally declared so that later
+	 * inheritance/trait copies still know the declaring class (needed for
+	 * PHP-compatible error messages on typed properties). */
+	if( pAttr->pDeclClass == 0 ){
+		pAttr->pDeclClass = pClass;
+	}
 	rc = SyHashInsert(&pClass->hAttr,(const void *)pName->zString,pName->nByte,pAttr);
 	return rc;
 }
@@ -813,6 +819,13 @@ static void PH7_ClassInstanceRelease(ph7_class_instance *pThis)
 	while((pEntry = SyHashGetNextEntry(&pThis->hAttr)) != 0 ){
 		VmClassAttr *pVmAttr = (VmClassAttr *)pEntry->pUserData;
 		if( (pVmAttr->pAttr->iFlags & (PH7_CLASS_ATTR_STATIC|PH7_CLASS_ATTR_CONSTANT)) == 0 ){
+			/* Drop any typed-property enforcement slot registered for this
+			 * memobj. Must happen before the memobj is returned to the free
+			 * list so a future recycled slot does not inherit the stale entry. */
+			if( pVmAttr->pAttr->iFlags & PH7_CLASS_ATTR_TYPED ){
+				SyHashDeleteEntry(&pVm->hTypedSlot,
+					(const void *)&pVmAttr->nIdx,sizeof(sxu32),0);
+			}
 			PH7_VmUnsetMemObj(pVm,pVmAttr->nIdx,TRUE);
 		}
 		SyMemBackendPoolFree(&pVm->sAllocator,pVmAttr);

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -634,12 +634,18 @@ struct ph7_class_attr
 	SySet aByteCode;     /* Compiled attribute body */
 	sxu32 nIdx;          /* Attribute index */
 	sxu32 nLine;         /* Line number on which this attribute was defined */
+	sxu32 nType;         /* Declared type: MEMOBJ_* bitmask, SXU32_HIGH for class, 0 = untyped */
+	SyString sClass;     /* Class/interface name when nType == SXU32_HIGH */
+	SyString sTypeName;  /* Original type text for error messages (e.g. "?int", "Foo") */
+	ph7_class *pDeclClass; /* Class that originally declared this attribute */
 };
 /* Attribute configuration */
 #define PH7_CLASS_ATTR_STATIC       0x001  /* Static attribute */
 #define PH7_CLASS_ATTR_CONSTANT     0x002  /* Constant attribute */
 #define PH7_CLASS_ATTR_ABSTRACT     0x004  /* Abstract method */
 #define PH7_CLASS_ATTR_FINAL        0x008  /* Final method */
+#define PH7_CLASS_ATTR_TYPED        0x010  /* Property has an explicit declared type */
+#define PH7_CLASS_ATTR_NULLABLE     0x020  /* Type has nullable '?' prefix */
 /*
  * Each class method is parsed out and stored in an instance of the following
  * structure.
@@ -693,7 +699,10 @@ struct VmClassAttr
 {
 	ph7_class_attr *pAttr; /* Class attribute */
 	sxu32 nIdx;            /* Memory object index */
+	sxi32 iState;          /* Per-instance state: VM_CLASS_ATTR_UNINIT */
+	ph7_class *pOwner;     /* Class that declares this attribute (for error msgs) */
 };
+#define VM_CLASS_ATTR_UNINIT  0x01 /* Typed property never written (PHP 7.4+) */
  /* Forward reference */
 typedef struct VmRefObj VmRefObj;
 /*
@@ -799,6 +808,7 @@ struct ph7_vm
 	SySet aShutdown;            /* Stack of shutdown user callbacks */
 	SySet aAutoload;            /* Stack of spl_autoload callbacks */
 	SyHash hAutoloadActive;     /* Classes currently being autoloaded (reentrancy guard) */
+	SyHash hTypedSlot;          /* memobj nIdx -> VmClassAttr* for typed property enforcement */
 	SySet aException;           /* Stack of loaded exception */
 	ph7_class_instance *pPendingException; /* Exception deferred past a finally block */
 	SySet aIOstream;            /* Installed IO stream container */

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -717,6 +717,29 @@ PH7_PRIVATE sxi32 VmMountUserClass(
 			pAttr->nIdx = pMemObj->nIdx;
 			/* Install static attribute in the reference table */
 			PH7_VmRefObjInstall(&(*pVm),pMemObj->nIdx,0,0,VM_REF_IDX_KEEP);
+			/* If this is a typed static property, register the slot so the
+			 * STORE path can enforce the declared type. We allocate a tiny
+			 * VmClassAttr to uniformize with instance properties; the key
+			 * points at its own nIdx field (stable for the VM lifetime). */
+			if( pAttr->iFlags & PH7_CLASS_ATTR_TYPED ){
+				VmClassAttr *pVmAttrS = (VmClassAttr *)SyMemBackendPoolAlloc(&pVm->sAllocator,sizeof(VmClassAttr));
+				if( pVmAttrS == 0 ){
+					return SXERR_MEM;
+				}
+				pVmAttrS->pAttr = pAttr;
+				pVmAttrS->nIdx = pMemObj->nIdx;
+				pVmAttrS->iState = 0;
+				pVmAttrS->pOwner = pClass;
+				/* Static typed property with no default starts uninitialized */
+				if( SySetUsed(&pAttr->aByteCode) == 0
+				 && (pAttr->iFlags & PH7_CLASS_ATTR_CONSTANT) == 0 ){
+					pVmAttrS->iState |= VM_CLASS_ATTR_UNINIT;
+				}
+				if( SyHashInsert(&pVm->hTypedSlot,(const void *)&pVmAttrS->nIdx,sizeof(sxu32),pVmAttrS) != SXRET_OK ){
+					SyMemBackendPoolFree(&pVm->sAllocator,pVmAttrS);
+					return SXERR_MEM;
+				}
+			}
 		}
 	}
 	/* Install class methods */
@@ -783,9 +806,15 @@ PH7_PRIVATE sxi32 PH7_VmCreateClassInstanceFrame(
 				return SXERR_MEM;
 			}
 			pVmAttr->nIdx = pMemObj->nIdx;
+			pVmAttr->iState = 0;
+			pVmAttr->pOwner = pClass;
 			if( SySetUsed(&pAttr->aByteCode) > 0 ){
 				/* Initialize attribute default value (any complex expression) */
 				VmLocalExec(&(*pVm),&pAttr->aByteCode,pMemObj);
+			}else if( pAttr->iFlags & PH7_CLASS_ATTR_TYPED ){
+				/* Typed property without a default: mark uninitialized. Reading
+				 * it before the first write is an Error in PHP 7.4+. */
+				pVmAttr->iState |= VM_CLASS_ATTR_UNINIT;
 			}
 			rc = SyHashInsert(&pObj->hAttr,SyStringData(&pAttr->sName),SyStringLength(&pAttr->sName),pVmAttr);
 			if( rc != SXRET_OK ){
@@ -799,9 +828,26 @@ PH7_PRIVATE sxi32 PH7_VmCreateClassInstanceFrame(
 			}
 			/* Install attribute in the reference table */
 			PH7_VmRefObjInstall(&(*pVm),pMemObj->nIdx,0,0,VM_REF_IDX_KEEP);
+			/* Register typed property slot for assignment-time enforcement.
+			 * On failure roll back the just-installed hAttr entry and the
+			 * reserved memobj so the caller sees a consistent instance. */
+			if( pAttr->iFlags & PH7_CLASS_ATTR_TYPED ){
+				rc = SyHashInsert(&pVm->hTypedSlot,(const void *)&pVmAttr->nIdx,sizeof(sxu32),pVmAttr);
+				if( rc != SXRET_OK ){
+					VmSlot sSlot;
+					SyHashDeleteEntry(&pObj->hAttr,SyStringData(&pAttr->sName),SyStringLength(&pAttr->sName),0);
+					sSlot.nIdx = pMemObj->nIdx;
+					sSlot.pUserData = 0;
+					SySetPut(&pVm->aFreeObj,(const void *)&sSlot);
+					SyMemBackendPoolFree(&pVm->sAllocator,pVmAttr);
+					return SXERR_MEM;
+				}
+			}
 		}else{
 			/* Install static/constant attribute */
 			pVmAttr->nIdx = pAttr->nIdx;
+			pVmAttr->iState = 0;
+			pVmAttr->pOwner = pClass;
 			rc = SyHashInsert(&pObj->hAttr,SyStringData(&pAttr->sName),SyStringLength(&pAttr->sName),pVmAttr);
 			if( rc != SXRET_OK ){
 				SyMemBackendPoolFree(&pVm->sAllocator,pVmAttr);
@@ -1313,6 +1359,7 @@ PH7_PRIVATE sxi32 PH7_VmInit(
 	SySetInit(&pVm->aShutdown,&pVm->sAllocator,sizeof(VmShutdownCB));
 	SySetInit(&pVm->aAutoload,&pVm->sAllocator,sizeof(VmAutoloadCB));
 	SyHashInit(&pVm->hAutoloadActive,&pVm->sAllocator,0,0);
+	SyHashInit(&pVm->hTypedSlot,&pVm->sAllocator,0,0);
 	SySetInit(&pVm->aException,&pVm->sAllocator,sizeof(ph7_exception *));
 	pVm->pPendingException = 0;
 	/* Configuration containers */
@@ -2479,6 +2526,266 @@ static sxi32 VmThrowErrorAp(
 	return rc;
 }
 /*
+ * Throw a PHP-compatible TypeError whose message describes a failed typed
+ * property assignment. Called from the STORE path when coercion is not
+ * possible.
+ */
+static sxi32 VmThrowPropertyTypeError(ph7_vm *pVm,VmClassAttr *pVmAttr,const char *zGiven)
+{
+	ph7_class *pClass;
+	ph7_class_attr *pAttr = pVmAttr->pAttr;
+	ph7_class_instance *pThis;
+	ph7_class_method *pCons;
+	ph7_value sArg;
+	ph7_value *apArg[1];
+	SyBlob sMsg;
+	SyString sMsgStr;
+	VmFrame *pFrame;
+	sxi32 rc;
+	pClass = PH7_VmExtractClass(&(*pVm),"TypeError",sizeof("TypeError")-1,TRUE,0);
+	if( pClass == 0 ){
+		return PH7_ABORT;
+	}
+	pThis = PH7_NewClassInstance(&(*pVm),pClass);
+	if( pThis == 0 ){
+		return PH7_ABORT;
+	}
+	SyBlobInit(&sMsg,&pVm->sAllocator);
+	/* Prefer the declaring class over the runtime instance class so that an
+	 * inherited typed property reports its original owner, matching PHP. */
+	{
+		ph7_class *pOwner = pAttr->pDeclClass ? pAttr->pDeclClass : pVmAttr->pOwner;
+		if( pOwner ){
+			SyBlobFormat(&sMsg,"Cannot assign %s to property %z::$%z of type %z",
+				zGiven,&pOwner->sName,&pAttr->sName,&pAttr->sTypeName);
+		}else{
+			SyBlobFormat(&sMsg,"Cannot assign %s to property $%z of type %z",
+				zGiven,&pAttr->sName,&pAttr->sTypeName);
+		}
+	}
+	pCons = PH7_ClassExtractMethod(pClass,"__construct",sizeof("__construct")-1);
+	if( pCons ){
+		SyStringInitFromBuf(&sMsgStr,(const char *)SyBlobData(&sMsg),SyBlobLength(&sMsg));
+		PH7_MemObjInitFromString(&(*pVm),&sArg,&sMsgStr);
+		apArg[0] = &sArg;
+		PH7_VmCallClassMethod(&(*pVm),pThis,pCons,0,1,apArg);
+		PH7_MemObjRelease(&sArg);
+	}
+	SyBlobRelease(&sMsg);
+	pFrame = pVm->pFrame;
+	if( pFrame ){
+		pFrame = VmSkipExceptionFrames(pFrame);
+		pFrame->iFlags |= VM_FRAME_THROW;
+	}
+	rc = VmThrowException(&(*pVm),pThis);
+	PH7_ClassInstanceUnref(pThis);
+	if( rc == SXERR_ABORT ){
+		return PH7_ABORT;
+	}
+	return PH7_EXCEPTION;
+}
+
+/*
+ * Throw a PHP-compatible Error for reading an uninitialized typed property.
+ */
+static sxi32 VmThrowUninitializedPropertyError(ph7_vm *pVm,ph7_class *pClass,ph7_class_attr *pAttr)
+{
+	ph7_class *pErrClass;
+	ph7_class_instance *pThis;
+	ph7_class_method *pCons;
+	ph7_value sArg;
+	ph7_value *apArg[1];
+	SyBlob sMsg;
+	SyString sMsgStr;
+	VmFrame *pFrame;
+	sxi32 rc;
+	pErrClass = PH7_VmExtractClass(&(*pVm),"Error",sizeof("Error")-1,TRUE,0);
+	if( pErrClass == 0 ){
+		return PH7_ABORT;
+	}
+	pThis = PH7_NewClassInstance(&(*pVm),pErrClass);
+	if( pThis == 0 ){
+		return PH7_ABORT;
+	}
+	SyBlobInit(&sMsg,&pVm->sAllocator);
+	{
+		ph7_class *pOwner = pAttr->pDeclClass ? pAttr->pDeclClass : pClass;
+		const char *zKind = (pAttr->iFlags & PH7_CLASS_ATTR_STATIC) ? "static property" : "property";
+		SyBlobFormat(&sMsg,"Typed %s %z::$%z must not be accessed before initialization",
+			zKind,&pOwner->sName,&pAttr->sName);
+	}
+	pCons = PH7_ClassExtractMethod(pErrClass,"__construct",sizeof("__construct")-1);
+	if( pCons ){
+		SyStringInitFromBuf(&sMsgStr,(const char *)SyBlobData(&sMsg),SyBlobLength(&sMsg));
+		PH7_MemObjInitFromString(&(*pVm),&sArg,&sMsgStr);
+		apArg[0] = &sArg;
+		PH7_VmCallClassMethod(&(*pVm),pThis,pCons,0,1,apArg);
+		PH7_MemObjRelease(&sArg);
+	}
+	SyBlobRelease(&sMsg);
+	pFrame = pVm->pFrame;
+	if( pFrame ){
+		pFrame = VmSkipExceptionFrames(pFrame);
+		pFrame->iFlags |= VM_FRAME_THROW;
+	}
+	rc = VmThrowException(&(*pVm),pThis);
+	PH7_ClassInstanceUnref(pThis);
+	if( rc == SXERR_ABORT ){
+		return PH7_ABORT;
+	}
+	return PH7_EXCEPTION;
+}
+
+/*
+ * Enforce a typed-property assignment. On entry pValue holds the incoming
+ * value. For scalar types it may be coerced in place (PHP 7.4 weak mode).
+ * For class types, instanceof is verified.
+ *
+ * Returns SXRET_OK on success (value may have been coerced), PH7_EXCEPTION
+ * after throwing TypeError, or PH7_ABORT on fatal error.
+ */
+/*
+ * PHP-strict numeric-string check used by typed-property enforcement.
+ * Returns TRUE only if the entire string (optionally surrounded by
+ * whitespace, with optional sign) is a valid numeric literal. Unlike the
+ * permissive is_numeric() implementation which accepts leading-numeric
+ * strings like "43x", this mirrors PHP's rules for coercing to int/float.
+ */
+static int VmStringIsStrictNumeric(ph7_value *pValue)
+{
+	const char *z, *zEnd, *zTail;
+	sxu32 n;
+	sxu8 bReal;
+	sxi32 rc;
+	if( (pValue->iFlags & MEMOBJ_STRING) == 0 ){
+		return 0;
+	}
+	z = (const char *)SyBlobData(&pValue->sBlob);
+	n = SyBlobLength(&pValue->sBlob);
+	zEnd = z + n;
+	if( n == 0 ){
+		return 0;
+	}
+	zTail = 0;
+	rc = SyStrIsNumeric(z,n,&bReal,&zTail);
+	if( rc != SXRET_OK || zTail == 0 ){
+		return 0;
+	}
+	/* Trailing whitespace is allowed by PHP, trailing anything else is not. */
+	while( zTail < zEnd && SyisSpace(zTail[0]) ){
+		zTail++;
+	}
+	return zTail == zEnd ? 1 : 0;
+}
+
+/*
+ * Format the class name of an object-typed ph7_value into a small caller
+ * buffer, for use in TypeError messages. Returns the buffer pointer.
+ */
+static const char *VmFormatValueClassName(ph7_value *pValue,char *zBuf,sxu32 nBuf)
+{
+	ph7_class_instance *pInst = (ph7_class_instance *)pValue->x.pOther;
+	SyBufferFormat(zBuf,nBuf,"%.*s",
+		(int)pInst->pClass->sName.nByte,pInst->pClass->sName.zString);
+	return zBuf;
+}
+
+static sxi32 VmEnforcePropertyTypeOnStore(ph7_vm *pVm,sxu32 nIdx,ph7_value *pValue)
+{
+	SyHashEntry *pSlot;
+	VmClassAttr *pVmAttr;
+	ph7_class_attr *pAttr;
+	pSlot = SyHashGet(&pVm->hTypedSlot,(const void *)&nIdx,sizeof(sxu32));
+	if( pSlot == 0 ){
+		return SXRET_OK; /* Not a typed slot */
+	}
+	pVmAttr = (VmClassAttr *)pSlot->pUserData;
+	pAttr = pVmAttr->pAttr;
+	if( pAttr == 0 || (pAttr->iFlags & PH7_CLASS_ATTR_TYPED) == 0 ){
+		return SXRET_OK;
+	}
+	/* NULL handling: allowed only if the type is nullable. */
+	if( pValue->iFlags & MEMOBJ_NULL ){
+		if( pAttr->iFlags & PH7_CLASS_ATTR_NULLABLE ){
+			pVmAttr->iState &= ~VM_CLASS_ATTR_UNINIT;
+			return SXRET_OK;
+		}
+		return VmThrowPropertyTypeError(pVm,pVmAttr,"null");
+	}
+	/* Bare 'object' type hint: accept any class instance, reject non-objects.
+	 * Must be checked before the generic scalar branch since MEMOBJ_OBJ is
+	 * otherwise treated as "scalar, not array" and would be rejected. */
+	if( pAttr->nType == MEMOBJ_OBJ ){
+		if( pValue->iFlags & MEMOBJ_OBJ ){
+			pVmAttr->iState &= ~VM_CLASS_ATTR_UNINIT;
+			return SXRET_OK;
+		}
+		return VmThrowPropertyTypeError(pVm,pVmAttr,ph7_type_name(pValue));
+	}
+	if( pAttr->nType == SXU32_HIGH ){
+		/* Class / interface type. Resolve self/parent relative to the class
+		 * currently active on the self-stack. */
+		ph7_class *pExpected = 0;
+		SyString *pClassName = &pAttr->sClass;
+		ph7_class *pSelfNow = 0;
+		if( SySetUsed(&pVm->aSelf) > 0 ){
+			ph7_class **apSelf = (ph7_class **)SySetBasePtr(&pVm->aSelf);
+			pSelfNow = apSelf[SySetUsed(&pVm->aSelf)-1];
+		}
+		if( pClassName->nByte == 4 && SyMemcmp(pClassName->zString,"self",4) == 0 ){
+			pExpected = pSelfNow;
+		}else if( pClassName->nByte == 6 && SyMemcmp(pClassName->zString,"parent",6) == 0 ){
+			pExpected = pSelfNow ? pSelfNow->pBase : 0;
+		}else{
+			pExpected = PH7_VmExtractClass(&(*pVm),pClassName->zString,pClassName->nByte,TRUE,0);
+		}
+		if( (pValue->iFlags & MEMOBJ_OBJ) == 0 ){
+			return VmThrowPropertyTypeError(pVm,pVmAttr,ph7_type_name(pValue));
+		}
+		if( pExpected ){
+			ph7_class_instance *pInst = (ph7_class_instance *)pValue->x.pOther;
+			if( !PH7_VmInstanceOf(pInst->pClass,pExpected) ){
+				char zBuf[128];
+				return VmThrowPropertyTypeError(pVm,pVmAttr,
+					VmFormatValueClassName(pValue,zBuf,sizeof(zBuf)));
+			}
+		}
+		pVmAttr->iState &= ~VM_CLASS_ATTR_UNINIT;
+		return SXRET_OK;
+	}
+	/* Scalar type. PHP 7.4 weak mode: attempt coercion using the same cast
+	 * helpers used by function-argument hints. Reject object→scalar. */
+	if( pValue->iFlags & MEMOBJ_OBJ ){
+		char zBuf[128];
+		return VmThrowPropertyTypeError(pVm,pVmAttr,
+			VmFormatValueClassName(pValue,zBuf,sizeof(zBuf)));
+	}
+	if( (pValue->iFlags & pAttr->nType) == 0 ){
+		ProcMemObjCast xCast = PH7_MemObjCastMethod(pAttr->nType);
+		if( xCast ){
+			/* Reject array<->scalar coercion to match PHP strictness */
+			if( pAttr->nType == MEMOBJ_HASHMAP && (pValue->iFlags & MEMOBJ_HASHMAP) == 0 ){
+				return VmThrowPropertyTypeError(pVm,pVmAttr,ph7_type_name(pValue));
+			}
+			if( pAttr->nType != MEMOBJ_HASHMAP && (pValue->iFlags & MEMOBJ_HASHMAP) ){
+				return VmThrowPropertyTypeError(pVm,pVmAttr,ph7_type_name(pValue));
+			}
+			/* PHP weak mode: reject string->int/float unless the string is
+			 * strictly numeric. Silent coercion of "abc" or "43x" to 0/43
+			 * would hide bugs and diverges from PHP's TypeError. */
+			if( (pAttr->nType == MEMOBJ_INT || pAttr->nType == MEMOBJ_REAL)
+			 && (pValue->iFlags & MEMOBJ_STRING)
+			 && !VmStringIsStrictNumeric(pValue) ){
+				return VmThrowPropertyTypeError(pVm,pVmAttr,"string");
+			}
+			xCast(pValue);
+		}
+	}
+	pVmAttr->iState &= ~VM_CLASS_ATTR_UNINIT;
+	return SXRET_OK;
+}
+
+/*
  * Format and throw a run-time error and invoke the supplied VM output consumer callback.
  * Refer to the implementation of [ph7_context_throw_error_format()] for additional
  * information.
@@ -2801,6 +3108,25 @@ static sxi32 VmByteCodeExec(
 	}
 	nExceptionBase = SySetUsed(&pVm->aException);
 	pc = nPc;
+/*
+ * Typed-property enforcement helper for compound stores. Called before
+ * PH7_MemObjStore writes into a member memobj slot. On failure throws a
+ * PHP TypeError and either jumps to the nearest catch block or propagates
+ * out of the VM loop. Must be used inside a case of the main switch.
+ */
+#define PH7_ENFORCE_TYPED_STORE(nIdxArg, pSrcArg) \
+	{ \
+		sxi32 _rcT = VmEnforcePropertyTypeOnStore(&(*pVm),(nIdxArg),(pSrcArg)); \
+		if( _rcT == PH7_ABORT ){ goto Abort; } \
+		if( _rcT == PH7_EXCEPTION ){ \
+			VmFrame *_pFrmT = pVm->pFrame; \
+			if( _pFrmT && (_pFrmT->iFlags & VM_FRAME_EXCEPTION) && _pFrmT->iExceptionJump > 0 ){ \
+				pc = _pFrmT->iExceptionJump - 1; \
+				break; \
+			} \
+			goto Exception; \
+		} \
+	}
 	/* Execute as much as we can */
 	for(;;){
 		/* Fetch the instruction to execute */
@@ -3728,6 +4054,7 @@ case PH7_OP_STORE: {
 #endif
 	if( pInstr->iP2 ){
 		sxu32 nIdx;
+		sxi32 rcT;
 		/* Member store operation */
 		nIdx = pTos->nIdx;
 		VmPopOperand(&pTos,1);
@@ -3736,6 +4063,26 @@ case PH7_OP_STORE: {
 				"Cannot perform assignment on a constant class attribute,PH7 is loading NULL");
 			pTos->nIdx = SXU32_HIGH;
 		}else{
+			/* Enforce typed property declaration if any. May coerce the
+			 * incoming value in place (weak mode) or throw TypeError. */
+			rcT = VmEnforcePropertyTypeOnStore(&(*pVm),nIdx,pTos);
+			if( rcT == PH7_ABORT ){
+				goto Abort;
+			}
+			if( rcT == PH7_EXCEPTION ){
+				/* TypeError was thrown. Pop the rejected rvalue and hand
+				 * control to the nearest catch block if any, otherwise
+				 * propagate out of the VM loop. */
+				VmPopOperand(&pTos,1);
+				{
+					VmFrame *pFrm2 = pVm->pFrame;
+					if( pFrm2 && (pFrm2->iFlags & VM_FRAME_EXCEPTION) && pFrm2->iExceptionJump > 0 ){
+						pc = pFrm2->iExceptionJump - 1;
+						break;
+					}
+				}
+				goto Exception;
+			}
 			/* Point to the desired memory object */
 			pObj = (ph7_value *)SySetAt(&pVm->aMemObj,nIdx);
 			if( pObj ){
@@ -4120,6 +4467,7 @@ case PH7_OP_MUL_STORE: {
 		if( pTos->nIdx == SXU32_HIGH ){
 			PH7_VmThrowError(&(*pVm),0,PH7_CTX_ERR,"Cannot perform assignment on a constant class attribute");
 		}else if( (pObj = (ph7_value *)SySetAt(&pVm->aMemObj,pTos->nIdx)) != 0 ){
+			PH7_ENFORCE_TYPED_STORE(pTos->nIdx,pNos);
 			PH7_MemObjStore(pNos,pObj);
 		}
 	}
@@ -4165,6 +4513,7 @@ case PH7_OP_ADD_STORE:{
 	if( nIdx == SXU32_HIGH ){
 		PH7_VmThrowError(&(*pVm),0,PH7_CTX_ERR,"Cannot perform assignment on a constant class attribute");
 	}else if( (pObj = (ph7_value *)SySetAt(&pVm->aMemObj,nIdx)) != 0 ){
+		PH7_ENFORCE_TYPED_STORE(nIdx,pTos);
 		PH7_MemObjStore(pTos,pObj);
 	}
 	/* Ticket 1433-35: Perform a stack dup */
@@ -4259,6 +4608,7 @@ case PH7_OP_SUB_STORE: {
 	if( pTos->nIdx == SXU32_HIGH ){
 		PH7_VmThrowError(&(*pVm),0,PH7_CTX_ERR,"Cannot perform assignment on a constant class attribute");
 	}else if( (pObj = (ph7_value *)SySetAt(&pVm->aMemObj,pTos->nIdx)) != 0 ){
+		PH7_ENFORCE_TYPED_STORE(pTos->nIdx,pNos);
 		PH7_MemObjStore(pNos,pObj);
 	}
 	VmPopOperand(&pTos,1);
@@ -4346,6 +4696,7 @@ case PH7_OP_MOD_STORE: {
 	if( pTos->nIdx == SXU32_HIGH ){
 		PH7_VmThrowError(&(*pVm),0,PH7_CTX_ERR,"Cannot perform assignment on a constant class attribute");
 	}else if( (pObj = (ph7_value *)SySetAt(&pVm->aMemObj,pTos->nIdx)) != 0 ){
+		PH7_ENFORCE_TYPED_STORE(pTos->nIdx,pNos);
 		PH7_MemObjStore(pNos,pObj);
 	}
 	VmPopOperand(&pTos,1);
@@ -4436,6 +4787,7 @@ case PH7_OP_DIV_STORE:{
 	if( pTos->nIdx == SXU32_HIGH ){
 		PH7_VmThrowError(&(*pVm),0,PH7_CTX_ERR,"Cannot perform assignment on a constant class attribute");
 	}else if( (pObj = (ph7_value *)SySetAt(&pVm->aMemObj,pTos->nIdx)) != 0 ){
+		PH7_ENFORCE_TYPED_STORE(pTos->nIdx,pNos);
 		PH7_MemObjStore(pNos,pObj);
 	}
 	VmPopOperand(&pTos,1);
@@ -4548,6 +4900,7 @@ case PH7_OP_BXOR_STORE:{
 	if( pTos->nIdx == SXU32_HIGH ){
 		PH7_VmThrowError(&(*pVm),0,PH7_CTX_ERR,"Cannot perform assignment on a constant class attribute");
 	}else if( (pObj = (ph7_value *)SySetAt(&pVm->aMemObj,pTos->nIdx)) != 0 ){
+		PH7_ENFORCE_TYPED_STORE(pTos->nIdx,pNos);
 		PH7_MemObjStore(pNos,pObj);
 	}
 	VmPopOperand(&pTos,1);
@@ -4644,6 +4997,7 @@ case PH7_OP_SHR_STORE: {
 	if( pTos->nIdx == SXU32_HIGH ){
 		PH7_VmThrowError(&(*pVm),0,PH7_CTX_ERR,"Cannot perform assignment on a constant class attribute");
 	}else if( (pObj = (ph7_value *)SySetAt(&pVm->aMemObj,pTos->nIdx)) != 0 ){
+		PH7_ENFORCE_TYPED_STORE(pTos->nIdx,pNos);
 		PH7_MemObjStore(pNos,pObj);
 	}
 	VmPopOperand(&pTos,1);
@@ -4714,6 +5068,7 @@ case PH7_OP_CAT_STORE:{
 	if( pTos->nIdx == SXU32_HIGH ){
 		PH7_VmThrowError(&(*pVm),0,PH7_CTX_ERR,"Cannot perform assignment on a constant class attribute");
 	}else if( (pObj = (ph7_value *)SySetAt(&pVm->aMemObj,pTos->nIdx)) != 0 ){
+		PH7_ENFORCE_TYPED_STORE(pTos->nIdx,pTos);
 		PH7_MemObjStore(pTos,pObj);
 	}
 	PH7_MemObjStore(pTos,pNos);
@@ -4831,6 +5186,7 @@ case PH7_OP_NULLC_STORE: {
 		PH7_VmThrowError(&(*pVm),0,PH7_CTX_ERR,
 			"Cannot perform assignment on a constant class attribute");
 	}else if( (pObj = (ph7_value *)SySetAt(&pVm->aMemObj,nIdx)) != 0 ){
+		PH7_ENFORCE_TYPED_STORE(nIdx,pTos);
 		PH7_MemObjStore(pTos,pObj);
 	}
 	PH7_MemObjStore(pTos,pNos);
@@ -5886,6 +6242,34 @@ case PH7_OP_MEMBER: {
 					ph7_value *pValue = 0; /* cc warning */
 					/* Check attribute access */
 					if( PH7_VmClassMemberAccess(&(*pVm),pClass,&pObjAttr->pAttr->sName,pObjAttr->pAttr->iProtection,FALSE) ){
+						/* PHP 7.4+: reading an uninitialized typed property is an Error.
+						 * We can only raise it on a real read, not when the slot is the
+						 * LHS of an assignment — peek at the next instruction to decide.
+						 * Safe: the compiler always emits a terminating PH7_OP_DONE, so
+						 * pInstr+1 is in-bounds while we are inside a non-DONE opcode. */
+						if( (pObjAttr->iState & VM_CLASS_ATTR_UNINIT)
+						 && (pObjAttr->pAttr->iFlags & PH7_CLASS_ATTR_TYPED) ){
+							VmInstr *pNext = pInstr + 1;
+							int bIsLhs = 0;
+							if( pNext->iOp == PH7_OP_STORE && pNext->iP2 ){
+								bIsLhs = 1;
+							}
+							if( !bIsLhs ){
+								sxi32 rcU = VmThrowUninitializedPropertyError(&(*pVm),pClass,pObjAttr->pAttr);
+								PH7_ClassInstanceUnref(pThis);
+								if( rcU == PH7_ABORT ){
+									goto Abort;
+								}
+								{
+									VmFrame *pFrm2 = pVm->pFrame;
+									if( pFrm2 && (pFrm2->iFlags & VM_FRAME_EXCEPTION) && pFrm2->iExceptionJump > 0 ){
+										pc = pFrm2->iExceptionJump - 1;
+										break;
+									}
+								}
+								goto Exception;
+							}
+						}
 						/* Load attribute */
 						pValue = (ph7_value *)SySetAt(&pVm->aMemObj,pObjAttr->nIdx);
 						if( pValue ){
@@ -6059,6 +6443,40 @@ case PH7_OP_MEMBER: {
 								ph7_value *pValue;
 								/* Check if the access to the attribute is allowed */
 								if( PH7_VmClassMemberAccess(&(*pVm),pClass,&pAttr->sName,pAttr->iProtection,FALSE) ){
+									/* PHP 7.4+: uninitialized typed static read.
+									 * Same LHS-of-store peek as the instance path. */
+									if( (pAttr->iFlags & PH7_CLASS_ATTR_TYPED) != 0
+									 && (pAttr->iFlags & PH7_CLASS_ATTR_CONSTANT) == 0 ){
+										SyHashEntry *pS = SyHashGet(&pVm->hTypedSlot,
+											(const void *)&pAttr->nIdx,sizeof(sxu32));
+										if( pS ){
+											VmClassAttr *pV = (VmClassAttr *)pS->pUserData;
+											if( pV && (pV->iState & VM_CLASS_ATTR_UNINIT) ){
+												VmInstr *pNext = pInstr + 1;
+												int bIsLhs = 0;
+												if( pNext->iOp == PH7_OP_STORE && pNext->iP2 ){
+													bIsLhs = 1;
+												}
+												if( !bIsLhs ){
+													sxi32 rcU = VmThrowUninitializedPropertyError(&(*pVm),pClass,pAttr);
+													if( pThis ){
+														PH7_ClassInstanceUnref(pThis);
+													}
+													if( rcU == PH7_ABORT ){
+														goto Abort;
+													}
+													{
+														VmFrame *pFrm2 = pVm->pFrame;
+														if( pFrm2 && (pFrm2->iFlags & VM_FRAME_EXCEPTION) && pFrm2->iExceptionJump > 0 ){
+															pc = pFrm2->iExceptionJump - 1;
+															break;
+														}
+													}
+													goto Exception;
+												}
+											}
+										}
+									}
 									/* Load the desired attribute */
 									pValue = (ph7_value *)SySetAt(&pVm->aMemObj,pAttr->nIdx);
 									if( pValue ){

--- a/tests/ph7/001-smoke/oo/typed_property_array.phpt
+++ b/tests/ph7/001-smoke/oo/typed_property_array.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: array with default and append
+--FILE--
+<?php
+class TpBag {
+    public array $items = [];
+}
+$b = new TpBag();
+$b->items[] = "a";
+$b->items[] = "b";
+$b->items[] = "c";
+echo implode(",", $b->items), "\n";
+echo count($b->items), "\n";
+?>
+--EXPECT--
+a,b,c
+3
+--CLEAN--
+<?php
+unset($b);

--- a/tests/ph7/001-smoke/oo/typed_property_bool.phpt
+++ b/tests/ph7/001-smoke/oo/typed_property_bool.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: bool
+--FILE--
+<?php
+class TpFlag {
+    public bool $active = false;
+}
+$f = new TpFlag();
+echo $f->active ? "yes" : "no", "\n";
+$f->active = true;
+echo $f->active ? "yes" : "no", "\n";
+?>
+--EXPECT--
+no
+yes
+--CLEAN--
+<?php
+unset($f);

--- a/tests/ph7/001-smoke/oo/typed_property_class.phpt
+++ b/tests/ph7/001-smoke/oo/typed_property_class.phpt
@@ -1,0 +1,27 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: user class type
+--FILE--
+<?php
+class TpPoint {
+    public int $x = 0;
+    public int $y = 0;
+}
+class TpBox {
+    public TpPoint $tl;
+    public TpPoint $br;
+}
+$b = new TpBox();
+$b->tl = new TpPoint();
+$b->br = new TpPoint();
+$b->tl->x = 1; $b->tl->y = 2;
+$b->br->x = 10; $b->br->y = 20;
+echo $b->tl->x, ",", $b->tl->y, " -> ", $b->br->x, ",", $b->br->y, "\n";
+?>
+--EXPECT--
+1,2 -> 10,20
+--CLEAN--
+<?php
+unset($b);

--- a/tests/ph7/001-smoke/oo/typed_property_coercion.phpt
+++ b/tests/ph7/001-smoke/oo/typed_property_coercion.phpt
@@ -1,0 +1,27 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: weak-mode numeric-string coercion
+--FILE--
+<?php
+class TpModel {
+    public int $n = 0;
+    public float $f = 0.0;
+    public string $s = "";
+}
+$m = new TpModel();
+$m->n = "42";
+$m->f = "3.14";
+$m->s = 99;
+echo $m->n, " ", is_int($m->n) ? "int" : "?", "\n";
+echo $m->f, " ", is_float($m->f) ? "float" : "?", "\n";
+echo $m->s, " ", is_string($m->s) ? "string" : "?", "\n";
+?>
+--EXPECT--
+42 int
+3.14 float
+99 string
+--CLEAN--
+<?php
+unset($m);

--- a/tests/ph7/001-smoke/oo/typed_property_default_null_nullable.phpt
+++ b/tests/ph7/001-smoke/oo/typed_property_default_null_nullable.phpt
@@ -1,0 +1,25 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: nullable with null default reads as null
+--FILE--
+<?php
+class TpCfg {
+    public ?string $host = null;
+    public ?int $port = null;
+}
+$c = new TpCfg();
+echo is_null($c->host) ? "null" : $c->host, "\n";
+echo is_null($c->port) ? "null" : $c->port, "\n";
+$c->host = "localhost";
+$c->port = 8080;
+echo $c->host, ":", $c->port, "\n";
+?>
+--EXPECT--
+null
+null
+localhost:8080
+--CLEAN--
+<?php
+unset($c);

--- a/tests/ph7/001-smoke/oo/typed_property_float.phpt
+++ b/tests/ph7/001-smoke/oo/typed_property_float.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: float
+--FILE--
+<?php
+class TpRate {
+    public float $value = 0.0;
+}
+$r = new TpRate();
+$r->value = 1.5;
+echo $r->value, "\n";
+$r->value = $r->value * 2;
+echo $r->value, "\n";
+?>
+--EXPECT--
+1.5
+3
+--CLEAN--
+<?php
+unset($r);

--- a/tests/ph7/001-smoke/oo/typed_property_inheritance.phpt
+++ b/tests/ph7/001-smoke/oo/typed_property_inheritance.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: subclass accesses inherited typed property
+--FILE--
+<?php
+class TpAnimal {
+    public string $name = "";
+    public int $legs = 4;
+}
+class TpDog extends TpAnimal {
+    public string $breed = "mutt";
+}
+$d = new TpDog();
+$d->name = "Rex";
+$d->breed = "labrador";
+echo $d->name, " (", $d->breed, ") has ", $d->legs, " legs\n";
+?>
+--EXPECT--
+Rex (labrador) has 4 legs
+--CLEAN--
+<?php
+unset($d);

--- a/tests/ph7/001-smoke/oo/typed_property_int.phpt
+++ b/tests/ph7/001-smoke/oo/typed_property_int.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: int
+--FILE--
+<?php
+class TpCounter {
+    public int $n = 0;
+}
+$c = new TpCounter();
+echo $c->n, "\n";
+$c->n = 42;
+echo $c->n, "\n";
+$c->n = $c->n + 1;
+echo $c->n, "\n";
+?>
+--EXPECT--
+0
+42
+43
+--CLEAN--
+<?php
+unset($c);

--- a/tests/ph7/001-smoke/oo/typed_property_method_setter.phpt
+++ b/tests/ph7/001-smoke/oo/typed_property_method_setter.phpt
@@ -1,0 +1,26 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: mutated via setter method
+--FILE--
+<?php
+class TpCell {
+    private int $value = 0;
+    public function set(int $v): void { $this->value = $v; }
+    public function get(): int { return $this->value; }
+}
+$c = new TpCell();
+echo $c->get(), "\n";
+$c->set(7);
+echo $c->get(), "\n";
+$c->set($c->get() * 3);
+echo $c->get(), "\n";
+?>
+--EXPECT--
+0
+7
+21
+--CLEAN--
+<?php
+unset($c);

--- a/tests/ph7/001-smoke/oo/typed_property_multi_decl.phpt
+++ b/tests/ph7/001-smoke/oo/typed_property_multi_decl.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: multiple declarations share the type
+--FILE--
+<?php
+class TpVec {
+    public int $a = 1, $b = 2, $c = 3;
+}
+$v = new TpVec();
+echo $v->a + $v->b + $v->c, "\n";
+$v->a = 10; $v->b = 20; $v->c = 30;
+echo $v->a + $v->b + $v->c, "\n";
+?>
+--EXPECT--
+6
+60
+--CLEAN--
+<?php
+unset($v);

--- a/tests/ph7/001-smoke/oo/typed_property_namespaced_class.phpt
+++ b/tests/ph7/001-smoke/oo/typed_property_namespaced_class.phpt
@@ -1,0 +1,25 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: full namespace-qualified class type resolves correctly
+--FILE--
+<?php
+namespace TpnAppModels;
+class Tag { public string $name = ""; }
+
+namespace TpnApp;
+class Post {
+    public \TpnAppModels\Tag $tag;
+}
+
+$p = new Post();
+$p->tag = new \TpnAppModels\Tag();
+$p->tag->name = "php";
+echo get_class($p->tag), " ", $p->tag->name, "\n";
+?>
+--EXPECT--
+TpnAppModels\Tag php
+--CLEAN--
+<?php
+unset($p);

--- a/tests/ph7/001-smoke/oo/typed_property_nullable.phpt
+++ b/tests/ph7/001-smoke/oo/typed_property_nullable.phpt
@@ -1,0 +1,29 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: nullable
+--FILE--
+<?php
+class TpProfile {
+    public ?string $nickname = null;
+    public ?int $age = null;
+}
+$p = new TpProfile();
+echo is_null($p->nickname) ? "null" : $p->nickname, "\n";
+echo is_null($p->age) ? "null" : $p->age, "\n";
+$p->nickname = "ada";
+$p->age = 36;
+echo $p->nickname, "\n", $p->age, "\n";
+$p->nickname = null;
+echo is_null($p->nickname) ? "null" : $p->nickname, "\n";
+?>
+--EXPECT--
+null
+null
+ada
+36
+null
+--CLEAN--
+<?php
+unset($p);

--- a/tests/ph7/001-smoke/oo/typed_property_object.phpt
+++ b/tests/ph7/001-smoke/oo/typed_property_object.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: bare object type accepts any class instance
+--FILE--
+<?php
+class TpoAlpha { public int $n = 1; }
+class TpoBeta { public string $s = "b"; }
+class TpoHolder { public object $o; }
+$h = new TpoHolder();
+$h->o = new TpoAlpha();
+echo get_class($h->o), "\n";
+$h->o = new TpoBeta();
+echo get_class($h->o), "\n";
+?>
+--EXPECT--
+TpoAlpha
+TpoBeta
+--CLEAN--
+<?php
+unset($h);

--- a/tests/ph7/001-smoke/oo/typed_property_self.phpt
+++ b/tests/ph7/001-smoke/oo/typed_property_self.phpt
@@ -1,0 +1,26 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: self (linked list node)
+--FILE--
+<?php
+class TpNode {
+    public int $value;
+    public ?self $next = null;
+    public function __construct(int $v) { $this->value = $v; }
+}
+$head = new TpNode(1);
+$head->next = new TpNode(2);
+$head->next->next = new TpNode(3);
+for ($n = $head; $n !== null; $n = $n->next) {
+    echo $n->value, "\n";
+}
+?>
+--EXPECT--
+1
+2
+3
+--CLEAN--
+<?php
+unset($head, $n);

--- a/tests/ph7/001-smoke/oo/typed_property_static.phpt
+++ b/tests/ph7/001-smoke/oo/typed_property_static.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: static
+--FILE--
+<?php
+class TpsCounter {
+    public static int $total = 0;
+    public static function bump(): int { return ++self::$total; }
+}
+TpsCounter::bump();
+TpsCounter::bump();
+TpsCounter::bump();
+echo TpsCounter::$total, "\n";
+?>
+--EXPECT--
+3
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/oo/typed_property_string.phpt
+++ b/tests/ph7/001-smoke/oo/typed_property_string.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: string
+--FILE--
+<?php
+class TpUser {
+    private string $name;
+    public function __construct(string $name) { $this->name = $name; }
+    public function getName(): string { return $this->name; }
+}
+$u = new TpUser("ada");
+echo $u->getName(), "\n";
+?>
+--EXPECT--
+ada
+--CLEAN--
+<?php
+unset($u);

--- a/tests/ph7/001-smoke/oo/typed_property_trait.phpt
+++ b/tests/ph7/001-smoke/oo/typed_property_trait.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: declared inside a trait
+--FILE--
+<?php
+trait TptCounter {
+    public int $count = 0;
+    public ?string $label = null;
+}
+class TptWidget {
+    use TptCounter;
+}
+$w = new TptWidget();
+$w->count = 10;
+$w->label = "clicks";
+echo $w->count, " ", $w->label, "\n";
+?>
+--EXPECT--
+10 clicks
+--CLEAN--
+<?php
+unset($w);

--- a/tests/ph7/002-integration/oo/typed_property_array_wrong_type.phpt
+++ b/tests/ph7/002-integration/oo/typed_property_array_wrong_type.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: array rejects scalar assignment
+--FILE--
+<?php
+class TpiList { public array $items = []; }
+$l = new TpiList();
+try {
+    $l->items = "not an array";
+} catch (TypeError $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+echo count($l->items), "\n";
+?>
+--EXPECT--
+caught: Cannot assign string to property TpiList::$items of type array
+0
+--CLEAN--
+<?php
+unset($l);

--- a/tests/ph7/002-integration/oo/typed_property_compound_assign.phpt
+++ b/tests/ph7/002-integration/oo/typed_property_compound_assign.phpt
@@ -1,0 +1,27 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: compound assignments go through type enforcement
+--FILE--
+<?php
+class TpcBag { public int $n = 0; public array $items = []; }
+$b = new TpcBag();
+$b->n += 5;
+echo "n=$b->n\n";
+$b->n *= 3;
+echo "n=$b->n\n";
+$b->n -= 1;
+echo "n=$b->n\n";
+try { $b->n .= "abc"; } catch (TypeError $e) { echo "catcat: ", $e->getMessage(), "\n"; }
+echo "n=$b->n\n";
+?>
+--EXPECT--
+n=5
+n=15
+n=14
+catcat: Cannot assign string to property TpcBag::$n of type int
+n=14
+--CLEAN--
+<?php
+unset($b);

--- a/tests/ph7/002-integration/oo/typed_property_inherited_owner.phpt
+++ b/tests/ph7/002-integration/oo/typed_property_inherited_owner.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: inherited property error reports declaring class
+--FILE--
+<?php
+class TpioThing {}
+class TpioBase { public int $n = 0; }
+class TpioChild extends TpioBase {}
+$c = new TpioChild();
+try {
+    $c->n = new TpioThing();
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Cannot assign TpioThing to property TpioBase::$n of type int
+--CLEAN--
+<?php
+unset($c);

--- a/tests/ph7/002-integration/oo/typed_property_non_numeric_string.phpt
+++ b/tests/ph7/002-integration/oo/typed_property_non_numeric_string.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: non-numeric string rejected for int/float
+--FILE--
+<?php
+class TpnmCell { public int $n = 0; public float $f = 0.0; }
+$c = new TpnmCell();
+try { $c->n = "abc"; } catch (TypeError $e) { echo "n1: ", $e->getMessage(), "\n"; }
+try { $c->n = "43x"; } catch (TypeError $e) { echo "n2: ", $e->getMessage(), "\n"; }
+try { $c->f = "abc"; } catch (TypeError $e) { echo "f1: ", $e->getMessage(), "\n"; }
+$c->n = "42";
+$c->f = "3.14";
+echo "ok $c->n $c->f\n";
+?>
+--EXPECT--
+n1: Cannot assign string to property TpnmCell::$n of type int
+n2: Cannot assign string to property TpnmCell::$n of type int
+f1: Cannot assign string to property TpnmCell::$f of type float
+ok 42 3.14
+--CLEAN--
+<?php
+unset($c);

--- a/tests/ph7/002-integration/oo/typed_property_null_non_nullable.phpt
+++ b/tests/ph7/002-integration/oo/typed_property_null_non_nullable.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: null into non-nullable throws TypeError
+--FILE--
+<?php
+class TpiBox { public int $n = 0; }
+$b = new TpiBox();
+try {
+    $b->n = null;
+} catch (TypeError $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+echo $b->n, "\n";
+?>
+--EXPECT--
+caught: Cannot assign null to property TpiBox::$n of type int
+0
+--CLEAN--
+<?php
+unset($b);

--- a/tests/ph7/002-integration/oo/typed_property_object_rejects_scalar.phpt
+++ b/tests/ph7/002-integration/oo/typed_property_object_rejects_scalar.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: object type rejects non-object values
+--FILE--
+<?php
+class TpoHolder { public object $o; }
+$h = new TpoHolder();
+try { $h->o = "str"; } catch (TypeError $e) { echo "s: ", $e->getMessage(), "\n"; }
+try { $h->o = 42; } catch (TypeError $e) { echo "i: ", $e->getMessage(), "\n"; }
+try { $h->o = [1]; } catch (TypeError $e) { echo "a: ", $e->getMessage(), "\n"; }
+?>
+--EXPECT--
+s: Cannot assign string to property TpoHolder::$o of type object
+i: Cannot assign int to property TpoHolder::$o of type object
+a: Cannot assign array to property TpoHolder::$o of type object
+--CLEAN--
+<?php
+unset($h);

--- a/tests/ph7/002-integration/oo/typed_property_scalar_from_array.phpt
+++ b/tests/ph7/002-integration/oo/typed_property_scalar_from_array.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: int rejects array assignment
+--FILE--
+<?php
+class TpiCell { public int $n = 0; }
+$c = new TpiCell();
+try {
+    $c->n = [1, 2, 3];
+} catch (TypeError $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+echo $c->n, "\n";
+?>
+--EXPECT--
+caught: Cannot assign array to property TpiCell::$n of type int
+0
+--CLEAN--
+<?php
+unset($c);

--- a/tests/ph7/002-integration/oo/typed_property_static_uninitialized.phpt
+++ b/tests/ph7/002-integration/oo/typed_property_static_uninitialized.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: reading uninitialized static typed property throws Error
+--FILE--
+<?php
+class TpsuRegistry { public static int $count; }
+try {
+    echo TpsuRegistry::$count, "\n";
+} catch (Error $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+TpsuRegistry::$count = 7;
+echo TpsuRegistry::$count, "\n";
+?>
+--EXPECT--
+caught: Typed static property TpsuRegistry::$count must not be accessed before initialization
+7
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/typed_property_static_wrong_type.phpt
+++ b/tests/ph7/002-integration/oo/typed_property_static_wrong_type.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: static typed property rejects wrong type
+--FILE--
+<?php
+class TpiRegistry { public static int $count = 0; }
+try {
+    TpiRegistry::$count = [1, 2];
+} catch (TypeError $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+echo TpiRegistry::$count, "\n";
+TpiRegistry::$count = 5;
+echo TpiRegistry::$count, "\n";
+?>
+--EXPECT--
+caught: Cannot assign array to property TpiRegistry::$count of type int
+0
+5
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/typed_property_uninitialized_read.phpt
+++ b/tests/ph7/002-integration/oo/typed_property_uninitialized_read.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: reading uninitialized throws Error
+--FILE--
+<?php
+class TpiLazy { public int $n; }
+$l = new TpiLazy();
+try {
+    echo $l->n, "\n";
+} catch (Error $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+$l->n = 7;
+echo $l->n, "\n";
+?>
+--EXPECT--
+caught: Typed property TpiLazy::$n must not be accessed before initialization
+7
+--CLEAN--
+<?php
+unset($l);

--- a/tests/ph7/002-integration/oo/typed_property_wrong_class.phpt
+++ b/tests/ph7/002-integration/oo/typed_property_wrong_class.phpt
@@ -1,0 +1,25 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: assigning unrelated class throws TypeError
+--FILE--
+<?php
+class TpiAlpha {}
+class TpiBeta {}
+class TpiSlot { public TpiAlpha $a; }
+$s = new TpiSlot();
+try {
+    $s->a = new TpiBeta();
+} catch (TypeError $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+$s->a = new TpiAlpha();
+echo "ok\n";
+?>
+--EXPECT--
+caught: Cannot assign TpiBeta to property TpiSlot::$a of type TpiAlpha
+ok
+--CLEAN--
+<?php
+unset($s);

--- a/tests/ph7/002-integration/oo/typed_property_wrong_class_nullable.phpt
+++ b/tests/ph7/002-integration/oo/typed_property_wrong_class_nullable.phpt
@@ -1,0 +1,30 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: nullable class accepts null but rejects wrong class
+--FILE--
+<?php
+class TpiA {}
+class TpiC {}
+class TpiHost { public ?TpiA $a = null; }
+$h = new TpiHost();
+echo is_null($h->a) ? "null" : "set", "\n";
+$h->a = new TpiA();
+echo get_class($h->a), "\n";
+$h->a = null;
+echo is_null($h->a) ? "null" : "set", "\n";
+try {
+    $h->a = new TpiC();
+} catch (TypeError $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+null
+TpiA
+null
+caught: Cannot assign TpiC to property TpiHost::$a of type ?TpiA
+--CLEAN--
+<?php
+unset($h);

--- a/tests/ph7/002-integration/oo/typed_property_wrong_type.phpt
+++ b/tests/ph7/002-integration/oo/typed_property_wrong_type.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: assigning object to int throws TypeError
+--FILE--
+<?php
+class TpiHolder { public int $n = 0; }
+class TpiThing {}
+$h = new TpiHolder();
+try {
+    $h->n = new TpiThing();
+} catch (TypeError $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+echo $h->n, "\n";
+?>
+--EXPECT--
+caught: Cannot assign TpiThing to property TpiHolder::$n of type int
+0
+--CLEAN--
+<?php
+unset($h);


### PR DESCRIPTION
Allow property declarations to carry a type hint: public int $x, private ?string $name = null, protected Foo $bar, etc. The parser, VM, and OO subsystem all grow typed-aware paths, while untyped properties retain their current behavior byte-for-byte.

ph7_class_attr gains nType/sClass/sTypeName fields plus TYPED and NULLABLE flag bits. A new pDeclClass pointer, set at install time in PH7_ClassInstallAttr, remembers the originally declaring class so inherited and trait-composed properties can still report their declarer in PHP-compatible error messages rather than the runtime instance class.

GenStateCompileClassAttr parses an optional type prefix before the $name. GenStateParsePropertyType handles ?, leading \, bare scalar keywords (array/bool/int/float/string/object), self/parent, and namespace-separated class names; void/never/mixed/callable are rejected up-front with PHP-matching messages. A shared GenStateLooksLikeTypedProperty lookahead lets the four class/trait body dispatch sites route typed declarations into
GenStateCompileClassAttr without mis-parsing method or constant headers that start with a keyword.

At runtime, ph7_vm grows an hTypedSlot hash keyed by memobj nIdx and mapped to the per-instance VmClassAttr (or a static shim). VmMountUserClass and PH7_VmCreateClassInstanceFrame populate it; PH7_ClassInstanceRelease deletes the entry before the memobj returns to the free list, which is essential because the memobj index is recycled and a stale slot would cause a use-after-free on the next typed property allocated in the same slot. Both population sites now propagate SXERR_MEM on SyHashInsert failure.

Enforcement lives in VmEnforcePropertyTypeOnStore, which is invoked from PH7_OP_STORE (member branch) and every compound- assign opcode (ADD/SUB/MUL/DIV/MOD/CAT/BAND/BOR/BXOR/SHL/SHR and NULLC store variants) via a PH7_ENFORCE_TYPED_STORE macro that either jumps to the nearest catch block or falls through to the existing Exception label. Nullability is honored for null writes; class types verify instanceof against pExpected resolved from self/parent on the self stack or from PH7_VmExtractClass by name; scalar types fall back to the same PH7_MemObjCastMethod helper that function-argument hints use, with two additions to match PHP's weak-mode rules: object-to-scalar is rejected, and string-to-int/float requires VmStringIsStrictNumeric (built on SyStrIsNumeric's pzTail) so "abc" and "43x" raise TypeError instead of silently coercing to 0 or 43.

PH7_OP_MEMBER raises Error: "Typed property X::$y must not be accessed before initialization" when a typed property without a default is read before any write. The check peeks at pInstr+1 to skip the case where the slot is the LHS of an immediate store, which is safe because the code generator always emits a trailing PH7_OP_DONE.
