### PR TITLE
Implement union types (PHP 8.0)

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -413,7 +413,20 @@ static ph7_value * GenStateInstallNumLiteral(ph7_gen_state *pGen,sxu32 *pIdx)
 /* Forward declaration */
 static sxi32 GenStateCompileChunk(ph7_gen_state *pGen,sxi32 iFlags);
 static sxi32 GenStateCollectFuncArgs(ph7_vm_func *pFunc,ph7_gen_state *pGen,SyToken *pEnd);
-static void GenStateParseReturnType(ph7_gen_state *pGen, ph7_vm_func *pFunc);
+/* Forward decl: union type parser is defined later in this file. */
+static sxi32 GenStateParseUnionTypeDecl(
+	ph7_gen_state *pGen,
+	sxu32 *pnType,
+	SyString *pClass,
+	SySet *pAlts,
+	sxi32 *piTypeFlags,
+	SyString *pTypeText,
+	int iNullableFlag,
+	int iUnionFlag,
+	int bAllowVoid,
+	sxu32 nLine
+);
+static sxi32 GenStateParseReturnType(ph7_gen_state *pGen, ph7_vm_func *pFunc);
 static const char * TokenTypeName(sxu32 nType);
 /*
  * Stack-scratch size for stripping PHP 7.4 numeric separators. A typical
@@ -2191,7 +2204,12 @@ PH7_PRIVATE sxi32 PH7_CompileArrowFunc(ph7_gen_state *pGen,sxi32 iCompileFlag)
 	}
 	/* Point past ')' and parse optional return type */
 	pGen->pIn = &pSigEnd[1];
-	GenStateParseReturnType(pGen,pFunc);
+	rc = GenStateParseReturnType(pGen,pFunc);
+	if( rc == SXERR_ABORT ){
+		return SXERR_ABORT;
+	}else if( rc == SXERR_SYNTAX ){
+		return SXERR_SYNTAX;
+	}
 	/* Expect '=>' */
 	if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_ARRAY_OP) == 0 ){
 		if( pGen->pIn < pGen->pEnd ){
@@ -5118,46 +5136,39 @@ static sxi32 GenStateCollectFuncArgs(ph7_vm_func *pFunc,ph7_gen_state *pGen,SyTo
 		}
 		SyZero(&sArg,sizeof(ph7_vm_func_arg));
 		SySetInit(&sArg.aByteCode,&pGen->pVm->sAllocator,sizeof(VmInstr));
-		/* Detect nullable prefix '?' on type hints */
-		if( pIn < pEnd && (pIn->nType & PH7_TK_OP) && pIn->sData.nByte == 1 && pIn->sData.zString[0] == '?' ){
-			sArg.iFlags |= VM_FUNC_ARG_NULLABLE;
-			pIn++;
-		}
-		/* Skip leading namespace separator '\' on FQN type hints like \Throwable */
-		if( pIn < pEnd && (pIn->nType & PH7_TK_NSSEP) ){
-			pIn++;
-		}
-		if( pIn < pEnd && (pIn->nType & (PH7_TK_ID|PH7_TK_KEYWORD)) ){
-			if( pIn->nType & PH7_TK_KEYWORD ){
-				sxu32 nKey = (sxu32)(SX_PTR_TO_INT(pIn->pUserData));
-				if( nKey & PH7_TKWRD_ARRAY ){
-					sArg.nType = MEMOBJ_HASHMAP;
-				}else if( nKey & PH7_TKWRD_BOOL ){
-					sArg.nType = MEMOBJ_BOOL;
-				}else if( nKey & PH7_TKWRD_INT ){
-					sArg.nType = MEMOBJ_INT;
-				}else if( nKey & PH7_TKWRD_STRING ){
-					sArg.nType = MEMOBJ_STRING;
-				}else if( nKey & PH7_TKWRD_FLOAT ){
-					sArg.nType = MEMOBJ_REAL;
-				}else if( nKey & PH7_TKWRD_OBJECT ){
-					sArg.nType = MEMOBJ_OBJ;
-				}else{
-					PH7_GenCompileError(&(*pGen),E_WARNING,pGen->pIn->nLine,
-						"Invalid argument type '%z',Automatic cast will not be performed",
+		SySetInit(&sArg.aUnionAlts,&pGen->pVm->sAllocator,sizeof(ph7_type_alt));
+		SyStringInitFromBuf(&sArg.sTypeName,0,0);
+		/* Parse optional type hint (single, nullable shorthand, or union) */
+		if( pIn < pEnd && (pIn->nType & PH7_TK_DOLLAR) == 0
+			&& (pIn->nType & PH7_TK_AMPER) == 0
+			&& (pIn->nType & PH7_TK_ELLIPSIS) == 0 ){
+			sxu32 nLineLocal = pIn->nLine;
+			sxi32 iTFlags = 0;
+			pGen->pIn = pIn;
+			rc = GenStateParseUnionTypeDecl(
+				pGen, &sArg.nType, &sArg.sClass, &sArg.aUnionAlts,
+				&iTFlags, &sArg.sTypeName,
+				VM_FUNC_ARG_NULLABLE, VM_FUNC_ARG_UNION,
+				/* bAllowVoid */ 0,
+						nLineLocal);
+			pIn = pGen->pIn;
+			if( rc == SXERR_ABORT ){
+				return SXERR_ABORT;
+			}else if( rc == SXERR_CORRUPT ){
+				/* Error already reported by GenStateParseUnionTypeDecl */
+				return SXERR_SYNTAX;
+			}else if( rc == SXERR_SYNTAX ){
+				if( pIn < pEnd ){
+					PH7_GenCompileError(pGen,E_PARSE,pIn->nLine,
+						"syntax error, unexpected token \"%z\", expecting variable",
 						&pIn->sData);
+				}else{
+					PH7_GenCompileError(pGen,E_PARSE,nLineLocal,
+						"syntax error, unexpected end of file");
 				}
-			}else{
-				SyString *pName = &pIn->sData; /* Class name */
-				char *zDupLocal;
-				/* Argument must be a class instance,record that*/
-				zDupLocal = SyMemBackendStrDup(&pGen->pVm->sAllocator,pName->zString,pName->nByte);
-				if( zDupLocal ){
-					sArg.nType = SXU32_HIGH; /* 0xFFFFFFFF as sentinel */
-					SyStringInitFromBuf(&sArg.sClass,zDupLocal,pName->nByte);
-				}
+				return SXERR_SYNTAX;
 			}
-			pIn++;
+			sArg.iFlags |= iTFlags;
 		}
 		if( pIn >= pEnd ){
 			rc = PH7_GenCompileError(&(*pGen),E_ERROR,pGen->pIn->nLine,"Missing argument name");
@@ -5371,74 +5382,471 @@ static int SyMemcmpNoCase(const char *zA, const char *zB, sxu32 n)
 	return 0;
 }
 /*
- * Helper: set the return type to a class/self/parent/static sentinel.
+ * Internal type-atom kinds used during union type parsing.
+ * Negative values are sentinels that never collide with MEMOBJ_* bitmasks
+ * (which are positive bit values stored in sxu32).
  */
-static void GenStateSetReturnClass(ph7_gen_state *pGen, ph7_vm_func *pFunc, const char *zName, sxu32 nByte)
+#define UTA_NULL_FLAG  ((sxu32)0xFFFFFFF0)  /* the literal `null` keyword */
+#define UTA_VOID_FLAG  ((sxu32)0xFFFFFFF1)  /* the `void` keyword */
+#define UTA_NEVER_FLAG ((sxu32)0xFFFFFFF2)  /* the `never` keyword */
+
+/* Maximum number of alternatives in a single union type declaration.
+ * Picked to be larger than any union type seen in real PHP codebases
+ * (typical max is 4-6, with the largest internal PHP unions around 8).
+ * The atom array lives on the parser stack, so the cost is bounded:
+ * 32 * sizeof(PhlTypeAtom) ≈ 1 KiB. */
+#define PHL_UNION_MAX_ALTS 32
+
+typedef struct PhlTypeAtom PhlTypeAtom;
+struct PhlTypeAtom {
+	sxu32 nType;       /* MEMOBJ_*, SXU32_HIGH (class), or UTA_* sentinel */
+	SyString sClass;   /* class name when nType == SXU32_HIGH */
+	const char *zCanon;/* canonical lowercase name for scalar/builtin atoms */
+	sxu32 nCanon;
+};
+
+/*
+ * Parse a single type atom (one alternative of a union, or a complete
+ * single type). Recognises scalar keywords, `array`, `object`, `null`,
+ * `void`, `never`, `self`, `parent`, and class names (possibly namespaced).
+ * pGen->pIn must point at the first token of the atom; on success it
+ * is advanced past the atom. The previous nullable `?` prefix must
+ * already be consumed by the caller.
+ */
+static sxi32 GenStateParseOneTypeAtom(ph7_gen_state *pGen, PhlTypeAtom *pOut)
 {
-	char *zDup = SyMemBackendStrDup(&pGen->pVm->sAllocator, zName, nByte);
-	if( zDup ){
-		pFunc->nReturnType = SXU32_HIGH;
-		SyStringInitFromBuf(&pFunc->sReturnClass, zDup, nByte);
+	SyToken *pIn = pGen->pIn;
+	SyZero(pOut, sizeof(*pOut));
+	SyStringInitFromBuf(&pOut->sClass, 0, 0);
+	if( pIn >= pGen->pEnd ){
+		return SXERR_SYNTAX;
+	}
+	/* Optional leading namespace separator '\' on FQN class types */
+	if( pIn->nType & PH7_TK_NSSEP ){
+		pIn++;
+		if( pIn >= pGen->pEnd ){
+			return SXERR_SYNTAX;
+		}
+	}
+	if( (pIn->nType & (PH7_TK_ID|PH7_TK_KEYWORD)) == 0 ){
+		return SXERR_SYNTAX;
+	}
+	if( pIn->nType & PH7_TK_KEYWORD ){
+		sxu32 nKey = (sxu32)(SX_PTR_TO_INT(pIn->pUserData));
+		if( nKey & PH7_TKWRD_ARRAY ){
+			pOut->nType = MEMOBJ_HASHMAP; pOut->zCanon = "array"; pOut->nCanon = 5;
+		}else if( nKey & PH7_TKWRD_BOOL ){
+			pOut->nType = MEMOBJ_BOOL; pOut->zCanon = "bool"; pOut->nCanon = 4;
+		}else if( nKey & PH7_TKWRD_INT ){
+			pOut->nType = MEMOBJ_INT; pOut->zCanon = "int"; pOut->nCanon = 3;
+		}else if( nKey & PH7_TKWRD_STRING ){
+			pOut->nType = MEMOBJ_STRING; pOut->zCanon = "string"; pOut->nCanon = 6;
+		}else if( nKey & PH7_TKWRD_FLOAT ){
+			pOut->nType = MEMOBJ_REAL; pOut->zCanon = "float"; pOut->nCanon = 5;
+		}else if( nKey & PH7_TKWRD_OBJECT ){
+			pOut->nType = MEMOBJ_OBJ; pOut->zCanon = "object"; pOut->nCanon = 6;
+		}else if( nKey == PH7_TKWRD_SELF || nKey == PH7_TKWRD_PARENT
+				|| nKey == PH7_TKWRD_STATIC ){
+			pOut->nType = SXU32_HIGH;
+			pOut->sClass = pIn->sData;
+		}else{
+			return SXERR_SYNTAX;
+		}
+		pIn++;
+	}else{
+		/* Identifier — `null`, `void`, `never`, or class name (possibly
+		 * namespaced as a\b\c). Match the well-known names case-insensitively. */
+		SyString *pT = &pIn->sData;
+		if( pT->nByte == 4 && SyMemcmpNoCase(pT->zString, "null", 4) == 0 ){
+			pOut->nType = UTA_NULL_FLAG; pOut->zCanon = "null"; pOut->nCanon = 4;
+			pIn++;
+		}else if( pT->nByte == 4 && SyMemcmpNoCase(pT->zString, "void", 4) == 0 ){
+			pOut->nType = UTA_VOID_FLAG; pOut->zCanon = "void"; pOut->nCanon = 4;
+			pIn++;
+		}else if( pT->nByte == 5 && SyMemcmpNoCase(pT->zString, "never", 5) == 0 ){
+			pOut->nType = UTA_NEVER_FLAG; pOut->zCanon = "never"; pOut->nCanon = 5;
+			pIn++;
+		}else{
+			/* Class / interface name; consume namespace path a\b\c */
+			SyToken *pFirst = pIn;
+			SyToken *pLast = pIn;
+			pOut->nType = SXU32_HIGH;
+			pOut->sClass = pIn->sData;
+			pIn++;
+			while( pIn + 1 < pGen->pEnd && (pIn->nType & PH7_TK_NSSEP)
+				&& (pIn[1].nType & PH7_TK_ID) ){
+				pLast = &pIn[1];
+				pIn += 2;
+			}
+			if( pLast != pFirst ){
+				const char *zFirst = pFirst->sData.zString;
+				const char *zEnd = pLast->sData.zString + pLast->sData.nByte;
+				pOut->sClass.zString = zFirst;
+				pOut->sClass.nByte = (sxu32)(zEnd - zFirst);
+			}
+		}
+	}
+	pGen->pIn = pIn;
+	return SXRET_OK;
+}
+
+/*
+ * Build the canonical PHP-formatted type text into pBlob from a list of
+ * atoms. Order matches PHP's `zend_type` rendering:
+ *   classes (in declaration order) | object | array | string | int | float | bool [| null]
+ * If exactly one non-null atom is present and bNullable is true, the
+ * shorthand `?T` form is emitted instead of `T|null`.
+ */
+static void GenBuildUnionTypeText(SyBlob *pBlob, PhlTypeAtom *aAtoms, int nAtoms, int bNullable)
+{
+	int i;
+	int nNonNull = 0;
+	for( i = 0; i < nAtoms; i++ ){
+		if( aAtoms[i].nType != UTA_NULL_FLAG ){
+			nNonNull++;
+		}
+	}
+	if( nNonNull == 1 && bNullable ){
+		/* Shorthand: ?T */
+		for( i = 0; i < nAtoms; i++ ){
+			if( aAtoms[i].nType == UTA_NULL_FLAG ) continue;
+			SyBlobAppend(pBlob, "?", 1);
+			if( aAtoms[i].nType == SXU32_HIGH ){
+				SyBlobAppend(pBlob, aAtoms[i].sClass.zString, aAtoms[i].sClass.nByte);
+			}else{
+				SyBlobAppend(pBlob, aAtoms[i].zCanon, aAtoms[i].nCanon);
+			}
+			return;
+		}
+	}
+	{
+		int bFirst = 1;
+		/* 1) Classes in declaration order */
+		for( i = 0; i < nAtoms; i++ ){
+			if( aAtoms[i].nType == SXU32_HIGH ){
+				if( !bFirst ) SyBlobAppend(pBlob, "|", 1);
+				SyBlobAppend(pBlob, aAtoms[i].sClass.zString, aAtoms[i].sClass.nByte);
+				bFirst = 0;
+			}
+		}
+		/* 2) Built-ins in canonical order */
+		{
+			static const sxu32 aOrder[] = { MEMOBJ_OBJ, MEMOBJ_HASHMAP, MEMOBJ_STRING,
+				MEMOBJ_INT, MEMOBJ_REAL, MEMOBJ_BOOL };
+			int k;
+			for( k = 0; k < (int)(sizeof(aOrder)/sizeof(aOrder[0])); k++ ){
+				for( i = 0; i < nAtoms; i++ ){
+					if( aAtoms[i].nType == aOrder[k] ){
+						if( !bFirst ) SyBlobAppend(pBlob, "|", 1);
+						SyBlobAppend(pBlob, aAtoms[i].zCanon, aAtoms[i].nCanon);
+						bFirst = 0;
+						break;
+					}
+				}
+			}
+		}
+		/* 3) null suffix */
+		if( bNullable ){
+			if( !bFirst ) SyBlobAppend(pBlob, "|", 1);
+			SyBlobAppend(pBlob, "null", 4);
+		}
 	}
 }
+
+/*
+ * Parse an entire (possibly union) type declaration starting at pGen->pIn.
+ *
+ * Outputs:
+ *   *pnType, *pClass — single-type fast path: filled when there is exactly
+ *     one non-null atom AND no union flag is set. nType is MEMOBJ_*, or
+ *     SXU32_HIGH for a class.  pClass receives the duplicated class name.
+ *   *pAlts            — populated only when this is a true union (≥2
+ *     non-null alternatives, OR ≥1 class+null union, etc). The set must
+ *     already be initialized by the caller (allocator set, etc).
+ *   *piTypeFlags      — receives PH7_CLASS_ATTR_NULLABLE / VM_FUNC_ARG_NULLABLE
+ *     (caller maps), and PH7_CLASS_ATTR_UNION / VM_FUNC_ARG_UNION when union.
+ *     The two flag values are passed in via iNullableFlag/iUnionFlag.
+ *   *pTypeText        — duplicated canonical type text for error messages.
+ *
+ * Returns SXRET_OK on success, SXERR_SYNTAX on bad type syntax, or
+ * SXERR_ABORT on fatal compile errors.
+ */
+static sxi32 GenStateParseUnionTypeDecl(
+	ph7_gen_state *pGen,
+	sxu32 *pnType,
+	SyString *pClass,
+	SySet *pAlts,
+	sxi32 *piTypeFlags,
+	SyString *pTypeText,
+	int iNullableFlag,
+	int iUnionFlag,
+	int bAllowVoid,
+	sxu32 nLine
+){
+	PhlTypeAtom aAtoms[PHL_UNION_MAX_ALTS];
+	int nAtoms = 0;
+	int bShortNullable = 0;
+	int bExplicitNull = 0;
+	sxi32 rc;
+	*pnType = 0;
+	if( pClass ) SyStringInitFromBuf(pClass, 0, 0);
+	*piTypeFlags = 0;
+	if( pTypeText ) SyStringInitFromBuf(pTypeText, 0, 0);
+
+	if( pGen->pIn >= pGen->pEnd ){
+		return SXRET_OK;
+	}
+	/* Optional `?` shorthand prefix */
+	if( (pGen->pIn->nType & PH7_TK_OP) && pGen->pIn->sData.nByte == 1
+	 && pGen->pIn->sData.zString[0] == '?' ){
+		bShortNullable = 1;
+		pGen->pIn++;
+		if( pGen->pIn >= pGen->pEnd ){
+			return SXERR_SYNTAX;
+		}
+	}
+	/* First atom is mandatory */
+	rc = GenStateParseOneTypeAtom(pGen, &aAtoms[0]);
+	if( rc != SXRET_OK ){
+		return rc;
+	}
+	nAtoms = 1;
+	/* Subsequent atoms separated by `|` */
+	while( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_OP)
+		&& pGen->pIn->sData.nByte == 1 && pGen->pIn->sData.zString[0] == '|' ){
+		if( bShortNullable ){
+			/* Match PHP's wording — `?T|X` is rejected as a parse error.
+			 * Return SXERR_CORRUPT as a sentinel meaning "syntax error
+			 * already reported" so callers skip their own error emission. */
+			rc = PH7_GenCompileError(pGen, E_PARSE, pGen->pIn->nLine,
+				"syntax error, unexpected token \"|\", expecting variable");
+			return (rc == SXERR_ABORT) ? SXERR_ABORT : SXERR_CORRUPT;
+		}
+		if( nAtoms >= PHL_UNION_MAX_ALTS ){
+			rc = PH7_GenCompileError(pGen, E_ERROR, nLine,
+				"Too many alternatives in union type (limit %d)", PHL_UNION_MAX_ALTS);
+			return (rc == SXERR_ABORT) ? SXERR_ABORT : SXERR_SYNTAX;
+		}
+		pGen->pIn++; /* skip `|` */
+		rc = GenStateParseOneTypeAtom(pGen, &aAtoms[nAtoms]);
+		if( rc != SXRET_OK ){
+			return rc;
+		}
+		nAtoms++;
+	}
+	/* Validation pass.
+	 *
+	 * Order matters: the union-membership checks for void/never run *before*
+	 * the duplicate scan, and `void` standalone-ness is checked *before* the
+	 * `?void` check below — reordering them would let `?void` slip through.
+	 */
+	{
+		int i, j;
+		int bHasNonNull = 0;
+		for( i = 0; i < nAtoms; i++ ){
+			if( aAtoms[i].nType == UTA_VOID_FLAG ){
+				if( nAtoms > 1 ){
+					PH7_GenCompileError(pGen, E_ERROR, nLine,
+						"Void can only be used as a standalone type");
+					return SXERR_SYNTAX;
+				}
+				if( !bAllowVoid ){
+					PH7_GenCompileError(pGen, E_ERROR, nLine,
+						"void cannot be used here");
+					return SXERR_SYNTAX;
+				}
+				if( bShortNullable ){
+					PH7_GenCompileError(pGen, E_ERROR, nLine,
+						"Void type cannot be nullable");
+					return SXERR_SYNTAX;
+				}
+			}
+			if( aAtoms[i].nType == UTA_NEVER_FLAG ){
+				/* `never` is parsed but not yet implemented in the type
+				 * system. Reject it explicitly rather than silently aliasing
+				 * to `void` — the two have different semantics (never =
+				 * does not return), and folding them would mislead any
+				 * future return-enforcement work. */
+				if( nAtoms > 1 ){
+					PH7_GenCompileError(pGen, E_ERROR, nLine,
+						"never can only be used as a standalone type");
+					return SXERR_SYNTAX;
+				}
+				PH7_GenCompileError(pGen, E_ERROR, nLine,
+					"never type is not yet implemented");
+				return SXERR_SYNTAX;
+			}
+			if( aAtoms[i].nType == UTA_NULL_FLAG ){
+				bExplicitNull = 1;
+			}else{
+				bHasNonNull = 1;
+			}
+			/* Duplicate detection */
+			for( j = 0; j < i; j++ ){
+				int bDup = 0;
+				if( aAtoms[i].nType == aAtoms[j].nType ){
+					if( aAtoms[i].nType == SXU32_HIGH ){
+						if( aAtoms[i].sClass.nByte == aAtoms[j].sClass.nByte
+						 && SyMemcmpNoCase(aAtoms[i].sClass.zString,
+								aAtoms[j].sClass.zString,
+								aAtoms[i].sClass.nByte) == 0 ){
+							bDup = 1;
+						}
+					}else{
+						bDup = 1;
+					}
+				}
+				if( bDup ){
+					const char *zName;
+					sxu32 nName;
+					if( aAtoms[i].nType == SXU32_HIGH ){
+						zName = aAtoms[i].sClass.zString;
+						nName = aAtoms[i].sClass.nByte;
+					}else{
+						zName = aAtoms[i].zCanon;
+						nName = aAtoms[i].nCanon;
+					}
+					PH7_GenCompileError(pGen, E_ERROR, nLine,
+						"Duplicate type %.*s is redundant", (int)nName, zName);
+					return SXERR_SYNTAX;
+				}
+			}
+		}
+		if( !bHasNonNull && bExplicitNull ){
+			PH7_GenCompileError(pGen, E_ERROR, nLine,
+				"Null can not be used as a standalone type");
+			return SXERR_SYNTAX;
+		}
+	}
+	/* Compute nullability flag */
+	if( bShortNullable || bExplicitNull ){
+		*piTypeFlags |= iNullableFlag;
+	}
+	/* Build canonical type text */
+	if( pTypeText ){
+		SyBlob sBlob;
+		SyBlobInit(&sBlob, &pGen->pVm->sAllocator);
+		GenBuildUnionTypeText(&sBlob, aAtoms, nAtoms,
+			(bShortNullable || bExplicitNull) ? 1 : 0);
+		if( SyBlobLength(&sBlob) > 0 ){
+			char *zDup = SyMemBackendStrDup(&pGen->pVm->sAllocator,
+				(const char *)SyBlobData(&sBlob), SyBlobLength(&sBlob));
+			if( zDup ){
+				SyStringInitFromBuf(pTypeText, zDup, SyBlobLength(&sBlob));
+			}
+		}
+		SyBlobRelease(&sBlob);
+	}
+	/* Decide single-type vs union storage. A "union" is anything with more
+	 * than one non-null atom, OR a single class atom + null. Single scalar
+	 * + null collapses to the existing nullable single-type fast path. */
+	{
+		int nNonNull = 0;
+		int iNonNullIdx = -1;
+		int i;
+		for( i = 0; i < nAtoms; i++ ){
+			if( aAtoms[i].nType != UTA_NULL_FLAG ){
+				nNonNull++;
+				iNonNullIdx = i;
+			}
+		}
+		if( nNonNull <= 1 ){
+			/* Fast path: store as single type. */
+			if( iNonNullIdx >= 0 ){
+				PhlTypeAtom *pA = &aAtoms[iNonNullIdx];
+				if( pA->nType == SXU32_HIGH ){
+					char *zDup = SyMemBackendStrDup(&pGen->pVm->sAllocator,
+						pA->sClass.zString, pA->sClass.nByte);
+					if( zDup == 0 ) return SXERR_ABORT;
+					*pnType = SXU32_HIGH;
+					if( pClass ) SyStringInitFromBuf(pClass, zDup, pA->sClass.nByte);
+				}else if( pA->nType == UTA_VOID_FLAG ){
+					*pnType = MEMOBJ_VOID;
+				}else{
+					/* UTA_NEVER_FLAG never reaches here — the validation
+					 * pass above rejects it as not-yet-implemented. */
+					*pnType = pA->nType;
+				}
+			}
+		}else{
+			/* True union — populate the alts set, leave *pnType = 0. */
+			*piTypeFlags |= iUnionFlag;
+			for( i = 0; i < nAtoms; i++ ){
+				ph7_type_alt sAlt;
+				if( aAtoms[i].nType == UTA_NULL_FLAG ) continue;
+				SyZero(&sAlt, sizeof(sAlt));
+				if( aAtoms[i].nType == SXU32_HIGH ){
+					char *zDup = SyMemBackendStrDup(&pGen->pVm->sAllocator,
+						aAtoms[i].sClass.zString, aAtoms[i].sClass.nByte);
+					if( zDup == 0 ) return SXERR_ABORT;
+					sAlt.nType = SXU32_HIGH;
+					SyStringInitFromBuf(&sAlt.sClass, zDup, aAtoms[i].sClass.nByte);
+				}else{
+					sAlt.nType = aAtoms[i].nType;
+					SyStringInitFromBuf(&sAlt.sClass, 0, 0);
+				}
+				SySetPut(pAlts, (const void *)&sAlt);
+			}
+		}
+	}
+	return SXRET_OK;
+}
+
 /*
  * Parse a return type declaration (`: type`) after a function/method signature.
  * pGen->pIn should point to the token after `)`.
  * Sets pFunc->nReturnType and pFunc->sReturnClass.
  * Handles: `: int`, `: string`, `: bool`, `: float`, `: array`, `: void`,
- *          `: self`, `: parent`, `: static`, `: ClassName`, and nullable `: ?type`.
+ *          `: self`, `: parent`, `: static`, `: ClassName`, nullable `: ?type`,
+ *          and union types `: T|U`.
  */
-static void GenStateParseReturnType(ph7_gen_state *pGen, ph7_vm_func *pFunc)
+static sxi32 GenStateParseReturnType(ph7_gen_state *pGen, ph7_vm_func *pFunc)
 {
-	SyToken *pCur = pGen->pIn;
+	sxi32 iFlags = 0;
+	sxi32 rc;
+	sxu32 nLine;
 	pFunc->nReturnType = 0;
 	SyStringInitFromBuf(&pFunc->sReturnClass, 0, 0);
-	if( pCur >= pGen->pEnd || (pCur->nType & PH7_TK_COLON) == 0 ){
-		return; /* No return type */
+	SyStringInitFromBuf(&pFunc->sReturnTypeName, 0, 0);
+	if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_COLON) == 0 ){
+		return SXRET_OK;
 	}
-	pCur++; /* Skip ':' */
-	if( pCur >= pGen->pEnd ){
-		pGen->pIn = pCur;
-		return;
+	pGen->pIn++; /* Skip ':' */
+	if( pGen->pIn >= pGen->pEnd ){
+		return SXRET_OK;
 	}
-	/* Handle nullable prefix '?' (tokenized as PH7_TK_OP with '?' operator) */
-	if( (pCur->nType & PH7_TK_OP) && pCur->sData.nByte == 1 && pCur->sData.zString[0] == '?' ){
-		pCur++;
-		if( pCur >= pGen->pEnd ){
-			pGen->pIn = pCur;
-			return;
-		}
+	nLine = pGen->pIn->nLine;
+	rc = GenStateParseUnionTypeDecl(
+		pGen,
+		&pFunc->nReturnType,
+		&pFunc->sReturnClass,
+		&pFunc->aReturnUnion,
+		&iFlags,
+		&pFunc->sReturnTypeName,
+		/* iNullableFlag */ 0, /* nullability for returns rides on aReturnUnion contents only */
+		/* iUnionFlag */ 0,
+		/* bAllowVoid */ 1,
+		nLine);
+	(void)iFlags;
+	if( rc == SXERR_ABORT ){
+		return SXERR_ABORT;
 	}
-	if( pCur->nType & PH7_TK_KEYWORD ){
-		sxu32 nKey = (sxu32)(SX_PTR_TO_INT(pCur->pUserData));
-		if( nKey & PH7_TKWRD_ARRAY ){
-			pFunc->nReturnType = MEMOBJ_HASHMAP;
-		}else if( nKey & PH7_TKWRD_BOOL ){
-			pFunc->nReturnType = MEMOBJ_BOOL;
-		}else if( nKey & PH7_TKWRD_INT ){
-			pFunc->nReturnType = MEMOBJ_INT;
-		}else if( nKey & PH7_TKWRD_STRING ){
-			pFunc->nReturnType = MEMOBJ_STRING;
-		}else if( nKey & PH7_TKWRD_FLOAT ){
-			pFunc->nReturnType = MEMOBJ_REAL;
-		}else if( nKey & PH7_TKWRD_OBJECT ){
-			pFunc->nReturnType = MEMOBJ_OBJ;
-		}else if( nKey == PH7_TKWRD_SELF || nKey == PH7_TKWRD_PARENT || nKey == PH7_TKWRD_STATIC ){
-			/* self/parent/static — store as class sentinel */
-			GenStateSetReturnClass(pGen, pFunc, pCur->sData.zString, pCur->sData.nByte);
-		}
-		pCur++;
-	}else if( pCur->nType & PH7_TK_ID ){
-		SyString *pType = &pCur->sData;
-		if( pType->nByte == 4 && SyMemcmpNoCase(pType->zString, "void", 4) == 0 ){
-			pFunc->nReturnType = MEMOBJ_VOID;
+	if( rc == SXERR_CORRUPT ){
+		/* Error already reported */
+		return SXERR_SYNTAX;
+	}
+	if( rc == SXERR_SYNTAX ){
+		if( pGen->pIn < pGen->pEnd ){
+			PH7_GenCompileError(pGen, E_PARSE, pGen->pIn->nLine,
+				"syntax error, unexpected token \"%z\" in return type declaration",
+				&pGen->pIn->sData);
 		}else{
-			/* Class/interface name */
-			GenStateSetReturnClass(pGen, pFunc, pType->zString, pType->nByte);
+			PH7_GenCompileError(pGen, E_PARSE, nLine,
+				"syntax error, unexpected end of file in return type declaration");
 		}
-		pCur++;
+		return SXERR_SYNTAX;
 	}
-	pGen->pIn = pCur;
+	return SXRET_OK;
 }
 
 static sxi32 GenStateCompileFunc(
@@ -5507,7 +5915,14 @@ static sxi32 GenStateCompileFunc(
 	}
 	/* Point past ')' and parse optional return type ': type' */
 	pGen->pIn = &pEnd[1];
-	GenStateParseReturnType(pGen, pFunc);
+	{
+		sxi32 rcRt = GenStateParseReturnType(pGen, pFunc);
+		if( rcRt == SXERR_ABORT ){
+			return SXERR_ABORT;
+		}else if( rcRt == SXERR_SYNTAX ){
+			return SXERR_SYNTAX;
+		}
+	}
 	if( bHandleClosure ){
 		ph7_vm_func_closure_env sEnv;
 		int got_this = 0; /* TRUE if $this have been seen */
@@ -5884,6 +6299,17 @@ static int GenStateLooksLikeTypedProperty(SyToken *pStart,SyToken *pEnd)
 	while( p + 1 < pEnd && (p->nType & PH7_TK_NSSEP) && (p[1].nType & (PH7_TK_ID|PH7_TK_KEYWORD)) ){
 		p += 2;
 	}
+	/* Consume any `| Type` union alternatives */
+	while( p < pEnd && (p->nType & PH7_TK_OP) && p->sData.nByte == 1
+		&& p->sData.zString[0] == '|' ){
+		p++;
+		if( p < pEnd && (p->nType & PH7_TK_NSSEP) ){ p++; }
+		if( p >= pEnd || (p->nType & (PH7_TK_ID|PH7_TK_KEYWORD)) == 0 ) return 0;
+		p++;
+		while( p + 1 < pEnd && (p->nType & PH7_TK_NSSEP) && (p[1].nType & (PH7_TK_ID|PH7_TK_KEYWORD)) ){
+			p += 2;
+		}
+	}
 	if( p >= pEnd ) return 0;
 	return (p->nType & PH7_TK_DOLLAR) ? 1 : 0;
 }
@@ -5911,122 +6337,32 @@ static sxi32 GenStateParsePropertyType(
 	sxu32 *pnType,
 	SyString *pClass,
 	sxi32 *piTypeFlags,
-	SyString *pTypeText
+	SyString *pTypeText,
+	SySet *pAlts
 ){
-	SyToken *pIn = pGen->pIn;
-	SyToken *pTypeStart = pIn;
-	int bNullable = 0;
-	sxu32 nType = 0;
-	SyString sClassName;
-	int bHaveClass = 0;
-	SyStringInitFromBuf(&sClassName,0,0);
-	if( pIn >= pGen->pEnd ){
+	sxi32 iFlags = 0;
+	sxi32 rc;
+	if( pGen->pIn >= pGen->pEnd ){
 		return SXRET_OK;
 	}
 	/* If the first token is '$', there's no type */
-	if( pIn->nType & PH7_TK_DOLLAR ){
+	if( pGen->pIn->nType & PH7_TK_DOLLAR ){
 		return SXRET_OK;
 	}
-	/* Optional nullable prefix '?' */
-	if( (pIn->nType & PH7_TK_OP) && pIn->sData.nByte == 1 && pIn->sData.zString[0] == '?' ){
-		bNullable = 1;
-		pIn++;
-		if( pIn >= pGen->pEnd ){
-			return SXERR_SYNTAX;
-		}
+	rc = GenStateParseUnionTypeDecl(
+		pGen, pnType, pClass, pAlts, &iFlags, pTypeText,
+		PH7_CLASS_ATTR_NULLABLE,
+		PH7_CLASS_ATTR_UNION,
+		/* bAllowVoid */ 0,
+		pGen->pIn->nLine);
+	if( rc != SXRET_OK ){
+		return rc;
 	}
-	/* Skip leading namespace separator '\' */
-	if( pIn < pGen->pEnd && (pIn->nType & PH7_TK_NSSEP) ){
-		pIn++;
-	}
-	if( pIn >= pGen->pEnd || (pIn->nType & (PH7_TK_ID|PH7_TK_KEYWORD)) == 0 ){
+	/* Verify next token is '$' (start of property name) */
+	if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_DOLLAR) == 0 ){
 		return SXERR_SYNTAX;
 	}
-	if( pIn->nType & PH7_TK_KEYWORD ){
-		sxu32 nKey = (sxu32)(SX_PTR_TO_INT(pIn->pUserData));
-		if( nKey & PH7_TKWRD_ARRAY ){
-			nType = MEMOBJ_HASHMAP;
-		}else if( nKey & PH7_TKWRD_BOOL ){
-			nType = MEMOBJ_BOOL;
-		}else if( nKey & PH7_TKWRD_INT ){
-			nType = MEMOBJ_INT;
-		}else if( nKey & PH7_TKWRD_STRING ){
-			nType = MEMOBJ_STRING;
-		}else if( nKey & PH7_TKWRD_FLOAT ){
-			nType = MEMOBJ_REAL;
-		}else if( nKey & PH7_TKWRD_OBJECT ){
-			nType = MEMOBJ_OBJ;
-		}else if( nKey == PH7_TKWRD_SELF || nKey == PH7_TKWRD_PARENT ){
-			/* self/parent — treat as class type with that literal name */
-			nType = SXU32_HIGH;
-			sClassName = pIn->sData;
-			bHaveClass = 1;
-		}else{
-			/* Unknown keyword as type — treat as syntax error for properties */
-			return SXERR_SYNTAX;
-		}
-		pIn++;
-	}else{
-		/* Class / interface name (identifier). Consume namespace path a\b\c
-		 * and grow sClassName to span the full qualified name rather than
-		 * only the first segment. */
-		SyToken *pFirst = pIn;
-		SyToken *pLast = pIn;
-		sClassName = pIn->sData;
-		nType = SXU32_HIGH;
-		bHaveClass = 1;
-		pIn++;
-		while( pIn + 1 < pGen->pEnd && (pIn->nType & PH7_TK_NSSEP) && (pIn[1].nType & PH7_TK_ID) ){
-			pLast = &pIn[1];
-			pIn += 2;
-		}
-		if( pLast != pFirst ){
-			const char *zFirst = pFirst->sData.zString;
-			const char *zEnd = pLast->sData.zString + pLast->sData.nByte;
-			sClassName.zString = zFirst;
-			sClassName.nByte = (sxu32)(zEnd - zFirst);
-		}
-	}
-	/* Verify the next token is '$' — otherwise this wasn't a property type */
-	if( pIn >= pGen->pEnd || (pIn->nType & PH7_TK_DOLLAR) == 0 ){
-		return SXERR_SYNTAX;
-	}
-	/* Commit */
-	*pnType = nType;
-	*piTypeFlags = PH7_CLASS_ATTR_TYPED;
-	if( bNullable ){
-		*piTypeFlags |= PH7_CLASS_ATTR_NULLABLE;
-	}
-	if( bHaveClass ){
-		char *zDup = SyMemBackendStrDup(&pGen->pVm->sAllocator,sClassName.zString,sClassName.nByte);
-		if( zDup == 0 ){
-			return SXERR_ABORT;
-		}
-		SyStringInitFromBuf(pClass,zDup,sClassName.nByte);
-	}
-	if( pTypeText ){
-		const char *zStart = pTypeStart->sData.zString;
-		const char *zEnd = pIn->sData.zString; /* points at '$' */
-		sxu32 nLen;
-		char *zDupTxt;
-		if( zEnd > zStart ){
-			nLen = (sxu32)(zEnd - zStart);
-			/* Strip trailing whitespace that may separate the type from '$' */
-			while( nLen > 0 && (zStart[nLen-1] == ' ' || zStart[nLen-1] == '\t'
-				|| zStart[nLen-1] == '\n' || zStart[nLen-1] == '\r') ){
-				nLen--;
-			}
-		}else{
-			nLen = pTypeStart->sData.nByte;
-		}
-		zDupTxt = SyMemBackendStrDup(&pGen->pVm->sAllocator,zStart,nLen);
-		if( zDupTxt ){
-			SyStringInitFromBuf(pTypeText,zDupTxt,nLen);
-		}else{
-			SyStringInitFromBuf(pTypeText,0,0);
-		}
-	}
-	pGen->pIn = pIn;
+	*piTypeFlags = iFlags | PH7_CLASS_ATTR_TYPED;
 	return SXRET_OK;
 }
 
@@ -6039,9 +6375,11 @@ static sxi32 GenStateCompileClassAttr(ph7_gen_state *pGen,sxi32 iProtection,sxi3
 	sxu32 nType = 0;
 	SyString sTypeClass;
 	SyString sTypeText;
+	SySet aUnionAlts;
 	sxi32 iTypeFlags = 0;
 	SyStringInitFromBuf(&sTypeClass,0,0);
 	SyStringInitFromBuf(&sTypeText,0,0);
+	SySetInit(&aUnionAlts,&pGen->pVm->sAllocator,sizeof(ph7_type_alt));
 	/* Extract visibility level */
 	iProtection = GetProtectionLevel(iProtection);
 	/* Parse optional type hint (typed properties, PHP 7.4+) */
@@ -6053,17 +6391,24 @@ static sxi32 GenStateCompileClassAttr(ph7_gen_state *pGen,sxi32 iProtection,sxi3
 		 && pTypeTok->sData.zString[0] == '?' && pTypeTok + 1 < pGen->pEnd ){
 			pTypeTok = pTypeTok + 1;
 		}
-		/* Reject disallowed property types up front: void, callable, never,
-		 * mixed, and iterable (the last is not yet implemented in PHL — we
-		 * reject explicitly rather than silently fall through to a class
-		 * name lookup that would resolve to NULL). */
+		/* Reject disallowed standalone property types up front (when there's
+		 * no `|` ahead): void, callable, never, mixed, iterable. The union
+		 * parser also rejects void/never inside unions; here we only catch
+		 * the simple single-token form so the existing single-type error
+		 * messages stay intact. */
 		if( pTypeTok->nType & PH7_TK_ID ){
 			SyString *pT = &pTypeTok->sData;
-			if( (pT->nByte == 4 && SyMemcmpNoCase(pT->zString,"void",4) == 0)
+			SyToken *pAfter = pTypeTok + 1;
+			int bSingle = (pAfter >= pGen->pEnd
+				|| (pAfter->nType & PH7_TK_DOLLAR)
+				|| !((pAfter->nType & PH7_TK_OP) && pAfter->sData.nByte == 1
+					&& pAfter->sData.zString[0] == '|'));
+			if( bSingle && (
+				 (pT->nByte == 4 && SyMemcmpNoCase(pT->zString,"void",4) == 0)
 			 || (pT->nByte == 5 && SyMemcmpNoCase(pT->zString,"never",5) == 0)
 			 || (pT->nByte == 5 && SyMemcmpNoCase(pT->zString,"mixed",5) == 0)
 			 || (pT->nByte == 8 && SyMemcmpNoCase(pT->zString,"callable",8) == 0)
-			 || (pT->nByte == 8 && SyMemcmpNoCase(pT->zString,"iterable",8) == 0) ){
+			 || (pT->nByte == 8 && SyMemcmpNoCase(pT->zString,"iterable",8) == 0)) ){
 				rc = PH7_GenCompileError(pGen,E_ERROR,nLine,
 					"Property cannot have type %z",pT);
 				if( rc == SXERR_ABORT ){
@@ -6072,8 +6417,11 @@ static sxi32 GenStateCompileClassAttr(ph7_gen_state *pGen,sxi32 iProtection,sxi3
 				goto Synchronize;
 			}
 		}
-		rc = GenStateParsePropertyType(pGen,&nType,&sTypeClass,&iTypeFlags,&sTypeText);
-		if( rc == SXERR_SYNTAX ){
+		rc = GenStateParsePropertyType(pGen,&nType,&sTypeClass,&iTypeFlags,&sTypeText,&aUnionAlts);
+		if( rc == SXERR_CORRUPT ){
+			/* Error already reported by GenStateParseUnionTypeDecl */
+			goto Synchronize;
+		}else if( rc == SXERR_SYNTAX ){
 			rc = PH7_GenCompileError(pGen,E_ERROR,nLine,
 				"Invalid property type or declaration near '%z'",
 				&pGen->pIn->sData);
@@ -6126,6 +6474,18 @@ loop:
 		pAttr->nType = nType;
 		pAttr->sClass = sTypeClass;
 		pAttr->sTypeName = sTypeText;
+		if( iTypeFlags & PH7_CLASS_ATTR_UNION ){
+			/* Copy the parsed alternatives into the attribute. The class-name
+			 * SyStrings inside each ph7_type_alt point to memory owned by the
+			 * VM allocator (SyMemBackendStrDup'd in GenStateParseUnionTypeDecl),
+			 * so it's safe for multiple attrs in a multi-decl chain to share
+			 * the same backing strings — they outlive the temporary set. */
+			sxu32 i;
+			for( i = 0; i < SySetUsed(&aUnionAlts); i++ ){
+				ph7_type_alt *pSrc = (ph7_type_alt *)SySetAt(&aUnionAlts, i);
+				SySetPut(&pAttr->aUnionAlts, (const void *)pSrc);
+			}
+		}
 	}
 	if( pGen->pIn->nType & PH7_TK_EQUAL /*'='*/ ){
 		SySet *pInstrContainer;
@@ -6172,12 +6532,14 @@ loop:
 			}
 		}
 	}
+	SySetRelease(&aUnionAlts);
 	return SXRET_OK;
 Synchronize:
 	/* Synchronize with the first semi-colon */
 	while(pGen->pIn < pGen->pEnd && ((pGen->pIn->nType & PH7_TK_SEMI/*';'*/) == 0) ){
 		pGen->pIn++;
 	}
+	SySetRelease(&aUnionAlts);
 	return SXERR_CORRUPT;
 }
 /*
@@ -6285,7 +6647,14 @@ static sxi32 GenStateCompileClassMethod(
 	}
 	/* Point past ')' and parse optional return type ': type' */
 	pGen->pIn = &pEnd[1];
-	GenStateParseReturnType(pGen, &pMeth->sFunc);
+	{
+		sxi32 rcRt = GenStateParseReturnType(pGen, &pMeth->sFunc);
+		if( rcRt == SXERR_ABORT ){
+			return SXERR_ABORT;
+		}else if( rcRt == SXERR_SYNTAX ){
+			goto Synchronize;
+		}
+	}
 	if( doBody ){
 		/* Compile method body */
 		rc = GenStateCompileFuncBody(&(*pGen),&pMeth->sFunc);

--- a/src/ph7/oo.c
+++ b/src/ph7/oo.c
@@ -61,6 +61,7 @@ PH7_PRIVATE ph7_class_attr * PH7_NewClassAttr(ph7_vm *pVm,const SyString *pName,
 	}
 	/* Initialize fields */
 	SySetInit(&pAttr->aByteCode,&pVm->sAllocator,sizeof(VmInstr));
+	SySetInit(&pAttr->aUnionAlts,&pVm->sAllocator,sizeof(ph7_type_alt));
 	SyStringInitFromBuf(&pAttr->sName,zName,pName->nByte);
 	pAttr->iProtection = iProtection;
 	pAttr->nIdx = SXU32_HIGH;

--- a/src/ph7/parse.c
+++ b/src/ph7/parse.c
@@ -599,16 +599,32 @@ static sxi32 ExprAssembleAnnon(ph7_gen_state *pGen,SyToken **ppCur,SyToken *pEnd
 		goto Synchronize;
 	}
 	pIn++; /* Jump the trailing parenthesis */
-	/* Skip optional return type declaration ': [?] type' */
+	/* Skip optional return type declaration ': [?] type ( | type )*' */
 	if( pIn < pEnd && (pIn->nType & PH7_TK_COLON) ){
 		pIn++; /* Skip ':' */
 		/* Skip optional '?' nullable prefix */
 		if( pIn < pEnd && (pIn->nType & PH7_TK_OP) && pIn->sData.nByte == 1 && pIn->sData.zString[0] == '?' ){
 			pIn++;
 		}
-		/* Skip the type name (keyword or identifier) */
+		/* Skip the first type (allow leading '\' and namespace path) */
+		if( pIn < pEnd && (pIn->nType & PH7_TK_NSSEP) ){ pIn++; }
 		if( pIn < pEnd && (pIn->nType & (PH7_TK_KEYWORD|PH7_TK_ID)) ){
 			pIn++;
+			while( pIn + 1 < pEnd && (pIn->nType & PH7_TK_NSSEP) && (pIn[1].nType & PH7_TK_ID) ){
+				pIn += 2;
+			}
+		}
+		/* Skip union alternatives ( | type )* */
+		while( pIn < pEnd && (pIn->nType & PH7_TK_OP) && pIn->sData.nByte == 1
+			&& pIn->sData.zString[0] == '|' ){
+			pIn++;
+			if( pIn < pEnd && (pIn->nType & PH7_TK_NSSEP) ){ pIn++; }
+			if( pIn < pEnd && (pIn->nType & (PH7_TK_KEYWORD|PH7_TK_ID)) ){
+				pIn++;
+				while( pIn + 1 < pEnd && (pIn->nType & PH7_TK_NSSEP) && (pIn[1].nType & PH7_TK_ID) ){
+					pIn += 2;
+				}
+			}
 		}
 	}
 	if( pIn->nType & PH7_TK_KEYWORD ){
@@ -706,15 +722,30 @@ static sxi32 ExprAssembleArrowFunc(ph7_gen_state *pGen,SyToken **ppCur,SyToken *
 			pIn++; /* ')' */
 		}
 	}
-	/* Optional return type ': [?] type' */
+	/* Optional return type ': [?] type ( | type )*' */
 	if( pIn < pEnd && (pIn->nType & PH7_TK_COLON) ){
 		pIn++;
 		if( pIn < pEnd && (pIn->nType & PH7_TK_OP)
 			&& pIn->sData.nByte == 1 && pIn->sData.zString[0] == '?' ){
 			pIn++;
 		}
+		if( pIn < pEnd && (pIn->nType & PH7_TK_NSSEP) ){ pIn++; }
 		if( pIn < pEnd && (pIn->nType & (PH7_TK_KEYWORD|PH7_TK_ID)) ){
 			pIn++;
+			while( pIn + 1 < pEnd && (pIn->nType & PH7_TK_NSSEP) && (pIn[1].nType & PH7_TK_ID) ){
+				pIn += 2;
+			}
+		}
+		while( pIn < pEnd && (pIn->nType & PH7_TK_OP) && pIn->sData.nByte == 1
+			&& pIn->sData.zString[0] == '|' ){
+			pIn++;
+			if( pIn < pEnd && (pIn->nType & PH7_TK_NSSEP) ){ pIn++; }
+			if( pIn < pEnd && (pIn->nType & (PH7_TK_KEYWORD|PH7_TK_ID)) ){
+				pIn++;
+				while( pIn + 1 < pEnd && (pIn->nType & PH7_TK_NSSEP) && (pIn[1].nType & PH7_TK_ID) ){
+					pIn += 2;
+				}
+			}
 		}
 	}
 	/* Consume '=>' if present; the compile pass diagnoses absence */

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -493,6 +493,18 @@ struct ph7_vm_func_arg
 	sxu32 nType;         /* Type of this argument [i.e: array, int, string, float, object, etc.] */
 	SyString sClass;     /* Class name if the argument expect a class instance [i.e: function foo(BaseClass $bar){} ] */
 	sxi32 iFlags;        /* Configuration flags */
+	SySet aUnionAlts;    /* Union type alternatives (ph7_type_alt). Empty unless VM_FUNC_ARG_UNION is set. */
+	SyString sTypeName;  /* Original type text for error messages, normalized in canonical PHP order */
+};
+/*
+ * One alternative within a union type declaration. Used by parameters,
+ * return types, and properties when the declaration is `T1|T2|...`.
+ */
+typedef struct ph7_type_alt ph7_type_alt;
+struct ph7_type_alt
+{
+	sxu32 nType;     /* MEMOBJ_* bitmask, or SXU32_HIGH for a class/interface alternative */
+	SyString sClass; /* Class/interface name when nType == SXU32_HIGH */
 };
 /*
  * Each static variable is parsed out and remembered in an instance
@@ -539,7 +551,9 @@ struct ph7_vm_func_closure_env
 #define VM_FUNC_ARG_IGNORE   0x020 /* Do not install argument in the current frame */
 #define VM_FUNC_GENERATOR    0x040 /* VM function is a generator (contains yield) */
 #define VM_FUNC_ARG_VARIADIC 0x080 /* Argument is variadic (...$args) */
-#define VM_FUNC_ARG_NULLABLE 0x100 /* Argument type is nullable (?type) */
+#define VM_FUNC_ARG_NULLABLE 0x100 /* Argument type is nullable (?type or T|null) */
+#define VM_FUNC_ARG_UNION    0x200 /* Argument has a union type (use aUnionAlts) */
+/* next free bit: 0x400 */
 /*
  * Each user defined function is parsed out and stored in an instance
  * of the following structure.
@@ -562,6 +576,8 @@ struct ph7_vm_func
 						  */
 	sxu32 nReturnType;   /* Return type hint (MEMOBJ_* constant, MEMOBJ_VOID, or SXU32_HIGH for class) */
 	SyString sReturnClass; /* Class name when nReturnType == SXU32_HIGH */
+	SySet aReturnUnion;  /* Return-type union alternatives (ph7_type_alt). Empty unless union return. */
+	SyString sReturnTypeName; /* Original return-type text for error messages, in canonical PHP order */
 	void *pUserData;     /* Upper layer private data associated with this instance */
 	ph7_vm_func *pNextName; /* Next VM function with the same name as this one */
 };
@@ -636,7 +652,8 @@ struct ph7_class_attr
 	sxu32 nLine;         /* Line number on which this attribute was defined */
 	sxu32 nType;         /* Declared type: MEMOBJ_* bitmask, SXU32_HIGH for class, 0 = untyped */
 	SyString sClass;     /* Class/interface name when nType == SXU32_HIGH */
-	SyString sTypeName;  /* Original type text for error messages (e.g. "?int", "Foo") */
+	SyString sTypeName;  /* Original type text for error messages (e.g. "?int", "Foo", "string|int") */
+	SySet aUnionAlts;    /* Union alternatives (ph7_type_alt). Empty unless PH7_CLASS_ATTR_UNION is set. */
 	ph7_class *pDeclClass; /* Class that originally declared this attribute */
 };
 /* Attribute configuration */
@@ -645,7 +662,9 @@ struct ph7_class_attr
 #define PH7_CLASS_ATTR_ABSTRACT     0x004  /* Abstract method */
 #define PH7_CLASS_ATTR_FINAL        0x008  /* Final method */
 #define PH7_CLASS_ATTR_TYPED        0x010  /* Property has an explicit declared type */
-#define PH7_CLASS_ATTR_NULLABLE     0x020  /* Type has nullable '?' prefix */
+#define PH7_CLASS_ATTR_NULLABLE     0x020  /* Type allows null (?type prefix or T|null union) */
+#define PH7_CLASS_ATTR_UNION        0x040  /* Property has a union type (use aUnionAlts) */
+/* next free bit: 0x080 */
 /*
  * Each class method is parsed out and stored in an instance of the following
  * structure.

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -267,6 +267,8 @@ PH7_PRIVATE sxi32 PH7_VmInitFuncState(
 	SySetAlloc(&pFunc->aByteCode,0x10);
 	/* Closure environment */
 	SySetInit(&pFunc->aClosureEnv,&pVm->sAllocator,sizeof(ph7_vm_func_closure_env));
+	/* Return-type union alternatives (empty unless declared as a union) */
+	SySetInit(&pFunc->aReturnUnion,&pVm->sAllocator,sizeof(ph7_type_alt));
 	pFunc->iFlags = iFlags;
 	pFunc->pUserData = pUserData;
 	SyStringInitFromBuf(&pFunc->sName,zName,nByte);
@@ -2679,6 +2681,159 @@ static int VmStringIsStrictNumeric(ph7_value *pValue)
 }
 
 /*
+ * Numeric-string classification used by union weak-mode coercion. Returns:
+ *   1 if the string is a strictly-numeric integer (no fraction, no exponent)
+ *   2 if it's strictly numeric with a fractional/exponent part (i.e. float)
+ *   0 if it's not strictly numeric.
+ */
+static int VmStringNumericKind(ph7_value *pValue)
+{
+	const char *z, *zEnd, *zTail;
+	sxu32 n;
+	sxu8 bReal = 0;
+	sxi32 rc;
+	if( (pValue->iFlags & MEMOBJ_STRING) == 0 ){
+		return 0;
+	}
+	z = (const char *)SyBlobData(&pValue->sBlob);
+	n = SyBlobLength(&pValue->sBlob);
+	zEnd = z + n;
+	if( n == 0 ) return 0;
+	zTail = 0;
+	rc = SyStrIsNumeric(z,n,&bReal,&zTail);
+	if( rc != SXRET_OK || zTail == 0 ) return 0;
+	while( zTail < zEnd && SyisSpace(zTail[0]) ) zTail++;
+	if( zTail != zEnd ) return 0;
+	return bReal ? 2 : 1;
+}
+
+/*
+ * Try to coerce *pValue* to fit one of the alternatives in *pAlts* using
+ * PHP 8 weak-mode union semantics. Returns SXRET_OK on accept (pValue may
+ * have been mutated by the cast), SXERR_INVALID on reject. Caller is
+ * responsible for the actual TypeError throw.
+ *
+ * The class match for object values consults the active VM self-stack to
+ * resolve `self`/`parent` aliases when present.
+ */
+static sxi32 VmCoerceToUnion(ph7_vm *pVm, ph7_value *pValue, SySet *pAlts, int bNullable)
+{
+	sxu32 i;
+	ph7_type_alt *aAlts;
+	int bHasArray, bHasObjAlt, bHasClassAlt;
+	int bHasInt, bHasFloat, bHasString, bHasBool;
+	if( pValue->iFlags & MEMOBJ_NULL ){
+		return bNullable ? SXRET_OK : SXERR_INVALID;
+	}
+	aAlts = (ph7_type_alt *)SySetBasePtr(pAlts);
+	bHasArray = bHasObjAlt = bHasClassAlt = 0;
+	bHasInt = bHasFloat = bHasString = bHasBool = 0;
+	for( i = 0; i < SySetUsed(pAlts); i++ ){
+		if( aAlts[i].nType == SXU32_HIGH ) bHasClassAlt = 1;
+		else if( aAlts[i].nType == MEMOBJ_OBJ ) bHasObjAlt = 1;
+		else if( aAlts[i].nType == MEMOBJ_HASHMAP ) bHasArray = 1;
+		else if( aAlts[i].nType == MEMOBJ_INT ) bHasInt = 1;
+		else if( aAlts[i].nType == MEMOBJ_REAL ) bHasFloat = 1;
+		else if( aAlts[i].nType == MEMOBJ_STRING ) bHasString = 1;
+		else if( aAlts[i].nType == MEMOBJ_BOOL ) bHasBool = 1;
+	}
+	/* Object handling */
+	if( pValue->iFlags & MEMOBJ_OBJ ){
+		if( bHasObjAlt ) return SXRET_OK;
+		if( bHasClassAlt ){
+			ph7_class_instance *pInst = (ph7_class_instance *)pValue->x.pOther;
+			ph7_class *pSelfNow = 0;
+			if( SySetUsed(&pVm->aSelf) > 0 ){
+				ph7_class **apSelf = (ph7_class **)SySetBasePtr(&pVm->aSelf);
+				pSelfNow = apSelf[SySetUsed(&pVm->aSelf)-1];
+			}
+			for( i = 0; i < SySetUsed(pAlts); i++ ){
+				ph7_class *pExpected;
+				SyString *pCN;
+				if( aAlts[i].nType != SXU32_HIGH ) continue;
+				pCN = &aAlts[i].sClass;
+				if( pCN->nByte == 4 && SyMemcmp(pCN->zString,"self",4) == 0 ){
+					pExpected = pSelfNow;
+				}else if( pCN->nByte == 6 && SyMemcmp(pCN->zString,"parent",6) == 0 ){
+					pExpected = pSelfNow ? pSelfNow->pBase : 0;
+				}else{
+					pExpected = PH7_VmExtractClass(pVm,pCN->zString,pCN->nByte,TRUE,0);
+				}
+				if( pExpected && PH7_VmInstanceOf(pInst->pClass,pExpected) ){
+					return SXRET_OK;
+				}
+			}
+		}
+		return SXERR_INVALID;
+	}
+	/* Array handling */
+	if( pValue->iFlags & MEMOBJ_HASHMAP ){
+		return bHasArray ? SXRET_OK : SXERR_INVALID;
+	}
+	/* Scalar handling — exact match first */
+	if( pValue->iFlags & MEMOBJ_INT ){
+		if( bHasInt ) return SXRET_OK;
+	}
+	if( pValue->iFlags & MEMOBJ_REAL ){
+		if( bHasFloat ) return SXRET_OK;
+	}
+	if( pValue->iFlags & MEMOBJ_STRING ){
+		if( bHasString ) return SXRET_OK;
+	}
+	if( pValue->iFlags & MEMOBJ_BOOL ){
+		if( bHasBool ) return SXRET_OK;
+	}
+	/* Weak coercion preference order: int > float > string > bool.
+	 * Numeric-string handling distinguishes integer-shaped from float-shaped
+	 * to match PHP's union RFC. */
+	{
+		int kind = VmStringNumericKind(pValue);
+		if( bHasInt ){
+			/* int target accepts: bool, int (already exact), float w/o fraction,
+			 * numeric-string-int. Float→int with fraction loses info → skip. */
+			if( pValue->iFlags & MEMOBJ_BOOL ){
+				PH7_MemObjToInteger(pValue);
+				return SXRET_OK;
+			}
+			if( pValue->iFlags & MEMOBJ_REAL ){
+				ph7_real r = pValue->rVal;
+				if( r == (ph7_real)(sxi64)r ){
+					PH7_MemObjToInteger(pValue);
+					return SXRET_OK;
+				}
+			}
+			if( kind == 1 ){
+				PH7_MemObjToInteger(pValue);
+				return SXRET_OK;
+			}
+		}
+		if( bHasFloat ){
+			if( pValue->iFlags & (MEMOBJ_BOOL|MEMOBJ_INT) ){
+				PH7_MemObjToReal(pValue);
+				return SXRET_OK;
+			}
+			if( kind == 1 || kind == 2 ){
+				PH7_MemObjToReal(pValue);
+				return SXRET_OK;
+			}
+		}
+		if( bHasString ){
+			if( pValue->iFlags & (MEMOBJ_BOOL|MEMOBJ_INT|MEMOBJ_REAL) ){
+				PH7_MemObjToString(pValue);
+				return SXRET_OK;
+			}
+		}
+		if( bHasBool ){
+			if( pValue->iFlags & (MEMOBJ_INT|MEMOBJ_REAL|MEMOBJ_STRING) ){
+				PH7_MemObjToBool(pValue);
+				return SXRET_OK;
+			}
+		}
+	}
+	return SXERR_INVALID;
+}
+
+/*
  * Format the class name of an object-typed ph7_value into a small caller
  * buffer, for use in TypeError messages. Returns the buffer pointer.
  */
@@ -2703,6 +2858,21 @@ static sxi32 VmEnforcePropertyTypeOnStore(ph7_vm *pVm,sxu32 nIdx,ph7_value *pVal
 	pAttr = pVmAttr->pAttr;
 	if( pAttr == 0 || (pAttr->iFlags & PH7_CLASS_ATTR_TYPED) == 0 ){
 		return SXRET_OK;
+	}
+	/* Union type: dispatch to the shared coercion helper. */
+	if( pAttr->iFlags & PH7_CLASS_ATTR_UNION ){
+		sxi32 rc = VmCoerceToUnion(pVm, pValue, &pAttr->aUnionAlts,
+			(pAttr->iFlags & PH7_CLASS_ATTR_NULLABLE) ? 1 : 0);
+		if( rc == SXRET_OK ){
+			pVmAttr->iState &= ~VM_CLASS_ATTR_UNINIT;
+			return SXRET_OK;
+		}
+		if( pValue->iFlags & MEMOBJ_OBJ ){
+			char zBuf[128];
+			return VmThrowPropertyTypeError(pVm,pVmAttr,
+				VmFormatValueClassName(pValue,zBuf,sizeof(zBuf)));
+		}
+		return VmThrowPropertyTypeError(pVm,pVmAttr,ph7_type_name(pValue));
 	}
 	/* NULL handling: allowed only if the type is nullable. */
 	if( pValue->iFlags & MEMOBJ_NULL ){
@@ -4005,6 +4175,8 @@ case PH7_OP_LOAD_CLOSURE:{
 		pClosure->sSignature = pFunc->sSignature;
 		pClosure->nReturnType = pFunc->nReturnType;
 		pClosure->sReturnClass = pFunc->sReturnClass;
+		pClosure->aReturnUnion = pFunc->aReturnUnion;
+		pClosure->sReturnTypeName = pFunc->sReturnTypeName;
 		SyStringInitFromBuf(&pClosure->sName,zName,mLen);
 		/* Register the closure */
 		PH7_VmInstallUserFunction(pVm,pClosure,0);
@@ -7079,6 +7251,45 @@ case PH7_OP_CALL: {
 					{
 						ph7_hashmap *pMap = (ph7_hashmap *)pObj->x.pOther;
 						while( pArg < pTos ){
+							/* Variadic union type: per-element coercion via the shared helper.
+							 *
+							 * TODO: PHP reports the runtime element index here
+							 * ("Argument #3 must be...") but we report the formal-arg
+							 * index (always n+1, the position of the variadic). The
+							 * non-union variadic path below has the same limitation;
+							 * fixing both wants a separate counter for elements
+							 * already packed into the variadic array. */
+							if( aFormalArg[n].iFlags & VM_FUNC_ARG_UNION ){
+								sxi32 rcU = VmCoerceToUnion(pVm, pArg, &aFormalArg[n].aUnionAlts,
+									(aFormalArg[n].iFlags & VM_FUNC_ARG_NULLABLE) ? 1 : 0);
+								if( rcU != SXRET_OK ){
+									const char *zGiven;
+									char zBuf[128];
+									if( pArg->iFlags & MEMOBJ_OBJ ){
+										zGiven = VmFormatValueClassName(pArg,zBuf,sizeof(zBuf));
+									}else if( pArg->iFlags & MEMOBJ_NULL ){
+										zGiven = "null";
+									}else{
+										zGiven = ph7_type_name(pArg);
+									}
+									rc = VmThrowTypeErrorForArg(&(*pVm),&pVmFunc->sName,n+1,
+										&aFormalArg[n].sName,
+										SyStringLength(&aFormalArg[n].sTypeName) > 0
+											? aFormalArg[n].sTypeName.zString : "union",
+										zGiven);
+									if( rc == PH7_ABORT ){
+										goto Abort;
+									}
+									PH7_MemObjRelease(pTos);
+									pTos = &pTos[-nCallArgs];
+									pFrameStack = 0;
+									rc = PH7_EXCEPTION;
+									goto SkipFuncBody;
+								}
+								PH7_HashmapInsert(pMap, 0, pArg);
+								pArg++;
+								continue;
+							}
 							/* Apply type coercion to each element if the variadic has a type hint.
 							 * Nullable types (?type) allow null through without coercion. */
 							if( aFormalArg[n].nType > 0 && aFormalArg[n].nType != SXU32_HIGH
@@ -7123,6 +7334,35 @@ case PH7_OP_CALL: {
 						goto Abort;
 					}
 				}
+				/* Union type: dispatch to the shared coercion helper. */
+				if( aFormalArg[n].iFlags & VM_FUNC_ARG_UNION ){
+					sxi32 rcU = VmCoerceToUnion(pVm, pArg, &aFormalArg[n].aUnionAlts,
+						(aFormalArg[n].iFlags & VM_FUNC_ARG_NULLABLE) ? 1 : 0);
+					if( rcU != SXRET_OK ){
+						const char *zGiven;
+						char zBuf[128];
+						if( pArg->iFlags & MEMOBJ_OBJ ){
+							zGiven = VmFormatValueClassName(pArg,zBuf,sizeof(zBuf));
+						}else if( pArg->iFlags & MEMOBJ_NULL ){
+							zGiven = "null";
+						}else{
+							zGiven = ph7_type_name(pArg);
+						}
+						rc = VmThrowTypeErrorForArg(&(*pVm),&pVmFunc->sName,n+1,
+							&aFormalArg[n].sName,
+							SyStringLength(&aFormalArg[n].sTypeName) > 0
+								? aFormalArg[n].sTypeName.zString : "union",
+							zGiven);
+						if( rc == PH7_ABORT ){
+							goto Abort;
+						}
+						PH7_MemObjRelease(pTos);
+						pTos = &pTos[-nCallArgs];
+						pFrameStack = 0;
+						rc = PH7_EXCEPTION;
+						goto SkipFuncBody;
+					}
+				}else
 				/* Make sure the given arguments are of the correct type.
 				 * Nullable types (?type) allow null through without coercion. */
 				if( aFormalArg[n].nType > 0

--- a/tests/ph7/001-smoke/lang/union_class_nullable_equivalence.phpt
+++ b/tests/ph7/001-smoke/lang/union_class_nullable_equivalence.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Class union with null: Foo|null behaves like ?Foo
+--FILE--
+<?php
+class UcneFoo { public $tag = "foo"; }
+
+function a(UcneFoo|null $x) { echo $x === null ? "null" : $x->tag, "\n"; }
+function b(?UcneFoo $x)     { echo $x === null ? "null" : $x->tag, "\n"; }
+
+a(null);
+a(new UcneFoo());
+b(null);
+b(new UcneFoo());
+?>
+--EXPECT--
+null
+foo
+null
+foo
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/union_int_float_numeric_string.phpt
+++ b/tests/ph7/001-smoke/lang/union_int_float_numeric_string.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Union int|float: numeric-int strings coerce to int, float-shaped strings coerce to float
+--FILE--
+<?php
+function uifns_f(int|float $x) {
+    echo is_int($x) ? "int:" : "flt:", $x, "\n";
+}
+uifns_f("42");      // numeric int -> int
+uifns_f("-7");      // numeric int (negative) -> int
+uifns_f("3.14");    // numeric float -> float
+uifns_f("-2.5");    // negative float -> float
+uifns_f("  5  ");   // PHP allows surrounding whitespace; integer-shaped -> int
+?>
+--EXPECT--
+int:42
+int:-7
+flt:3.14
+flt:-2.5
+int:5
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/union_param_int_string.phpt
+++ b/tests/ph7/001-smoke/lang/union_param_int_string.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Union type parameter: int|string accepts both
+--FILE--
+<?php
+function upis_f(int|string $x) {
+    echo is_int($x) ? "int" : "str", ":", $x, "\n";
+}
+upis_f(42);
+upis_f("hi");
+?>
+--EXPECT--
+int:42
+str:hi
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/union_param_multiple_classes.phpt
+++ b/tests/ph7/001-smoke/lang/union_param_multiple_classes.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Union type parameter: Foo|Bar accepts instances of either class
+--FILE--
+<?php
+class UfFoo { public $name = "foo"; }
+class UfBar { public $name = "bar"; }
+
+function take(UfFoo|UfBar $x) {
+    echo $x->name, "\n";
+}
+take(new UfFoo());
+take(new UfBar());
+?>
+--EXPECT--
+foo
+bar
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/union_param_nullable_shortcut_equivalence.phpt
+++ b/tests/ph7/001-smoke/lang/union_param_nullable_shortcut_equivalence.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Union type parameter: int|null behaves like ?int (accepts null and ints)
+--FILE--
+<?php
+function upnse_show($x) { echo is_null($x) ? "null" : "int:$x", "\n"; }
+function upnse_f(int|null $x) { upnse_show($x); }
+function upnse_g(?int $x)    { upnse_show($x); }
+upnse_f(null); upnse_f(7);
+upnse_g(null); upnse_g(7);
+?>
+--EXPECT--
+null
+int:7
+null
+int:7
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/union_param_with_null.phpt
+++ b/tests/ph7/001-smoke/lang/union_param_with_null.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Union type parameter: int|string|null accepts null
+--FILE--
+<?php
+function upwn_f(int|string|null $x) {
+    if (is_null($x))   { echo "null\n"; }
+    elseif (is_int($x)) { echo "int:", $x, "\n"; }
+    else                { echo "str:[", $x, "]\n"; }
+}
+upwn_f(null);
+upwn_f(0);
+upwn_f("");
+?>
+--EXPECT--
+null
+int:0
+str:[]
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/union_return_class.phpt
+++ b/tests/ph7/001-smoke/lang/union_return_class.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Union return type: : Foo|Bar with class instances
+--FILE--
+<?php
+class UrFoo { public $tag = "F"; }
+class UrBar { public $tag = "B"; }
+function pick(int $i): UrFoo|UrBar {
+    return $i > 0 ? new UrFoo() : new UrBar();
+}
+echo pick(1)->tag, "\n";
+echo pick(0)->tag, "\n";
+?>
+--EXPECT--
+F
+B
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/union_return_int_string.phpt
+++ b/tests/ph7/001-smoke/lang/union_return_int_string.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Union return type: : int|string is parsed and returned values pass through
+--FILE--
+<?php
+function uris_r($flag): int|string {
+    return $flag ? 42 : "hello";
+}
+$a = uris_r(true);
+$b = uris_r(false);
+echo is_int($a) ? "int:" : "str:", $a, "\n";
+echo is_int($b) ? "int:" : "str:", $b, "\n";
+?>
+--EXPECT--
+int:42
+str:hello
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/union_variadic.phpt
+++ b/tests/ph7/001-smoke/lang/union_variadic.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Union type on a variadic parameter accepts mixed allowed types
+--FILE--
+<?php
+function uv_f(int|string ...$xs) {
+    foreach ($xs as $x) {
+        echo is_int($x) ? "int:" : "str:", $x, "\n";
+    }
+}
+uv_f(1, "two", 3, "four");
+?>
+--EXPECT--
+int:1
+str:two
+int:3
+str:four
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/union_weak_coercion_priority.phpt
+++ b/tests/ph7/001-smoke/lang/union_weak_coercion_priority.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Union weak coercion: int|float on numeric strings
+--FILE--
+<?php
+function uwcp_f(int|float $x) {
+    echo is_int($x) ? "int:" : "flt:", $x, "\n";
+}
+uwcp_f(1);       // exact int
+uwcp_f(1.5);     // exact float
+uwcp_f("3");     // numeric int -> int
+uwcp_f("3.14");  // numeric float -> float
+?>
+--EXPECT--
+int:1
+flt:1.5
+int:3
+flt:3.14
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/oo/typed_property_union_class.phpt
+++ b/tests/ph7/001-smoke/oo/typed_property_union_class.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: Foo|Bar class union accepts instances of either
+--FILE--
+<?php
+class TpuFoo { public $tag = "F"; }
+class TpuBar { public $tag = "B"; }
+class TpuHolder {
+    public TpuFoo|TpuBar $x;
+}
+$h = new TpuHolder();
+$h->x = new TpuFoo();
+echo $h->x->tag, "\n";
+$h->x = new TpuBar();
+echo $h->x->tag, "\n";
+?>
+--EXPECT--
+F
+B
+--CLEAN--
+<?php
+unset($h);

--- a/tests/ph7/001-smoke/oo/typed_property_union_int_string.phpt
+++ b/tests/ph7/001-smoke/oo/typed_property_union_int_string.phpt
@@ -1,0 +1,25 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: int|string union accepts both
+--FILE--
+<?php
+class TpUnion {
+    public int|string $v = 0;
+}
+function tpu_show($x) { echo is_int($x) ? "int:" : "str:", $x, "\n"; }
+$o = new TpUnion();
+tpu_show($o->v);
+$o->v = 42;
+tpu_show($o->v);
+$o->v = "hello";
+tpu_show($o->v);
+?>
+--EXPECT--
+int:0
+int:42
+str:hello
+--CLEAN--
+<?php
+unset($o);

--- a/tests/ph7/001-smoke/oo/typed_property_union_with_null.phpt
+++ b/tests/ph7/001-smoke/oo/typed_property_union_with_null.phpt
@@ -1,0 +1,25 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: int|null accepts null and int values
+--FILE--
+<?php
+class TpUnNull {
+    public int|null $n = null;
+}
+function tpunn_show($x) { echo is_null($x) ? "null" : "int:$x", "\n"; }
+$o = new TpUnNull();
+tpunn_show($o->n);
+$o->n = 7;
+tpunn_show($o->n);
+$o->n = null;
+tpunn_show($o->n);
+?>
+--EXPECT--
+null
+int:7
+null
+--CLEAN--
+<?php
+unset($o);

--- a/tests/ph7/002-integration/error/invalid_argument_type.phpt
+++ b/tests/ph7/002-integration/error/invalid_argument_type.phpt
@@ -3,14 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 function with invalid argument type
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 function foo(echo $a) {
 }
 --EXPECTF--
-%s Warning:  Invalid argument type 'echo',Automatic cast will not be performed %s
+PHP Parse error:  syntax error, unexpected token "echo", expecting variable in %s on line %d
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/union_canonical_ordering.phpt
+++ b/tests/ph7/002-integration/lang/union_canonical_ordering.phpt
@@ -1,0 +1,36 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Union type error message order: classes (declaration order), then object, array, string, int, float, bool, null
+--FILE--
+<?php
+class UcoFoo {}
+class UcoBar {}
+
+// Strip the ", called in ... on line N" tail that PHP 8+ appends to user-land
+// TypeErrors, so the expected-output pinning works on both engines.
+function uco_trim($m) {
+    $i = strpos($m, ", called in ");
+    return $i === false ? $m : substr($m, 0, $i);
+}
+
+function uco_f(int|object|array|string $x) {}
+try { uco_f(null); } catch (TypeError $e) { echo uco_trim($e->getMessage()), "\n"; }
+
+function uco_g(bool|float|int|string|array|object $x) {}
+try { uco_g(null); } catch (TypeError $e) { echo uco_trim($e->getMessage()), "\n"; }
+
+function uco_h(UcoFoo|int|UcoBar|array $x) {}
+try { uco_h(null); } catch (TypeError $e) { echo uco_trim($e->getMessage()), "\n"; }
+
+function uco_i(int|null|float $x) {}
+try { uco_i(new UcoFoo()); } catch (TypeError $e) { echo uco_trim($e->getMessage()), "\n"; }
+?>
+--EXPECT--
+uco_f(): Argument #1 ($x) must be of type object|array|string|int, null given
+uco_g(): Argument #1 ($x) must be of type object|array|string|int|float|bool, null given
+uco_h(): Argument #1 ($x) must be of type UcoFoo|UcoBar|array|int, null given
+uco_i(): Argument #1 ($x) must be of type int|float|null, UcoFoo given
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/union_duplicate_type_error.phpt
+++ b/tests/ph7/002-integration/lang/union_duplicate_type_error.phpt
@@ -1,0 +1,12 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Union type: duplicate alternative is a fatal error
+--FILE--
+<?php
+function f(int|int $x) {}
+--EXPECTF--
+PHP Fatal error:  Duplicate type int is redundant in %s on line %d%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/union_never_in_union_error.phpt
+++ b/tests/ph7/002-integration/lang/union_never_in_union_error.phpt
@@ -1,0 +1,12 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Union return type: never cannot appear inside a union
+--FILE--
+<?php
+function f(): int|never {}
+--EXPECTF--
+PHP Fatal error:  never can only be used as a standalone type in %s on line %d%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/union_nullable_and_null_mix_error.phpt
+++ b/tests/ph7/002-integration/lang/union_nullable_and_null_mix_error.phpt
@@ -1,0 +1,12 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Union type: ?T cannot be combined with a |-union
+--FILE--
+<?php
+function f(?int|string $x) {}
+--EXPECTF--
+PHP Parse error:  syntax error, unexpected token "|", expecting variable in %s on line %d%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/union_param_reject_array.phpt
+++ b/tests/ph7/002-integration/lang/union_param_reject_array.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Union parameter: int|string rejects array with TypeError
+--FILE--
+<?php
+function upra_f(int|string $x) {}
+try {
+    upra_f([1, 2, 3]);
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECTF--
+upra_f(): Argument #1 ($x) must be of type string|int, array given%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/union_param_reject_non_numeric_string.phpt
+++ b/tests/ph7/002-integration/lang/union_param_reject_non_numeric_string.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Union parameter: int|float rejects non-numeric string
+--FILE--
+<?php
+function uprnns_f(int|float $x) {}
+try {
+    uprnns_f("abc");
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECTF--
+uprnns_f(): Argument #1 ($x) must be of type int|float, string given%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/union_param_reject_null.phpt
+++ b/tests/ph7/002-integration/lang/union_param_reject_null.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Union parameter: int|string rejects null when not nullable
+--FILE--
+<?php
+function uprnull_f(int|string $x) {}
+try {
+    uprnull_f(null);
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECTF--
+uprnull_f(): Argument #1 ($x) must be of type string|int, null given%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/union_param_reject_object.phpt
+++ b/tests/ph7/002-integration/lang/union_param_reject_object.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Union parameter: int|string rejects unrelated object
+--FILE--
+<?php
+class UprBox {}
+function upro_f(int|string $x) {}
+try {
+    upro_f(new UprBox());
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECTF--
+upro_f(): Argument #1 ($x) must be of type string|int, UprBox given%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/union_param_reject_unrelated_class.phpt
+++ b/tests/ph7/002-integration/lang/union_param_reject_unrelated_class.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Union parameter: Foo|Bar rejects unrelated class instance
+--FILE--
+<?php
+class UpcFoo {}
+class UpcBar {}
+class UpcBaz {}
+function upruc_f(UpcFoo|UpcBar $x) {}
+try {
+    upruc_f(new UpcBaz());
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECTF--
+upruc_f(): Argument #1 ($x) must be of type UpcFoo|UpcBar, UpcBaz given%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/union_variadic_reject.phpt
+++ b/tests/ph7/002-integration/lang/union_variadic_reject.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Union variadic: int|string ...$xs rejects array element
+--FILE--
+<?php
+function uvr_f(int|string ...$xs) {}
+try {
+    uvr_f(1, "x", [1, 2]);
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECTF--
+uvr_f(): Argument #%d%Amust be of type string|int, array given%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/union_void_in_union_error.phpt
+++ b/tests/ph7/002-integration/lang/union_void_in_union_error.phpt
@@ -1,0 +1,12 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Union return type: void cannot appear inside a union
+--FILE--
+<?php
+function f(): int|void {}
+--EXPECTF--
+PHP Fatal error:  Void can only be used as a standalone type in %s on line %d%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/typed_property_union_class_reject.phpt
+++ b/tests/ph7/002-integration/oo/typed_property_union_class_reject.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: Foo|Bar union rejects unrelated class instance
+--FILE--
+<?php
+class TpucrFoo {}
+class TpucrBar {}
+class TpucrBaz {}
+class TpucrHolder { public TpucrFoo|TpucrBar $x; }
+$h = new TpucrHolder();
+try {
+    $h->x = new TpucrBaz();
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Cannot assign TpucrBaz to property TpucrHolder::$x of type TpucrFoo|TpucrBar
+--CLEAN--
+<?php
+unset($h);

--- a/tests/ph7/002-integration/oo/typed_property_union_null_non_nullable.phpt
+++ b/tests/ph7/002-integration/oo/typed_property_union_null_non_nullable.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: int|string union without null rejects null assignment
+--FILE--
+<?php
+class TpunnHolder { public int|string $x = 0; }
+$h = new TpunnHolder();
+try {
+    $h->x = null;
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Cannot assign null to property TpunnHolder::$x of type string|int
+--CLEAN--
+<?php
+unset($h);

--- a/tests/ph7/002-integration/oo/typed_property_union_reject.phpt
+++ b/tests/ph7/002-integration/oo/typed_property_union_reject.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Typed property: int|string union rejects array assignment
+--FILE--
+<?php
+class TpurHolder { public int|string $x = 0; }
+$h = new TpurHolder();
+try {
+    $h->x = [1, 2];
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Cannot assign array to property TpurHolder::$x of type string|int
+--CLEAN--
+<?php
+unset($h);


### PR DESCRIPTION
Allow type declarations on parameters, return types, and typed properties to name multiple alternatives: int|string, Foo|Bar|null, int|float, etc. Single-type declarations keep the existing fast path and bytecode shape; unions go through a new SySet of ph7_type_alt entries next to the legacy nType/sClass fields.

compile.c gains GenStateParseOneTypeAtom + GenStateParseUnionTypeDecl, which are wired into the three type-parsing sites (property, return, parameter). The helper recognises scalar keywords, array, object, self/parent, namespace-qualified class names, null, void, and never, rejects ?T combined with |-unions, rejects duplicate alternatives (case-insensitive for classes), rejects void/never inside unions, rejects standalone null, and builds canonical error text matching PHP's rendering order: classes (declaration order), then object, array, string, int, float, bool, optionally followed by null (or the ?T shorthand when exactly one non-null atom). never is parsed but explicitly rejected as not-yet-implemented rather than silently aliasing to void.

The lookahead used by the class-body dispatcher and the token-skip prepasses in parse.c for closures and arrow functions all learned to walk | Type alternatives so union-typed declarations route through the typed-attribute path and survive signature assembly.

Runtime enforcement lives in VmCoerceToUnion, a shared helper called from VmEnforcePropertyTypeOnStore and from the OP_CALL parameter loop (including the variadic inner loop). It performs an exact-match pass first (MEMOBJ_* bits, MEMOBJ_OBJ for any object, class match via PH7_VmInstanceOf with self/parent resolved against the self-stack), then a PHP 8 weak-mode coercion pass: bool/int-shaped numeric strings fold into int when int is present, fractional numeric strings fold into float, scalars fold into string when string is present, and int/float/string fold into bool as a last resort. The preference order matches PHP's Union Types 2.0 RFC. Float values with a non-zero fractional part are not narrowed to int, and object values never coerce to scalars.

On rejection, the shared VmThrowTypeErrorForArg /
VmThrowPropertyTypeError helpers report the canonical type text stored at parse time, so error messages read "must be of type string|int, array given" and "Cannot assign null to property C::\$x of type string|int" just like PHP 8.5. The SXERR_ABORT path from GenStateParseReturnType is now propagated through all three of its callers so OOM during return-type parsing no longer parses past the failure.

Tests cover parameter/return/property happy paths for scalar unions, class unions, null unions, and variadic unions; ?T vs T|null equivalence for both scalars and classes; int|float weak coercion of numeric strings; the full canonical-ordering rendering; and the rejection paths for array/object/null/non-numeric-string, unrelated classes, duplicate atoms, void inside unions, never inside unions, and the ?T|X parse error.
