### PR TITLE
Implement exponentiation operators ** and **= (PHP 5.6)

### DIFF
--- a/src/ph7/lex.c
+++ b/src/ph7/lex.c
@@ -524,9 +524,18 @@ static sxi32 TokenizePHP(SyStream *pStream,SyToken *pToken,void *pUserData,void 
 			}
 			break;
 		case '*':
-			if( pStream->zText < pStream->zEnd && pStream->zText[0] == '=' ){
-				/* Current operator: *= */
-				pStream->zText++;
+			if( pStream->zText < pStream->zEnd ){
+				if( pStream->zText[0] == '*' ){
+					/* Current operator: ** or **= */
+					pStream->zText++;
+					if( pStream->zText < pStream->zEnd && pStream->zText[0] == '=' ){
+						/* Current operator: **= */
+						pStream->zText++;
+					}
+				}else if( pStream->zText[0] == '=' ){
+					/* Current operator: *= */
+					pStream->zText++;
+				}
 			}
 			break;
 		case '/':

--- a/src/ph7/parse.c
+++ b/src/ph7/parse.c
@@ -177,6 +177,8 @@ static const ph7_expr_op aOpTable[] = {
 	{ {"(object)", sizeof("(object)")-1}, EXPR_OP_TYPECAST, 4, EXPR_OP_ASSOC_RIGHT, PH7_OP_CVT_OBJ  },
 	{ {"(unset)",  sizeof("(unset)")-1 }, EXPR_OP_TYPECAST, 4, EXPR_OP_ASSOC_RIGHT, PH7_OP_CVT_NULL },
 	                           /* Binary operators */
+	/* Precedence 5,right-associative: exponentiation (PHP 5.6) */
+	{ {"**",sizeof(char)*2}, EXPR_OP_POW, 5, EXPR_OP_ASSOC_RIGHT, PH7_OP_POW},
 	/* Precedence 7,left-associative */
 	{ {"instanceof",sizeof("instanceof")-1}, EXPR_OP_INSTOF, 7, EXPR_OP_NON_ASSOC, PH7_OP_IS_A},
 	{ {"*",sizeof(char)}, EXPR_OP_MUL, 7, EXPR_OP_ASSOC_LEFT , PH7_OP_MUL},
@@ -231,6 +233,7 @@ static const ph7_expr_op aOpTable[] = {
 	{ {"*=",sizeof(char)*2},  EXPR_OP_MUL_ASSIGN, 18,  EXPR_OP_ASSOC_RIGHT, PH7_OP_MUL_STORE },
 	{ {"/=",sizeof(char)*2},  EXPR_OP_DIV_ASSIGN, 18,  EXPR_OP_ASSOC_RIGHT, PH7_OP_DIV_STORE },
 	{ {"%=",sizeof(char)*2},  EXPR_OP_MOD_ASSIGN, 18,  EXPR_OP_ASSOC_RIGHT, PH7_OP_MOD_STORE },
+	{ {"**=",sizeof(char)*3}, EXPR_OP_POW_ASSIGN, 18,  EXPR_OP_ASSOC_RIGHT, PH7_OP_POW_STORE },
 	{ {"&=",sizeof(char)*2},  EXPR_OP_AND_ASSIGN, 18,  EXPR_OP_ASSOC_RIGHT, PH7_OP_BAND_STORE },
 	{ {"|=",sizeof(char)*2},  EXPR_OP_OR_ASSIGN,  18,  EXPR_OP_ASSOC_RIGHT, PH7_OP_BOR_STORE  },
 	{ {"^=",sizeof(char)*2},  EXPR_OP_XOR_ASSIGN, 18,  EXPR_OP_ASSOC_RIGHT, PH7_OP_BXOR_STORE },
@@ -1324,10 +1327,20 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 			 iCur++;
 		 }
 		 if( iCur - iLeft > 1 ){
+			 sxi32 j;
 			 /* Recurse and process this expression */
 			 rc = ExprMakeTree(&(*pGen),&apNode[iLeft + 1],iCur - iLeft - 1);
 			 if( rc != SXRET_OK ){
 				 return rc;
+			 }
+			 /* Mark the subtree root as coming from an explicit parenthesised
+			  * group. Consumed by the ** precedence-5 phase so it does not
+			  * hoist a unary operator that the user explicitly isolated. */
+			 for( j = iLeft + 1 ; j < iCur ; ++j ){
+				 if( apNode[j] ){
+					 apNode[j]->iFlags |= EXPR_NODE_PARENS;
+					 break;
+				 }
 			 }
 		 }
 		 /* Free the left and right nodes */
@@ -1654,6 +1667,77 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 			  iLeft = iCur;
 		  }
 	  }
+	 /* Process right-associative binary operators at precedence 5 (**):
+	  * PHP's exponentiation is right-associative (2**3**2 == 512) and binds
+	  * tighter than *. Walk right-to-left so the rightmost ** collapses first,
+	  * yielding a right-leaning tree. */
+	 for( iCur = nToken - 1 ; iCur >= 0 ; --iCur ){
+		 if( apNode[iCur] == 0 ){
+			 continue;
+		 }
+		 pNode = apNode[iCur];
+		 if( pNode->pOp && pNode->pOp->iPrec == 5 && pNode->pLeft == 0 ){
+			 sxi32 iL, iR;
+			 /* Find the right operand */
+			 iR = -1;
+			 {
+				 sxi32 j;
+				 for( j = iCur + 1 ; j < nToken ; ++j ){
+					 if( apNode[j] ){ iR = j; break; }
+				 }
+			 }
+			 /* Find the left operand */
+			 iL = -1;
+			 {
+				 sxi32 j;
+				 for( j = iCur - 1 ; j >= 0 ; --j ){
+					 if( apNode[j] ){ iL = j; break; }
+				 }
+			 }
+			 if( iR < 0 || iL < 0 || !NODE_ISTERM(iR) || !NODE_ISTERM(iL) ){
+				 rc = PH7_GenCompileError(pGen,E_ERROR,pNode->pStart->nLine,
+					 "'%z': Missing/Invalid operand",&pNode->pOp->sOp);
+				 if( rc != SXERR_ABORT ){
+					 rc = SXERR_SYNTAX;
+				 }
+				 return rc;
+			 }
+			 pNode->pLeft  = apNode[iL];
+			 pNode->pRight = apNode[iR];
+			 apNode[iL] = 0;
+			 apNode[iR] = 0;
+			 /* PHP compat: ** binds tighter than unary -,+,~,!,(cast).
+			  * The unary phase already attached its operand (pLeft) before
+			  * we ran, so `-X ** Y` currently looks like (-X) ** Y. Push
+			  * the ** beneath the deepest unary so we get -(X ** Y). For
+			  * chains (e.g. `- -2 ** 2`), preserve the original unary order
+			  * — the outer unary must remain on top. Stop at parentheses or
+			  * at the error-suppression operator '@', which PHP leaves
+			  * wrapping the whole expression. */
+			 if( pNode->pLeft && pNode->pLeft->pOp
+				 && pNode->pLeft->pOp->iPrec == 4
+				 && pNode->pLeft->pOp->iOp != EXPR_OP_ALT
+				 && pNode->pLeft->pLeft != 0
+				 && (pNode->pLeft->iFlags & EXPR_NODE_PARENS) == 0 ){
+				 ph7_expr_node *pHead = pNode->pLeft;
+				 ph7_expr_node *pTail = pHead;
+				 /* Walk down to the innermost hoistable unary — the one
+				  * whose pLeft is a term or a parenthesised subtree. */
+				 while( pTail->pLeft
+					 && pTail->pLeft->pOp
+					 && pTail->pLeft->pOp->iPrec == 4
+					 && pTail->pLeft->pOp->iOp != EXPR_OP_ALT
+					 && pTail->pLeft->pLeft != 0
+					 && (pTail->pLeft->iFlags & EXPR_NODE_PARENS) == 0 ){
+					 pTail = pTail->pLeft;
+				 }
+				 /* Splice pNode (**) between pTail and its former operand. */
+				 pNode->pLeft = pTail->pLeft;
+				 pTail->pLeft = pNode;
+				 apNode[iCur] = pHead;
+			 }
+		 }
+	 }
 	 /* Process left and non-associative binary operators [i.e: *,/,&&,||...]*/
 	 for( i = 7 ; i < 17 ; i++ ){
 		 iLeft = -1;

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -335,6 +335,7 @@ struct ph7_expr_node
 #define EXPR_NODE_PRE_INCR    0x01 /* Pre-icrement/decrement [i.e: ++$i,--$j] node */
 #define EXPR_NODE_SPREAD      0x02 /* Argument unpacking: ...$expr */
 #define EXPR_NODE_NAMED_ARG   0x04 /* Named argument: name: $expr */
+#define EXPR_NODE_PARENS      0x08 /* Root of a parenthesized sub-expression */
 /*
  * A block of instructions is recorded in an instance of the following structure.
  * This structure is used only during compile-time and have no meaning
@@ -985,6 +986,7 @@ enum ph7_vm_op {
   PH7_OP_MUL,          /* Multiplication '*' */
   PH7_OP_DIV,          /* Division '/' */
   PH7_OP_MOD,          /* Modulus '%' */
+  PH7_OP_POW,          /* Exponentiation '**' */
   PH7_OP_ADD,          /* Add '+' */
   PH7_OP_SUB,          /* Sub '-' */
   PH7_OP_SHL,          /* Left shift '<<' */
@@ -1023,6 +1025,7 @@ enum ph7_vm_op {
   PH7_OP_MUL_STORE,    /* Mul and store '*=' */
   PH7_OP_DIV_STORE,    /* Div and store '/=' */
   PH7_OP_MOD_STORE,    /* Mod and store '%=' */
+  PH7_OP_POW_STORE,    /* Pow and store '**=' */
   PH7_OP_CAT_STORE,    /* Cat and store '.=' */
   PH7_OP_SHL_STORE,    /* Shift left and store '>>=' */
   PH7_OP_SHR_STORE,    /* Shift right and store '<<=' */
@@ -1082,6 +1085,7 @@ enum ph7_expr_id {
 	EXPR_OP_MUL,       /* Multiplication */
 	EXPR_OP_DIV,       /* division */
 	EXPR_OP_MOD,       /* Modulus */
+	EXPR_OP_POW,       /* Exponentiation ** */
 	EXPR_OP_ADD,       /* Addition */
 	EXPR_OP_SUB,       /* Substraction */
 	EXPR_OP_DOT,       /* Concatenation */
@@ -1113,6 +1117,7 @@ enum ph7_expr_id {
 	EXPR_OP_MUL_ASSIGN, /* Combined operator: *= */
 	EXPR_OP_DIV_ASSIGN, /* Combined operator: /= */
 	EXPR_OP_MOD_ASSIGN, /* Combined operator: %= */
+	EXPR_OP_POW_ASSIGN, /* Combined operator: **= */
 	EXPR_OP_DOT_ASSIGN, /* Combined operator: .= */
 	EXPR_OP_AND_ASSIGN, /* Combined operator: &= */
 	EXPR_OP_OR_ASSIGN,  /* Combined operator: |= */

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -6,6 +6,52 @@
 #include "ph7int.h"
 #include <stddef.h>
 #include <stdlib.h>
+#ifndef PH7_OMIT_FLOATING_POINT
+#include <math.h>
+#endif
+/* Signed 64-bit multiplication with overflow detection. GCC/Clang expose
+ * __builtin_mul_overflow; MSVC does not, so we fall back to a portable
+ * UB-free bound-check implementation. Sets *pR to the wrapped product and
+ * returns non-zero on overflow. The fallback never divides a potentially-
+ * overflowed intermediate: all divisions are of compile-time constants
+ * (LARGEST_INT64/SMALLEST_INT64) by a factor already proven not to be -1,
+ * and the product itself is computed via unsigned multiplication to avoid
+ * signed-overflow UB. */
+#if defined(__GNUC__) || defined(__clang__)
+#define VmMulOverflow64(a,b,pR) __builtin_mul_overflow((a),(b),(pR))
+#else
+static int VmMulOverflow64(sxi64 a, sxi64 b, sxi64 *pR)
+{
+	*pR = (sxi64)((sxu64)a * (sxu64)b);
+	/* Factors of 0 or ±1 never overflow; handle up front so the divisions
+	 * below are guaranteed safe (no SMALLEST_INT64 / -1, no /0). */
+	if( a == 0 || b == 0 || a == 1 || b == 1 ){
+		return 0;
+	}
+	if( a == -1 ){
+		return b == SMALLEST_INT64;
+	}
+	if( b == -1 ){
+		return a == SMALLEST_INT64;
+	}
+	/* |a|,|b| >= 2 and neither is -1.  Bound check against the MAX/MIN
+	 * thresholds.  No division by -1 is possible here, and the quotients
+	 * of compile-time constants by {a,b} always fit in sxi64. */
+	if( a > 0 ){
+		if( b > 0 ){
+			return a > LARGEST_INT64 / b;
+		}else{
+			return b < SMALLEST_INT64 / a;
+		}
+	}else{
+		if( b > 0 ){
+			return a < SMALLEST_INT64 / b;
+		}else{
+			return b < LARGEST_INT64 / a;
+		}
+	}
+}
+#endif
 /*
  * The code in this file implements execution method of the PH7 Virtual Machine.
  * The PH7 compiler (implemented in 'compiler.c' and 'parse.c') generates a bytecode program
@@ -5098,6 +5144,128 @@ case PH7_OP_MUL_STORE: {
 		MemObjSetType(pNos,MEMOBJ_INT);
 	}
 	if( pInstr->iOp == PH7_OP_MUL_STORE ){
+		ph7_value *pObj;
+		if( pTos->nIdx == SXU32_HIGH ){
+			PH7_VmThrowError(&(*pVm),0,PH7_CTX_ERR,"Cannot perform assignment on a constant class attribute");
+		}else if( (pObj = (ph7_value *)SySetAt(&pVm->aMemObj,pTos->nIdx)) != 0 ){
+			PH7_ENFORCE_TYPED_STORE(pTos->nIdx,pNos);
+			PH7_MemObjStore(pNos,pObj);
+		}
+	}
+	VmPopOperand(&pTos,1);
+	break;
+				 }
+/* OP_POW * * *
+ * OP_POW_STORE * * *
+ *
+ * Pop the top two elements from the stack, raise the second to the
+ * power of the first, and push the result. PHP semantics: int**int
+ * stays integer iff the exponent is non-negative and the exact result
+ * fits in sxi64; otherwise the result is a double.
+ */
+case PH7_OP_POW:
+case PH7_OP_POW_STORE: {
+	ph7_value *pNos = &pTos[-1];
+	int bStore = (pInstr->iOp == PH7_OP_POW_STORE);
+	/* Operand order convention (matches DIV/SUB_STORE):
+	 *   POW:       base = pNos (evaluated first),   exp = pTos
+	 *   POW_STORE: base = pTos (lvalue, last),       exp = pNos
+	 */
+	ph7_value *pBase = bStore ? pTos : pNos;
+	ph7_value *pExp  = bStore ? pNos : pTos;
+#ifndef PH7_OMIT_FLOATING_POINT
+	int bBothInt;
+	int usedInt = 0;
+	ph7_real a, b, r;
+#endif
+	sxi64 base_i = 0, exp_i = 0;
+#ifdef UNTRUST
+	if( pNos < pStack ){
+		goto Abort;
+	}
+#endif
+	PH7_MemObjToNumeric(pTos);
+	PH7_MemObjToNumeric(pNos);
+#ifndef PH7_OMIT_FLOATING_POINT
+	bBothInt = ((pTos->iFlags & MEMOBJ_REAL) == 0) &&
+	           ((pNos->iFlags & MEMOBJ_REAL) == 0);
+	if( bBothInt ){
+		base_i = pBase->x.iVal;
+		exp_i  = pExp->x.iVal;
+	}
+	if( (pBase->iFlags & MEMOBJ_REAL) == 0 ){
+		PH7_MemObjToReal(pBase);
+	}
+	if( (pExp->iFlags & MEMOBJ_REAL) == 0 ){
+		PH7_MemObjToReal(pExp);
+	}
+	a = pBase->rVal;
+	b = pExp->rVal;
+	r = pow(a, b);
+	/* Match PHP: int**non-negative-int stays int when the exact result
+	 * fits in sxi64. Use exponentiation by squaring with overflow checks
+	 * rather than casting the double back, because the boundary 2^63 is
+	 * representable as double but not as signed int64. */
+	if( bBothInt && exp_i >= 0 ){
+		sxi64 result_i = 1;
+		sxi64 cur_base = base_i;
+		sxi64 cur_exp  = exp_i;
+		int overflow = 0;
+		while( cur_exp > 0 ){
+			if( cur_exp & 1 ){
+				if( VmMulOverflow64(result_i, cur_base, &result_i) ){
+					overflow = 1;
+					break;
+				}
+			}
+			cur_exp >>= 1;
+			if( cur_exp > 0 ){
+				if( VmMulOverflow64(cur_base, cur_base, &cur_base) ){
+					overflow = 1;
+					break;
+				}
+			}
+		}
+		if( !overflow ){
+			pNos->x.iVal = result_i;
+			MemObjSetType(pNos, MEMOBJ_INT);
+			usedInt = 1;
+		}
+	}
+	if( !usedInt ){
+		pNos->rVal = r;
+		MemObjSetType(pNos, MEMOBJ_REAL);
+	}
+#else
+	/* PH7_OMIT_FLOATING_POINT: integer-only build. No libm / no pow().
+	 * Exponentiation by squaring with silent wrap on overflow, matching
+	 * the integer-wrap semantics of PH7_OP_MUL in the same build mode.
+	 * Negative exponents yield 0 since fractional results cannot be
+	 * represented. */
+	base_i = pBase->x.iVal;
+	exp_i  = pExp->x.iVal;
+	{
+		sxi64 result_i = 1;
+		sxi64 cur_base = base_i;
+		sxi64 cur_exp  = exp_i;
+		if( cur_exp < 0 ){
+			result_i = 0;
+		}else{
+			while( cur_exp > 0 ){
+				if( cur_exp & 1 ){
+					result_i *= cur_base;
+				}
+				cur_exp >>= 1;
+				if( cur_exp > 0 ){
+					cur_base *= cur_base;
+				}
+			}
+		}
+		pNos->x.iVal = result_i;
+		MemObjSetType(pNos, MEMOBJ_INT);
+	}
+#endif /* PH7_OMIT_FLOATING_POINT */
+	if( bStore ){
 		ph7_value *pObj;
 		if( pTos->nIdx == SXU32_HIGH ){
 			PH7_VmThrowError(&(*pVm),0,PH7_CTX_ERR,"Cannot perform assignment on a constant class attribute");

--- a/tests/ph7/001-smoke/lang/exponentiation_assignment.phpt
+++ b/tests/ph7/001-smoke/lang/exponentiation_assignment.phpt
@@ -1,0 +1,62 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Power-assignment operator **= (PHP 5.6)
+--FILE--
+<?php
+$a = 2;
+$a **= 10;
+echo $a, "\n";
+echo is_int($a) ? "int\n" : "float\n";
+
+$b = 3;
+$b **= 0;
+echo $b, "\n";
+echo is_int($b) ? "int\n" : "float\n";
+
+$c = 2;
+$c **= 3;
+$c **= 2;
+echo $c, "\n";
+echo is_int($c) ? "int\n" : "float\n";
+
+$d = 10;
+$d **= 3;
+echo $d, "\n";
+echo is_int($d) ? "int\n" : "float\n";
+
+$e = 2.5;
+$e **= 2;
+echo $e, "\n";
+echo is_float($e) ? "float\n" : "int\n";
+
+$arr = [2, 3];
+$arr[0] **= 3;
+echo $arr[0], "\n";
+echo is_int($arr[0]) ? "int\n" : "float\n";
+
+class PowTestHost { public int $n = 2; }
+$o = new PowTestHost();
+$o->n **= 4;
+echo $o->n, "\n";
+echo is_int($o->n) ? "int\n" : "float\n";
+?>
+--EXPECT--
+1024
+int
+1
+int
+64
+int
+1000
+int
+6.25
+float
+8
+int
+16
+int
+--CLEAN--
+<?php
+unset($a, $b, $c, $d, $e, $arr, $o);

--- a/tests/ph7/001-smoke/lang/exponentiation_operator.phpt
+++ b/tests/ph7/001-smoke/lang/exponentiation_operator.phpt
@@ -1,0 +1,41 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Exponentiation operator ** (PHP 5.6)
+--FILE--
+<?php
+echo 2 ** 10, "\n";
+echo 2 ** 0, "\n";
+echo 0 ** 0, "\n";
+echo 0 ** 5, "\n";
+echo 1 ** 50, "\n";
+echo 10 ** 3, "\n";
+echo 2 ** 3 ** 2, "\n";
+echo (2 ** 3) ** 2, "\n";
+echo 2.5 ** 2, "\n";
+echo 2 ** -2, "\n";
+echo (-2) ** 3, "\n";
+echo (-2) ** 2, "\n";
+echo 2 ** 3, "\n";
+echo is_int(2 ** 3) ? "int\n" : "float\n";
+echo 3 ** 4, "\n";
+echo is_int(3 ** 4) ? "int\n" : "float\n";
+?>
+--EXPECT--
+1024
+1
+1
+0
+1
+1000
+512
+64
+6.25
+0.25
+-8
+4
+8
+int
+81
+int

--- a/tests/ph7/001-smoke/lang/exponentiation_overflow.phpt
+++ b/tests/ph7/001-smoke/lang/exponentiation_overflow.phpt
@@ -1,0 +1,34 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Exponentiation: integer overflow promotes to float
+--FILE--
+<?php
+// 2^62 fits in signed int64: stays int
+echo 2 ** 62, "\n";
+echo is_int(2 ** 62) ? "int\n" : "float\n";
+
+// 2^63 overflows signed int64: becomes float
+echo is_float(2 ** 63) ? "float\n" : "int\n";
+
+// Large base squared overflows
+echo is_float(PHP_INT_MAX ** 2) ? "float\n" : "int\n";
+
+// Float operand makes result float even when magnitude fits
+echo is_float(2.0 ** 3) ? "float\n" : "int\n";
+echo is_float(2 ** 3.0) ? "float\n" : "int\n";
+
+// Integer stays integer when both operands are int and exponent >= 0
+echo is_int(3 ** 10) ? "int\n" : "float\n";
+echo is_int(7 ** 7) ? "int\n" : "float\n";
+?>
+--EXPECT--
+4611686018427387904
+int
+float
+float
+float
+float
+int
+int

--- a/tests/ph7/001-smoke/lang/exponentiation_precedence.phpt
+++ b/tests/ph7/001-smoke/lang/exponentiation_precedence.phpt
@@ -1,0 +1,86 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Exponentiation precedence vs *, /, %, +, unary, cast, parens
+--FILE--
+<?php
+// ** tighter than * / %
+echo 2 * 3 ** 2, "\n";       // 2 * 9 = 18
+echo 3 ** 2 * 2, "\n";       // 9 * 2 = 18
+echo 2 ** 3 / 2, "\n";       // 8 / 2 = 4
+echo 2 ** 3 % 5, "\n";       // 8 % 5 = 3
+
+// ** tighter than +
+echo 2 ** 3 + 1, "\n";       // 8 + 1 = 9
+echo 2 ** (3 + 1), "\n";     // 2 ** 4 = 16
+
+// ** right-associative
+echo 2 ** 3 ** 2, "\n";      // 2 ** (3 ** 2) = 512
+echo 4 ** 2 ** 2, "\n";      // 4 ** 4 = 256
+echo 2 ** -3 ** 2, "\n";     // 2 ** (-(3**2)) = 2 ** -9
+
+// ** binds tighter than unary -, +, ~, (cast)
+echo -2 ** 2, "\n";          // -(2**2) = -4
+echo -3 ** 3, "\n";          // -(3**3) = -27
+echo ~2 ** 2, "\n";          // ~(2**2) = ~4 = -5
+echo (int) 2.5 ** 2, "\n";   // (int)(2.5**2) = (int)6.25 = 6
+echo (float) 2 ** 3, "\n";   // (float)(2**3) = 8
+
+// Nested unary preserves order: - -2 ** 2 = -(-(2**2)) = -(-4) = 4
+echo - -2 ** 2, "\n";
+echo ~-2 ** 2, "\n";         // ~(-(2**2)) = ~(-4) = 3
+
+// Parens override the unary hoist
+echo (-2) ** 2, "\n";        // 4
+echo (-2) ** 3, "\n";        // -8
+echo -(-2) ** 3, "\n";       // -((-2)**3) = -(-8) = 8
+
+// ! has lower precedence than ** in PHP — hoist still gives the right answer
+echo !2 ** 2 ? "T" : "F", "\n";  // !(2**2) = !4 = false
+
+// Negative exponent yields float
+echo 2 ** -2, "\n";          // 0.25
+
+// Interplay with variables and compound assign
+$a = 2;
+$a = 3 ** $a;
+echo $a, "\n";               // 9
+$b = 5;
+$b **= 2;
+echo $b, "\n";               // 25
+
+// Non-commutative **= (operand order sanity)
+$c = 3; $c **= 2; echo $c, "\n";   // 9
+$d = 2; $d **= 3; echo $d, "\n";   // 8
+
+// String operands are coerced to int
+echo "2" ** "10", "\n";      // 1024
+?>
+--EXPECT--
+18
+18
+4
+3
+9
+16
+512
+256
+0.001953125
+-4
+-27
+-5
+6
+8
+4
+3
+4
+-8
+8
+F
+0.25
+9
+25
+9
+8
+1024


### PR DESCRIPTION
Right-associative with precedence tighter than * and tighter than unary -/+/~/(cast); integer**non-negative-integer preserves int via exp-by-squaring with overflow detection, falling back to float on overflow or non-integer operands. Parenthesised sub-expressions are tagged so the -X ** Y hoist does not wrap an explicitly isolated unary.
