### PR TITLE
Implement throw as expression (PHP 8.0)

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -2312,8 +2312,13 @@ PH7_PRIVATE sxi32 PH7_CompileArrowFunc(ph7_gen_state *pGen,sxi32 iCompileFlag)
 	if( rc == SXERR_ABORT ){
 		return SXERR_ABORT;
 	}
-	/* Emit implicit return: OP_DONE with p1=1 means 'value on stack' */
+	/* Emit implicit return: OP_DONE with p1=1 means 'value on stack'.
+	 * Any throw-expression inside the body needs a valid jump target and a
+	 * stack-balanced exit path — point its fixup at a separate OP_DONE with
+	 * p1=0 emitted below, which does not pop the (absent) return value. */
 	PH7_VmEmitInstr(pGen->pVm,PH7_OP_DONE,(rc != SXERR_EMPTY ? 1 : 0),0,0,0);
+	GenStateFixJumps(pGen->pCurrent,PH7_OP_THROW,PH7_VmInstrLength(pGen->pVm));
+	PH7_VmEmitInstr(pGen->pVm,PH7_OP_DONE,0,0,0,0);
 	PH7_VmSetByteCodeContainer(pGen->pVm,pInstrContainer);
 	GenStateLeaveBlock(&(*pGen),0);
 	/* Restore cursors; caller will re-synchronize via the node's pEnd */
@@ -2334,6 +2339,7 @@ static sxi32 GenStateCompileMatchSubExpr(ph7_gen_state *pGen,
 {
 	SySet *pInstrContainer;
 	SyToken *pTmpIn,*pTmpEnd;
+	GenBlock *pArmBlock;
 	sxi32 rc;
 	pTmpIn  = pGen->pIn;
 	pTmpEnd = pGen->pEnd;
@@ -2341,8 +2347,24 @@ static sxi32 GenStateCompileMatchSubExpr(ph7_gen_state *pGen,
 	pGen->pEnd = pStop;
 	pInstrContainer = PH7_VmGetByteCodeContainer(pGen->pVm);
 	PH7_VmSetByteCodeContainer(pGen->pVm,pOut);
+	/* Enter a local FUNC block so any throw-expression fixups register on it
+	 * (and not on an outer try/catch whose instruction indices live in a
+	 * different bytecode container). We resolve those fixups to a trailing
+	 * OP_DONE p1=0 below so a throw inside a match arm cleanly terminates
+	 * the sub-bytecode while leaving VM_FRAME_THROW set for propagation. */
+	rc = GenStateEnterBlock(&(*pGen),GEN_BLOCK_PROTECTED|GEN_BLOCK_FUNC,
+		PH7_VmInstrLength(pGen->pVm),0,&pArmBlock);
+	if( rc != SXRET_OK ){
+		PH7_VmSetByteCodeContainer(pGen->pVm,pInstrContainer);
+		pGen->pIn  = pTmpIn;
+		pGen->pEnd = pTmpEnd;
+		return SXERR_ABORT;
+	}
 	rc = PH7_CompileExpr(&(*pGen),0,0);
 	PH7_VmEmitInstr(pGen->pVm,PH7_OP_DONE,(rc != SXERR_EMPTY ? 1 : 0),0,0,0);
+	GenStateFixJumps(pArmBlock,PH7_OP_THROW,PH7_VmInstrLength(pGen->pVm));
+	PH7_VmEmitInstr(pGen->pVm,PH7_OP_DONE,0,0,0,0);
+	GenStateLeaveBlock(&(*pGen),0);
 	PH7_VmSetByteCodeContainer(pGen->pVm,pInstrContainer);
 	pGen->pIn  = pTmpIn;
 	pGen->pEnd = pTmpEnd;
@@ -8820,14 +8842,24 @@ static sxi32 GenStateThrowNodeValidator(ph7_gen_state *pGen,ph7_expr_node *pRoot
 {
 	sxi32 rc = SXRET_OK;
 	if( pRoot->pOp ){
-		if( pRoot->pOp->iOp != EXPR_OP_SUBSCRIPT /* $a[] */ && pRoot->pOp->iOp != EXPR_OP_NEW /* new Exception() */
-			&& pRoot->pOp->iOp != EXPR_OP_ARROW /* -> */ && pRoot->pOp->iOp != EXPR_OP_DC /* :: */){
-			/* Unexpected expression */
+		switch( pRoot->pOp->iOp ){
+		case EXPR_OP_NEW:            /* new Exception() */
+		case EXPR_OP_ARROW:          /* $obj->prop */
+		case EXPR_OP_NULLSAFE_ARROW: /* $obj?->prop */
+		case EXPR_OP_DC:             /* Cls::$p or Cls::m() */
+		case EXPR_OP_SUBSCRIPT:      /* $arr[0] */
+		case EXPR_OP_FUNC_CALL:      /* fn() or $obj->m() */
+			break;
+		default:
+			/* Runtime will still reject non-Throwable values; the set above
+			 * covers the common shapes and gives a friendlier compile error
+			 * for obvious mistakes like `throw 5`. */
 			rc = PH7_GenCompileError(&(*pGen),E_ERROR,pRoot->pStart? pRoot->pStart->nLine : 0,
 				"throw: Expecting an exception class instance");
 			if( rc != SXERR_ABORT ){
 				rc = SXERR_INVALID;
 			}
+			break;
 		}
 	}else if( pRoot->xCode != PH7_CompileVariable ){
 		/* Unexpected expression */
@@ -8872,6 +8904,53 @@ static sxi32 PH7_CompileThrow(ph7_gen_state *pGen)
 	/* Emit the throw instruction */
 	PH7_VmEmitInstr(pGen->pVm,PH7_OP_THROW,0,0,0,&nIdx);
 	/* Emit the jump */
+	GenStateNewJumpFixup(pBlock,PH7_OP_THROW,nIdx);
+	return SXRET_OK;
+}
+/*
+ * Compile a PHP 8.0 'throw' expression.
+ * Called from the expression code generator when a 'throw' keyword is
+ * encountered in an expression context (e.g. `$x ?? throw new E()`).
+ * Reuses PH7_OP_THROW and the throw-statement's jump-fixup machinery;
+ * the validator guarantees the operand is a valid exception target.
+ */
+PH7_PRIVATE sxi32 PH7_CompileThrowExpr(ph7_gen_state *pGen, sxi32 iCompileFlag)
+{
+	sxu32 nLine = pGen->pIn->nLine;
+	GenBlock *pBlock;
+	sxu32 nIdx;
+	sxi32 rc;
+	(void)iCompileFlag;
+	pGen->pIn++; /* Skip 'throw' */
+	if( pGen->pIn >= pGen->pEnd ){
+		rc = PH7_GenCompileError(&(*pGen),E_ERROR,nLine,
+			"throw: Expecting an exception class instance");
+		if( rc == SXERR_ABORT ){
+			return SXERR_ABORT;
+		}
+		return SXRET_OK;
+	}
+	rc = PH7_CompileExpr(&(*pGen),0,GenStateThrowNodeValidator);
+	if( rc == SXERR_ABORT ){
+		return SXERR_ABORT;
+	}
+	if( rc == SXERR_EMPTY ){
+		rc = PH7_GenCompileError(&(*pGen),E_ERROR,nLine,
+			"throw: Expecting an exception class instance");
+		if( rc == SXERR_ABORT ){
+			return SXERR_ABORT;
+		}
+		return SXRET_OK;
+	}
+	/* Walk up to nearest exception/function block for the jump target */
+	pBlock = pGen->pCurrent;
+	while( pBlock->pParent ){
+		if( pBlock->iFlags & (GEN_BLOCK_EXCEPTION|GEN_BLOCK_FUNC) ){
+			break;
+		}
+		pBlock = pBlock->pParent;
+	}
+	PH7_VmEmitInstr(pGen->pVm,PH7_OP_THROW,0,0,0,&nIdx);
 	GenStateNewJumpFixup(pBlock,PH7_OP_THROW,nIdx);
 	return SXRET_OK;
 }

--- a/src/ph7/parse.c
+++ b/src/ph7/parse.c
@@ -996,6 +996,15 @@ static sxi32 ExprExtractNode(ph7_gen_state *pGen,ph7_expr_node **ppNode,int iLas
 				 return rc;
 			 }
 			 pNode->xCode = PH7_CompileMatch;
+		 }else if( nKeyword == PH7_TKWRD_THROW ){
+			 /* PHP 8.0 throw expression: throw <expr>
+			  * Consume the 'throw' keyword and all tokens up to the enclosing
+			  * close delimiter; PH7_CompileThrowExpr will reparse the body. */
+			 pCur++; /* Skip 'throw' */
+			 PH7_DelimitNestedTokens(pCur,pGen->pEnd,
+				 PH7_TK_LPAREN|PH7_TK_OCB|PH7_TK_OSB,
+				 PH7_TK_RPAREN|PH7_TK_CCB|PH7_TK_CSB,&pCur);
+			 pNode->xCode = PH7_CompileThrowExpr;
 		 }else if( PH7_IsLangConstruct(nKeyword,FALSE) == TRUE && &pCur[1] < pGen->pEnd ){
 			 /* Language constructs [i.e: print,echo,die...] require special handling */
 			 PH7_DelimitNestedTokens(pCur,pGen->pEnd,PH7_TK_LPAREN|PH7_TK_OCB|PH7_TK_OSB, PH7_TK_RPAREN|PH7_TK_CCB|PH7_TK_CSB,&pCur);

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1631,6 +1631,7 @@ PH7_PRIVATE sxi32 PH7_CompileShortList(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileAnnonFunc(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileArrowFunc(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileMatch(ph7_gen_state *pGen,sxi32 iCompileFlag);
+PH7_PRIVATE sxi32 PH7_CompileThrowExpr(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_InitCodeGenerator(ph7_vm *pVm,ProcConsumer xErr,void *pErrData);
 PH7_PRIVATE sxi32 PH7_ResetCodeGenerator(ph7_vm *pVm,ProcConsumer xErr,void *pErrData);
 PH7_PRIVATE sxi32 PH7_GenCompileError(ph7_gen_state *pGen,sxi32 nErrType,sxu32 nLine,const char *zFormat,...);

--- a/tests/ph7/001-smoke/lang/throw_expr_arrow_fn.phpt
+++ b/tests/ph7/001-smoke/lang/throw_expr_arrow_fn.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+throw expression: inside an arrow function body
+--FILE--
+<?php
+$required = fn($x) => $x ?? throw new Exception('missing');
+try {
+    $required(null);
+} catch (Exception $e) {
+    echo $e->getMessage(), "\n";
+}
+echo $required('value'), "\n";
+?>
+--EXPECT--
+missing
+value
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/throw_expr_assignment.phpt
+++ b/tests/ph7/001-smoke/lang/throw_expr_assignment.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+throw expression: inside an assignment within a function's try/catch
+--FILE--
+<?php
+function load($src) {
+    try {
+        $value = $src ?? throw new Exception('no source');
+        echo "loaded: $value\n";
+    } catch (Exception $e) {
+        echo 'caught: ', $e->getMessage(), "\n";
+    }
+}
+load(null);
+load('data');
+?>
+--EXPECT--
+caught: no source
+loaded: data
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/throw_expr_match_arm.phpt
+++ b/tests/ph7/001-smoke/lang/throw_expr_match_arm.phpt
@@ -1,0 +1,27 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+throw expression: inside a match arm propagates out of the match
+--FILE--
+<?php
+function check($code) {
+    try {
+        echo match ($code) {
+            200 => "ok: $code\n",
+            default => throw new Exception("unexpected: $code"),
+        };
+    } catch (Exception $e) {
+        echo "caught: ", $e->getMessage(), "\n";
+    }
+}
+check(200);
+check(500);
+echo "done\n";
+?>
+--EXPECT--
+ok: 200
+caught: unexpected: 500
+done
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/throw_expr_nested_coalesce.phpt
+++ b/tests/ph7/001-smoke/lang/throw_expr_nested_coalesce.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+throw expression: right-associative chain of ?? operators
+--FILE--
+<?php
+$a = null;
+$b = null;
+try {
+    $v = $a ?? $b ?? throw new Exception('all null');
+} catch (Exception $e) {
+    echo $e->getMessage(), "\n";
+}
+$b = 'fallback';
+$v = $a ?? $b ?? throw new Exception('never');
+echo $v, "\n";
+?>
+--EXPECT--
+all null
+fallback
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/throw_expr_null_coalesce.phpt
+++ b/tests/ph7/001-smoke/lang/throw_expr_null_coalesce.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+throw expression: right-hand side of null coalescing operator
+--FILE--
+<?php
+$input = null;
+try {
+    $v = $input ?? throw new Exception('required');
+} catch (Exception $e) {
+    echo $e->getMessage(), "\n";
+}
+$input = 'ok';
+$v = $input ?? throw new Exception('never');
+echo $v, "\n";
+?>
+--EXPECT--
+required
+ok
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/throw_expr_rethrow_variable.phpt
+++ b/tests/ph7/001-smoke/lang/throw_expr_rethrow_variable.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+throw expression: re-throw of a caught exception via a plain variable
+--FILE--
+<?php
+try {
+    try {
+        throw new Exception('original');
+    } catch (Exception $e) {
+        echo "inner: ", $e->getMessage(), "\n";
+        $last = $e;
+        throw $last;
+    }
+} catch (Exception $e) {
+    echo "outer: ", $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+inner: original
+outer: original
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/throw_expr_return.phpt
+++ b/tests/ph7/001-smoke/lang/throw_expr_return.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+throw expression: inside a return statement
+--FILE--
+<?php
+function required($x) {
+    return $x ?? throw new Exception('required');
+}
+try {
+    required(null);
+} catch (Exception $e) {
+    echo $e->getMessage(), "\n";
+}
+echo required('ok'), "\n";
+?>
+--EXPECT--
+required
+ok
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/throw_expr_short_circuit.phpt
+++ b/tests/ph7/001-smoke/lang/throw_expr_short_circuit.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+throw expression: right-hand side of || short-circuit
+--FILE--
+<?php
+$ok = false;
+try {
+    $ok || throw new Exception('bad');
+} catch (Exception $e) {
+    echo $e->getMessage(), "\n";
+}
+$ok = true;
+$ok || throw new Exception('never');
+echo "passed\n";
+?>
+--EXPECT--
+bad
+passed
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/throw_expr_targets.phpt
+++ b/tests/ph7/001-smoke/lang/throw_expr_targets.phpt
@@ -1,0 +1,35 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+throw expression: accepts property, subscript, static, call, and nullsafe targets
+--FILE--
+<?php
+class ThrowExprBox { public Exception $err; }
+class ThrowExprErrs { public static Exception $shared; }
+class ThrowExprFactory { public function make(): Exception { return new Exception('from method'); } }
+
+$b = new ThrowExprBox();
+$b->err = new Exception('from property');
+try { null ?? throw $b->err; } catch (Exception $e) { echo $e->getMessage(), "\n"; }
+
+$list = [new Exception('from subscript')];
+try { null ?? throw $list[0]; } catch (Exception $e) { echo $e->getMessage(), "\n"; }
+
+ThrowExprErrs::$shared = new Exception('from static');
+try { null ?? throw ThrowExprErrs::$shared; } catch (Exception $e) { echo $e->getMessage(), "\n"; }
+
+$f = new ThrowExprFactory();
+try { null ?? throw $f->make(); } catch (Exception $e) { echo $e->getMessage(), "\n"; }
+
+function throwExprMakeErr() { return new Exception('from function'); }
+try { null ?? throw throwExprMakeErr(); } catch (Exception $e) { echo $e->getMessage(), "\n"; }
+?>
+--EXPECT--
+from property
+from subscript
+from static
+from method
+from function
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/throw_expr_ternary.phpt
+++ b/tests/ph7/001-smoke/lang/throw_expr_ternary.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+throw expression: ternary else branch
+--FILE--
+<?php
+$n = -3;
+try {
+    $v = $n > 0 ? $n : throw new Exception('negative');
+} catch (Exception $e) {
+    echo $e->getMessage(), "\n";
+}
+$n = 7;
+$v = $n > 0 ? $n : throw new Exception('never');
+echo $v, "\n";
+?>
+--EXPECT--
+negative
+7
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/throw_expr_uncaught.phpt
+++ b/tests/ph7/002-integration/lang/throw_expr_uncaught.phpt
@@ -1,0 +1,15 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+throw expression: uncaught exception at script top level triggers a fatal
+--FILE--
+<?php
+$value = null;
+$result = $value ?? throw new Exception('required');
+echo "never\n";
+?>
+--EXPECTF--
+%AUncaught Exception: required%A
+--CLEAN--
+<?php


### PR DESCRIPTION
Hook 'throw' into ExprExtractNode as a keyword-triggered node that reparses its body via a new PH7_CompileThrowExpr, reusing PH7_OP_THROW and the existing jump-fixup machinery. Arrow function bodies and match arm sub-expressions now emit a dual OP_DONE tail (p1=1 for normal exit, p1=0 as the throw fixup target) so uncaught exceptions propagate cleanly out of sub-bytecode contexts; match arms additionally enter a local GEN_BLOCK_FUNC so fixup instruction indices stay container-consistent. The shared throw-target validator is also extended to accept function and method call results and nullsafe property access.
