### PR TITLE
Implement nullsafe operator ?-> (PHP 8.0)

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -9232,6 +9232,42 @@ Synchronize:
 	return SXRET_OK;
 }
 /*
+ * Chain operators participate in a postfix member-access chain.
+ * A `?->` emitted inside such a chain must short-circuit to the end of
+ * the chain, not just past its own member access. Any non-chain ancestor
+ * terminates the chain and is where pending NULLSAFE_JMP targets are patched.
+ */
+#define GEN_IS_CHAIN_OP(iOp) \
+  ((iOp) == EXPR_OP_ARROW || (iOp) == EXPR_OP_NULLSAFE_ARROW || \
+   (iOp) == EXPR_OP_DC    || (iOp) == EXPR_OP_SUBSCRIPT     || \
+   (iOp) == EXPR_OP_FUNC_CALL)
+
+/*
+ * Patch every pending NULLSAFE_JMP recorded after the given baseline so
+ * that it jumps to the current end-of-emission instruction. Then drop the
+ * patched entries from the pending set.
+ */
+static void GenStatePatchNullsafeJumps(ph7_gen_state *pGen, sxu32 nBaseline)
+{
+	sxu32 nCur = SySetUsed(&pGen->aNullsafeJmp);
+	sxu32 nTarget;
+	sxu32 *aIdx;
+	sxu32 i;
+	if( nCur <= nBaseline ){
+		return;
+	}
+	aIdx = (sxu32 *)SySetBasePtr(&pGen->aNullsafeJmp);
+	nTarget = PH7_VmInstrLength(pGen->pVm);
+	for( i = nBaseline ; i < nCur ; ++i ){
+		VmInstr *pInstr = PH7_VmGetInstr(pGen->pVm, aIdx[i]);
+		if( pInstr ){
+			pInstr->iP2 = (sxi32)nTarget;
+		}
+	}
+	SySetTruncate(&pGen->aNullsafeJmp, nBaseline);
+}
+
+/*
  * Generate bytecode for a given expression tree.
  * If something goes wrong while generating bytecode
  * for the expression tree (A very unlikely scenario)
@@ -9251,6 +9287,8 @@ static sxi32 GenStateEmitExprCode(
 	void *p3  = 0;
 	sxi32 iVmOp;
 	sxi32 rc;
+	int bIsChainOp = 0; /* Set below once we know pNode->pOp */
+	sxu32 nRhsNsBase = 0;
 	if( pNode->xCode ){
 		SyToken *pTmpIn,*pTmpEnd;
 		/* Compile node */
@@ -9267,6 +9305,7 @@ static sxi32 GenStateEmitExprCode(
 	iVmOp = pNode->pOp->iVmOp;
 	if( pNode->pOp->iOp == EXPR_OP_NULLC_ASSIGN ){
 		sxu32 nJmp = 0;
+		sxu32 nNcNsBase;
 		VmInstr *pInstrFix;
 		/* Null coalescing assignment requires a custom compile order: the LHS
 		 * target (pRight for prec-18 right-assoc ops) must be evaluated first
@@ -9274,10 +9313,12 @@ static sxi32 GenStateEmitExprCode(
 		 * EXPR_FLAG_LOAD_IDX_STORE so subscript LHS auto-vivifies and the
 		 * stack slot carries a writable nIdx. */
 		if( pNode->pRight ){
+			nNcNsBase = SySetUsed(&pGen->aNullsafeJmp);
 			rc = GenStateEmitExprCode(&(*pGen),pNode->pRight,iFlags|EXPR_FLAG_LOAD_IDX_STORE);
 			if( rc != SXRET_OK ){
 				return rc;
 			}
+			GenStatePatchNullsafeJumps(pGen, nNcNsBase);
 			/* Optimisation: if the outermost LHS access is a subscript, demote
 			 * its LOAD_IDX from write-context (iP2=1, eager COW separation +
 			 * insert) to peek-mode (iP2=3, separate-only-on-null/missing). On
@@ -9294,10 +9335,12 @@ static sxi32 GenStateEmitExprCode(
 		PH7_VmEmitInstr(pGen->pVm,PH7_OP_NULLC_JMP,0,0,0,&nJmp);
 		/* Compile the RHS value (pLeft for prec-18 right-assoc). */
 		if( pNode->pLeft ){
+			nNcNsBase = SySetUsed(&pGen->aNullsafeJmp);
 			rc = GenStateEmitExprCode(&(*pGen),pNode->pLeft,iFlags);
 			if( rc != SXRET_OK ){
 				return rc;
 			}
+			GenStatePatchNullsafeJumps(pGen, nNcNsBase);
 		}
 		/* Store RHS into LHS's memobj slot; leave RHS as the result on stack. */
 		PH7_VmEmitInstr(pGen->pVm,PH7_OP_NULLC_STORE,0,0,0,0);
@@ -9312,22 +9355,30 @@ static sxi32 GenStateEmitExprCode(
 	}
 	if( pNode->pOp->iOp == EXPR_OP_QUESTY ){
 		sxu32 nJz,nJmp;
+		sxu32 nTernaryNsBase;
 		/* Ternary operator require special handling */
 		/* Phase#1: Compile the condition */
+		nTernaryNsBase = SySetUsed(&pGen->aNullsafeJmp);
 		rc = GenStateEmitExprCode(&(*pGen),pNode->pCond,iFlags);
 		if( rc != SXRET_OK ){
 			return rc;
 		}
+		/* Ternary is not a chain operator: any nullsafe jumps emitted while
+		 * compiling the condition must short-circuit to the end of the
+		 * condition expression, not leak past the ternary. */
+		GenStatePatchNullsafeJumps(pGen, nTernaryNsBase);
 		nJz = nJmp = 0; /* cc -O6 warning */
 		if( pNode->pLeft ){
 			/* Standard ternary: (expr) ? (then) : (else) */
 			/* Phase#2: Emit the false jump (pops condition) */
 			PH7_VmEmitInstr(pGen->pVm,PH7_OP_JZ,0,0,0,&nJz);
 			/* Phase#3: Compile the 'then' expression  */
+			nTernaryNsBase = SySetUsed(&pGen->aNullsafeJmp);
 			rc = GenStateEmitExprCode(&(*pGen),pNode->pLeft,iFlags);
 			if( rc != SXRET_OK ){
 				return rc;
 			}
+			GenStatePatchNullsafeJumps(pGen, nTernaryNsBase);
 		}else{
 			/* Elvis operator: (expr) ?: (else)
 			 * Duplicate condition so original value is the 'then' result.
@@ -9348,10 +9399,12 @@ static sxi32 GenStateEmitExprCode(
 		}
 		/* Phase#6: Compile the 'else' expression */
 		if( pNode->pRight ){
+			nTernaryNsBase = SySetUsed(&pGen->aNullsafeJmp);
 			rc = GenStateEmitExprCode(&(*pGen),pNode->pRight,iFlags);
 			if( rc != SXRET_OK ){
 				return rc;
 			}
+			GenStatePatchNullsafeJumps(pGen, nTernaryNsBase);
 		}
 		if( nJmp > 0 ){
 			/* Phase#7: Fix the unconditional jump */
@@ -9363,8 +9416,10 @@ static sxi32 GenStateEmitExprCode(
 		/* All done */
 		return SXRET_OK;
 	}
+	bIsChainOp = GEN_IS_CHAIN_OP(pNode->pOp->iOp);
 	/* Generate code for the left tree */
 	if( pNode->pLeft ){
+		sxu32 nLhsNsBase = SySetUsed(&pGen->aNullsafeJmp);
 		if( iVmOp == PH7_OP_CALL ){
 			ph7_expr_node **apNode;
 			int hasSpread = 0;
@@ -9391,10 +9446,13 @@ static sxi32 GenStateEmitExprCode(
 			/* Read-only load */
 			iFlags |= EXPR_FLAG_RDONLY_LOAD;
 			for( n = 0 ; n < nArgs ; ++n ){
+				sxu32 nArgNsBase = SySetUsed(&pGen->aNullsafeJmp);
 				rc = GenStateEmitExprCode(&(*pGen),apNode[n],iFlags&~EXPR_FLAG_LOAD_IDX_STORE);
 				if( rc != SXRET_OK ){
 					return rc;
 				}
+				/* Each argument is an independent nullsafe scope. */
+				GenStatePatchNullsafeJumps(pGen, nArgNsBase);
 				if( apNode[n]->iFlags & EXPR_NODE_SPREAD ){
 					/* Emit spread opcode to unpack this array argument */
 					PH7_VmEmitInstr(pGen->pVm, PH7_OP_SPREAD, 0, 0, 0, 0);
@@ -9443,6 +9501,11 @@ static sxi32 GenStateEmitExprCode(
 		rc = GenStateEmitExprCode(&(*pGen),pNode->pLeft,iFlags);
 		if( rc != SXRET_OK ){
 			return rc;
+		}
+		if( !bIsChainOp ){
+			/* Non-chain parent: any nullsafe jumps produced by the LHS sub-tree
+			 * target the end of that LHS chain, which is right here. */
+			GenStatePatchNullsafeJumps(pGen, nLhsNsBase);
 		}
 		if( iVmOp == PH7_OP_CALL ){
 			pInstr = PH7_VmPeekInstr(pGen->pVm);
@@ -9493,10 +9556,13 @@ static sxi32 GenStateEmitExprCode(
 			/* Recurse and generate bytecodes for array index */
 			apNode = (ph7_expr_node **)SySetBasePtr(&pNode->aNodeArgs);
 			for( n = 0 ; n < (sxi32)SySetUsed(&pNode->aNodeArgs) ; ++n ){
+				sxu32 nIdxNsBase = SySetUsed(&pGen->aNullsafeJmp);
 				rc = GenStateEmitExprCode(&(*pGen),apNode[n],iFlags&~EXPR_FLAG_LOAD_IDX_STORE);
 				if( rc != SXRET_OK ){
 					return rc;
 				}
+				/* Each subscript index is an independent nullsafe scope. */
+				GenStatePatchNullsafeJumps(pGen, nIdxNsBase);
 			}
 			if( SySetUsed(&pNode->aNodeArgs) > 0 ){
 				iP1 = 1; /* Node have an index associated with it */
@@ -9556,10 +9622,26 @@ static sxi32 GenStateEmitExprCode(
 			/* Null coalescing: if LHS is not null, jump past RHS */
 			iVmOp = 0; /* No binary operator to emit */
 			PH7_VmEmitInstr(pGen->pVm,PH7_OP_NULLC,0,0,0,&nJmpIdx);
+		}else if( pNode->pOp && pNode->pOp->iOp == EXPR_OP_NULLSAFE_ARROW ){
+			/* Nullsafe operator `?->` (PHP 8.0): if LHS is null, short-circuit
+			 * the entire containing postfix chain to null. The jump target is
+			 * patched later by the innermost non-chain ancestor (or by
+			 * PH7_CompileExpr at the outer boundary). Leaves NULL on the stack
+			 * when taken; otherwise falls through, leaving the object on stack
+			 * so the PH7_OP_MEMBER that follows can consume it. */
+			sxu32 nNsJmp = 0;
+			PH7_VmEmitInstr(pGen->pVm,PH7_OP_NULLSAFE_JMP,0,0,0,&nNsJmp);
+			SySetPut(&pGen->aNullsafeJmp,(const void *)&nNsJmp);
 		}else if( pNode->pOp->iPrec == 18 /* Combined binary operators [i.e: =,'.=','+=',*=' ...] precedence */ ){
 			iFlags |= EXPR_FLAG_LOAD_IDX_STORE;
 		}
+		nRhsNsBase = SySetUsed(&pGen->aNullsafeJmp);
 		rc = GenStateEmitExprCode(&(*pGen),pNode->pRight,iFlags);
+		if( !bIsChainOp ){
+			/* Non-chain parent: RHS nullsafe chain ends here, before the
+			 * operator instruction is emitted. */
+			GenStatePatchNullsafeJumps(pGen, nRhsNsBase);
+		}
 		if( iVmOp == PH7_OP_STORE ){
 			if( pNode->pRight && (pNode->pRight->xCode == PH7_CompileList ||
 				pNode->pRight->xCode == PH7_CompileShortList) ){
@@ -9718,9 +9800,13 @@ static sxi32 PH7_CompileExpr(
 	sxi32 nExpr;
 	sxi32 iNest;
 	sxi32 rc;
+	sxu32 nNullsafeBase;
 	/* Initialize worker variables */
 	nExpr = 0;
 	pRoot = 0;
+	/* Any nullsafe jumps still pending belong to an outer scope; isolate
+	 * this expression so its `?->` short-circuits don't leak out. */
+	nNullsafeBase = SySetUsed(&pGen->aNullsafeJmp);
 	SySetInit(&sExprNode,&pGen->pVm->sAllocator,sizeof(ph7_expr_node *));
 	SySetAlloc(&sExprNode,0x10);
 	rc = SXRET_OK;
@@ -9775,6 +9861,9 @@ static sxi32 PH7_CompileExpr(
 			if( rc != SXERR_ABORT ){
 				/* Generate code for the given tree */
 				rc = GenStateEmitExprCode(&(*pGen),pRoot,iFlags);
+				/* Patch any unresolved nullsafe jumps emitted by this
+				 * expression so they short-circuit to its end. */
+				GenStatePatchNullsafeJumps(pGen, nNullsafeBase);
 			}
 			nExpr = 1;
 		}
@@ -9819,6 +9908,22 @@ PH7_PRIVATE ProcNodeConstruct PH7_GetNodeHandler(sxu32 nNodeType)
 	return 0;
 }
 /*
+ * Tree validator for unset() arguments — rejects any `?->` node in
+ * the argument expression with PHP's "Can't use nullsafe operator
+ * in write context" parse error.
+ */
+static sxi32 GenStateUnsetValidator(ph7_gen_state *pGen, ph7_expr_node *pNode)
+{
+	sxi32 rc;
+	if( !PH7_ExprContainsNullsafe(pNode) ){
+		return SXRET_OK;
+	}
+	rc = PH7_GenCompileError(pGen,E_PARSE,
+		pNode ? pNode->pStart->nLine : 1,
+		"Can't use nullsafe operator in write context");
+	return rc == SXERR_ABORT ? SXERR_ABORT : SXERR_SYNTAX;
+}
+/*
  * Compile an unset() statement.
  * unset($var, $arr[$key], ...);
  * Each argument is compiled with EXPR_FLAG_LOAD_IDX_STORE so that
@@ -9859,7 +9964,8 @@ static sxi32 PH7_CompileUnset(ph7_gen_state *pGen)
 		if( pGen->pIn < pNext ){
 			pGen->pEnd = pNext;
 			rc = PH7_CompileExpr(&(*pGen),
-				EXPR_FLAG_RDONLY_LOAD|EXPR_FLAG_LOAD_IDX_STORE,0);
+				EXPR_FLAG_RDONLY_LOAD|EXPR_FLAG_LOAD_IDX_STORE,
+				GenStateUnsetValidator);
 			if( rc == SXERR_ABORT ){
 				return SXERR_ABORT;
 			}
@@ -10135,6 +10241,7 @@ static sxi32 PH7_CompilePHP(
 	/* Reset container */
 	SySetReset(&pGen->aGoto);
 	SySetReset(&pGen->aLabel);
+	SySetReset(&pGen->aNullsafeJmp);
 	/* Compilation result */
 	return rc;
 }
@@ -10253,6 +10360,7 @@ PH7_PRIVATE sxi32 PH7_InitCodeGenerator(
 	pGen->pErrData = pErrData;
 	SySetInit(&pGen->aLabel,&pVm->sAllocator,sizeof(Label));
 	SySetInit(&pGen->aGoto,&pVm->sAllocator,sizeof(JumpFixup));
+	SySetInit(&pGen->aNullsafeJmp,&pVm->sAllocator,sizeof(sxu32));
 	SyHashInit(&pGen->hLiteral,&pVm->sAllocator,0,0);
 	SyHashInit(&pGen->hVar,&pVm->sAllocator,0,0);
 	/* Error log buffer */
@@ -10284,6 +10392,7 @@ PH7_PRIVATE sxi32 PH7_ResetCodeGenerator(
 	/* Reset state */
 	SySetReset(&pGen->aLabel);
 	SySetReset(&pGen->aGoto);
+	SySetReset(&pGen->aNullsafeJmp);
 	SyBlobRelease(&pGen->sErrBuf);
 	SyBlobRelease(&pGen->sWorker);
 	SyBlobRelease(&pGen->sNamespace);

--- a/src/ph7/lex.c
+++ b/src/ph7/lex.c
@@ -613,6 +613,10 @@ static sxi32 TokenizePHP(SyStream *pStream,SyToken *pToken,void *pUserData,void 
 					/* Null coalescing assignment operator (PHP 7.4) */
 					pStream->zText++;
 				}
+			}else if( (pStream->zEnd - pStream->zText) >= 2
+				&& pStream->zText[0] == '-' && pStream->zText[1] == '>' ){
+				/* Nullsafe object operator (PHP 8.0): ?-> */
+				pStream->zText += 2;
 			}
 			break;
 		default:

--- a/src/ph7/parse.c
+++ b/src/ph7/parse.c
@@ -155,6 +155,7 @@ static const ph7_expr_op aOpTable[] = {
 	                              /* Postfix operators */
 	/* Precedence 2(Highest),left-associative */
 	{ {"->",sizeof(char)*2}, EXPR_OP_ARROW,     2, EXPR_OP_ASSOC_LEFT , PH7_OP_MEMBER},
+	{ {"?->",sizeof(char)*3},EXPR_OP_NULLSAFE_ARROW, 2, EXPR_OP_ASSOC_LEFT, PH7_OP_MEMBER},
 	{ {"::",sizeof(char)*2}, EXPR_OP_DC,        2, EXPR_OP_ASSOC_LEFT , PH7_OP_MEMBER},
 	{ {"[",sizeof(char)},    EXPR_OP_SUBSCRIPT, 2, EXPR_OP_ASSOC_LEFT , PH7_OP_LOAD_IDX},
 	/* Precedence 3,non-associative  */
@@ -1106,6 +1107,29 @@ PH7_PRIVATE sxi32 PH7_ExprFreeTree(ph7_gen_state *pGen,SySet *pNodeSet)
 	return SXRET_OK;
 }
 /*
+ * Return TRUE if any node in the expression subtree is the nullsafe
+ * operator `?->`.  Used by write-context checks to reject assignments,
+ * references, and unset() that target any link of a nullsafe chain
+ * (PHP 8.0 makes this a fatal parse error:
+ * "Can't use nullsafe operator in write context").
+ */
+PH7_PRIVATE int PH7_ExprContainsNullsafe(ph7_expr_node *pNode)
+{
+	if( pNode == 0 ){
+		return 0;
+	}
+	if( pNode->pOp && pNode->pOp->iOp == EXPR_OP_NULLSAFE_ARROW ){
+		return 1;
+	}
+	if( PH7_ExprContainsNullsafe(pNode->pLeft) ){
+		return 1;
+	}
+	if( PH7_ExprContainsNullsafe(pNode->pRight) ){
+		return 1;
+	}
+	return 0;
+}
+/*
  * Check if the given node is a modifialbe l/r-value.
  * Return TRUE if modifiable.FALSE otherwise.
  */
@@ -1462,7 +1486,8 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 				 }
 				 /* Link the node to the tree */
 				 pNode->pLeft = apNode[iLeft];
-				 if( pNode->pOp->iOp == EXPR_OP_ARROW /*'->'*/ && pNode->pLeft->pOp == 0 &&
+				 if( (pNode->pOp->iOp == EXPR_OP_ARROW /*'->'*/ || pNode->pOp->iOp == EXPR_OP_NULLSAFE_ARROW /*'?->'*/)
+					 && pNode->pLeft->pOp == 0 &&
 					 pNode->pLeft->xCode != PH7_CompileVariable ){
 						 /* Syntax error */
 						 rc = PH7_GenCompileError(pGen,E_ERROR,pNode->pStart->nLine,
@@ -1645,6 +1670,18 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 				 if( pNode->pOp->iOp == EXPR_OP_REF ){
 					 sxi32  iTmp;
 					 /* Reference operator [i.e: '&=' ]*/
+					 /* PHP 8.0: `&$a?->b` is a parse error — references
+					  * cannot target a nullsafe chain anywhere. Check the
+					  * right operand first since EXPR_OP_REF's operand order
+					  * is swapped below. */
+					 if( PH7_ExprContainsNullsafe(apNode[iRight]) ){
+						 rc = PH7_GenCompileError(pGen,E_PARSE,pNode->pStart->nLine,
+							 "Can't use nullsafe operator in write context");
+						 if( rc != SXERR_ABORT ){
+							 rc = SXERR_SYNTAX;
+						 }
+						 return rc;
+					 }
 					 if( ExprIsModifiableValue(apNode[iLeft],FALSE) == FALSE || (apNode[iLeft]->pOp && apNode[iLeft]->pOp->iVmOp == PH7_OP_MEMBER /*->,::*/) ){
 						 /* Left operand must be a modifiable l-value */
 						 rc = PH7_GenCompileError(pGen,E_ERROR,pNode->pStart->nLine,"'&': Left operand must be a modifiable l-value");
@@ -1777,6 +1814,19 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 				 }else{
 					 rc = PH7_GenCompileError(pGen,E_ERROR,pNode->pStart->nLine,"'%z': Missing/Invalid operand",&pNode->pOp->sOp);
 				 }
+				 if( rc != SXERR_ABORT ){
+					 rc = SXERR_SYNTAX;
+				 }
+				 return rc;
+			 }
+			 /* PHP 8.0: reject any nullsafe link in an assignment LHS,
+			  * including deeper chains like $a?->b->c = 1 and
+			  * $a?->b[0] = 1 where the outer op is '->' or '[' but the
+			  * chain still contains a `?->` that cannot participate in
+			  * a write. */
+			 if( PH7_ExprContainsNullsafe(apNode[iLeft]) ){
+				 rc = PH7_GenCompileError(pGen,E_PARSE,pNode->pStart->nLine,
+					 "Can't use nullsafe operator in write context");
 				 if( rc != SXERR_ABORT ){
 					 rc = SXERR_SYNTAX;
 				 }

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -375,6 +375,7 @@ struct ph7_gen_state
 	void *pErrData;      /* Third argument to xErr() */
 	SySet aLabel;        /* Label table */
 	SySet aGoto;         /* Gotos table */
+	SySet aNullsafeJmp;  /* Pending NULLSAFE_JMP instruction indices (sxu32) */
 	SyBlob sWorker;      /* General purpose working buffer */
 	SyBlob sErrBuf;      /* Error buffer */
 	SyBlob sNamespace;   /* Current namespace path (e.g. "App\\Models") */
@@ -1045,6 +1046,7 @@ enum ph7_vm_op {
   PH7_OP_NULLC,         /* Null coalescing ?? */
   PH7_OP_NULLC_JMP,     /* Null coalescing assign short-circuit jump */
   PH7_OP_NULLC_STORE,   /* Null coalescing assign store */
+  PH7_OP_NULLSAFE_JMP,  /* Nullsafe (?->) short-circuit jump */
   PH7_OP_SPREAD         /* Mark TOS for argument unpacking (...$arr) */
 };
 /* -- END-OF INSTRUCTIONS -- */
@@ -1055,6 +1057,7 @@ enum ph7_expr_id {
 	EXPR_OP_NEW = 1,   /* new */
 	EXPR_OP_CLONE,     /* clone */
 	EXPR_OP_ARROW,     /* -> */
+	EXPR_OP_NULLSAFE_ARROW, /* ?-> (PHP 8.0 nullsafe) */
 	EXPR_OP_DC,        /* :: */
 	EXPR_OP_SUBSCRIPT, /* []: Subscripting */
 	EXPR_OP_FUNC_CALL, /* func_call() */
@@ -1604,6 +1607,7 @@ PH7_PRIVATE int PH7_Utf8Read(
 /* parse.c function prototypes */
 PH7_PRIVATE int PH7_IsLangConstruct(sxu32 nKeyID,sxu8 bCheckFunc);
 PH7_PRIVATE sxi32 PH7_ExprMakeTree(ph7_gen_state *pGen,SySet *pExprNode,ph7_expr_node **ppRoot);
+PH7_PRIVATE int PH7_ExprContainsNullsafe(ph7_expr_node *pNode);
 PH7_PRIVATE sxi32 PH7_GetNextExpr(SyToken *pStart,SyToken *pEnd,SyToken **ppNext);
 PH7_PRIVATE void PH7_DelimitNestedTokens(SyToken *pIn,SyToken *pEnd,sxu32 nTokStart,sxu32 nTokEnd,SyToken **ppEnd);
 PH7_PRIVATE const ph7_expr_op * PH7_ExprExtractOperator(SyString *pStr,SyToken *pLast);

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -5443,6 +5443,27 @@ case PH7_OP_NULLC_JMP: {
  * replace pNos with the RHS value, pop pTos. Leaves the RHS value as the
  * expression result.
  */
+/*
+ * OP_NULLSAFE_JMP: * P2 *
+ * Nullsafe object operator short-circuit (PHP 8.0 `?->`).
+ * Peek TOS (the object operand): if it is null, jump to P2 leaving NULL
+ * on the stack as the result of the entire containing postfix chain. If
+ * non-null, fall through without modifying the stack so the following
+ * PH7_OP_MEMBER can consume the object as usual.
+ */
+case PH7_OP_NULLSAFE_JMP: {
+#ifdef UNTRUST
+	if( pTos < pStack ){
+		goto Abort;
+	}
+#endif
+	if( (pTos->iFlags & MEMOBJ_NULL) || pTos->iFlags == 0 ){
+		/* Object operand is NULL (or uninitialized) — short-circuit. The
+		 * NULL slot already on TOS becomes the chain's final value. */
+		pc = pInstr->iP2 - 1; /* Jump (will be incremented by the loop) */
+	}
+	break;
+}
 case PH7_OP_NULLC_STORE: {
 	ph7_value *pNos = &pTos[-1];
 	ph7_value *pObj;
@@ -9505,6 +9526,7 @@ static const char * VmInstrToString(sxi32 nOp)
 	case PH7_OP_NULLC:      zOp = "NULLC      "; break;
 	case PH7_OP_NULLC_JMP:  zOp = "NULLC_JMP  "; break;
 	case PH7_OP_NULLC_STORE:zOp = "NULLC_STORE"; break;
+	case PH7_OP_NULLSAFE_JMP:zOp = "NULLSAFE_JMP"; break;
 	case PH7_OP_SPREAD:     zOp = "SPREAD     "; break;
 	case PH7_OP_CVT_BOOL:   zOp = "CVT_BOOL   "; break;
 	case PH7_OP_CVT_NULL:   zOp = "CVT_NULL   "; break;

--- a/tests/ph7/001-smoke/oo/nullsafe_chain_mixed.phpt
+++ b/tests/ph7/001-smoke/oo/nullsafe_chain_mixed.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe chain passes through when LHS is a real object
+--FILE--
+<?php
+class NsfChainMixedInner { public $name = "inner"; }
+class NsfChainMixedOuter { public $in; function __construct() { $this->in = new NsfChainMixedInner(); } }
+$nsfChainMixed_o = new NsfChainMixedOuter();
+echo $nsfChainMixed_o?->in->name, "\n";
+?>
+--EXPECT--
+inner
+--CLEAN--
+<?php
+unset($nsfChainMixed_o);

--- a/tests/ph7/001-smoke/oo/nullsafe_chain_second_link.phpt
+++ b/tests/ph7/001-smoke/oo/nullsafe_chain_second_link.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe on the second link short-circuits when the intermediate value is null
+--FILE--
+<?php
+class NsfSecondLinkHolder { public $child = null; }
+$nsfSecondLink_h = new NsfSecondLinkHolder();
+$nsfSecondLink_r = $nsfSecondLink_h->child?->anything;
+echo ($nsfSecondLink_r === null ? "yes" : "no"), "\n";
+?>
+--EXPECT--
+yes
+--CLEAN--
+<?php
+unset($nsfSecondLink_h, $nsfSecondLink_r);

--- a/tests/ph7/001-smoke/oo/nullsafe_chain_short_circuit.phpt
+++ b/tests/ph7/001-smoke/oo/nullsafe_chain_short_circuit.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe chain short-circuits the entire postfix access chain when LHS is null
+--FILE--
+<?php
+class NsfShortCircuitNever {
+    public $z = 42;
+    public function boom() { echo "SHOULD_NOT_RUN\n"; return $this; }
+}
+$nsfShortCircuit_a = null;
+$nsfShortCircuit_r = $nsfShortCircuit_a?->b->c->boom()->z;
+echo ($nsfShortCircuit_r === null ? "yes" : "no"), "\n";
+?>
+--EXPECT--
+yes
+--CLEAN--
+<?php
+unset($nsfShortCircuit_a, $nsfShortCircuit_r);

--- a/tests/ph7/001-smoke/oo/nullsafe_exception_propagates.phpt
+++ b/tests/ph7/001-smoke/oo/nullsafe_exception_propagates.phpt
@@ -1,0 +1,25 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe does not swallow exceptions thrown by the called method
+--FILE--
+<?php
+class NsfExcBoom {
+    public function go() { throw new \Exception("bang"); }
+}
+$nsfExc_a = new NsfExcBoom();
+try {
+    $nsfExc_a?->go();
+    echo "no-throw\n";
+} catch (\Exception $e) {
+    echo "caught:", $e->getMessage(), "\n";
+}
+echo "done\n";
+?>
+--EXPECT--
+caught:bang
+done
+--CLEAN--
+<?php
+unset($nsfExc_a);

--- a/tests/ph7/001-smoke/oo/nullsafe_in_array_literal.phpt
+++ b/tests/ph7/001-smoke/oo/nullsafe_in_array_literal.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe in array literal — each element is an independent scope
+--FILE--
+<?php
+class NsfArrLitBox { public $v = 7; }
+$nsfArrLit_a = null;
+$nsfArrLit_b = new NsfArrLitBox();
+$nsfArrLit_out = array($nsfArrLit_a?->v, $nsfArrLit_b?->v, $nsfArrLit_a?->v ?? "fallback");
+echo ($nsfArrLit_out[0] === null ? "null" : "no"), "\n";
+echo $nsfArrLit_out[1], "\n";
+echo $nsfArrLit_out[2], "\n";
+?>
+--EXPECT--
+null
+7
+fallback
+--CLEAN--
+<?php
+unset($nsfArrLit_a, $nsfArrLit_b, $nsfArrLit_out);

--- a/tests/ph7/001-smoke/oo/nullsafe_in_call_argument.phpt
+++ b/tests/ph7/001-smoke/oo/nullsafe_in_call_argument.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe result as a function argument is isolated from surrounding chain
+--FILE--
+<?php
+class NsfCallArgThing { public $v = 7; }
+function nsfCallArg_label($x) { return $x === null ? "null" : "val:$x"; }
+$nsfCallArg_a = null;
+echo nsfCallArg_label($nsfCallArg_a?->v), "\n";
+$nsfCallArg_b = new NsfCallArgThing();
+echo nsfCallArg_label($nsfCallArg_b?->v), "\n";
+?>
+--EXPECT--
+null
+val:7
+--CLEAN--
+<?php
+unset($nsfCallArg_a, $nsfCallArg_b);

--- a/tests/ph7/001-smoke/oo/nullsafe_in_concatenation.phpt
+++ b/tests/ph7/001-smoke/oo/nullsafe_in_concatenation.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe in string concatenation — each `.` operand is an independent chain scope
+--FILE--
+<?php
+class NsfConcatUser { public $name = "bob"; }
+$nsfConcat_u = new NsfConcatUser();
+$nsfConcat_none = null;
+echo "[" . ($nsfConcat_u?->name ?? "-") . "/" . ($nsfConcat_none?->name ?? "-") . "]\n";
+?>
+--EXPECT--
+[bob/-]
+--CLEAN--
+<?php
+unset($nsfConcat_u, $nsfConcat_none);

--- a/tests/ph7/001-smoke/oo/nullsafe_in_condition.phpt
+++ b/tests/ph7/001-smoke/oo/nullsafe_in_condition.phpt
@@ -1,0 +1,27 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe expression is usable inside an if condition
+--FILE--
+<?php
+class NsfCondFlag { public $on = true; }
+$nsfCond_f = null;
+if ($nsfCond_f?->on) {
+    echo "branch-a\n";
+} else {
+    echo "branch-b\n";
+}
+$nsfCond_g = new NsfCondFlag();
+if ($nsfCond_g?->on) {
+    echo "branch-c\n";
+} else {
+    echo "branch-d\n";
+}
+?>
+--EXPECT--
+branch-b
+branch-c
+--CLEAN--
+<?php
+unset($nsfCond_f, $nsfCond_g);

--- a/tests/ph7/001-smoke/oo/nullsafe_in_foreach.phpt
+++ b/tests/ph7/001-smoke/oo/nullsafe_in_foreach.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe element access inside a loop, each iteration an independent scope
+--FILE--
+<?php
+class NsfForeachWrap { public $v = 0; function __construct($v) { $this->v = $v; } }
+$nsfForeach_items = array(new NsfForeachWrap(1), null, new NsfForeachWrap(3), null, new NsfForeachWrap(5));
+$nsfForeach_sum = 0;
+foreach ($nsfForeach_items as $nsfForeach_it) {
+    $nsfForeach_sum += ($nsfForeach_it?->v ?? 0);
+}
+echo $nsfForeach_sum, "\n";
+?>
+--EXPECT--
+9
+--CLEAN--
+<?php
+unset($nsfForeach_items, $nsfForeach_sum, $nsfForeach_it);

--- a/tests/ph7/001-smoke/oo/nullsafe_in_return.phpt
+++ b/tests/ph7/001-smoke/oo/nullsafe_in_return.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe expression used as a return value
+--FILE--
+<?php
+class NsfReturnItem { public $label = "widget"; }
+function nsfReturn_labelOf($item) {
+    return $item?->label;
+}
+echo (nsfReturn_labelOf(null) === null ? "null" : "no"), "\n";
+echo nsfReturn_labelOf(new NsfReturnItem()), "\n";
+?>
+--EXPECT--
+null
+widget
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/oo/nullsafe_in_ternary.phpt
+++ b/tests/ph7/001-smoke/oo/nullsafe_in_ternary.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe expression inside a ternary condition short-circuits within the condition scope
+--FILE--
+<?php
+class NsfTernaryFlag { public $on = false; }
+$nsfTernary_a = null;
+echo ($nsfTernary_a?->on ? "t" : "f"), "\n";
+$nsfTernary_b = new NsfTernaryFlag();
+echo ($nsfTernary_b?->on ? "t" : "f"), "\n";
+$nsfTernary_b->on = true;
+echo ($nsfTernary_b?->on ? "t" : "f"), "\n";
+?>
+--EXPECT--
+f
+f
+t
+--CLEAN--
+<?php
+unset($nsfTernary_a, $nsfTernary_b);

--- a/tests/ph7/001-smoke/oo/nullsafe_independent_chains.phpt
+++ b/tests/ph7/001-smoke/oo/nullsafe_independent_chains.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Two nullsafe chains in the same expression short-circuit independently
+--FILE--
+<?php
+class NsfIndepNum { public $v = 10; }
+$nsfIndep_a = null;
+$nsfIndep_b = new NsfIndepNum();
+$nsfIndep_sum = ($nsfIndep_a?->v ?? 0) + ($nsfIndep_b?->v ?? 0);
+echo $nsfIndep_sum, "\n";
+$nsfIndep_a2 = new NsfIndepNum();
+$nsfIndep_b2 = null;
+$nsfIndep_sum2 = ($nsfIndep_a2?->v ?? 0) + ($nsfIndep_b2?->v ?? 0);
+echo $nsfIndep_sum2, "\n";
+?>
+--EXPECT--
+10
+10
+--CLEAN--
+<?php
+unset($nsfIndep_a, $nsfIndep_b, $nsfIndep_a2, $nsfIndep_b2, $nsfIndep_sum, $nsfIndep_sum2);

--- a/tests/ph7/001-smoke/oo/nullsafe_inheritance.phpt
+++ b/tests/ph7/001-smoke/oo/nullsafe_inheritance.phpt
@@ -1,0 +1,25 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe reaches inherited properties and methods
+--FILE--
+<?php
+class NsfInheritBase {
+    public $inherited = "base-prop";
+    public function greet() { return "base-greet"; }
+}
+class NsfInheritChild extends NsfInheritBase {}
+$nsfInherit_c = new NsfInheritChild();
+echo $nsfInherit_c?->inherited, "\n";
+echo $nsfInherit_c?->greet(), "\n";
+$nsfInherit_n = null;
+echo ($nsfInherit_n?->inherited ?? "-"), "\n";
+?>
+--EXPECT--
+base-prop
+base-greet
+-
+--CLEAN--
+<?php
+unset($nsfInherit_c, $nsfInherit_n);

--- a/tests/ph7/001-smoke/oo/nullsafe_method_null.phpt
+++ b/tests/ph7/001-smoke/oo/nullsafe_method_null.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe method call on null returns null and never runs the body
+--FILE--
+<?php
+class NsfMethodNullGreeter {
+    public function greet() { echo "SHOULD_NOT_RUN\n"; return "hi"; }
+}
+$nsfMethodNull_g = null;
+$nsfMethodNull_r = $nsfMethodNull_g?->greet();
+echo ($nsfMethodNull_r === null ? "yes" : "no"), "\n";
+?>
+--EXPECT--
+yes
+--CLEAN--
+<?php
+unset($nsfMethodNull_g, $nsfMethodNull_r);

--- a/tests/ph7/001-smoke/oo/nullsafe_method_object.phpt
+++ b/tests/ph7/001-smoke/oo/nullsafe_method_object.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe method call on a real object invokes the method with arguments
+--FILE--
+<?php
+class NsfMethodObjAdder {
+    public function add($a, $b) { return $a + $b; }
+}
+$nsfMethodObj_x = new NsfMethodObjAdder();
+echo $nsfMethodObj_x?->add(2, 3), "\n";
+?>
+--EXPECT--
+5
+--CLEAN--
+<?php
+unset($nsfMethodObj_x);

--- a/tests/ph7/001-smoke/oo/nullsafe_nested.phpt
+++ b/tests/ph7/001-smoke/oo/nullsafe_nested.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nested nullsafe operators in the same chain
+--FILE--
+<?php
+class NsfNestedLeaf { public $v = 99; }
+class NsfNestedMid { public $leaf; function __construct() { $this->leaf = new NsfNestedLeaf(); } }
+class NsfNestedRoot { public $mid; function __construct($m) { $this->mid = $m; } }
+
+$nsfNested_r1 = new NsfNestedRoot(null);
+$nsfNested_x = $nsfNested_r1?->mid?->leaf?->v;
+echo ($nsfNested_x === null ? "yes" : "no"), "\n";
+
+$nsfNested_r2 = new NsfNestedRoot(new NsfNestedMid());
+echo $nsfNested_r2?->mid?->leaf?->v, "\n";
+?>
+--EXPECT--
+yes
+99
+--CLEAN--
+<?php
+unset($nsfNested_r1, $nsfNested_r2, $nsfNested_x);

--- a/tests/ph7/001-smoke/oo/nullsafe_on_clone.phpt
+++ b/tests/ph7/001-smoke/oo/nullsafe_on_clone.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe reads the cloned instance's property
+--FILE--
+<?php
+class NsfCloneBox { public $v = 1; }
+$nsfClone_a = new NsfCloneBox();
+$nsfClone_a->v = 5;
+$nsfClone_b = clone $nsfClone_a;
+$nsfClone_b->v = 9;
+echo $nsfClone_a?->v, "\n";
+echo $nsfClone_b?->v, "\n";
+?>
+--EXPECT--
+5
+9
+--CLEAN--
+<?php
+unset($nsfClone_a, $nsfClone_b);

--- a/tests/ph7/001-smoke/oo/nullsafe_on_this.phpt
+++ b/tests/ph7/001-smoke/oo/nullsafe_on_this.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe usable on $this inside a method body
+--FILE--
+<?php
+class NsfOnThisC {
+    public $val = 42;
+    public function viaThis() { return $this?->val; }
+}
+$nsfOnThis_o = new NsfOnThisC();
+echo $nsfOnThis_o->viaThis(), "\n";
+?>
+--EXPECT--
+42
+--CLEAN--
+<?php
+unset($nsfOnThis_o);

--- a/tests/ph7/001-smoke/oo/nullsafe_property_null.phpt
+++ b/tests/ph7/001-smoke/oo/nullsafe_property_null.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe property access on null returns null
+--FILE--
+<?php
+$a = null;
+$r = $a?->foo;
+echo ($r === null ? "yes" : "no"), "\n";
+?>
+--EXPECT--
+yes
+--CLEAN--
+<?php
+unset($a, $r);

--- a/tests/ph7/001-smoke/oo/nullsafe_property_object.phpt
+++ b/tests/ph7/001-smoke/oo/nullsafe_property_object.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe property access on a real object returns the property value
+--FILE--
+<?php
+class NsfPropObjBox { public $label = "hello"; }
+$nsfPropObj_b = new NsfPropObjBox();
+echo $nsfPropObj_b?->label, "\n";
+?>
+--EXPECT--
+hello
+--CLEAN--
+<?php
+unset($nsfPropObj_b);

--- a/tests/ph7/001-smoke/oo/nullsafe_ternary_scope.phpt
+++ b/tests/ph7/001-smoke/oo/nullsafe_ternary_scope.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe jump inside a ternary branch is confined to that branch
+--FILE--
+<?php
+class NsfTerScopePair { public $a = 1; public $b = 2; }
+$nsfTerScope_p = null;
+$nsfTerScope_q = new NsfTerScopePair();
+$nsfTerScope_x = ($nsfTerScope_p ? $nsfTerScope_p?->a : $nsfTerScope_q?->b);
+echo $nsfTerScope_x, "\n";
+$nsfTerScope_y = ($nsfTerScope_q ? $nsfTerScope_q?->a : $nsfTerScope_p?->b);
+echo $nsfTerScope_y, "\n";
+?>
+--EXPECT--
+2
+1
+--CLEAN--
+<?php
+unset($nsfTerScope_p, $nsfTerScope_q, $nsfTerScope_x, $nsfTerScope_y);

--- a/tests/ph7/001-smoke/oo/nullsafe_with_call_chain.phpt
+++ b/tests/ph7/001-smoke/oo/nullsafe_with_call_chain.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe short-circuits across chained method calls
+--FILE--
+<?php
+class NsfCallChainChain {
+    public function getSelf() { echo "SHOULD_NOT_RUN\n"; return $this; }
+    public function getName() { echo "SHOULD_NOT_RUN\n"; return "x"; }
+}
+$nsfCallChain_c = null;
+$nsfCallChain_r = $nsfCallChain_c?->getSelf()->getName();
+echo ($nsfCallChain_r === null ? "yes" : "no"), "\n";
+?>
+--EXPECT--
+yes
+--CLEAN--
+<?php
+unset($nsfCallChain_c, $nsfCallChain_r);

--- a/tests/ph7/001-smoke/oo/nullsafe_with_null_coalesce.phpt
+++ b/tests/ph7/001-smoke/oo/nullsafe_with_null_coalesce.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe chain combined with null coalescing ?? falls back on null
+--FILE--
+<?php
+class NsfCoalesceCfg { public $name = "alice"; }
+$nsfCoalesce_a = null;
+echo ($nsfCoalesce_a?->name ?? "default"), "\n";
+$nsfCoalesce_b = new NsfCoalesceCfg();
+echo ($nsfCoalesce_b?->name ?? "default"), "\n";
+?>
+--EXPECT--
+default
+alice
+--CLEAN--
+<?php
+unset($nsfCoalesce_a, $nsfCoalesce_b);

--- a/tests/ph7/001-smoke/oo/nullsafe_with_subscript.phpt
+++ b/tests/ph7/001-smoke/oo/nullsafe_with_subscript.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe short-circuit spans a trailing subscript access
+--FILE--
+<?php
+class NsfSubscriptBag { public $items = array("a", "b", "c"); }
+$nsfSubscript_b = null;
+$nsfSubscript_r = $nsfSubscript_b?->items[0];
+echo ($nsfSubscript_r === null ? "yes" : "no"), "\n";
+$nsfSubscript_c = new NsfSubscriptBag();
+echo $nsfSubscript_c?->items[1], "\n";
+?>
+--EXPECT--
+yes
+b
+--CLEAN--
+<?php
+unset($nsfSubscript_b, $nsfSubscript_c, $nsfSubscript_r);

--- a/tests/ph7/002-integration/lang/nullsafe_compound_assign.phpt
+++ b/tests/ph7/002-integration/lang/nullsafe_compound_assign.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Compound assignment (+=) targeting a nullsafe chain is a parse error
+--FILE--
+<?php
+class NsfCompoundBox { public $v = 1; }
+$nsfCompound_a = new NsfCompoundBox();
+$nsfCompound_a?->v += 1;
+echo "never\n";
+?>
+--EXPECTF--
+%ACan't use nullsafe operator in write context%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/nullsafe_non_null_non_object.phpt
+++ b/tests/ph7/002-integration/lang/nullsafe_non_null_non_object.phpt
@@ -1,0 +1,28 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe on a non-null non-object LHS does not short-circuit: the underlying `->` raises an error (PHP Warning / PHL Error) and execution continues with null. Nullsafe only suppresses the NULL case.
+--FILE--
+<?php
+$nsfNonObj_fired = 0;
+function nsfNonObj_handler($errno, $errstr) {
+    global $nsfNonObj_fired;
+    $nsfNonObj_fired = 1;
+    return true;
+}
+set_error_handler('nsfNonObj_handler');
+$nsfNonObj_a = 5;
+$nsfNonObj_r = $nsfNonObj_a?->foo;
+echo "error-fired:", ($nsfNonObj_fired ? "yes" : "no"), "\n";
+echo "r-is-null:", ($nsfNonObj_r === null ? "yes" : "no"), "\n";
+echo "done\n";
+restore_error_handler();
+?>
+--EXPECT--
+error-fired:yes
+r-is-null:yes
+done
+--CLEAN--
+<?php
+unset($nsfNonObj_a, $nsfNonObj_r, $nsfNonObj_fired);

--- a/tests/ph7/002-integration/lang/nullsafe_reference.phpt
+++ b/tests/ph7/002-integration/lang/nullsafe_reference.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Reference operator cannot target a nullsafe chain
+--FILE--
+<?php
+class NsfRefBox { public $v = 1; }
+$nsfRef_a = new NsfRefBox();
+$nsfRef_x = &$nsfRef_a?->v;
+echo "never\n";
+?>
+--EXPECTF--
+%Anullsafe%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/nullsafe_unset.phpt
+++ b/tests/ph7/002-integration/lang/nullsafe_unset.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+unset() cannot target a nullsafe chain
+--FILE--
+<?php
+class NsfUnsetBox { public $x = 1; }
+$nsfUnset_a = new NsfUnsetBox();
+unset($nsfUnset_a?->x);
+echo "never\n";
+?>
+--EXPECTF--
+%ACan't use nullsafe operator in write context%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/nullsafe_write_context.phpt
+++ b/tests/ph7/002-integration/lang/nullsafe_write_context.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe operator cannot be used as the target of an assignment
+--FILE--
+<?php
+class NsfWriteBox { public $x = 0; }
+$nsfWrite_a = new NsfWriteBox();
+$nsfWrite_a?->x = 5;
+echo "never\n";
+?>
+--EXPECTF--
+%ACan't use nullsafe operator in write context%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/nullsafe_write_deep_property.phpt
+++ b/tests/ph7/002-integration/lang/nullsafe_write_deep_property.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe anywhere in an assignment LHS chain is a parse error, even when the outer op is `->`
+--FILE--
+<?php
+class NsfWriteDeepBox { public $b; }
+$nsfWriteDeep_a = new NsfWriteDeepBox();
+$nsfWriteDeep_a->b = new NsfWriteDeepBox();
+$nsfWriteDeep_a?->b->c = 1;
+echo "never\n";
+?>
+--EXPECTF--
+%ACan't use nullsafe operator in write context%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/nullsafe_write_deep_subscript.phpt
+++ b/tests/ph7/002-integration/lang/nullsafe_write_deep_subscript.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullsafe anywhere in an assignment LHS chain is a parse error, even when the outer op is subscript
+--FILE--
+<?php
+class NsfWriteDeepArr { public $arr = array(0); }
+$nsfWriteDeep_a = new NsfWriteDeepArr();
+$nsfWriteDeep_a?->arr[0] = 1;
+echo "never\n";
+?>
+--EXPECTF--
+%ACan't use nullsafe operator in write context%A
+--CLEAN--
+<?php


### PR DESCRIPTION
Short-circuits the entire containing postfix chain to null when the LHS is null, without raising a warning. Uses a new PH7_OP_NULLSAFE_JMP opcode and a per-expression stack of pending jumps that non-chain ancestors patch to the end of their operand — so `$a?->b + $c?->d` keeps each chain independent and `$a?->b->c[0]->d()` collapses as a whole. Assignment/reference/unset targets on a nullsafe chain raise a PHP-compatible parse error.
