### PR TITLE
Implement str_contains, str_starts_with, str_ends_with (PHP 8.0)

### DIFF
--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -2624,6 +2624,206 @@ static int PH7_builtin_strpos(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	return PH7_OK;
 }
 /*
+ * Validate and resolve a single string-typed parameter for str_contains/
+ * str_starts_with/str_ends_with. Emits an E_DEPRECATED notice for null
+ * (matching PHP 8.1+; falls through with an empty string), and throws
+ * TypeError for arrays, resources, and objects without __toString.
+ *
+ * For objects with __toString, invokes the method directly into pTmp and
+ * uses its raw byte buffer. This preserves empty results, which the
+ * engine's MemObjStringValue otherwise replaces with the literal "Object".
+ *
+ * On success, pzOut/pnOut point at the resolved byte buffer; the buffer
+ * is valid until pTmp is released or pArg is mutated.
+ */
+static sxi32 StrPredicateResolveArg(
+	ph7_context *pCtx,
+	ph7_value *pArg,
+	const char *zFunc,
+	int iArgNum,
+	const char *zParamName,
+	const char *zNullMsg,
+	ph7_value *pTmp,
+	const char **pzOut,
+	int *pnOut
+){
+	if( ph7_value_is_null(pArg) ){
+		PH7_VmThrowError(pCtx->pVm,0,E_DEPRECATED,zNullMsg);
+		*pzOut = "";
+		*pnOut = 0;
+		return PH7_OK;
+	}
+	if( ph7_value_is_array(pArg) || ph7_value_is_resource(pArg) ||
+	    ( ph7_value_is_object(pArg) &&
+	      ((ph7_class_instance *)pArg->x.pOther) != 0 &&
+	      PH7_ClassExtractMethod(((ph7_class_instance *)pArg->x.pOther)->pClass,
+	        "__toString",sizeof("__toString")-1) == 0
+	    )
+	){
+		const char *zType = ph7_type_name(pArg);
+		if( ph7_value_is_object(pArg) ){
+			ph7_class_instance *pInst = (ph7_class_instance *)pArg->x.pOther;
+			if( pInst && pInst->pClass ){
+				zType = SyStringData(&pInst->pClass->sName);
+			}
+		}
+		return PH7_VmThrowException(pCtx,
+			"TypeError",
+			"%s(): Argument #%d (%s) must be of type string, %s given",
+			zFunc, iArgNum, zParamName, zType
+			);
+	}
+	if( ph7_value_is_object(pArg) ){
+		ph7_class_instance *pInst = (ph7_class_instance *)pArg->x.pOther;
+		ph7_class_method *pMethod = PH7_ClassExtractMethod(pInst->pClass,
+			"__toString",sizeof("__toString")-1);
+		PH7_VmCallClassMethod(pCtx->pVm,pInst,pMethod,pTmp,0,0);
+		*pzOut = (const char *)SyBlobData(&pTmp->sBlob);
+		*pnOut = (int)SyBlobLength(&pTmp->sBlob);
+		return PH7_OK;
+	}
+	*pzOut = ph7_value_to_string(pArg,pnOut);
+	return PH7_OK;
+}
+/*
+ * bool str_contains(string $haystack, string $needle)
+ *  Determine if a string contains a given substring (PHP 8.0).
+ * Return
+ *  TRUE if needle occurs in haystack. An empty needle always returns TRUE.
+ */
+static int PH7_builtin_str_contains(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	const char *zHaystack,*zNeedle;
+	int nHayLen,nNeedleLen;
+	ph7_value sHayTmp,sNeedleTmp;
+	sxi32 rc;
+	if( nArg != 2 ){
+		return PH7_VmThrowException(pCtx,
+			"ArgumentCountError",
+			"str_contains() expects exactly 2 arguments, %d given",
+			nArg
+			);
+	}
+	PH7_MemObjInit(pCtx->pVm,&sHayTmp);
+	PH7_MemObjInit(pCtx->pVm,&sNeedleTmp);
+	rc = StrPredicateResolveArg(pCtx,apArg[0],"str_contains",1,"$haystack",
+		"str_contains(): Passing null to parameter #1 ($haystack) "
+		"of type string is deprecated",
+		&sHayTmp,&zHaystack,&nHayLen);
+	if( rc != PH7_OK ) goto out;
+	rc = StrPredicateResolveArg(pCtx,apArg[1],"str_contains",2,"$needle",
+		"str_contains(): Passing null to parameter #2 ($needle) "
+		"of type string is deprecated",
+		&sNeedleTmp,&zNeedle,&nNeedleLen);
+	if( rc != PH7_OK ) goto out;
+	if( nNeedleLen < 1 ){
+		ph7_result_bool(pCtx,1);
+	}else if( nHayLen < nNeedleLen ){
+		ph7_result_bool(pCtx,0);
+	}else{
+		sxi32 srch = SyBlobSearch((const void *)zHaystack,(sxu32)nHayLen,
+		                          (const void *)zNeedle,(sxu32)nNeedleLen,0);
+		ph7_result_bool(pCtx,srch == SXRET_OK ? 1 : 0);
+	}
+	rc = PH7_OK;
+out:
+	PH7_MemObjRelease(&sHayTmp);
+	PH7_MemObjRelease(&sNeedleTmp);
+	return rc;
+}
+/*
+ * bool str_starts_with(string $haystack, string $needle)
+ *  Check if a string starts with a given substring (PHP 8.0).
+ * Return
+ *  TRUE if haystack begins with needle. An empty needle always returns TRUE.
+ *  Comparison is binary-safe (uses SyMemcmp, not SyStrncmp).
+ */
+static int PH7_builtin_str_starts_with(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	const char *zHaystack,*zNeedle;
+	int nHayLen,nNeedleLen;
+	ph7_value sHayTmp,sNeedleTmp;
+	sxi32 rc;
+	if( nArg != 2 ){
+		return PH7_VmThrowException(pCtx,
+			"ArgumentCountError",
+			"str_starts_with() expects exactly 2 arguments, %d given",
+			nArg
+			);
+	}
+	PH7_MemObjInit(pCtx->pVm,&sHayTmp);
+	PH7_MemObjInit(pCtx->pVm,&sNeedleTmp);
+	rc = StrPredicateResolveArg(pCtx,apArg[0],"str_starts_with",1,"$haystack",
+		"str_starts_with(): Passing null to parameter #1 ($haystack) "
+		"of type string is deprecated",
+		&sHayTmp,&zHaystack,&nHayLen);
+	if( rc != PH7_OK ) goto out;
+	rc = StrPredicateResolveArg(pCtx,apArg[1],"str_starts_with",2,"$needle",
+		"str_starts_with(): Passing null to parameter #2 ($needle) "
+		"of type string is deprecated",
+		&sNeedleTmp,&zNeedle,&nNeedleLen);
+	if( rc != PH7_OK ) goto out;
+	if( nNeedleLen < 1 ){
+		ph7_result_bool(pCtx,1);
+	}else if( nHayLen < nNeedleLen ){
+		ph7_result_bool(pCtx,0);
+	}else{
+		ph7_result_bool(pCtx,
+			SyMemcmp(zHaystack,zNeedle,(sxu32)nNeedleLen) == 0 ? 1 : 0);
+	}
+	rc = PH7_OK;
+out:
+	PH7_MemObjRelease(&sHayTmp);
+	PH7_MemObjRelease(&sNeedleTmp);
+	return rc;
+}
+/*
+ * bool str_ends_with(string $haystack, string $needle)
+ *  Check if a string ends with a given substring (PHP 8.0).
+ * Return
+ *  TRUE if haystack ends with needle. An empty needle always returns TRUE.
+ *  Comparison is binary-safe (uses SyMemcmp, not SyStrncmp).
+ */
+static int PH7_builtin_str_ends_with(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	const char *zHaystack,*zNeedle;
+	int nHayLen,nNeedleLen;
+	ph7_value sHayTmp,sNeedleTmp;
+	sxi32 rc;
+	if( nArg != 2 ){
+		return PH7_VmThrowException(pCtx,
+			"ArgumentCountError",
+			"str_ends_with() expects exactly 2 arguments, %d given",
+			nArg
+			);
+	}
+	PH7_MemObjInit(pCtx->pVm,&sHayTmp);
+	PH7_MemObjInit(pCtx->pVm,&sNeedleTmp);
+	rc = StrPredicateResolveArg(pCtx,apArg[0],"str_ends_with",1,"$haystack",
+		"str_ends_with(): Passing null to parameter #1 ($haystack) "
+		"of type string is deprecated",
+		&sHayTmp,&zHaystack,&nHayLen);
+	if( rc != PH7_OK ) goto out;
+	rc = StrPredicateResolveArg(pCtx,apArg[1],"str_ends_with",2,"$needle",
+		"str_ends_with(): Passing null to parameter #2 ($needle) "
+		"of type string is deprecated",
+		&sNeedleTmp,&zNeedle,&nNeedleLen);
+	if( rc != PH7_OK ) goto out;
+	if( nNeedleLen < 1 ){
+		ph7_result_bool(pCtx,1);
+	}else if( nHayLen < nNeedleLen ){
+		ph7_result_bool(pCtx,0);
+	}else{
+		ph7_result_bool(pCtx,
+			SyMemcmp(zHaystack + (nHayLen - nNeedleLen),zNeedle,(sxu32)nNeedleLen) == 0 ? 1 : 0);
+	}
+	rc = PH7_OK;
+out:
+	PH7_MemObjRelease(&sHayTmp);
+	PH7_MemObjRelease(&sNeedleTmp);
+	return rc;
+}
+/*
  * int stripos(string $haystack,string $needle [,int $offset = 0 ] )
  *  Case-insensitive strpos.
  * Parameters
@@ -6701,6 +6901,9 @@ static const ph7_builtin_func aBuiltInFunc[] = {
 	{ "strrev",       PH7_builtin_strrev     },
 	{ "ucwords",      PH7_builtin_ucwords    },
 	{ "str_repeat",   PH7_builtin_str_repeat },
+	{ "str_contains", PH7_builtin_str_contains },
+	{ "str_starts_with", PH7_builtin_str_starts_with },
+	{ "str_ends_with", PH7_builtin_str_ends_with },
 	{ "nl2br",        PH7_builtin_nl2br      },
 #endif /* PH7_NEED_BUILTIN_REG */
 #ifdef PH7_NEED_FMT_AND_INI

--- a/tests/ph7/001-smoke/function/str_contains/str_contains.phpt
+++ b/tests/ph7/001-smoke/function/str_contains/str_contains.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_contains finds substring
+--FILE--
+<?php
+echo "match=" . (str_contains("Hello World", "World") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+match=true
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_contains/str_contains_argcount_error.phpt
+++ b/tests/ph7/001-smoke/function/str_contains/str_contains_argcount_error.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_contains throws ArgumentCountError on wrong arg count
+--FILE--
+<?php
+try { str_contains(); } catch (ArgumentCountError $e) { echo "0:" . $e->getMessage() . "\n"; }
+try { str_contains("a"); } catch (ArgumentCountError $e) { echo "1:" . $e->getMessage() . "\n"; }
+try { str_contains("a", "b", "c"); } catch (ArgumentCountError $e) { echo "3:" . $e->getMessage() . "\n"; }
+?>
+--EXPECT--
+0:str_contains() expects exactly 2 arguments, 0 given
+1:str_contains() expects exactly 2 arguments, 1 given
+3:str_contains() expects exactly 2 arguments, 3 given
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_contains/str_contains_binary.phpt
+++ b/tests/ph7/001-smoke/function/str_contains/str_contains_binary.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_contains is binary-safe (NUL and UTF-8 bytes)
+--FILE--
+<?php
+echo "utf8="              . (str_contains("caf\xC3\xA9 latte", "\xC3\xA9") ? 'true' : 'false') . "\n";
+echo "nulbyte="           . (str_contains("a\x00b\x00c", "\x00b") ? 'true' : 'false') . "\n";
+echo "match_after_nul="   . (str_contains("zza\x00Yzz", "a\x00Y") ? 'true' : 'false') . "\n";
+echo "diverge_after_nul=" . (str_contains("a\x00X", "a\x00Y") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+utf8=true
+nulbyte=true
+match_after_nul=true
+diverge_after_nul=false
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_contains/str_contains_both_empty.phpt
+++ b/tests/ph7/001-smoke/function/str_contains/str_contains_both_empty.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_contains both empty returns true
+--FILE--
+<?php
+echo "match=" . (str_contains("", "") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+match=true
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_contains/str_contains_case_sensitive.phpt
+++ b/tests/ph7/001-smoke/function/str_contains/str_contains_case_sensitive.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_contains is case-sensitive
+--FILE--
+<?php
+echo "lower=" . (str_contains("Hello World", "hello") ? 'true' : 'false') . "\n";
+echo "upper=" . (str_contains("Hello World", "WORLD") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+lower=false
+upper=false
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_contains/str_contains_coercion.phpt
+++ b/tests/ph7/001-smoke/function/str_contains/str_contains_coercion.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_contains coerces scalar needle to string
+--FILE--
+<?php
+echo "int="     . (str_contains("test123",  123)   ? 'true' : 'false') . "\n";
+echo "intzero=" . (str_contains("a0b",      0)     ? 'true' : 'false') . "\n";
+echo "float="   . (str_contains("pi=3.14",  3.14)  ? 'true' : 'false') . "\n";
+echo "booltrue=" . (str_contains("a1b",     true)  ? 'true' : 'false') . "\n";
+echo "boolfalse=" . (str_contains("abc",    false) ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+int=true
+intzero=true
+float=true
+booltrue=true
+boolfalse=true
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_contains/str_contains_empty_haystack.phpt
+++ b/tests/ph7/001-smoke/function/str_contains/str_contains_empty_haystack.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_contains empty haystack with non-empty needle returns false
+--FILE--
+<?php
+echo "match=" . (str_contains("", "x") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+match=false
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_contains/str_contains_empty_needle.phpt
+++ b/tests/ph7/001-smoke/function/str_contains/str_contains_empty_needle.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_contains empty needle returns true
+--FILE--
+<?php
+echo "match=" . (str_contains("Hello", "") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+match=true
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_contains/str_contains_equal.phpt
+++ b/tests/ph7/001-smoke/function/str_contains/str_contains_equal.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_contains needle equal to haystack returns true
+--FILE--
+<?php
+echo "match=" . (str_contains("abcdef", "abcdef") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+match=true
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_contains/str_contains_mismatch.phpt
+++ b/tests/ph7/001-smoke/function/str_contains/str_contains_mismatch.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_contains absent substring returns false
+--FILE--
+<?php
+echo "match=" . (str_contains("Hello World", "Mars") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+match=false
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_contains/str_contains_needle_longer.phpt
+++ b/tests/ph7/001-smoke/function/str_contains/str_contains_needle_longer.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_contains needle longer than haystack returns false
+--FILE--
+<?php
+echo "match=" . (str_contains("abc", "abcd") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+match=false
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_contains/str_contains_null_deprecated.phpt
+++ b/tests/ph7/001-smoke/function/str_contains/str_contains_null_deprecated.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_contains emits E_DEPRECATED on null and falls through to coerce as ""
+--FILE--
+<?php
+set_error_handler(function ($errno, $errstr) {
+    echo "DEP[" . $errno . "]: " . $errstr . "\n";
+    return true;
+});
+echo "h_null=" . (str_contains(null, "x") ? 'true' : 'false') . "\n";
+echo "n_null=" . (str_contains("abc", null) ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+DEP[8192]: str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated
+h_null=false
+DEP[8192]: str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated
+n_null=true
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_contains/str_contains_overlap.phpt
+++ b/tests/ph7/001-smoke/function/str_contains/str_contains_overlap.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_contains finds overlapping and repeating patterns
+--FILE--
+<?php
+echo "overlap="   . (str_contains("abab",   "aba") ? 'true' : 'false') . "\n";
+echo "repeat="    . (str_contains("aaaa",   "aa")  ? 'true' : 'false') . "\n";
+echo "near_miss=" . (str_contains("ababab", "abc") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+overlap=true
+repeat=true
+near_miss=false
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_contains/str_contains_stringable.phpt
+++ b/tests/ph7/001-smoke/function/str_contains/str_contains_stringable.phpt
@@ -1,0 +1,30 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_contains accepts an object with __toString()
+--FILE--
+<?php
+class StringableContains {
+    public function __toString(): string { return "Hello World"; }
+}
+class EmptyStringableContains {
+    public function __toString(): string { return ""; }
+}
+$obj = new StringableContains();
+$empty = new EmptyStringableContains();
+echo "h_obj="        . (str_contains($obj, "World") ? 'true' : 'false') . "\n";
+echo "n_obj="        . (str_contains("Greetings, Hello World", $obj) ? 'true' : 'false') . "\n";
+echo "n_empty_obj="  . (str_contains("abc", $empty) ? 'true' : 'false') . "\n";
+echo "h_empty_obj="  . (str_contains($empty, "x") ? 'true' : 'false') . "\n";
+echo "both_empty="   . (str_contains($empty, $empty) ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+h_obj=true
+n_obj=true
+n_empty_obj=true
+h_empty_obj=false
+both_empty=true
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_contains/str_contains_type_error.phpt
+++ b/tests/ph7/001-smoke/function/str_contains/str_contains_type_error.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_contains throws TypeError for array/object args
+--FILE--
+<?php
+class NoToStringContains {}
+try { str_contains(array(), "x"); } catch (TypeError $e) { echo "h_arr:" . $e->getMessage() . "\n"; }
+try { str_contains("x", array()); } catch (TypeError $e) { echo "n_arr:" . $e->getMessage() . "\n"; }
+try { str_contains(new NoToStringContains(), "x"); } catch (TypeError $e) { echo "h_obj:" . $e->getMessage() . "\n"; }
+try { str_contains("x", new NoToStringContains()); } catch (TypeError $e) { echo "n_obj:" . $e->getMessage() . "\n"; }
+?>
+--EXPECT--
+h_arr:str_contains(): Argument #1 ($haystack) must be of type string, array given
+n_arr:str_contains(): Argument #2 ($needle) must be of type string, array given
+h_obj:str_contains(): Argument #1 ($haystack) must be of type string, NoToStringContains given
+n_obj:str_contains(): Argument #2 ($needle) must be of type string, NoToStringContains given
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_ends_with/str_ends_with.phpt
+++ b/tests/ph7/001-smoke/function/str_ends_with/str_ends_with.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_ends_with suffix match
+--FILE--
+<?php
+echo "match=" . (str_ends_with("Hello World", "World") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+match=true
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_argcount_error.phpt
+++ b/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_argcount_error.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_ends_with throws ArgumentCountError on wrong arg count
+--FILE--
+<?php
+try { str_ends_with(); } catch (ArgumentCountError $e) { echo "0:" . $e->getMessage() . "\n"; }
+try { str_ends_with("a"); } catch (ArgumentCountError $e) { echo "1:" . $e->getMessage() . "\n"; }
+try { str_ends_with("a", "b", "c"); } catch (ArgumentCountError $e) { echo "3:" . $e->getMessage() . "\n"; }
+?>
+--EXPECT--
+0:str_ends_with() expects exactly 2 arguments, 0 given
+1:str_ends_with() expects exactly 2 arguments, 1 given
+3:str_ends_with() expects exactly 2 arguments, 3 given
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_binary.phpt
+++ b/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_binary.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_ends_with is binary-safe (NUL and UTF-8 bytes)
+--FILE--
+<?php
+echo "utf8="              . (str_ends_with("caf\xC3\xA9", "\xC3\xA9") ? 'true' : 'false') . "\n";
+echo "nulbyte="           . (str_ends_with("abc\x00", "\x00") ? 'true' : 'false') . "\n";
+echo "match_after_nul="   . (str_ends_with("zza\x00Y", "a\x00Y") ? 'true' : 'false') . "\n";
+echo "diverge_after_nul=" . (str_ends_with("zza\x00X", "a\x00Y") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+utf8=true
+nulbyte=true
+match_after_nul=true
+diverge_after_nul=false
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_both_empty.phpt
+++ b/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_both_empty.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_ends_with both empty returns true
+--FILE--
+<?php
+echo "match=" . (str_ends_with("", "") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+match=true
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_case_sensitive.phpt
+++ b/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_case_sensitive.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_ends_with is case-sensitive
+--FILE--
+<?php
+echo "match=" . (str_ends_with("Hello World", "WORLD") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+match=false
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_coercion.phpt
+++ b/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_coercion.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_ends_with coerces scalar needle to string
+--FILE--
+<?php
+echo "int="       . (str_ends_with("abc123",    123)   ? 'true' : 'false') . "\n";
+echo "intzero="   . (str_ends_with("xyz0",      0)     ? 'true' : 'false') . "\n";
+echo "float="     . (str_ends_with("pi=3.14",   3.14)  ? 'true' : 'false') . "\n";
+echo "booltrue="  . (str_ends_with("test1",     true)  ? 'true' : 'false') . "\n";
+echo "boolfalse=" . (str_ends_with("hello",     false) ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+int=true
+intzero=true
+float=true
+booltrue=true
+boolfalse=true
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_empty_haystack.phpt
+++ b/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_empty_haystack.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_ends_with empty haystack with non-empty needle returns false
+--FILE--
+<?php
+echo "match=" . (str_ends_with("", "x") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+match=false
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_empty_needle.phpt
+++ b/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_empty_needle.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_ends_with empty needle returns true
+--FILE--
+<?php
+echo "match=" . (str_ends_with("Hello", "") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+match=true
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_equal.phpt
+++ b/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_equal.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_ends_with needle equal to haystack returns true
+--FILE--
+<?php
+echo "match=" . (str_ends_with("abcdef", "abcdef") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+match=true
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_mismatch.phpt
+++ b/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_mismatch.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_ends_with wrong suffix returns false
+--FILE--
+<?php
+echo "match=" . (str_ends_with("Hello World", "Hello") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+match=false
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_needle_longer.phpt
+++ b/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_needle_longer.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_ends_with needle longer than haystack returns false
+--FILE--
+<?php
+echo "match=" . (str_ends_with("abc", "abcd") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+match=false
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_not_at_end.phpt
+++ b/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_not_at_end.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_ends_with rejects substring not at end
+--FILE--
+<?php
+echo "middle=" . (str_ends_with("Hello World", "Worl") ? 'true' : 'false') . "\n";
+echo "start="  . (str_ends_with("Hello World", "Hello") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+middle=false
+start=false
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_null_deprecated.phpt
+++ b/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_null_deprecated.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_ends_with emits E_DEPRECATED on null and falls through to coerce as ""
+--FILE--
+<?php
+set_error_handler(function ($errno, $errstr) {
+    echo "DEP[" . $errno . "]: " . $errstr . "\n";
+    return true;
+});
+echo "h_null=" . (str_ends_with(null, "x") ? 'true' : 'false') . "\n";
+echo "n_null=" . (str_ends_with("abc", null) ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+DEP[8192]: str_ends_with(): Passing null to parameter #1 ($haystack) of type string is deprecated
+h_null=false
+DEP[8192]: str_ends_with(): Passing null to parameter #2 ($needle) of type string is deprecated
+n_null=true
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_partial.phpt
+++ b/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_partial.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_ends_with rejects suffix that diverges in earlier byte
+--FILE--
+<?php
+echo "diverge_first=" . (str_ends_with("xyzabc", "Xabc") ? 'true' : 'false') . "\n";
+echo "diverge_mid="   . (str_ends_with("abcdef", "cdXf") ? 'true' : 'false') . "\n";
+echo "exact_suffix="  . (str_ends_with("abcdef", "def")  ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+diverge_first=false
+diverge_mid=false
+exact_suffix=true
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_stringable.phpt
+++ b/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_stringable.phpt
@@ -1,0 +1,30 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_ends_with accepts an object with __toString()
+--FILE--
+<?php
+class StringableEndsWith {
+    public function __toString(): string { return "World"; }
+}
+class EmptyStringableEndsWith {
+    public function __toString(): string { return ""; }
+}
+$obj = new StringableEndsWith();
+$empty = new EmptyStringableEndsWith();
+echo "h_obj="       . (str_ends_with($obj, "rld") ? 'true' : 'false') . "\n";
+echo "n_obj="       . (str_ends_with("Hello World", $obj) ? 'true' : 'false') . "\n";
+echo "n_empty_obj=" . (str_ends_with("abc", $empty) ? 'true' : 'false') . "\n";
+echo "h_empty_obj=" . (str_ends_with($empty, "x") ? 'true' : 'false') . "\n";
+echo "both_empty="  . (str_ends_with($empty, $empty) ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+h_obj=true
+n_obj=true
+n_empty_obj=true
+h_empty_obj=false
+both_empty=true
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_type_error.phpt
+++ b/tests/ph7/001-smoke/function/str_ends_with/str_ends_with_type_error.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_ends_with throws TypeError for array/object args
+--FILE--
+<?php
+class NoToStringEndsWith {}
+try { str_ends_with(array(), "x"); } catch (TypeError $e) { echo "h_arr:" . $e->getMessage() . "\n"; }
+try { str_ends_with("x", array()); } catch (TypeError $e) { echo "n_arr:" . $e->getMessage() . "\n"; }
+try { str_ends_with(new NoToStringEndsWith(), "x"); } catch (TypeError $e) { echo "h_obj:" . $e->getMessage() . "\n"; }
+try { str_ends_with("x", new NoToStringEndsWith()); } catch (TypeError $e) { echo "n_obj:" . $e->getMessage() . "\n"; }
+?>
+--EXPECT--
+h_arr:str_ends_with(): Argument #1 ($haystack) must be of type string, array given
+n_arr:str_ends_with(): Argument #2 ($needle) must be of type string, array given
+h_obj:str_ends_with(): Argument #1 ($haystack) must be of type string, NoToStringEndsWith given
+n_obj:str_ends_with(): Argument #2 ($needle) must be of type string, NoToStringEndsWith given
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_starts_with/str_starts_with.phpt
+++ b/tests/ph7/001-smoke/function/str_starts_with/str_starts_with.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_starts_with prefix match
+--FILE--
+<?php
+echo "match=" . (str_starts_with("Hello World", "Hello") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+match=true
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_argcount_error.phpt
+++ b/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_argcount_error.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_starts_with throws ArgumentCountError on wrong arg count
+--FILE--
+<?php
+try { str_starts_with(); } catch (ArgumentCountError $e) { echo "0:" . $e->getMessage() . "\n"; }
+try { str_starts_with("a"); } catch (ArgumentCountError $e) { echo "1:" . $e->getMessage() . "\n"; }
+try { str_starts_with("a", "b", "c"); } catch (ArgumentCountError $e) { echo "3:" . $e->getMessage() . "\n"; }
+?>
+--EXPECT--
+0:str_starts_with() expects exactly 2 arguments, 0 given
+1:str_starts_with() expects exactly 2 arguments, 1 given
+3:str_starts_with() expects exactly 2 arguments, 3 given
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_binary.phpt
+++ b/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_binary.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_starts_with is binary-safe (NUL and UTF-8 bytes)
+--FILE--
+<?php
+echo "utf8="              . (str_starts_with("\xC3\xA9clair", "\xC3\xA9") ? 'true' : 'false') . "\n";
+echo "nulbyte="           . (str_starts_with("\x00abc", "\x00") ? 'true' : 'false') . "\n";
+echo "match_after_nul="   . (str_starts_with("a\x00Yzz", "a\x00Y") ? 'true' : 'false') . "\n";
+echo "diverge_after_nul=" . (str_starts_with("a\x00X", "a\x00Y") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+utf8=true
+nulbyte=true
+match_after_nul=true
+diverge_after_nul=false
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_both_empty.phpt
+++ b/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_both_empty.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_starts_with both empty returns true
+--FILE--
+<?php
+echo "match=" . (str_starts_with("", "") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+match=true
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_case_sensitive.phpt
+++ b/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_case_sensitive.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_starts_with is case-sensitive
+--FILE--
+<?php
+echo "match=" . (str_starts_with("Hello World", "hello") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+match=false
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_coercion.phpt
+++ b/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_coercion.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_starts_with coerces scalar needle to string
+--FILE--
+<?php
+echo "int="       . (str_starts_with("123abc",   123)   ? 'true' : 'false') . "\n";
+echo "intzero="   . (str_starts_with("0xyz",     0)     ? 'true' : 'false') . "\n";
+echo "float="     . (str_starts_with("3.14pi",   3.14)  ? 'true' : 'false') . "\n";
+echo "booltrue="  . (str_starts_with("1abc",     true)  ? 'true' : 'false') . "\n";
+echo "boolfalse=" . (str_starts_with("hello",    false) ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+int=true
+intzero=true
+float=true
+booltrue=true
+boolfalse=true
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_empty_haystack.phpt
+++ b/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_empty_haystack.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_starts_with empty haystack with non-empty needle returns false
+--FILE--
+<?php
+echo "match=" . (str_starts_with("", "x") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+match=false
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_empty_needle.phpt
+++ b/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_empty_needle.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_starts_with empty needle returns true
+--FILE--
+<?php
+echo "match=" . (str_starts_with("Hello", "") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+match=true
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_equal.phpt
+++ b/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_equal.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_starts_with needle equal to haystack returns true
+--FILE--
+<?php
+echo "match=" . (str_starts_with("abcdef", "abcdef") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+match=true
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_mismatch.phpt
+++ b/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_mismatch.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_starts_with wrong prefix returns false
+--FILE--
+<?php
+echo "match=" . (str_starts_with("Hello World", "World") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+match=false
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_needle_longer.phpt
+++ b/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_needle_longer.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_starts_with needle longer than haystack returns false
+--FILE--
+<?php
+echo "match=" . (str_starts_with("abc", "abcd") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+match=false
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_not_at_start.phpt
+++ b/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_not_at_start.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_starts_with rejects substring not at start
+--FILE--
+<?php
+echo "middle=" . (str_starts_with("Hello World", "ello") ? 'true' : 'false') . "\n";
+echo "end="    . (str_starts_with("Hello World", "World") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+middle=false
+end=false
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_null_deprecated.phpt
+++ b/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_null_deprecated.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_starts_with emits E_DEPRECATED on null and falls through to coerce as ""
+--FILE--
+<?php
+set_error_handler(function ($errno, $errstr) {
+    echo "DEP[" . $errno . "]: " . $errstr . "\n";
+    return true;
+});
+echo "h_null=" . (str_starts_with(null, "x") ? 'true' : 'false') . "\n";
+echo "n_null=" . (str_starts_with("abc", null) ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+DEP[8192]: str_starts_with(): Passing null to parameter #1 ($haystack) of type string is deprecated
+h_null=false
+DEP[8192]: str_starts_with(): Passing null to parameter #2 ($needle) of type string is deprecated
+n_null=true
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_partial.phpt
+++ b/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_partial.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_starts_with rejects prefix that diverges mid-needle
+--FILE--
+<?php
+echo "diverge_last="  . (str_starts_with("abcdef", "abcx") ? 'true' : 'false') . "\n";
+echo "diverge_mid="   . (str_starts_with("abcdef", "abXdef") ? 'true' : 'false') . "\n";
+echo "exact_prefix="  . (str_starts_with("abcdef", "abc") ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+diverge_last=false
+diverge_mid=false
+exact_prefix=true
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_stringable.phpt
+++ b/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_stringable.phpt
@@ -1,0 +1,30 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_starts_with accepts an object with __toString()
+--FILE--
+<?php
+class StringableStartsWith {
+    public function __toString(): string { return "Hello"; }
+}
+class EmptyStringableStartsWith {
+    public function __toString(): string { return ""; }
+}
+$obj = new StringableStartsWith();
+$empty = new EmptyStringableStartsWith();
+echo "h_obj="       . (str_starts_with($obj, "Hel") ? 'true' : 'false') . "\n";
+echo "n_obj="       . (str_starts_with("Hello World", $obj) ? 'true' : 'false') . "\n";
+echo "n_empty_obj=" . (str_starts_with("abc", $empty) ? 'true' : 'false') . "\n";
+echo "h_empty_obj=" . (str_starts_with($empty, "x") ? 'true' : 'false') . "\n";
+echo "both_empty="  . (str_starts_with($empty, $empty) ? 'true' : 'false') . "\n";
+?>
+--EXPECT--
+h_obj=true
+n_obj=true
+n_empty_obj=true
+h_empty_obj=false
+both_empty=true
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_type_error.phpt
+++ b/tests/ph7/001-smoke/function/str_starts_with/str_starts_with_type_error.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_starts_with throws TypeError for array/object args
+--FILE--
+<?php
+class NoToStringStartsWith {}
+try { str_starts_with(array(), "x"); } catch (TypeError $e) { echo "h_arr:" . $e->getMessage() . "\n"; }
+try { str_starts_with("x", array()); } catch (TypeError $e) { echo "n_arr:" . $e->getMessage() . "\n"; }
+try { str_starts_with(new NoToStringStartsWith(), "x"); } catch (TypeError $e) { echo "h_obj:" . $e->getMessage() . "\n"; }
+try { str_starts_with("x", new NoToStringStartsWith()); } catch (TypeError $e) { echo "n_obj:" . $e->getMessage() . "\n"; }
+?>
+--EXPECT--
+h_arr:str_starts_with(): Argument #1 ($haystack) must be of type string, array given
+n_arr:str_starts_with(): Argument #2 ($needle) must be of type string, array given
+h_obj:str_starts_with(): Argument #1 ($haystack) must be of type string, NoToStringStartsWith given
+n_obj:str_starts_with(): Argument #2 ($needle) must be of type string, NoToStringStartsWith given
+--CLEAN--
+<?php
+

--- a/tests/ph7/002-integration/function/str_contains/str_contains_array.phpt
+++ b/tests/ph7/002-integration/function/str_contains/str_contains_array.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_contains(array, ...) raises TypeError
+--FILE--
+<?php
+str_contains(array(), "x");
+?>
+--EXPECTF--
+%s Fatal error:  Uncaught TypeError: str_contains(): Argument #1 ($haystack) must be of type string, array given in %s
+--CLEAN--
+<?php
+

--- a/tests/ph7/002-integration/function/str_contains/str_contains_extra_args.phpt
+++ b/tests/ph7/002-integration/function/str_contains/str_contains_extra_args.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_contains() with too many arguments raises ArgumentCountError
+--FILE--
+<?php
+str_contains("a", "b", "c");
+?>
+--EXPECTF--
+%s Fatal error:  Uncaught ArgumentCountError: str_contains() expects exactly 2 arguments, 3 given in %s
+--CLEAN--
+<?php
+

--- a/tests/ph7/002-integration/function/str_contains/str_contains_no_args.phpt
+++ b/tests/ph7/002-integration/function/str_contains/str_contains_no_args.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_contains() with no arguments raises ArgumentCountError
+--FILE--
+<?php
+str_contains();
+?>
+--EXPECTF--
+%s Fatal error:  Uncaught ArgumentCountError: str_contains() expects exactly 2 arguments, 0 given in %s
+--CLEAN--
+<?php
+

--- a/tests/ph7/002-integration/function/str_ends_with/str_ends_with_array.phpt
+++ b/tests/ph7/002-integration/function/str_ends_with/str_ends_with_array.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_ends_with(array, ...) raises TypeError
+--FILE--
+<?php
+str_ends_with(array(), "x");
+?>
+--EXPECTF--
+%s Fatal error:  Uncaught TypeError: str_ends_with(): Argument #1 ($haystack) must be of type string, array given in %s
+--CLEAN--
+<?php
+

--- a/tests/ph7/002-integration/function/str_ends_with/str_ends_with_extra_args.phpt
+++ b/tests/ph7/002-integration/function/str_ends_with/str_ends_with_extra_args.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_ends_with() with too many arguments raises ArgumentCountError
+--FILE--
+<?php
+str_ends_with("a", "b", "c");
+?>
+--EXPECTF--
+%s Fatal error:  Uncaught ArgumentCountError: str_ends_with() expects exactly 2 arguments, 3 given in %s
+--CLEAN--
+<?php
+

--- a/tests/ph7/002-integration/function/str_ends_with/str_ends_with_no_args.phpt
+++ b/tests/ph7/002-integration/function/str_ends_with/str_ends_with_no_args.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_ends_with() with no arguments raises ArgumentCountError
+--FILE--
+<?php
+str_ends_with();
+?>
+--EXPECTF--
+%s Fatal error:  Uncaught ArgumentCountError: str_ends_with() expects exactly 2 arguments, 0 given in %s
+--CLEAN--
+<?php
+

--- a/tests/ph7/002-integration/function/str_starts_with/str_starts_with_array.phpt
+++ b/tests/ph7/002-integration/function/str_starts_with/str_starts_with_array.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_starts_with(array, ...) raises TypeError
+--FILE--
+<?php
+str_starts_with(array(), "x");
+?>
+--EXPECTF--
+%s Fatal error:  Uncaught TypeError: str_starts_with(): Argument #1 ($haystack) must be of type string, array given in %s
+--CLEAN--
+<?php
+

--- a/tests/ph7/002-integration/function/str_starts_with/str_starts_with_extra_args.phpt
+++ b/tests/ph7/002-integration/function/str_starts_with/str_starts_with_extra_args.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_starts_with() with too many arguments raises ArgumentCountError
+--FILE--
+<?php
+str_starts_with("a", "b", "c");
+?>
+--EXPECTF--
+%s Fatal error:  Uncaught ArgumentCountError: str_starts_with() expects exactly 2 arguments, 3 given in %s
+--CLEAN--
+<?php
+

--- a/tests/ph7/002-integration/function/str_starts_with/str_starts_with_no_args.phpt
+++ b/tests/ph7/002-integration/function/str_starts_with/str_starts_with_no_args.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: str_starts_with() with no arguments raises ArgumentCountError
+--FILE--
+<?php
+str_starts_with();
+?>
+--EXPECTF--
+%s Fatal error:  Uncaught ArgumentCountError: str_starts_with() expects exactly 2 arguments, 0 given in %s
+--CLEAN--
+<?php
+


### PR DESCRIPTION
Wires the three predicates to existing SyBlobSearch/SyStrncmp helpers and adds full PHP 8 error semantics: ArgumentCountError on wrong arg count, TypeError on array/resource/object-without-__toString (with class name in the message), E_DEPRECATED on null with fall-through coercion, and Stringable acceptance. Error messages are byte-identical to PHP 8.5.
