### PR TITLE
Implement Throwable interface and hierarchy cleanup (PHP 7.0)

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -413,6 +413,7 @@ static ph7_value * GenStateInstallNumLiteral(ph7_gen_state *pGen,sxu32 *pIdx)
 /* Forward declaration */
 static sxi32 GenStateCompileChunk(ph7_gen_state *pGen,sxi32 iFlags);
 static sxi32 GenStateCollectFuncArgs(ph7_vm_func *pFunc,ph7_gen_state *pGen,SyToken *pEnd,int bCtorCtx,int bAbstractCtx);
+static sxi32 GenStateParseClassReference(ph7_gen_state *pGen,SyBlob *pFqn);
 /* Forward decl: union type parser is defined later in this file. */
 static sxi32 GenStateParseUnionTypeDecl(
 	ph7_gen_state *pGen,
@@ -2923,8 +2924,11 @@ static sxi32 GenStateResolveNamespaceLiteral(ph7_gen_state *pGen)
 				GenStateInstallLiteral(&(*pGen),pObj,nIdx);
 			}
 			/* Emit the load constant instruction.
-			 * P1=1 means candidate for constant/function/class expansion. */
-			PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOADC,1,nIdx,0,0);
+			 * iP1 bit 0 (PH7_LOADC_EXPAND): candidate for constant/function/class expansion.
+			 * iP1 bit 1 (PH7_LOADC_ABSOLUTE): fully-qualified; skip namespace prefixing. */
+			PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOADC,
+				isAbsolute ? (PH7_LOADC_EXPAND|PH7_LOADC_ABSOLUTE) : PH7_LOADC_EXPAND,
+				nIdx,0,0);
 			return SXRET_OK;
 		}
 	}
@@ -7265,44 +7269,41 @@ static sxi32 PH7_CompileClassInterface(ph7_gen_state *pGen)
 	if( pGen->pIn < pGen->pEnd  && (pGen->pIn->nType & PH7_TK_KEYWORD) ){
 		nKwrd = SX_PTR_TO_INT(pGen->pIn->pUserData);
 		if( nKwrd == PH7_TKWRD_EXTENDS /* interface b extends a */ ){
-			SyString *pBaseName;
+			SyBlob sResolved;
+			SyString sBaseName;
+			sxu32 nRefLine;
 			/* Extract base interface */
 			pGen->pIn++;
-			if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_ID) == 0 ){
-				/* Syntax error */
+			nRefLine = (pGen->pIn < pGen->pEnd) ? pGen->pIn->nLine : nLine;
+			SyBlobInit(&sResolved,&pGen->pVm->sAllocator);
+			if( GenStateParseClassReference(pGen,&sResolved) != SXRET_OK ){
+				SyBlobRelease(&sResolved);
 				rc = PH7_GenCompileError(pGen,E_ERROR,nLine,
 					"Expected 'interface_name' after 'extends' keyword inside interface '%z'",
 					pName);
 				SyMemBackendPoolFree(&pGen->pVm->sAllocator,pClass);
 				if( rc == SXERR_ABORT ){
-					/* Error count limit reached,abort immediately */
 					return SXERR_ABORT;
 				}
 				return SXRET_OK;
 			}
-			pBaseName = &pGen->pIn->sData;
-			{
-				SyBlob sResolved;
-				SyBlobInit(&sResolved,&pGen->pVm->sAllocator);
-				GenStateResolveName(pGen,pBaseName,&sResolved);
-				pBase = PH7_VmExtractClass(pGen->pVm,
-					(const char *)SyBlobData(&sResolved),(sxu32)SyBlobLength(&sResolved),FALSE,0);
-				SyBlobRelease(&sResolved);
-			}
+			pBase = PH7_VmExtractClass(pGen->pVm,
+				(const char *)SyBlobData(&sResolved),(sxu32)SyBlobLength(&sResolved),FALSE,0);
+			SyStringInitFromBuf(&sBaseName,
+				(const char *)SyBlobData(&sResolved),SyBlobLength(&sResolved));
 			/* Only interfaces is allowed */
 			while( pBase && (pBase->iFlags & PH7_CLASS_INTERFACE) == 0 ){
 				pBase = pBase->pNextName;
 			}
 			if( pBase == 0 ){
-				/* Inexistant interface */
-				rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,"Inexistant base interface '%z'",pBaseName);
+				rc = PH7_GenCompileError(pGen,E_ERROR,nRefLine,
+					"Nonexistent base interface '%z'",&sBaseName);
 				if( rc == SXERR_ABORT ){
-					/* Error count limit reached,abort immediately */
+					SyBlobRelease(&sResolved);
 					return SXERR_ABORT;
 				}
 			}
-			/* Advance the stream cursor */
-			pGen->pIn++;
+			SyBlobRelease(&sResolved);
 		}
 	}
 	if( pGen->pIn >= pGen->pEnd  || (pGen->pIn->nType & PH7_TK_OCB /*'{'*/) == 0 ){
@@ -7739,6 +7740,103 @@ static sxi32 GenStateCheckAbstractMethods(ph7_gen_state *pGen,ph7_class *pClass)
 	}
 	return SXRET_OK;
 }
+/*
+ * Parse a class/interface name reference from the current token stream.
+ * Handles an optional leading '\' (absolute) and multi-segment namespaced
+ * names (`Foo\Bar\Baz`). On success, writes the resolved FQN into pFqn
+ * (which must be an initialized, empty SyBlob) and advances pGen->pIn past
+ * the last consumed token. Returns SXRET_OK on success, SXERR_INVALID if
+ * the stream has no valid name at the current position (pGen->pIn is left
+ * untouched in that case so the caller can produce its own diagnostic).
+ */
+static sxi32 GenStateParseClassReference(ph7_gen_state *pGen,SyBlob *pFqn)
+{
+	int isAbsolute = 0;
+	SyToken *pStart = pGen->pIn;
+	SyBlob sName;
+	if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_NSSEP) ){
+		isAbsolute = 1;
+		pGen->pIn++;
+	}
+	if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & (PH7_TK_ID|PH7_TK_KEYWORD)) == 0 ){
+		pGen->pIn = pStart;
+		return SXERR_INVALID;
+	}
+	SyBlobInit(&sName,&pGen->pVm->sAllocator);
+	SyBlobAppend(&sName,pGen->pIn->sData.zString,pGen->pIn->sData.nByte);
+	pGen->pIn++;
+	while( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_NSSEP) &&
+		&pGen->pIn[1] < pGen->pEnd && (pGen->pIn[1].nType & (PH7_TK_ID|PH7_TK_KEYWORD)) ){
+		SyBlobAppend(&sName,"\\",1);
+		pGen->pIn++;
+		SyBlobAppend(&sName,pGen->pIn->sData.zString,pGen->pIn->sData.nByte);
+		pGen->pIn++;
+	}
+	if( isAbsolute ){
+		SyBlobAppend(pFqn,(const char *)SyBlobData(&sName),SyBlobLength(&sName));
+	}else{
+		SyString sRaw;
+		SyStringInitFromBuf(&sRaw,(const char *)SyBlobData(&sName),SyBlobLength(&sName));
+		GenStateResolveName(pGen,&sRaw,pFqn);
+	}
+	SyBlobRelease(&sName);
+	return SXRET_OK;
+}
+/*
+ * Return TRUE if pInterface is Throwable or transitively extends Throwable.
+ * Walks both the interface `extends` chain (pBase) and any parent-interface
+ * set (aInterface). Depth is counted for every traversal step — recursion
+ * through aInterface *and* sibling iteration through pBase — so a cycle in
+ * either direction cannot run unbounded.
+ */
+#define PH7_THROWABLE_WALK_MAX_DEPTH 64
+static int GenStateInterfaceIsThrowableAt(ph7_class *pInterface,int iDepth)
+{
+	ph7_class **apParent;
+	sxu32 n;
+	while( pInterface ){
+		if( iDepth > PH7_THROWABLE_WALK_MAX_DEPTH ){
+			return FALSE;
+		}
+		if( pInterface->sName.nByte == sizeof("Throwable")-1 &&
+			SyMemcmp(pInterface->sName.zString,"Throwable",sizeof("Throwable")-1) == 0 ){
+			return TRUE;
+		}
+		apParent = (ph7_class **)SySetBasePtr(&pInterface->aInterface);
+		for( n = 0 ; n < SySetUsed(&pInterface->aInterface) ; ++n ){
+			if( GenStateInterfaceIsThrowableAt(apParent[n],iDepth+1) ){
+				return TRUE;
+			}
+		}
+		pInterface = pInterface->pBase;
+		iDepth++;
+	}
+	return FALSE;
+}
+static int GenStateInterfaceIsThrowable(ph7_class *pInterface)
+{
+	return GenStateInterfaceIsThrowableAt(pInterface,0);
+}
+/*
+ * Return TRUE if pBase is (or transitively extends) the Exception or Error
+ * base class. Used to enforce that user classes can only acquire Throwable
+ * via `extends Exception` / `extends Error`, matching PHP 7+ behavior.
+ */
+static int GenStateClassIsExceptionOrError(ph7_class *pBase)
+{
+	while( pBase ){
+		if( pBase->sName.nByte == sizeof("Exception")-1 &&
+			SyMemcmp(pBase->sName.zString,"Exception",sizeof("Exception")-1) == 0 ){
+			return TRUE;
+		}
+		if( pBase->sName.nByte == sizeof("Error")-1 &&
+			SyMemcmp(pBase->sName.zString,"Error",sizeof("Error")-1) == 0 ){
+			return TRUE;
+		}
+		pBase = pBase->pBase;
+	}
+	return FALSE;
+}
 static sxi32 GenStateCompileClass(ph7_gen_state *pGen,sxi32 iFlags)
 {
 	sxu32 nLine = pGen->pIn->nLine;
@@ -7789,41 +7887,38 @@ static sxi32 GenStateCompileClass(ph7_gen_state *pGen,sxi32 iFlags)
 	/* Assume a standalone class */
 	pBase = 0;
 	if( pGen->pIn < pGen->pEnd  && (pGen->pIn->nType & PH7_TK_KEYWORD) ){
-		SyString *pBaseName;
 		nKwrd = SX_PTR_TO_INT(pGen->pIn->pUserData);
 		if( nKwrd == PH7_TKWRD_EXTENDS /* class b extends a */ ){
-			pGen->pIn++; /* Advance the stream cursor */
-			if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_ID) == 0 ){
-				/* Syntax error */
+			SyBlob sResolved;
+			SyString sBaseName;
+			sxu32 nRefLine;
+			pGen->pIn++; /* Advance past 'extends' */
+			nRefLine = (pGen->pIn < pGen->pEnd) ? pGen->pIn->nLine : nLine;
+			SyBlobInit(&sResolved,&pGen->pVm->sAllocator);
+			if( GenStateParseClassReference(pGen,&sResolved) != SXRET_OK ){
+				SyBlobRelease(&sResolved);
 				rc = PH7_GenCompileError(pGen,E_ERROR,nLine,
 					"Expected 'class_name' after 'extends' keyword inside class '%z'",
 					pName);
 				SyMemBackendPoolFree(&pGen->pVm->sAllocator,pClass);
 				if( rc == SXERR_ABORT ){
-					/* Error count limit reached,abort immediately */
 					return SXERR_ABORT;
 				}
 				return SXRET_OK;
 			}
-			/* Extract base class name and resolve through namespace/imports */
-			pBaseName = &pGen->pIn->sData;
-			{
-				SyBlob sResolved;
-				SyBlobInit(&sResolved,&pGen->pVm->sAllocator);
-				GenStateResolveName(pGen,pBaseName,&sResolved);
-				pBase = PH7_VmExtractClass(pGen->pVm,
-					(const char *)SyBlobData(&sResolved),(sxu32)SyBlobLength(&sResolved),FALSE,0);
-				SyBlobRelease(&sResolved);
-			}
+			pBase = PH7_VmExtractClass(pGen->pVm,
+				(const char *)SyBlobData(&sResolved),(sxu32)SyBlobLength(&sResolved),FALSE,0);
+			SyStringInitFromBuf(&sBaseName,
+				(const char *)SyBlobData(&sResolved),SyBlobLength(&sResolved));
 			/* Interfaces are not allowed */
 			while( pBase && (pBase->iFlags & PH7_CLASS_INTERFACE) ){
 				pBase = pBase->pNextName;
 			}
 			if( pBase == 0 ){
-				/* Inexistant base class */
-				rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,"Inexistant base class '%z'",pBaseName);
+				rc = PH7_GenCompileError(pGen,E_ERROR,nRefLine,
+					"Nonexistent base class '%z'",&sBaseName);
 				if( rc == SXERR_ABORT ){
-					/* Error count limit reached,abort immediately */
+					SyBlobRelease(&sResolved);
 					return SXERR_ABORT;
 				}
 			}else{
@@ -7831,58 +7926,78 @@ static sxi32 GenStateCompileClass(ph7_gen_state *pGen,sxi32 iFlags)
 					rc = PH7_GenCompileError(pGen,E_ERROR,nLine,
 						"Class '%z' may not inherit from final class '%z'",pName,&pBase->sName);
 					if( rc == SXERR_ABORT ){
-						/* Error count limit reached,abort immediately */
+						SyBlobRelease(&sResolved);
 						return SXERR_ABORT;
 					}
 				}
 			}
-			/* Advance the stream cursor */
-			pGen->pIn++;
+			SyBlobRelease(&sResolved);
 		}
 		if (pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_KEYWORD) && SX_PTR_TO_INT(pGen->pIn->pUserData) == PH7_TKWRD_IMPLEMENTS ){
 			ph7_class *pInterface;
-			SyString *pIntName;
 			/* Interface implementation */
 			pGen->pIn++; /* Advance the stream cursor */
 			for(;;){
-				if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_ID) == 0 ){
-					/* Syntax error */
+				SyBlob sResolved;
+				SyString sIntName;
+				sxu32 nRefLine;
+				nRefLine = (pGen->pIn < pGen->pEnd) ? pGen->pIn->nLine : nLine;
+				SyBlobInit(&sResolved,&pGen->pVm->sAllocator);
+				if( GenStateParseClassReference(pGen,&sResolved) != SXRET_OK ){
+					SyBlobRelease(&sResolved);
 					rc = PH7_GenCompileError(pGen,E_ERROR,nLine,
 						"Expected 'interface_name' after 'implements' keyword inside class '%z' declaration",
 						pName);
 					if( rc == SXERR_ABORT ){
-						/* Error count limit reached,abort immediately */
 						return SXERR_ABORT;
 					}
 					break;
 				}
-				/* Extract interface name and resolve through namespace/imports */
-				pIntName = &pGen->pIn->sData;
-				{
-					SyBlob sResolved;
-					SyBlobInit(&sResolved,&pGen->pVm->sAllocator);
-					GenStateResolveName(pGen,pIntName,&sResolved);
-					pInterface = PH7_VmExtractClass(pGen->pVm,
-						(const char *)SyBlobData(&sResolved),(sxu32)SyBlobLength(&sResolved),FALSE,0);
-					SyBlobRelease(&sResolved);
-				}
+				pInterface = PH7_VmExtractClass(pGen->pVm,
+					(const char *)SyBlobData(&sResolved),(sxu32)SyBlobLength(&sResolved),FALSE,0);
+				SyStringInitFromBuf(&sIntName,
+					(const char *)SyBlobData(&sResolved),SyBlobLength(&sResolved));
 				/* Only interfaces are allowed */
 				while( pInterface && (pInterface->iFlags & PH7_CLASS_INTERFACE) == 0 ){
 					pInterface = pInterface->pNextName;
 				}
 				if( pInterface == 0 ){
-					/* Inexistant interface */
-					rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,"Inexistant base interface '%z'",pIntName);
+					rc = PH7_GenCompileError(pGen,E_ERROR,nRefLine,
+						"Nonexistent base interface '%z'",&sIntName);
 					if( rc == SXERR_ABORT ){
-						/* Error count limit reached,abort immediately */
+						SyBlobRelease(&sResolved);
 						return SXERR_ABORT;
 					}
 				}else{
-					/* Register interface */
-					SySetPut(&aInterfaces,(const void *)&pInterface);
+					/* Reject user classes that try to implement Throwable
+					 * directly (or via an interface that extends Throwable)
+					 * unless they already extend Exception or Error.
+					 * Exception and Error themselves are compiled from the
+					 * built-in library and are exempt by FQN — a namespaced
+					 * `Foo\Exception` is a different class and not exempt. */
+					SyString *pFqn = &pClass->sName;
+					int bIsExceptionOrError =
+						(pFqn->nByte == sizeof("Exception")-1 &&
+						 SyMemcmp(pFqn->zString,"Exception",sizeof("Exception")-1) == 0) ||
+						(pFqn->nByte == sizeof("Error")-1 &&
+						 SyMemcmp(pFqn->zString,"Error",sizeof("Error")-1) == 0);
+					if( GenStateInterfaceIsThrowable(pInterface) &&
+						!GenStateClassIsExceptionOrError(pBase) &&
+						!bIsExceptionOrError ){
+						rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,
+							"Class %z cannot implement interface Throwable, extend Exception or Error instead",
+							&pClass->sName);
+						if( rc == SXERR_ABORT ){
+							SyBlobRelease(&sResolved);
+							return SXERR_ABORT;
+						}
+						/* Skip registration so the follow-up abstract-method
+						 * check does not produce a duplicate fatal. */
+					}else{
+						SySetPut(&aInterfaces,(const void *)&pInterface);
+					}
 				}
-				/* Advance the stream cursor */
-				pGen->pIn++;
+				SyBlobRelease(&sResolved);
 				if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_COMMA) == 0 ){
 					break;
 				}
@@ -8993,17 +9108,10 @@ static sxi32 PH7_CompileCatch(ph7_gen_state *pGen,ph7_exception *pException)
 	/* Extract the exception class(es) — supports multi-catch: catch (A | B $e) */
 	pGen->pIn++; /* Jump the left parenthesis '(' */
 	for(;;){
-		int isAbsolute = 0;
-		SyBlob sName;
-		SyBlobInit(&sName,&pGen->pVm->sAllocator);
-		/* Accept optional leading '\' for fully-qualified names */
-		if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_NSSEP) ){
-			isAbsolute = 1;
-			pGen->pIn++;
-		}
-		if( pGen->pIn >= pGen->pEnd ||
-			(pGen->pIn->nType & (PH7_TK_ID|PH7_TK_KEYWORD)) == 0 ){
-			SyBlobRelease(&sName);
+		SyBlob sResolved;
+		SyBlobInit(&sResolved,&pGen->pVm->sAllocator);
+		if( GenStateParseClassReference(pGen,&sResolved) != SXRET_OK ){
+			SyBlobRelease(&sResolved);
 			pToken = pGen->pIn;
 			if( pToken >= pGen->pEnd ){
 				pToken--;
@@ -9016,34 +9124,12 @@ static sxi32 PH7_CompileCatch(ph7_gen_state *pGen,ph7_exception *pException)
 			}
 			return SXERR_INVALID;
 		}
-		/* Collect namespace-qualified name: ID [\ ID]* */
-		SyBlobAppend(&sName,pGen->pIn->sData.zString,pGen->pIn->sData.nByte);
-		pGen->pIn++;
-		while( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_NSSEP) &&
-			&pGen->pIn[1] < pGen->pEnd && (pGen->pIn[1].nType & (PH7_TK_ID|PH7_TK_KEYWORD)) ){
-			SyBlobAppend(&sName,"\\",1);
-			pGen->pIn++; /* Skip '\' separator */
-			SyBlobAppend(&sName,pGen->pIn->sData.zString,pGen->pIn->sData.nByte);
-			pGen->pIn++;
-		}
-		/* Resolve through namespace/imports for non-absolute names */
-		if( !isAbsolute ){
-			SyString sRaw;
-			SyBlob sResolved;
-			SyStringInitFromBuf(&sRaw,(const char *)SyBlobData(&sName),SyBlobLength(&sName));
-			SyBlobInit(&sResolved,&pGen->pVm->sAllocator);
-			GenStateResolveName(pGen,&sRaw,&sResolved);
-			zDup = SyMemBackendStrDup(&pGen->pVm->sAllocator,
-				(const char *)SyBlobData(&sResolved),SyBlobLength(&sResolved));
-			SyStringInitFromBuf(&sClassName,zDup,SyBlobLength(&sResolved));
-			SyBlobRelease(&sResolved);
-		}else{
-			/* Absolute name: use as-is without namespace prefix */
-			zDup = SyMemBackendStrDup(&pGen->pVm->sAllocator,
-				(const char *)SyBlobData(&sName),SyBlobLength(&sName));
-			SyStringInitFromBuf(&sClassName,zDup,SyBlobLength(&sName));
-		}
-		SyBlobRelease(&sName);
+		/* Persist the FQN beyond this function — aClasses outlives the
+		 * transient SyBlob allocation. */
+		zDup = SyMemBackendStrDup(&pGen->pVm->sAllocator,
+			(const char *)SyBlobData(&sResolved),SyBlobLength(&sResolved));
+		SyStringInitFromBuf(&sClassName,zDup,SyBlobLength(&sResolved));
+		SyBlobRelease(&sResolved);
 		if( zDup == 0 ){
 			goto Mem;
 		}
@@ -9857,15 +9943,20 @@ static sxi32 GenStateEmitExprCode(
 				if ( pInstr->iOp == PH7_OP_LOADC ){
 					sxu32 nOrig = (sxu32)pInstr->iP2;
 					sxu32 nQual;
-					/* Prevent constant expansion */
-					pInstr->iP1 = 0;
-					/* Namespace-qualify the function name for CALL.
-					 * Only check function imports — class imports must NOT
-					 * affect function resolution.  For `new Foo()`, the CALL
-					 * handler fires before NEW; we store the original literal
-					 * index in the CALL instruction's iP2 so the NEW handler
-					 * can recover the unqualified name and re-qualify with
-					 * class imports. */ {
+					int bAbsolute = (pInstr->iP1 & PH7_LOADC_ABSOLUTE) != 0;
+					/* Prevent constant expansion but preserve the absolute flag
+					 * so the later NEW handler (if any) can see it. */
+					pInstr->iP1 &= ~PH7_LOADC_EXPAND;
+					/* Namespace-qualify the function name for CALL, unless the
+					 * literal is absolute (`\Foo(...)`). Only check function
+					 * imports — class imports must NOT affect function
+					 * resolution. For `new Foo()`, the CALL handler fires
+					 * before NEW; we store the original literal index in the
+					 * CALL instruction's iP2 so the NEW handler can recover
+					 * the unqualified name and re-qualify with class imports. */
+					if( bAbsolute ){
+						pInstr->iP2 = (sxi32)nOrig;
+					}else{
 						int fromImport = 0;
 						nQual = GenStateNsQualifyName(pGen,nOrig,&pGen->hUseFuncImports,&fromImport);
 						pInstr->iP2 = (sxi32)nQual;
@@ -10044,6 +10135,7 @@ static sxi32 GenStateEmitExprCode(
 					pPeek = PH7_VmPeekNextInstr(pGen->pVm);
 				}
 				if( pPeek && pPeek->iOp == PH7_OP_LOADC ){
+					int bAbsolute = (pPeek->iP1 & PH7_LOADC_ABSOLUTE) != 0;
 					sxu32 nLitForClass;
 					/* If the CALL handler already qualified the name using
 					 * function imports, recover the original unqualified
@@ -10054,7 +10146,11 @@ static sxi32 GenStateEmitExprCode(
 						nLitForClass = (sxu32)pPeek->iP2;
 					}
 					pPeek->iP1 = 0;
-					pPeek->iP2 = (sxi32)GenStateNsQualifyName(pGen,nLitForClass,&pGen->hUseImports,0);
+					if( !bAbsolute ){
+						pPeek->iP2 = (sxi32)GenStateNsQualifyName(pGen,nLitForClass,&pGen->hUseImports,0);
+					}else{
+						pPeek->iP2 = (sxi32)nLitForClass;
+					}
 				}
 			}
 			pInstr = PH7_VmPeekInstr(pGen->pVm);
@@ -10072,10 +10168,11 @@ static sxi32 GenStateEmitExprCode(
 			}
 		}else if( iVmOp == PH7_OP_IS_A ){
 			/* instanceof: right operand is a class name, not a constant.
-			 * Namespace-qualify it, but skip self/static/parent. */
+			 * Namespace-qualify it, but skip self/static/parent and absolute refs. */
 			pInstr = PH7_VmPeekInstr(pGen->pVm);
 			if( pInstr && pInstr->iOp == PH7_OP_LOADC ){
 				ph7_value *pLitChk = (ph7_value *)SySetAt(&pGen->pVm->aLitObj,(sxu32)pInstr->iP2);
+				int bAbsolute = (pInstr->iP1 & PH7_LOADC_ABSOLUTE) != 0;
 				int isSpecialIs = 0;
 				if( pLitChk && (pLitChk->iFlags & MEMOBJ_STRING) ){
 					const char *z = (const char *)SyBlobData(&pLitChk->sBlob);
@@ -10087,7 +10184,7 @@ static sxi32 GenStateEmitExprCode(
 					}
 				}
 				pInstr->iP1 = 0;
-				if( !isSpecialIs ){
+				if( !isSpecialIs && !bAbsolute ){
 					pInstr->iP2 = (sxi32)GenStateNsQualifyName(pGen,(sxu32)pInstr->iP2,&pGen->hUseImports,0);
 				}
 			}

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1051,6 +1051,9 @@ enum ph7_vm_op {
   PH7_OP_NULLSAFE_JMP,  /* Nullsafe (?->) short-circuit jump */
   PH7_OP_SPREAD         /* Mark TOS for argument unpacking (...$arr) */
 };
+/* LOADC.iP1 bit flags */
+#define PH7_LOADC_EXPAND   0x01 /* Candidate for constant/function/class expansion */
+#define PH7_LOADC_ABSOLUTE 0x02 /* Fully-qualified — skip namespace prefixing */
 /* -- END-OF INSTRUCTIONS -- */
 /*
  * Expression Operators ID.

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -950,14 +950,24 @@ static int vm_builtin_Generator_destruct(ph7_context *pCtx, int nArg, ph7_value 
  * directly as foreign functions.
  */
 #define PH7_BUILTIN_LIB \
-	"class Exception { "\
-    "protected $message = 'Unknown exception';"\
+	"interface Throwable {"\
+	"public function getMessage();"\
+	"public function getCode();"\
+	"public function getFile();"\
+	"public function getLine();"\
+	"public function getTrace();"\
+	"public function getTraceAsString();"\
+	"public function getPrevious();"\
+	"public function __toString();"\
+	"}"\
+	"class Exception implements Throwable { "\
+    "protected $message = '';"\
     "protected $code = 0;"\
     "protected $file;"\
     "protected $line;"\
     "protected $trace;"\
     "protected $previous;"\
-	"public function __construct($message = null, $code = 0, Exception $previous = null){"\
+	"public function __construct($message = null, $code = 0, Throwable $previous = null){"\
 	"   if( isset($message) ){"\
 	"	  $this->message = $message;"\
 	"   }"\
@@ -994,7 +1004,50 @@ static int vm_builtin_Generator_destruct(ph7_context *pCtx, int nArg, ph7_value 
 	"   return $this->file.' '.$this->line.' '.$this->code.' '.$this->message;"\
     "}"\
 	"}"\
-	"class Error extends Exception { }"\
+	"class Error implements Throwable { "\
+    "protected $message = '';"\
+    "protected $code = 0;"\
+    "protected $file;"\
+    "protected $line;"\
+    "protected $trace;"\
+    "protected $previous;"\
+	"public function __construct($message = null, $code = 0, Throwable $previous = null){"\
+	"   if( isset($message) ){"\
+	"	  $this->message = $message;"\
+	"   }"\
+	"   $this->code = $code;"\
+	"   $this->file = __FILE__;"\
+	"   $this->line = __LINE__;"\
+	"   $this->trace = debug_backtrace();"\
+	"   if( isset($previous) ){"\
+	"     $this->previous = $previous;"\
+	"   }"\
+	"}"\
+	"public function getMessage(){"\
+	"   return $this->message;"\
+	"}"\
+	"public function getCode(){"\
+	"  return $this->code;"\
+	"}"\
+	"public function getFile(){"\
+	"  return $this->file;"\
+	"}"\
+	"public function getLine(){"\
+	"  return $this->line;"\
+	"}"\
+	"public function getTrace(){"\
+	"   return $this->trace;"\
+	"}"\
+	"public function getTraceAsString(){"\
+	"  return debug_string_backtrace();"\
+	"}"\
+	"public function getPrevious(){"\
+	"    return $this->previous;"\
+	"}"\
+	"public function __toString(){"\
+	"   return $this->file.' '.$this->line.' '.$this->code.' '.$this->message;"\
+	"}"\
+	"}"\
 	"class TypeError extends Error { }"\
 	"class ArgumentCountError extends TypeError { }"\
 	"class ValueError extends Error { }"\
@@ -1005,7 +1058,7 @@ static int vm_builtin_Generator_destruct(ph7_context *pCtx, int nArg, ph7_value 
 	"class ErrorException extends Exception { "\
 	"protected $severity;"\
 	"public function __construct(string $message = null,"\
-	"int $code = 0,int $severity = 1,string $filename = __FILE__ ,int $lineno = __LINE__ ,Exception $previous = null){"\
+	"int $code = 0,int $severity = 1,string $filename = __FILE__ ,int $lineno = __LINE__ ,Throwable $previous = null){"\
 	"   if( isset($message) ){"\
 	"	  $this->message = $message;"\
 	"   }"\
@@ -3085,10 +3138,6 @@ static sxi32 VmReportUncaughtException(ph7_vm *pVm,const char *zClass,sxu32 nCla
 		zClass = "Exception";
 		nClass = (sxu32)sizeof("Exception") - 1;
 	}
-	if( zMsg == 0 ){
-		zMsg = "Unknown exception";
-		nMsg = (sxu32)sizeof("Unknown exception") - 1;
-	}
 	if( zFuncName == 0 || nFuncLen <= 0 ){
 		VmGetFrameContext(pVm,&zFuncName,&nFuncLen);
 	}
@@ -3096,8 +3145,10 @@ static sxi32 VmReportUncaughtException(ph7_vm *pVm,const char *zClass,sxu32 nCla
 	SyBlobInit(&sOut,&pVm->sAllocator);
 	SyBlobAppend(&sOut,"PHP Fatal error:  Uncaught ",sizeof("PHP Fatal error:  Uncaught ")-1);
 	SyBlobAppend(&sOut,zClass,nClass);
-	SyBlobAppend(&sOut,": ",sizeof(": ")-1);
-	SyBlobAppend(&sOut,zMsg,nMsg);
+	if( zMsg && nMsg > 0 ){
+		SyBlobAppend(&sOut,": ",sizeof(": ")-1);
+		SyBlobAppend(&sOut,zMsg,nMsg);
+	}
 	if( pFile ){
 		SyBlobAppend(&sOut," in ",sizeof(" in ")-1);
 		SyBlobAppend(&sOut,pFile->zString,pFile->nByte);
@@ -3820,7 +3871,7 @@ case PH7_OP_LOADC: {
 	/* Reserve a room */
 	pTos++;
 	if( (pObj = (ph7_value *)SySetAt(&pVm->aLitObj,pInstr->iP2)) != 0 ){
-		if( pInstr->iP1 == 1 && SyBlobLength(&pObj->sBlob) <= 64 ){
+		if( (pInstr->iP1 & PH7_LOADC_EXPAND) && SyBlobLength(&pObj->sBlob) <= 64 ){
 			SyHashEntry *pEntry;
 			/* Check use const imports first — imports take precedence */
 			{
@@ -3856,13 +3907,14 @@ case PH7_OP_LOADC: {
 			}
 			/* Constant not found by bare name.  If a namespace is active and
 			 * the name is unqualified, try namespace\name (PHP resolution order:
-			 * use-const imports → current NS → global → string fallback). */
+			 * use-const imports → current NS → global → string fallback).
+			 * Absolute references (\NAME) skip the NS fallback too. */
 			{
 				const char *zLit = (const char *)SyBlobData(&pObj->sBlob);
 				sxu32 nLit = (sxu32)SyBlobLength(&pObj->sBlob);
 				sxu32 j;
-				int isQualified = 0;
-				for( j = 0; j < nLit; j++ ){
+				int isQualified = (pInstr->iP1 & PH7_LOADC_ABSOLUTE) != 0;
+				for( j = 0; !isQualified && j < nLit; j++ ){
 					if( zLit[j] == '\\' ){ isQualified = 1; break; }
 				}
 				if( !isQualified && SyBlobLength(&pVm->sNamespace) > 0 ){
@@ -6084,16 +6136,45 @@ case PH7_OP_THROW: {
 	pFrameLocal->iFlags |= VM_FRAME_THROW;
 	if( pTos->iFlags & MEMOBJ_OBJ ){
 		ph7_class_instance *pThis = (ph7_class_instance *)pTos->x.pOther;
-		ph7_class *pException;
-		/* Make sure the loaded object is an instance of the 'Exception' base class.
-		 */
-		pException = PH7_VmExtractClass(&(*pVm),"Exception",sizeof("Exception")-1,TRUE,0);
-		if( pException == 0 || !PH7_VmInstanceOf(pThis->pClass,pException) ){
-			/* Exceptions must be valid objects derived from the Exception base class */
-			rc = VmUncaughtException(&(*pVm),pThis);
-			if( rc == SXERR_ABORT ){
-				/* Abort processing immediately */
-				goto Abort;
+		ph7_class *pThrowable;
+		/* Thrown object must implement the Throwable interface (PHP 7+). */
+		pThrowable = PH7_VmExtractClass(&(*pVm),"Throwable",sizeof("Throwable")-1,FALSE,0);
+		if( pThrowable == 0 || !PH7_VmInstanceOf(pThis->pClass,pThrowable) ){
+			/* Not a Throwable: replace with Error(msg) matching PHP behavior.
+			 * Error::__construct is defined in the built-in library and
+			 * cannot realistically fail, so we do not check its return. */
+			ph7_class *pErrorClass = PH7_VmExtractClass(&(*pVm),"Error",sizeof("Error")-1,TRUE,0);
+			ph7_class_instance *pErrInst = 0;
+			if( pErrorClass ){
+				pErrInst = PH7_NewClassInstance(&(*pVm),pErrorClass);
+			}
+			if( pErrInst ){
+				ph7_class_method *pCons;
+				pCons = PH7_ClassExtractMethod(pErrorClass,"__construct",sizeof("__construct")-1);
+				if( pCons ){
+					ph7_value sArg;
+					ph7_value *apArg[1];
+					SyString sMsgStr;
+					static const char zErrMsg[] =
+						"Cannot throw objects that do not implement Throwable";
+					SyStringInitFromBuf(&sMsgStr,zErrMsg,sizeof(zErrMsg)-1);
+					PH7_MemObjInit(pVm,&sArg);
+					PH7_MemObjInitFromString(pVm,&sArg,&sMsgStr);
+					apArg[0] = &sArg;
+					PH7_VmCallClassMethod(&(*pVm),pErrInst,pCons,0,1,apArg);
+					PH7_MemObjRelease(&sArg);
+				}
+				rc = VmThrowException(&(*pVm),pErrInst);
+				PH7_ClassInstanceUnref(pErrInst);
+				if( rc == SXERR_ABORT ){
+					goto Abort;
+				}
+			}else{
+				/* Bootstrap failure — fall back to uncaught reporting */
+				rc = VmUncaughtException(&(*pVm),pThis);
+				if( rc == SXERR_ABORT ){
+					goto Abort;
+				}
 			}
 		}else{
 			/* Throw the exception */
@@ -11863,9 +11944,6 @@ static sxi32 VmUncaughtException(
 				PH7_MemObjRelease(&sMsg);
 			}
 		}
-		if( SyBlobLength(&sMsgBuf) == 0 ){
-			SyBlobAppend(&sMsgBuf,"Unknown exception",sizeof("Unknown exception")-1);
-		}
 		zMsg = (const char *)SyBlobData(&sMsgBuf);
 		nMsg = (sxu32)SyBlobLength(&sMsgBuf);
 		VmGetFrameContext(pVm,&zFuncName,&nFuncLen);
@@ -11937,10 +12015,12 @@ static sxi32 VmThrowException(
 			nNames = SySetUsed(&aCatch[j].aClasses);
 			matched = 0;
 			for( k = 0 ; k < nNames ; ++k ){
-				/* Extract the target class */
-				pClass = PH7_VmExtractClass(&(*pVm),aNames[k].zString,aNames[k].nByte,TRUE,0);
-				if( pClass == 0 ){
-					/* No such class */
+				/* Extract the target class or interface (iLoadable=FALSE so
+				 * interfaces like Throwable are resolvable as catch targets).
+				 * Traits are never instance-compatible, so skip them explicitly. */
+				pClass = PH7_VmExtractClass(&(*pVm),aNames[k].zString,aNames[k].nByte,FALSE,0);
+				if( pClass == 0 || (pClass->iFlags & PH7_CLASS_TRAIT) ){
+					/* No such class, or trait — cannot match */
 					continue;
 				}
 				if( PH7_VmInstanceOf(pThis->pClass,pClass) ){

--- a/tests/ph7/001-smoke/lang/throwable_absolute_qualifier.phpt
+++ b/tests/ph7/001-smoke/lang/throwable_absolute_qualifier.phpt
@@ -1,0 +1,27 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Throwable: absolute qualifiers in extends/implements
+--FILE--
+<?php
+class AbsQualA extends \Exception {}
+class AbsQualB extends \Error {}
+interface AbsQualI extends \Throwable {}
+class AbsQualC extends \Error implements AbsQualI {}
+echo (new AbsQualA() instanceof Throwable) ? "yes\n" : "no\n";
+echo (new AbsQualB() instanceof Throwable) ? "yes\n" : "no\n";
+echo (new AbsQualC() instanceof AbsQualI) ? "yes\n" : "no\n";
+try {
+    throw new AbsQualC("abs");
+} catch (\Throwable $t) {
+    echo get_class($t), ":", $t->getMessage(), "\n";
+}
+?>
+--EXPECT--
+yes
+yes
+yes
+AbsQualC:abs
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/throwable_catch_error.phpt
+++ b/tests/ph7/001-smoke/lang/throwable_catch_error.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Throwable: catch Error via Throwable
+--FILE--
+<?php
+try {
+    throw new Error("engine");
+} catch (Throwable $t) {
+    echo get_class($t), ":", $t->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Error:engine
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/throwable_catch_exception.phpt
+++ b/tests/ph7/001-smoke/lang/throwable_catch_exception.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Throwable: catch user Exception via Throwable
+--FILE--
+<?php
+try {
+    throw new Exception("boom");
+} catch (Throwable $t) {
+    echo get_class($t), ":", $t->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Exception:boom
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/throwable_catch_typeerror.phpt
+++ b/tests/ph7/001-smoke/lang/throwable_catch_typeerror.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Throwable: engine-raised ArgumentCountError caught via Throwable
+--FILE--
+<?php
+try {
+    abs();
+} catch (Throwable $t) {
+    echo get_class($t), ":", $t->getMessage(), "\n";
+}
+?>
+--EXPECT--
+ArgumentCountError:abs() expects exactly 1 argument, 0 given
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/throwable_deep_chain.phpt
+++ b/tests/ph7/001-smoke/lang/throwable_deep_chain.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Throwable: deep extends chain + explicit implements Throwable
+--FILE--
+<?php
+class DeepA extends Exception {}
+class DeepB extends DeepA {}
+class DeepC extends DeepB implements Throwable {}
+echo (new DeepC() instanceof Throwable) ? "yes\n" : "no\n";
+echo (new DeepC() instanceof Exception) ? "yes\n" : "no\n";
+try {
+    throw new DeepC("d");
+} catch (Throwable $t) {
+    echo get_class($t), ":", $t->getMessage(), "\n";
+}
+?>
+--EXPECT--
+yes
+yes
+DeepC:d
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/throwable_empty_message.phpt
+++ b/tests/ph7/001-smoke/lang/throwable_empty_message.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Throwable: default message is empty string
+--FILE--
+<?php
+$e = new Exception();
+echo "Exception:[", $e->getMessage(), "]\n";
+echo strlen($e->getMessage()), "\n";
+$r = new Error();
+echo "Error:[", $r->getMessage(), "]\n";
+echo strlen($r->getMessage()), "\n";
+?>
+--EXPECT--
+Exception:[]
+0
+Error:[]
+0
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/throwable_error_not_exception.phpt
+++ b/tests/ph7/001-smoke/lang/throwable_error_not_exception.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Throwable: Error is not an Exception (PHP 7+ hierarchy)
+--FILE--
+<?php
+echo (new Error() instanceof Exception) ? "yes\n" : "no\n";
+try {
+    throw new Error("e");
+} catch (Exception $e) {
+    echo "wrong:Exception\n";
+} catch (Error $e) {
+    echo "right:Error:", $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+no
+right:Error:e
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/throwable_errorexception_previous.phpt
+++ b/tests/ph7/001-smoke/lang/throwable_errorexception_previous.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Throwable: ErrorException accepts Error as previous
+--FILE--
+<?php
+$inner = new Error("root cause");
+$e = new ErrorException("outer", 0, 1, __FILE__, 10, $inner);
+echo $e->getMessage(), "\n";
+echo $e->getSeverity(), "\n";
+$prev = $e->getPrevious();
+echo get_class($prev), ":", $prev->getMessage(), "\n";
+?>
+--EXPECT--
+outer
+1
+Error:root cause
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/throwable_instanceof.phpt
+++ b/tests/ph7/001-smoke/lang/throwable_instanceof.phpt
@@ -1,0 +1,34 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Throwable: instanceof across the hierarchy
+--FILE--
+<?php
+function thb($v) { echo $v ? "yes\n" : "no\n"; }
+thb(new Exception() instanceof Throwable);
+thb(new Error() instanceof Throwable);
+thb(new TypeError() instanceof Throwable);
+thb(new ArgumentCountError() instanceof Throwable);
+thb(new ValueError() instanceof Throwable);
+thb(new ArithmeticError() instanceof Throwable);
+thb(new DivisionByZeroError() instanceof Throwable);
+thb(new AssertionError() instanceof Throwable);
+thb(new ErrorException() instanceof Throwable);
+thb(new TypeError() instanceof Error);
+thb(new ArgumentCountError() instanceof TypeError);
+?>
+--EXPECT--
+yes
+yes
+yes
+yes
+yes
+yes
+yes
+yes
+yes
+yes
+yes
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/throwable_interface_methods.phpt
+++ b/tests/ph7/001-smoke/lang/throwable_interface_methods.phpt
@@ -1,0 +1,30 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Throwable: both Exception and Error implement all interface methods
+--FILE--
+<?php
+$e = new Exception("msg-e", 42);
+echo $e->getMessage(), "\n";
+echo $e->getCode(), "\n";
+echo ($e->getPrevious() === null) ? "no-prev\n" : "has-prev\n";
+
+$r = new Error("msg-r", 7);
+echo $r->getMessage(), "\n";
+echo $r->getCode(), "\n";
+echo ($r->getPrevious() === null) ? "no-prev\n" : "has-prev\n";
+echo is_int($r->getLine()) ? "line-int\n" : "line-other\n";
+echo is_array($r->getTrace()) ? "trace-array\n" : "trace-other\n";
+?>
+--EXPECT--
+msg-e
+42
+no-prev
+msg-r
+7
+no-prev
+line-int
+trace-array
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/throwable_multi_catch.phpt
+++ b/tests/ph7/001-smoke/lang/throwable_multi_catch.phpt
@@ -1,0 +1,28 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Throwable: mixed with multi-catch
+--FILE--
+<?php
+function run($throwable) {
+    try {
+        throw $throwable;
+    } catch (TypeError | ValueError $e) {
+        echo "specific:", get_class($e), "\n";
+    } catch (Throwable $t) {
+        echo "throwable:", get_class($t), "\n";
+    }
+}
+run(new TypeError("t"));
+run(new ValueError("v"));
+run(new Error("e"));
+run(new Exception("x"));
+?>
+--EXPECT--
+specific:TypeError
+specific:ValueError
+throwable:Error
+throwable:Exception
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/throwable_multi_segment_absolute.phpt
+++ b/tests/ph7/001-smoke/lang/throwable_multi_segment_absolute.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Throwable: multi-segment absolute qualifier in extends and catch
+--FILE--
+<?php
+namespace Msg\Deep;
+class Err extends \Exception {}
+class Inner extends \Msg\Deep\Err {}
+try {
+    throw new \Msg\Deep\Inner("deep");
+} catch (\Msg\Deep\Err $e) {
+    echo get_class($e), ":", $e->getMessage(), "\n";
+}
+echo (new \Msg\Deep\Inner() instanceof \Throwable) ? "yes\n" : "no\n";
+?>
+--EXPECT--
+Msg\Deep\Inner:deep
+yes
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/throwable_previous_chaining.phpt
+++ b/tests/ph7/001-smoke/lang/throwable_previous_chaining.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Throwable: Exception accepts an Error as previous
+--FILE--
+<?php
+$inner = new Error("inner");
+$outer = new Exception("outer", 0, $inner);
+echo $outer->getMessage(), "\n";
+$prev = $outer->getPrevious();
+echo get_class($prev), ":", $prev->getMessage(), "\n";
+echo ($prev instanceof Throwable) ? "throwable\n" : "not\n";
+?>
+--EXPECT--
+outer
+Error:inner
+throwable
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/throwable_throw_non_throwable.phpt
+++ b/tests/ph7/001-smoke/lang/throwable_throw_non_throwable.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Throwable: throwing a non-Throwable raises Error
+--FILE--
+<?php
+class NtPlain { public $x = 1; }
+try {
+    throw new NtPlain();
+} catch (Throwable $t) {
+    echo get_class($t), ":", $t->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Error:Cannot throw objects that do not implement Throwable
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/throwable_bare_backslash_extends.phpt
+++ b/tests/ph7/002-integration/oo/throwable_bare_backslash_extends.phpt
@@ -1,0 +1,13 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Throwable: `extends \` with no identifier produces a fatal
+--FILE--
+<?php
+class BareBsExt extends \ {}
+?>
+--EXPECTF--
+%APHP %s error: %A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/throwable_direct_implement_forbidden.phpt
+++ b/tests/ph7/002-integration/oo/throwable_direct_implement_forbidden.phpt
@@ -1,0 +1,13 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Throwable: user class cannot implement Throwable directly
+--FILE--
+<?php
+class ThDirect implements Throwable {}
+?>
+--EXPECTF--
+%s Fatal error:  Class ThDirect cannot implement interface Throwable, extend Exception or Error instead%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/throwable_namespaced_forbidden.phpt
+++ b/tests/ph7/002-integration/oo/throwable_namespaced_forbidden.phpt
@@ -1,0 +1,15 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Throwable: namespaced user class still forbidden from direct implement
+--FILE--
+<?php
+namespace ThNs;
+use Throwable;
+class MyThrow implements Throwable {}
+?>
+--EXPECTF--
+%s Fatal error:  Class ThNs\MyThrow cannot implement interface Throwable, extend Exception or Error instead%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/throwable_via_subinterface_forbidden.phpt
+++ b/tests/ph7/002-integration/oo/throwable_via_subinterface_forbidden.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Throwable: user class cannot reach Throwable via a sub-interface
+--FILE--
+<?php
+interface ThSub extends Throwable {}
+class ThViaSub implements ThSub {}
+?>
+--EXPECTF--
+%s Fatal error:  Class ThViaSub cannot implement interface Throwable, extend Exception or Error instead%A
+--CLEAN--
+<?php


### PR DESCRIPTION
Adds the Throwable interface, makes Exception and Error sibling classes both implementing it, and enforces PHP's rule that user classes cannot directly implement Throwable. Also fixes several pre-existing issues surfaced along the way: non-Throwable throws now raise an Error, default exception messages are empty strings, and absolute class qualifiers (\Foo) now work in extends/implements/new/instanceof.
