### PR TITLE
Implement named arguments (PHP 8.0)

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -9121,12 +9121,29 @@ static sxi32 GenStateEmitExprCode(
 		if( iVmOp == PH7_OP_CALL ){
 			ph7_expr_node **apNode;
 			int hasSpread = 0;
+			int hasNamed = 0;
+			sxi32 nArgs;
 			sxi32 n;
 			/* Recurse and generate bytecodes for function arguments */
 			apNode = (ph7_expr_node **)SySetBasePtr(&pNode->aNodeArgs);
+			nArgs = (sxi32)SySetUsed(&pNode->aNodeArgs);
+			/* Validate: no positional arguments after named arguments */
+			{
+				int seenNamed = 0;
+				for( n = 0; n < nArgs; ++n ){
+					if( apNode[n]->iFlags & EXPR_NODE_NAMED_ARG ){
+						seenNamed = 1;
+						hasNamed = 1;
+					}else if( seenNamed && !(apNode[n]->iFlags & EXPR_NODE_SPREAD) ){
+						rc = PH7_GenCompileError(&(*pGen),E_ERROR,apNode[n]->pStart->nLine,
+							"Cannot use positional argument after named argument");
+						return SXERR_SYNTAX;
+					}
+				}
+			}
 			/* Read-only load */
 			iFlags |= EXPR_FLAG_RDONLY_LOAD;
-			for( n = 0 ; n < (sxi32)SySetUsed(&pNode->aNodeArgs) ; ++n ){
+			for( n = 0 ; n < nArgs ; ++n ){
 				rc = GenStateEmitExprCode(&(*pGen),apNode[n],iFlags&~EXPR_FLAG_LOAD_IDX_STORE);
 				if( rc != SXRET_OK ){
 					return rc;
@@ -9138,8 +9155,41 @@ static sxi32 GenStateEmitExprCode(
 				}
 			}
 			/* Total number of given arguments */
-			iP1 = (sxi32)SySetUsed(&pNode->aNodeArgs);
+			iP1 = nArgs;
 			iP2 = hasSpread;
+			/* Build VmCallArgMap if named arguments are present.
+			 * Deep-copy name strings so they survive token stream cleanup. */
+			if( hasNamed ){
+				sxu32 nStrBytes = 0;
+				char *zBuf;
+				for( n = 0; n < nArgs; ++n ){
+					if( apNode[n]->iFlags & EXPR_NODE_NAMED_ARG ){
+						nStrBytes += (sxu32)apNode[n]->sArgName.nByte;
+					}
+				}
+				{
+				sxu32 mapSize = sizeof(VmCallArgMap) + nArgs * sizeof(SyString) + nStrBytes;
+				VmCallArgMap *pMap = (VmCallArgMap *)SyMemBackendAlloc(
+					&pGen->pVm->sAllocator, mapSize);
+				if( pMap ){
+					SyZero(pMap, mapSize);
+					pMap->bHasNamed = 1;
+					pMap->nTotal = (sxu32)nArgs;
+					pMap->aNames = (SyString *)&pMap[1];
+					zBuf = (char *)&pMap->aNames[nArgs]; /* string storage after SyString array */
+					for( n = 0; n < nArgs; ++n ){
+						if( apNode[n]->iFlags & EXPR_NODE_NAMED_ARG ){
+							sxu32 nb = (sxu32)apNode[n]->sArgName.nByte;
+							SyMemcpy(apNode[n]->sArgName.zString, zBuf, nb);
+							SyStringInitFromBuf(&pMap->aNames[n], zBuf, nb);
+							zBuf += nb;
+						}
+						/* else: aNames[n] remains {NULL, 0} for positional */
+					}
+					p3 = (void *)pMap;
+				}
+				}
+			}
 			/* Remove stale flags now */
 			iFlags &= ~EXPR_FLAG_RDONLY_LOAD;
 		}
@@ -9170,7 +9220,18 @@ static sxi32 GenStateEmitExprCode(
 							 * NEW handler can recover the unqualified name. */
 							iP2 = (sxi32)(nOrig + 1); /* +1 to distinguish from default 0 */
 							if( !fromImport ){
-								p3 = (void *)1;
+								/* Mark as namespace-qualified via VmCallArgMap */
+								if( p3 == 0 ){
+									VmCallArgMap *pMap = (VmCallArgMap *)SyMemBackendAlloc(
+										&pGen->pVm->sAllocator, sizeof(VmCallArgMap));
+									if( pMap ){
+										SyZero(pMap, sizeof(VmCallArgMap));
+										p3 = (void *)pMap;
+									}
+								}
+								if( p3 ){
+									((VmCallArgMap *)p3)->bIsNamespaced = 1;
+								}
 							}
 						}
 					}
@@ -9328,8 +9389,11 @@ static sxi32 GenStateEmitExprCode(
 				VmInstr *pPrev;
 				pPrev = PH7_VmPeekNextInstr(pGen->pVm);
 				if( pPrev == 0 || pPrev->iOp != PH7_OP_MEMBER ){
-					/* Pop the call instruction */
+					/* Pop the call instruction, preserve named-arg map */
 					iP1 = pInstr->iP1;
+					if( pInstr->p3 ){
+						p3 = pInstr->p3; /* Transfer VmCallArgMap to NEW */
+					}
 					(void)PH7_VmPopInstr(pGen->pVm);
 				}
 			}

--- a/src/ph7/parse.c
+++ b/src/ph7/parse.c
@@ -469,14 +469,18 @@ static sxi32 ExprVerifyNodes(ph7_gen_state *pGen,ph7_expr_node **apNode,sxi32 nN
 			}
 			iBraces--;
 		}else if ( apNode[i]->pStart->nType & PH7_TK_COLON ){
-			if( iQuesty <= 0 ){
+			if( iQuesty > 0 ){
+				iQuesty--;
+			}else if( iParen <= 0 ){
+				/* Colon outside parentheses with no matching '?' — syntax error.
+				 * Colons inside parentheses may be named arguments (name: value)
+				 * and are validated later by ExprProcessFuncArguments. */
 				rc = PH7_GenCompileError(&(*pGen),E_ERROR,apNode[i]->pStart->nLine,"Syntax error: Unexpected token ':'");
 				if( rc != SXERR_ABORT ){
 					rc = SXERR_SYNTAX;
 				}
 				return rc;
 			}
-			iQuesty--;
 		}else if( apNode[i]->pStart->nType & PH7_TK_OP ){
 			const ph7_expr_op *pOp = (const ph7_expr_op *)apNode[i]->pOp;
 			if( pOp->iOp == EXPR_OP_QUESTY ){
@@ -1121,6 +1125,36 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 			iCur++;
 		}
 		if( iCur > iNode ){
+			SyString sArgName = {0, 0};
+			/* Check for named argument pattern: identifier ':' expr.
+			 * PHP allows reserved keywords as parameter names (e.g. function
+			 * f($class){}), so accept PH7_TK_KEYWORD labels here too. */
+			if( (iCur - iNode) >= 2
+				&& apNode[iNode]
+				&& (apNode[iNode]->pStart->nType & (PH7_TK_ID|PH7_TK_KEYWORD))
+				&& apNode[iNode]->xCode == PH7_CompileLiteral
+				&& apNode[iNode+1]
+				&& (apNode[iNode+1]->pStart->nType & PH7_TK_COLON) ){
+				/* Named argument detected: save name, free ID and colon nodes */
+				sArgName = apNode[iNode]->pStart->sData;
+				ExprFreeTree(&(*pGen),apNode[iNode]);
+				apNode[iNode] = 0;
+				ExprFreeTree(&(*pGen),apNode[iNode+1]);
+				apNode[iNode+1] = 0;
+				iNode += 2;
+				/* Guard: the value expression must not be empty.  Catches
+				 * degenerate forms like f(a:) or f(a:,b:1). */
+				if( iNode >= iCur ){
+					rc = PH7_GenCompileError(&(*pGen),E_PARSE,
+						pOp->pStart->nLine,
+						"syntax error, expected expression after named argument '%z:'",
+						&sArgName);
+					if( rc != SXERR_ABORT ){
+						rc = SXERR_SYNTAX;
+					}
+					return rc;
+				}
+			}
 			if( apNode[iNode] && (apNode[iNode]->pStart->nType & PH7_TK_AMPER /*'&'*/) && ((iCur - iNode) == 2)
 				&& apNode[iNode+1]->xCode == PH7_CompileVariable ){
 					PH7_GenCompileError(&(*pGen),E_WARNING,apNode[iNode]->pStart->nLine,
@@ -1130,6 +1164,10 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 			}
 			ExprMakeTree(&(*pGen),&apNode[iNode],iCur-iNode);
 			if( apNode[iNode] ){
+				if( sArgName.nByte > 0 ){
+					apNode[iNode]->iFlags |= EXPR_NODE_NAMED_ARG;
+					apNode[iNode]->sArgName = sArgName;
+				}
 				/* Put a pointer to the root of the tree in the arguments set */
 				SySetPut(&pOp->aNodeArgs,(const void *)&apNode[iNode]);
 			}else{

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -328,11 +328,13 @@ struct ph7_expr_node
 	sxi32 iFlags;            /* Node construct flags */
 	ProcNodeConstruct xCode; /* C routine responsible of compiling this node */
 	SySet aNodeArgs;         /* Node arguments. Only used by postfix operators [i.e: function call]*/
+	SyString sArgName;       /* Named argument label (empty if positional) */
 	ph7_expr_node *pCond;    /* Condition: Only used by the ternary operator '?:' */
 };
 /* Node Construct flags */
-#define EXPR_NODE_PRE_INCR 0x01 /* Pre-icrement/decrement [i.e: ++$i,--$j] node */
-#define EXPR_NODE_SPREAD   0x02 /* Argument unpacking: ...$expr */
+#define EXPR_NODE_PRE_INCR    0x01 /* Pre-icrement/decrement [i.e: ++$i,--$j] node */
+#define EXPR_NODE_SPREAD      0x02 /* Argument unpacking: ...$expr */
+#define EXPR_NODE_NAMED_ARG   0x04 /* Named argument: name: $expr */
 /*
  * A block of instructions is recorded in an instance of the following structure.
  * This structure is used only during compile-time and have no meaning
@@ -709,6 +711,18 @@ struct VmInstr
 	sxi32 iP1; /* First operand */
 	sxu32 iP2; /* Second operand (Often the jump destination) */
 	void *p3;  /* Third operand (Often Upper layer private data) */
+};
+/*
+ * Named-argument metadata attached to PH7_OP_CALL instructions via p3.
+ * Also carries the namespace-qualification flag formerly stored as p3=(void*)1.
+ */
+typedef struct VmCallArgMap VmCallArgMap;
+struct VmCallArgMap
+{
+	sxu8 bHasNamed;      /* 1 if any argument uses name: syntax */
+	sxu8 bIsNamespaced;  /* 1 if compiler namespace-qualified the call */
+	sxu32 nTotal;        /* Total number of compile-time arguments */
+	SyString *aNames;    /* Array of nTotal names. nByte==0 means positional. */
 };
 /* Each active class instance attribute is represented by an instance
  * of the following structure.

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -930,6 +930,9 @@ static ph7_exec_ctx * VmNewExecCtx(ph7_vm *pVm, ph7_vm_func *pFunc);
 static void VmReleaseExecCtx(ph7_vm *pVm, ph7_exec_ctx *pCtx);
 static sxi32 VmFiberSetupFrame(ph7_vm *pVm, ph7_exec_ctx *pExecCtx,
 	ph7_class_instance *pClosureThis, int nArg, ph7_value **apArg);
+static sxi32 VmCallClassMethodWithMap(ph7_vm *pVm, ph7_class_instance *pThis,
+	ph7_class_method *pMethod, ph7_value *pResult, int nArg,
+	ph7_value **apArg, VmCallArgMap *pMap);
 /* Forward declarations for Generator helpers and C functions */
 static ph7_generator * VmNewGenerator(ph7_vm *pVm, ph7_exec_ctx *pCtx);
 static void VmReleaseGenerator(ph7_vm *pVm, ph7_generator *pGen);
@@ -3020,6 +3023,17 @@ static sxi32 VmThrowTypeErrorForArg(ph7_vm *pVm,SyString *pFuncName,sxu32 nArg,S
 	return PH7_EXCEPTION;
 }
 /*
+ * Report a fatal named-argument error.
+ * Outputs a PHP-compatible "Uncaught Error:" message and aborts execution.
+ */
+static sxi32 VmThrowNamedArgError(ph7_vm *pVm,const char *zMsg,sxu32 nMsg)
+{
+	const char *zFunc = 0;
+	int nFunc = 0;
+	VmGetFrameContext(pVm,&zFunc,&nFunc);
+	return VmReportUncaughtException(pVm,"Error",5,zMsg,nMsg,zFunc,nFunc);
+}
+/*
  * Format and throw a run-time error and invoke the supplied VM output consumer callback.
  * Refer to the implementation of [ph7_context_throw_error_format()] for additional
  * information.
@@ -3238,6 +3252,91 @@ static sxi32 VmSuspendCtx(
 	pCtx->nTos = nTos;
 	pCtx->iState = PH7_CTX_STATE_SUSPENDED;
 	return PH7_SUSPEND;
+}
+/*
+ * Resolve named-argument mapping.
+ *
+ * For each actual argument in the call, determine which formal parameter it
+ * maps to (by name or by position).  On success, aSlot[i] contains the
+ * formal-parameter index for actual arg i, -1 if it overflows into the
+ * variadic collector, or -2 if still unresolved.  aUsed[k] is set to 1 for
+ * every formal parameter that received a value.
+ *
+ * Returns SXRET_OK on success.  On error (duplicate, unknown parameter,
+ * positional-overlaps-named) it calls VmThrowNamedArgError and returns
+ * PH7_ABORT so the caller can jump to its Abort label.
+ */
+static sxi32 VmResolveNamedArgs(
+	ph7_vm *pVm,
+	VmCallArgMap *pMap,           /* Named-arg metadata from the instruction */
+	ph7_vm_func_arg *aFormalArg,  /* Formal parameter array */
+	sxu32 nNonVariadic,           /* Number of non-variadic formal params */
+	sxi32 iVariadicIdx,           /* Index of the variadic param, or -1 */
+	sxu32 nActual,                /* Number of actual arguments on the stack */
+	sxi32 *aSlot,                 /* OUT: mapping actual->formal */
+	sxu8  *aUsed                  /* OUT: which formals are used */
+)
+{
+	sxi32 posIdx = 0;
+	sxu32 i;
+	char zErrMsg[256];
+	SyZero(aUsed, nNonVariadic * sizeof(sxu8));
+	for( i = 0; i < nActual; i++ ){
+		aSlot[i] = -2;
+	}
+	for( i = 0; i < nActual; i++ ){
+		if( i < pMap->nTotal && pMap->aNames[i].nByte > 0 ){
+			/* Named argument — find formal by name */
+			int found = 0;
+			sxu32 k;
+			for( k = 0; k < nNonVariadic; k++ ){
+				if( aFormalArg[k].sName.nByte == pMap->aNames[i].nByte
+					&& SyMemcmp(aFormalArg[k].sName.zString,
+						pMap->aNames[i].zString,
+						pMap->aNames[i].nByte) == 0 ){
+					if( aUsed[k] ){
+						SyBufferFormat(zErrMsg,sizeof(zErrMsg),
+							"Named parameter $%.*s overwrites previous argument",
+							(int)pMap->aNames[i].nByte,pMap->aNames[i].zString);
+						VmThrowNamedArgError(&(*pVm),zErrMsg,(sxu32)SyStrlen(zErrMsg));
+						return PH7_ABORT;
+					}
+					aSlot[i] = (sxi32)k;
+					aUsed[k] = 1;
+					found = 1;
+					break;
+				}
+			}
+			if( !found ){
+				if( iVariadicIdx >= 0 ){
+					aSlot[i] = -1; /* goes to variadic with string key */
+				}else{
+					SyBufferFormat(zErrMsg,sizeof(zErrMsg),
+						"Unknown named parameter $%.*s",
+						(int)pMap->aNames[i].nByte,pMap->aNames[i].zString);
+					VmThrowNamedArgError(&(*pVm),zErrMsg,(sxu32)SyStrlen(zErrMsg));
+					return PH7_ABORT;
+				}
+			}
+		}else{
+			/* Positional argument */
+			if( (sxu32)posIdx < nNonVariadic ){
+				if( aUsed[posIdx] ){
+					SyBufferFormat(zErrMsg,sizeof(zErrMsg),
+						"Named parameter $%.*s overwrites previous argument",
+						(int)aFormalArg[posIdx].sName.nByte,aFormalArg[posIdx].sName.zString);
+					VmThrowNamedArgError(&(*pVm),zErrMsg,(sxu32)SyStrlen(zErrMsg));
+					return PH7_ABORT;
+				}
+				aSlot[i] = posIdx;
+				aUsed[posIdx] = 1;
+			}else if( iVariadicIdx >= 0 ){
+				aSlot[i] = -1; /* overflow to variadic */
+			}
+			posIdx++;
+		}
+	}
+	return SXRET_OK;
 }
 /*
  * Execute as much of a PH7 bytecode program as we can then return.
@@ -6747,17 +6846,23 @@ case PH7_OP_NEW: {
 			pCons = PH7_ClassExtractMethod(pClass,pName->zString,pName->nByte);
 		}
 		if( pCons ){
-			/* Call the class constructor */
+			/* Call the class constructor.  Collect args in stack order and
+			 * forward any VmCallArgMap from the NEW instruction so the
+			 * receiving OP_CALL path runs its named-argument matching
+			 * (including variadic string-key packing). */
+			VmCallArgMap *pNewMap = (VmCallArgMap *)pInstr->p3;
 			SySetReset(&aArg);
 			while( pArg < pTos ){
 				SySetPut(&aArg,(const void *)&pArg);
 				pArg++;
 			}
-			if( pVm->bErrReport ){
+			if( pVm->bErrReport && !(pNewMap && pNewMap->bHasNamed) ){
 				ph7_vm_func_arg *pFuncArg;
 				sxu32 n;
 				n = SySetUsed(&aArg);
-				/* Emit a notice for missing arguments */
+				/* Emit a notice for missing arguments (positional-only:
+				 * for named args the missing-arg check happens downstream
+				 * after resolution). */
 				while( n < SySetUsed(&pCons->sFunc.aArgs) ){
 					pFuncArg = (ph7_vm_func_arg *)SySetAt(&pCons->sFunc.aArgs,n);
 					if( pFuncArg ){
@@ -6769,7 +6874,7 @@ case PH7_OP_NEW: {
 					n++;
 				}
 			}
-			PH7_VmCallClassMethod(&(*pVm),pNew,pCons,0,(int)SySetUsed(&aArg),(ph7_value **)SySetBasePtr(&aArg));
+			VmCallClassMethodWithMap(&(*pVm),pNew,pCons,0,(int)SySetUsed(&aArg),(ph7_value **)SySetBasePtr(&aArg),pNewMap);
 			/* TICKET 1433-52: Unsetting $this in the constructor body */
 			if( pNew->iRef < 1 ){
 				pNew->iRef = 1;
@@ -6979,12 +7084,14 @@ case PH7_OP_CALL: {
 	 * Static names are already namespace-qualified by the compiler.
 	 * Dynamic names (from variables) use exact match only, matching PHP behavior. */
 	pEntry = SyHashGet(&pVm->hFunction,(const void *)sName.zString,sName.nByte);
-	/* If the compiler qualified this call with a namespace (pInstr->p3 != 0)
-	 * and the namespaced function is not found, retry with the global name
-	 * (strip the namespace prefix up to the last backslash) before falling
-	 * back to host functions. This mirrors PHP's lookup order for unqualified
-	 * function calls inside namespaces. */
-	if( pEntry == 0 && pInstr->p3 != 0 ){
+	/* If the compiler qualified this call with a namespace, and the namespaced
+	 * function is not found, retry with the global name (strip the namespace
+	 * prefix up to the last backslash) before falling back to host functions.
+	 * This mirrors PHP's lookup order for unqualified function calls inside
+	 * namespaces. The namespace flag is stored in VmCallArgMap.bIsNamespaced. */
+	{
+	VmCallArgMap *pCallMap = (VmCallArgMap *)pInstr->p3;
+	if( pEntry == 0 && pCallMap && pCallMap->bIsNamespaced ){
 		const char *zFunc;
 		const char *zEnd;
 		const char *z;
@@ -7005,6 +7112,7 @@ case PH7_OP_CALL: {
 			pEntry = SyHashGet(&pVm->hFunction,(const void *)sGlobal.zString,sGlobal.nByte);
 		}
 	}
+	} /* end VmCallArgMap namespace scope */
 	if( pEntry ){
 		ph7_vm_func_arg *aFormalArg;
 		ph7_class_instance *pThis;
@@ -7122,8 +7230,63 @@ case PH7_OP_CALL: {
 					/* OOM: fall back to zero args rather than NULL-deref */
 					nGenArgs = 0;
 				}else{
-					for( iArg = 0; iArg < nGenArgs; iArg++ ){
-						apCallArgs[iArg] = &pArg[iArg];
+					VmCallArgMap *pGenMap = (VmCallArgMap *)pInstr->p3;
+					int didReorder = 0;
+					if( pGenMap && pGenMap->bHasNamed ){
+						/* Named-argument reordering for generator */
+						ph7_vm_func_arg *aFA = (ph7_vm_func_arg *)SySetBasePtr(&pVmFunc->aArgs);
+						sxu32 nF = SySetUsed(&pVmFunc->aArgs);
+						sxu32 nNV = nF;
+						sxi32 iVIdx = -1;
+						sxi32 *aGSlot;
+						sxu8 *aGUsed;
+						sxu32 gi;
+						for( gi = 0; gi < nF; gi++ ){
+							if( aFA[gi].iFlags & VM_FUNC_ARG_VARIADIC ){ nNV = gi; iVIdx = (sxi32)gi; break; }
+						}
+						aGSlot = (sxi32 *)SyMemBackendAlloc(&pVm->sAllocator,
+							(sxu32)nGenArgs * sizeof(sxi32) + nNV * sizeof(sxu8));
+						if( aGSlot ){
+							aGUsed = (sxu8 *)&aGSlot[nGenArgs];
+							rc = VmResolveNamedArgs(&(*pVm),pGenMap,aFA,nNV,iVIdx,
+								(sxu32)nGenArgs,aGSlot,aGUsed);
+							if( rc == PH7_ABORT ){
+								SyMemBackendFree(&pVm->sAllocator, aGSlot);
+								SyMemBackendFree(&pVm->sAllocator, apCallArgs);
+								goto Abort;
+							}
+							/* Build apCallArgs in formal-parameter order, then
+							 * append overflow (variadic / positional beyond
+							 * formals) so downstream sees every argument. */
+							{
+								int nOut = 0;
+								for( gi = 0; gi < nNV; gi++ ){
+									sxu32 gj;
+									for( gj = 0; gj < (sxu32)nGenArgs; gj++ ){
+										if( aGSlot[gj] == (sxi32)gi ){
+											apCallArgs[nOut++] = &pArg[gj];
+											break;
+										}
+									}
+								}
+								for( gi = 0; gi < (sxu32)nGenArgs; gi++ ){
+									if( aGSlot[gi] == -1 || aGSlot[gi] == -2 ){
+										apCallArgs[nOut++] = &pArg[gi];
+									}
+								}
+								nGenArgs = nOut;
+							}
+							SyMemBackendFree(&pVm->sAllocator, aGSlot);
+							didReorder = 1;
+						}
+						/* If aGSlot allocation failed, fall through to
+						 * positional fill below — preserves arg order rather
+						 * than passing an uninitialized apCallArgs. */
+					}
+					if( !didReorder ){
+						for( iArg = 0; iArg < nGenArgs; iArg++ ){
+							apCallArgs[iArg] = &pArg[iArg];
+						}
 					}
 				}
 			}
@@ -7240,6 +7403,248 @@ case PH7_OP_CALL: {
 			}
 		}
 		/* Push arguments in the local frame */
+		{
+		VmCallArgMap *pCallMap3 = (VmCallArgMap *)pInstr->p3;
+		if( pCallMap3 && pCallMap3->bHasNamed ){
+			/* ============================================================
+			 * Named-argument matching path (PHP 8.0)
+			 *
+			 * Resolve each actual argument to its formal parameter by name
+			 * or position, then install them in the frame.
+			 * ============================================================ */
+			sxu32 nFormal = SySetUsed(&pVmFunc->aArgs);
+			sxu32 nActual = (sxu32)(pTos - pArg);
+			sxi32 iVariadicIdx = -1;
+			sxu32 nNonVariadic;
+			sxi32 *aSlot;
+			sxu8  *aUsed;
+			sxu32 i;
+			/* Find variadic parameter index */
+			for( i = 0; i < nFormal; i++ ){
+				if( aFormalArg[i].iFlags & VM_FUNC_ARG_VARIADIC ){
+					iVariadicIdx = (sxi32)i;
+					break;
+				}
+			}
+			nNonVariadic = iVariadicIdx >= 0 ? (sxu32)iVariadicIdx : nFormal;
+			/* Allocate mapping arrays */
+			aSlot = (sxi32 *)SyMemBackendAlloc(&pVm->sAllocator,
+				nActual * sizeof(sxi32) + nNonVariadic * sizeof(sxu8));
+			if( aSlot == 0 ){
+				VmErrorFormat(&(*pVm),PH7_CTX_ERR,"Out of memory during named argument resolution");
+				goto Abort;
+			}
+			aUsed = (sxu8 *)&aSlot[nActual];
+			/* Resolve named arguments to formal parameters */
+			rc = VmResolveNamedArgs(&(*pVm),pCallMap3,aFormalArg,
+				nNonVariadic,iVariadicIdx,nActual,aSlot,aUsed);
+			if( rc == PH7_ABORT ){
+				SyMemBackendFree(&pVm->sAllocator, aSlot);
+				goto Abort;
+			}
+			/* Pass 2: install arguments into the frame by formal parameter order */
+			for( n = 0; n < nNonVariadic; n++ ){
+				/* Find the stack arg mapped to formal n */
+				sxi32 iSrc = -1;
+				for( i = 0; i < nActual; i++ ){
+					if( aSlot[i] == (sxi32)n ){
+						iSrc = (sxi32)i;
+						break;
+					}
+				}
+				if( iSrc >= 0 ){
+					/* Argument was provided — install with type checking */
+					ph7_value *pVal = &pArg[iSrc];
+					/* NULL-to-default redirect (existing behavior) */
+					if( (pVal->iFlags & MEMOBJ_NULL) && SySetUsed(&aFormalArg[n].aByteCode) > 0
+						&& !(aFormalArg[n].iFlags & VM_FUNC_ARG_NULLABLE) ){
+						rc = VmLocalExec(&(*pVm),&aFormalArg[n].aByteCode,pVal);
+						if( rc == PH7_ABORT ) goto Abort;
+					}
+					/* Type checking: union types */
+					if( aFormalArg[n].iFlags & VM_FUNC_ARG_UNION ){
+						sxi32 rcU = VmCoerceToUnion(pVm, pVal, &aFormalArg[n].aUnionAlts,
+							(aFormalArg[n].iFlags & VM_FUNC_ARG_NULLABLE) ? 1 : 0);
+						if( rcU != SXRET_OK ){
+							const char *zGiven;
+							char zBuf[128];
+							if( pVal->iFlags & MEMOBJ_OBJ ){
+								zGiven = VmFormatValueClassName(pVal,zBuf,sizeof(zBuf));
+							}else if( pVal->iFlags & MEMOBJ_NULL ){
+								zGiven = "null";
+							}else{
+								zGiven = ph7_type_name(pVal);
+							}
+							rc = VmThrowTypeErrorForArg(&(*pVm),&pVmFunc->sName,n+1,
+								&aFormalArg[n].sName,
+								SyStringLength(&aFormalArg[n].sTypeName) > 0
+									? aFormalArg[n].sTypeName.zString : "union",
+								zGiven);
+							if( rc == PH7_ABORT ) goto Abort;
+							SyMemBackendFree(&pVm->sAllocator, aSlot);
+							PH7_MemObjRelease(pTos);
+							pTos = &pTos[-nCallArgs];
+							pFrameStack = 0;
+							rc = PH7_EXCEPTION;
+							goto SkipFuncBody;
+						}
+					}else if( aFormalArg[n].nType > 0
+						&& !((aFormalArg[n].iFlags & VM_FUNC_ARG_NULLABLE) && (pVal->iFlags & MEMOBJ_NULL)) ){
+						/* Scalar/class type checking */
+						if( aFormalArg[n].nType == SXU32_HIGH ){
+							SyString *pName = &aFormalArg[n].sClass;
+							ph7_class *pClass = PH7_VmExtractClass(&(*pVm),pName->zString,pName->nByte,TRUE,0);
+							if( pClass ){
+								if( (pVal->iFlags & MEMOBJ_OBJ) == 0 ){
+									if( (pVal->iFlags & MEMOBJ_NULL) == 0 ){
+										VmErrorFormat(&(*pVm),PH7_CTX_WARNING,
+											"Function '%z()':Argument %u must be an object of type '%z',PH7 is loading NULL instead",
+											&pVmFunc->sName,n+1,pName);
+										PH7_MemObjRelease(pVal);
+									}
+								}else{
+									ph7_class_instance *pInst = (ph7_class_instance *)pVal->x.pOther;
+									if( !PH7_VmInstanceOf(pInst->pClass,pClass) ){
+										VmErrorFormat(&(*pVm),PH7_CTX_ERR,
+											"Function '%z()':Argument %u must be an object of type '%z',PH7 is loading NULL instead",
+											&pVmFunc->sName,n+1,pName);
+										PH7_MemObjRelease(pVal);
+									}
+								}
+							}
+						}else if( (pVal->iFlags & aFormalArg[n].nType) == 0 ){
+							if( aFormalArg[n].nType == MEMOBJ_OBJ ){
+								rc = VmThrowTypeErrorForArg(&(*pVm),&pVmFunc->sName,n+1,
+									&aFormalArg[n].sName,"object",ph7_type_name(pVal));
+								if( rc == PH7_ABORT ) goto Abort;
+								SyMemBackendFree(&pVm->sAllocator, aSlot);
+								PH7_MemObjRelease(pTos);
+								pTos = &pTos[-nCallArgs];
+								pFrameStack = 0;
+								rc = PH7_EXCEPTION;
+								goto SkipFuncBody;
+							}else{
+								ProcMemObjCast xCast = PH7_MemObjCastMethod(aFormalArg[n].nType);
+								if( xCast ) xCast(pVal);
+							}
+						}
+					}
+					/* Install: by reference or by value */
+					if( aFormalArg[n].iFlags & VM_FUNC_ARG_BY_REF ){
+						if( pVal->nIdx == SXU32_HIGH ){
+							if( (pVal->iFlags & (MEMOBJ_HASHMAP|MEMOBJ_OBJ|MEMOBJ_RES|MEMOBJ_NULL)) == 0 ){
+								VmErrorFormat(&(*pVm),PH7_CTX_WARNING,
+									"Function '%z',%d argument: Pass by reference,expecting a variable not a "
+									"constant,PH7 is switching to pass by value",&pVmFunc->sName,n+1);
+							}
+							pObj = VmExtractMemObj(&(*pVm),&aFormalArg[n].sName,FALSE,TRUE);
+						}else{
+							SyHashEntry *pRefEntry = SyHashGet(&pFrame->hVar,
+								SyStringData(&aFormalArg[n].sName),SyStringLength(&aFormalArg[n].sName));
+							if( pRefEntry == 0 ){
+								SyHashInsert(&pFrame->hVar,SyStringData(&aFormalArg[n].sName),
+									SyStringLength(&aFormalArg[n].sName),SX_INT_TO_PTR(pVal->nIdx));
+								sArg.nIdx = pVal->nIdx;
+								sArg.pUserData = 0;
+								SySetPut(&pFrame->sArg,(const void *)&sArg);
+							}
+							pObj = 0;
+						}
+					}else{
+						pObj = VmExtractMemObj(&(*pVm),&aFormalArg[n].sName,FALSE,TRUE);
+					}
+					if( pObj ){
+						PH7_MemObjStore(pVal,pObj);
+						sArg.nIdx = pObj->nIdx;
+						sArg.pUserData = 0;
+						SySetPut(&pFrame->sArg,(const void *)&sArg);
+					}
+				}else{
+					/* Argument was NOT provided — use default or leave unset */
+					if( aFormalArg[n].iFlags & VM_FUNC_ARG_VARIADIC ){
+						/* Should not reach here; variadic handled separately below */
+					}else if( SySetUsed(&aFormalArg[n].aByteCode) > 0 ){
+						pObj = VmExtractMemObj(&(*pVm),&aFormalArg[n].sName,FALSE,TRUE);
+						if( pObj ){
+							rc = VmLocalExec(&(*pVm),&aFormalArg[n].aByteCode,pObj);
+							if( rc == PH7_ABORT ) goto Abort;
+							sArg.nIdx = pObj->nIdx;
+							sArg.pUserData = 0;
+							SySetPut(&pFrame->sArg,(const void *)&sArg);
+							if( aFormalArg[n].nType > 0 && aFormalArg[n].nType != MEMOBJ_OBJ
+								&& (pObj->iFlags & aFormalArg[n].nType) == 0 ){
+								ProcMemObjCast xCast = PH7_MemObjCastMethod(aFormalArg[n].nType);
+								if( xCast ) xCast(pObj);
+							}
+						}
+					}
+					/* else: required param missing — leave unset (matches existing behavior) */
+				}
+			}
+			/* Handle variadic parameter */
+			if( iVariadicIdx >= 0 ){
+				pObj = VmExtractMemObj(&(*pVm),&aFormalArg[iVariadicIdx].sName,FALSE,TRUE);
+				if( pObj ){
+					PH7_MemObjToHashmap(pObj);
+					{
+						ph7_hashmap *pVarMap = (ph7_hashmap *)pObj->x.pOther;
+						for( i = 0; i < nActual; i++ ){
+							if( aSlot[i] == -1 ){
+								if( i < pCallMap3->nTotal && pCallMap3->aNames[i].nByte > 0 ){
+									/* Named variadic entry: insert with string key */
+									ph7_value sKey;
+									PH7_MemObjInit(pVm, &sKey);
+									PH7_MemObjStringAppend(&sKey,
+										pCallMap3->aNames[i].zString,
+										(sxu32)pCallMap3->aNames[i].nByte);
+									PH7_HashmapInsert(pVarMap, &sKey, &pArg[i]);
+									PH7_MemObjRelease(&sKey);
+								}else{
+									/* Positional variadic entry */
+									PH7_HashmapInsert(pVarMap, 0, &pArg[i]);
+								}
+							}
+						}
+					}
+					sArg.nIdx = pObj->nIdx;
+					sArg.pUserData = 0;
+					SySetPut(&pFrame->sArg,(const void *)&sArg);
+				}
+			}else{
+				/* No variadic — preserve unresolved positional overflow
+				 * (aSlot[i] == -2) as anonymous frame args so
+				 * func_get_args() / func_num_args() still see them, matching
+				 * the positional-only path's behavior. */
+				sxu32 nAnon = nNonVariadic;
+				for( i = 0; i < nActual; i++ ){
+					if( aSlot[i] == -2 ){
+						char zAnonBuf[32];
+						SyString sAnonName;
+						sAnonName.nByte = SyBufferFormat(zAnonBuf,sizeof(zAnonBuf),
+							"[%u]apArg",nAnon);
+						sAnonName.zString = zAnonBuf;
+						pObj = VmExtractMemObj(&(*pVm),&sAnonName,TRUE,TRUE);
+						if( pObj ){
+							PH7_MemObjStore(&pArg[i],pObj);
+							sArg.nIdx = pObj->nIdx;
+							sArg.pUserData = 0;
+							SySetPut(&pFrame->sArg,(const void *)&sArg);
+						}
+						nAnon++;
+					}
+				}
+			}
+			/* Release all stack arguments */
+			for( i = 0; i < nActual; i++ ){
+				PH7_MemObjRelease(&pArg[i]);
+			}
+			SyMemBackendFree(&pVm->sAllocator, aSlot);
+			/* Set n to nFormal so the defaults loop below is skipped */
+			n = nFormal;
+		}else{
+		/* ============================================================
+		 * Positional-only matching path (original)
+		 * ============================================================ */
 		n = 0;
 		while( pArg < pTos ){
 			if( n < SySetUsed(&pVmFunc->aArgs) && (aFormalArg[n].iFlags & VM_FUNC_ARG_VARIADIC) ){
@@ -7462,6 +7867,7 @@ case PH7_OP_CALL: {
 			pArg++;
 			++n;
 		}
+		} /* end named vs positional branch */
 		/* Set up closure environment */
 		if( pVmFunc->iFlags & VM_FUNC_CLOSURE ){
 			ph7_vm_func_closure_env *aEnv,*pEnv;
@@ -7521,6 +7927,7 @@ case PH7_OP_CALL: {
 			}
 			++n;
 		}
+		} /* end VmCallArgMap scope */
 		/* Pop arguments,function name from the operand stack and assume the function
 		 * does not return anything.
 		 */
@@ -7627,13 +8034,13 @@ SkipFuncBody:
 		ph7_value sRet;
 		/* Look for an installed foreign function.
 		 * Host functions are registered with short names (strlen, etc.).
-		 * If the CALL instruction's p3 is set (compiler-qualified name),
-		 * extract the short name (last component after \) and try that.
-		 * This implements PHP's global fallback for unqualified function
-		 * calls in namespaces. User-written qualified names (like
-		 * \Bogus\strlen) do NOT get this fallback. */
+		 * If the compiler namespace-qualified the name, extract the short
+		 * name (last component after \) and try that. This implements PHP's
+		 * global fallback for unqualified function calls in namespaces. */
 		pEntry = SyHashGet(&pVm->hHostFunction,(const void *)sName.zString,sName.nByte);
-		if( pEntry == 0 && pInstr->p3 != 0 ){
+		{
+		VmCallArgMap *pCallMap2 = (VmCallArgMap *)pInstr->p3;
+		if( pEntry == 0 && pCallMap2 && pCallMap2->bIsNamespaced ){
 			/* Compiler-qualified: try short name as global fallback */
 			const char *zShort = sName.zString;
 			sxu32 i;
@@ -7647,6 +8054,7 @@ SkipFuncBody:
 				pEntry = SyHashGet(&pVm->hHostFunction,(const void *)zShort,nShort);
 			}
 		}
+		} /* end VmCallArgMap namespace scope */
 		if( pEntry == 0 ){
 			/* Call to undefined function */
 			VmErrorFormat(&(*pVm),PH7_CTX_WARNING,"Call to undefined function '%z',NULL will be returned",&sName);
@@ -9571,6 +9979,60 @@ PH7_PRIVATE ph7_class * PH7_VmPeekDeclaringClass(ph7_vm *pVm)
  * Return SXRET_OK if the method was successfuly called.Any other
  * return value indicates failure.
  */
+/*
+ * Internal variant of PH7_VmCallClassMethod that threads a VmCallArgMap
+ * through to the synthetic CALL instruction.  Used by the NEW handler so
+ * that constructor calls with named arguments reach the named-arg path
+ * (with variadic string-key packing) rather than the positional path.
+ */
+static sxi32 VmCallClassMethodWithMap(
+	ph7_vm *pVm,
+	ph7_class_instance *pThis,
+	ph7_class_method *pMethod,
+	ph7_value *pResult,
+	int nArg,
+	ph7_value **apArg,
+	VmCallArgMap *pMap
+	)
+{
+	ph7_value *aStack;
+	VmInstr aInstr[2];
+	int iCursor;
+	int i;
+	aStack = VmNewOperandStack(&(*pVm),2+nArg);
+	if( aStack == 0 ){
+		PH7_VmThrowError(&(*pVm),0,PH7_CTX_ERR,
+			"PH7 is running out of memory while invoking class method");
+		return SXERR_MEM;
+	}
+	for( i = 0 ; i < nArg ; i++ ){
+		PH7_MemObjLoad(apArg[i],&aStack[i]);
+		aStack[i].nIdx = apArg[i]->nIdx;
+	}
+	iCursor = nArg + 1;
+	if( pThis ){
+		pThis->iRef++;
+		aStack[i].x.pOther = pThis;
+		aStack[i].iFlags = MEMOBJ_OBJ;
+	}
+	aStack[i].nIdx = SXU32_HIGH;
+	i++;
+	SyBlobReset(&aStack[i].sBlob);
+	SyBlobAppend(&aStack[i].sBlob,(const void *)SyStringData(&pMethod->sVmName),SyStringLength(&pMethod->sVmName));
+	aStack[i].iFlags = MEMOBJ_STRING;
+	aStack[i].nIdx = SXU32_HIGH;
+	aInstr[0].iOp = PH7_OP_CALL;
+	aInstr[0].iP1 = nArg;
+	aInstr[0].iP2 = 0;
+	aInstr[0].p3  = (void *)pMap; /* forward named-arg metadata */
+	aInstr[1].iOp = PH7_OP_DONE;
+	aInstr[1].iP1 = 1;
+	aInstr[1].iP2 = 0;
+	aInstr[1].p3  = 0;
+	VmByteCodeExec(&(*pVm),aInstr,aStack,iCursor,pResult,0,TRUE,0);
+	SyMemBackendFree(&pVm->sAllocator,aStack);
+	return PH7_OK;
+}
 PH7_PRIVATE sxi32 PH7_VmCallClassMethod(
 	ph7_vm *pVm,               /* Target VM */
 	ph7_class_instance *pThis, /* Target class instance [i.e: Object in the PHP jargon]*/
@@ -9580,57 +10042,7 @@ PH7_PRIVATE sxi32 PH7_VmCallClassMethod(
 	ph7_value **apArg          /* Method arguments */
 	)
 {
-	ph7_value *aStack;
-	VmInstr aInstr[2];
-	int iCursor;
-	int i;
-	/* Create a new operand stack */
-	aStack = VmNewOperandStack(&(*pVm),2/* Method name + Aux data */+nArg);
-	if( aStack == 0 ){
-		PH7_VmThrowError(&(*pVm),0,PH7_CTX_ERR,
-			"PH7 is running out of memory while invoking class method");
-		return SXERR_MEM;
-	}
-	/* Fill the operand stack with the given arguments */
-	for( i = 0 ; i < nArg ; i++ ){
-		PH7_MemObjLoad(apArg[i],&aStack[i]);
-		/*
-		 * Symisc eXtension:
-		 *  Parameters to [call_user_func()] can be passed by reference.
-		 */
-		aStack[i].nIdx = apArg[i]->nIdx;
-	}
-	iCursor = nArg + 1;
-	if( pThis ){
-		/*
-		 * Push the class instance so that the '$this' variable will be available.
-		 */
-		pThis->iRef++; /* Increment reference count */
-		aStack[i].x.pOther = pThis;
-		aStack[i].iFlags = MEMOBJ_OBJ;
-	}
-	aStack[i].nIdx = SXU32_HIGH; /* Mark as constant */
-	i++;
-	/* Push method name */
-	SyBlobReset(&aStack[i].sBlob);
-	SyBlobAppend(&aStack[i].sBlob,(const void *)SyStringData(&pMethod->sVmName),SyStringLength(&pMethod->sVmName));
-	aStack[i].iFlags = MEMOBJ_STRING;
-	aStack[i].nIdx = SXU32_HIGH;
-	/* Emit the CALL istruction */
-	aInstr[0].iOp = PH7_OP_CALL;
-	aInstr[0].iP1 = nArg; /* Total number of given arguments */
-	aInstr[0].iP2 = 0;
-	aInstr[0].p3  = 0;
-	/* Emit the DONE instruction */
-	aInstr[1].iOp = PH7_OP_DONE;
-	aInstr[1].iP1 = 1;   /* Extract method return value */
-	aInstr[1].iP2 = 0;
-	aInstr[1].p3  = 0;
-	/* Execute the method body (if available) */
-	VmByteCodeExec(&(*pVm),aInstr,aStack,iCursor,pResult,0,TRUE,0);
-	/* Clean up the mess left behind */
-	SyMemBackendFree(&pVm->sAllocator,aStack);
-	return PH7_OK;
+	return VmCallClassMethodWithMap(pVm,pThis,pMethod,pResult,nArg,apArg,0);
 }
 /*
  * Call a user defined or foreign function where the name of the function

--- a/tests/ph7/001-smoke/lang/named_args_basic.phpt
+++ b/tests/ph7/001-smoke/lang/named_args_basic.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Named arguments: basic out-of-order calling
+--FILE--
+<?php
+function nabf($a, $b, $c) {
+    echo "a=$a b=$b c=$c\n";
+}
+nabf(c: 3, a: 1, b: 2);
+nabf(b: 20, c: 30, a: 10);
+?>
+--EXPECT--
+a=1 b=2 c=3
+a=10 b=20 c=30
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/named_args_byref.phpt
+++ b/tests/ph7/001-smoke/lang/named_args_byref.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Named arguments: pass by reference
+--FILE--
+<?php
+function nabrf($a, &$b) {
+    $b = $a * 2;
+}
+$val = 0;
+nabrf(b: $val, a: 5);
+echo "val=$val\n";
+nabrf(a: 10, b: $val);
+echo "val=$val\n";
+?>
+--EXPECT--
+val=10
+val=20
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/named_args_closure.phpt
+++ b/tests/ph7/001-smoke/lang/named_args_closure.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Named arguments: closures and anonymous functions
+--FILE--
+<?php
+$nacf = function($a, $b) {
+    echo "a=$a b=$b\n";
+};
+$nacf(b: "world", a: "hello");
+$nacf(a: "X", b: "Y");
+?>
+--EXPECT--
+a=hello b=world
+a=X b=Y
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/named_args_constructor.phpt
+++ b/tests/ph7/001-smoke/lang/named_args_constructor.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Named arguments: constructor calls
+--FILE--
+<?php
+class NamPt {
+    public $x;
+    public $y;
+    public function __construct($x, $y) {
+        $this->x = $x;
+        $this->y = $y;
+    }
+}
+$p = new NamPt(y: 20, x: 10);
+echo "x={$p->x} y={$p->y}\n";
+?>
+--EXPECT--
+x=10 y=20
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/named_args_generator.phpt
+++ b/tests/ph7/001-smoke/lang/named_args_generator.phpt
@@ -1,0 +1,29 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Named arguments: generator functions with out-of-order args
+--FILE--
+<?php
+function nagenf($start, $end) {
+    for ($i = $start; $i <= $end; $i++) {
+        yield $i;
+    }
+}
+$result = [];
+foreach (nagenf(end: 5, start: 3) as $v) {
+    $result[] = $v;
+}
+echo implode(",", $result) . "\n";
+
+$result2 = [];
+foreach (nagenf(start: 10, end: 12) as $v) {
+    $result2[] = $v;
+}
+echo implode(",", $result2) . "\n";
+?>
+--EXPECT--
+3,4,5
+10,11,12
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/named_args_keyword_label.phpt
+++ b/tests/ph7/001-smoke/lang/named_args_keyword_label.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Named arguments: reserved keywords are accepted as labels
+--FILE--
+<?php
+function naklf($class, $type, $default) {
+    echo "class=$class type=$type default=$default\n";
+}
+naklf(class: "Foo", type: "int", default: "x");
+naklf(default: "y", type: "str", class: "Bar");
+?>
+--EXPECT--
+class=Foo type=int default=x
+class=Bar type=str default=y
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/named_args_method.phpt
+++ b/tests/ph7/001-smoke/lang/named_args_method.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Named arguments: instance and static method calls
+--FILE--
+<?php
+class NamCls {
+    public function greet($name, $greeting) {
+        echo "$greeting, $name!\n";
+    }
+    public static function sgreet($name, $greeting) {
+        echo "static: $greeting, $name!\n";
+    }
+}
+$obj = new NamCls();
+$obj->greet(greeting: "Hello", name: "World");
+NamCls::sgreet(greeting: "Hi", name: "PHP");
+?>
+--EXPECT--
+Hello, World!
+static: Hi, PHP!
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/named_args_mixed.phpt
+++ b/tests/ph7/001-smoke/lang/named_args_mixed.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Named arguments: mixed positional and named
+--FILE--
+<?php
+function namf($a, $b, $c) {
+    echo "a=$a b=$b c=$c\n";
+}
+namf(1, c: 3, b: 2);
+namf(1, 2, c: 3);
+?>
+--EXPECT--
+a=1 b=2 c=3
+a=1 b=2 c=3
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/named_args_nested_call.phpt
+++ b/tests/ph7/001-smoke/lang/named_args_nested_call.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Named arguments: nested function calls with named args
+--FILE--
+<?php
+function nanci($x) { return $x * 2; }
+function nancp($a, $b) { echo "a=$a b=$b\n"; }
+nancp(b: nanci(x: 5), a: nanci(x: 3));
+nancp(a: nanci(x: 10), b: nanci(x: 20));
+?>
+--EXPECT--
+a=6 b=10
+a=20 b=40
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/named_args_nullable.phpt
+++ b/tests/ph7/001-smoke/lang/named_args_nullable.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Named arguments: nullable parameters and null values
+--FILE--
+<?php
+function nanlf(?string $a, ?int $b) {
+    echo "a=" . (is_null($a) ? "NULL" : $a);
+    echo " b=" . (is_null($b) ? "NULL" : $b) . "\n";
+}
+nanlf(a: null, b: null);
+nanlf(b: 5, a: "hi");
+nanlf(b: null, a: "x");
+nanlf(a: null, b: 7);
+?>
+--EXPECT--
+a=NULL b=NULL
+a=hi b=5
+a=x b=NULL
+a=NULL b=7
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/named_args_skip_defaults.phpt
+++ b/tests/ph7/001-smoke/lang/named_args_skip_defaults.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Named arguments: skipping parameters with defaults
+--FILE--
+<?php
+function nasdf($a, $b = "B", $c = "C", $d = "D") {
+    echo "a=$a b=$b c=$c d=$d\n";
+}
+nasdf(a: "X");
+nasdf(a: "X", d: "Y");
+nasdf(a: "X", c: "Z");
+nasdf("A", d: "DD");
+?>
+--EXPECT--
+a=X b=B c=C d=D
+a=X b=B c=C d=Y
+a=X b=B c=Z d=D
+a=A b=B c=C d=DD
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/named_args_spread_positional.phpt
+++ b/tests/ph7/001-smoke/lang/named_args_spread_positional.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Named arguments: spread with positional args only (no named mixing)
+--FILE--
+<?php
+function naspf($a, $b, $c) {
+    echo "a=$a b=$b c=$c\n";
+}
+$arr = [1, 2, 3];
+naspf(...$arr);
+
+$partial = [10, 20];
+naspf(5, ...$partial);
+?>
+--EXPECT--
+a=1 b=2 c=3
+a=5 b=10 c=20
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/named_args_ternary_value.phpt
+++ b/tests/ph7/001-smoke/lang/named_args_ternary_value.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Named arguments: ternary expression as argument value
+--FILE--
+<?php
+function natvf($x) { echo "x=$x\n"; }
+$a = true;
+natvf(x: $a ? "yes" : "no");
+natvf(x: !$a ? "yes" : "no");
+natvf(x: 1 > 0 ? "gt" : "lt");
+?>
+--EXPECT--
+x=yes
+x=no
+x=gt
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/named_args_trailing_comma.phpt
+++ b/tests/ph7/001-smoke/lang/named_args_trailing_comma.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Named arguments: trailing comma
+--FILE--
+<?php
+function natcf($x, $y) { echo "x=$x y=$y\n"; }
+natcf(x: 1, y: 2,);
+natcf(y: 20, x: 10,);
+?>
+--EXPECT--
+x=1 y=2
+x=10 y=20
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/named_args_type_coercion.phpt
+++ b/tests/ph7/001-smoke/lang/named_args_type_coercion.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Named arguments: type coercion with type hints
+--FILE--
+<?php
+function natcof(int $a, string $b) {
+    echo (is_int($a) ? "int" : "?") . ":$a ";
+    echo (is_string($b) ? "string" : "?") . ":$b\n";
+}
+natcof(b: 42, a: "7");
+natcof(a: 3, b: 100);
+?>
+--EXPECT--
+int:7 string:42
+int:3 string:100
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/named_args_union_type.phpt
+++ b/tests/ph7/001-smoke/lang/named_args_union_type.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Named arguments: union type hints with out-of-order args
+--FILE--
+<?php
+function nautf(int|string $x, float|int $y) {
+    $tx = is_int($x) ? "int" : (is_string($x) ? "string" : "?");
+    $ty = is_int($y) ? "int" : (is_float($y) ? "float" : "?");
+    echo "$tx:$x $ty:$y\n";
+}
+nautf(y: 3, x: "hello");
+nautf(y: 2.5, x: 42);
+nautf(x: "test", y: 100);
+?>
+--EXPECT--
+string:hello int:3
+int:42 float:2.5
+string:test int:100
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/named_args_variadic.phpt
+++ b/tests/ph7/001-smoke/lang/named_args_variadic.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Named arguments: extra named args collected in variadic with string keys
+--FILE--
+<?php
+function navf($a, ...$rest) {
+    echo "a=$a\n";
+    foreach ($rest as $k => $v) {
+        echo "  $k => $v\n";
+    }
+}
+navf(a: 1, x: 2, y: 3);
+navf(1, extra: 42);
+?>
+--EXPECT--
+a=1
+  x => 2
+  y => 3
+a=1
+  extra => 42
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/named_args_variadic_constructor.phpt
+++ b/tests/ph7/001-smoke/lang/named_args_variadic_constructor.phpt
@@ -1,0 +1,34 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Named arguments: constructor with variadic collects named overflow with string keys
+--FILE--
+<?php
+class Cbox {
+    public $a; public $b; public $rest;
+    public function __construct($a, $b, ...$rest) {
+        $this->a = $a;
+        $this->b = $b;
+        $this->rest = $rest;
+    }
+}
+$b1 = new Cbox(b: 20, a: 10);
+echo "1: a={$b1->a} b={$b1->b} rest_count=" . count($b1->rest) . "\n";
+
+$b2 = new Cbox(10, 20, 30, 40);
+echo "2: a={$b2->a} b={$b2->b} rest=" . implode(",", $b2->rest) . "\n";
+
+$b3 = new Cbox(a: 1, b: 2, x: 99, y: 88);
+echo "3: a={$b3->a} b={$b3->b}";
+foreach ($b3->rest as $k => $v) {
+    echo " $k=$v";
+}
+echo "\n";
+?>
+--EXPECT--
+1: a=10 b=20 rest_count=0
+2: a=10 b=20 rest=30,40
+3: a=1 b=2 x=99 y=88
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/named_args_error_double_pass.phpt
+++ b/tests/ph7/002-integration/lang/named_args_error_double_pass.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Named arguments: same parameter passed positionally and by name throws Error
+--FILE--
+<?php
+function naedpf($a, $b) { echo "$a $b\n"; }
+naedpf(1, a: 2);
+?>
+--EXPECTF--
+%s Fatal error:  Uncaught Error: Named parameter $a overwrites previous argument%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/named_args_error_duplicate.phpt
+++ b/tests/ph7/002-integration/lang/named_args_error_duplicate.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Named arguments: duplicate named argument throws Error
+--FILE--
+<?php
+function naedf($a, $b) { echo "$a $b\n"; }
+naedf(a: 1, a: 2);
+?>
+--EXPECTF--
+%s Fatal error:  Uncaught Error: Named parameter $a overwrites previous argument%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/named_args_error_missing_value.phpt
+++ b/tests/ph7/002-integration/lang/named_args_error_missing_value.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Named arguments: missing value after label is a parse error
+--FILE--
+<?php
+function naemvf($a) {}
+naemvf(a:);
+?>
+--EXPECTF--
+%s Parse error:  syntax error,%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/named_args_error_positional_after.phpt
+++ b/tests/ph7/002-integration/lang/named_args_error_positional_after.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Named arguments: positional argument after named argument is a compile error
+--FILE--
+<?php
+function naepaf($a, $b) { echo "$a $b\n"; }
+naepaf(a: 1, 2);
+?>
+--EXPECTF--
+%s Fatal error:  Cannot use positional argument after named argument%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/named_args_error_unknown_param.phpt
+++ b/tests/ph7/002-integration/lang/named_args_error_unknown_param.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Named arguments: unknown parameter name throws Error
+--FILE--
+<?php
+function naeupf($a) { echo "a=$a\n"; }
+naeupf(b: 1);
+?>
+--EXPECTF--
+%s Fatal error:  Uncaught Error: Unknown named parameter $b%A
+--CLEAN--
+<?php


### PR DESCRIPTION
Allow function, method, and constructor calls to pass arguments by parameter name using the `name: value` syntax. Named arguments may be mixed with positional arguments (positional first) and may appear in any order; skipped parameters fall back to their defaults.

Parser changes (parse.c): ExprProcessFuncArguments detects the `identifier ':' expr` pattern at the head of each comma-delimited argument slice, strips the ID and colon tokens, and tags the resulting expression-tree root with EXPR_NODE_NAMED_ARG plus an sArgName label. The pre-pass colon check in ExprVerifyNodes was relaxed so colons inside parentheses are not rejected outright. Named-arg colons are consumed by ExprProcessFuncArguments, while stray colons inside grouping parens are still caught by the recursive ExprMakeTree call that processes each parenthesised sub-expression.

Compile changes (compile.c): The PH7_OP_CALL emission path now walks pNode->aNodeArgs twice, first to reject `positional after named` at compile time, then to build a VmCallArgMap containing the full label table. Label strings are deep-copied into the map's trailing buffer so they survive token-stream cleanup. The namespace-qualification flag that previously lived in p3 as (void*)1 now moves into VmCallArgMap.bIsNamespaced, and the CALL→NEW rewrite for `new Foo(...)` hands the same map off to the NEW instruction.

Runtime changes (vm.c): A new VmResolveNamedArgs helper performs the name/position-to-formal-parameter mapping in one place; it fills an aSlot[] table for each actual arg and an aUsed[] table for each formal, reports duplicates, unknown parameters, and positional-overwrites-named via a shared VmThrowNamedArgError → VmReportUncaughtException path that emits a PHP-compatible "Uncaught Error:" message. The helper is called from three sites: OP_CALL (user functions and methods), OP_NEW (constructors), and the generator arg-collection block inside OP_CALL, so `new Foo(y: 2, x: 1)` and `foreach (gen(end: 5, start: 1) as $v)` both reorder correctly before frame setup. After resolution, OP_CALL installs arguments in formal-parameter order with the existing type-coercion, by-reference, nullable, union-type, and default-value logic, and any leftover actuals marked for the variadic slot are inserted with string keys (for named overflow) or integer keys (for positional overflow).

VmCallArgMap is defined next to VmInstr in ph7int.h; the per-node label is stored in ph7_expr_node.sArgName alongside the new EXPR_NODE_NAMED_ARG flag.

Tests cover the happy path (basic, mixed positional+named, out-of-order reordering, skipping defaults, method/static/closure/constructor/ nested calls, variadic with string keys, trailing comma, type coercion, by-ref, ternary in values, union types, nullable, generator functions, spread-only positional) and the full error matrix (compile-time positional-after-named, runtime unknown parameter, duplicate named argument, same param passed positionally and by name).
