### PR TITLE
Implement random_int and random_bytes (PHP 7.0)

### DIFF
--- a/build-aux/nmake.mk
+++ b/build-aux/nmake.mk
@@ -30,9 +30,10 @@ tiny_CFLAGS = $(BASE_CFLAGS) /Os $(tiny_DEFINES:-=/) $(tiny_EXTRA_CFLAGS) /Fd$(B
 coverage_CFLAGS = $(BASE_CFLAGS) /Od /Zi $(coverage_DEFINES:-=/) $(coverage_EXTRA_CFLAGS) /DPH7_DEBUG /Fd$(BUILD_DIR:/=\)\coverage\ph7-coverage.pdb
 
 # Per-mode LDFLAGS (used by patterns.mk generated link rules)
-full_LDFLAGS = /nologo /link advapi32.lib ws2_32.lib $(PCRE2_LIBS) /subsystem:console /entry:mainCRTStartup
-tiny_LDFLAGS = /nologo /link advapi32.lib /subsystem:console /entry:mainCRTStartup
-coverage_LDFLAGS = /nologo /link advapi32.lib dbghelp.lib ws2_32.lib $(PCRE2_LIBS) /subsystem:console /entry:mainCRTStartup
+# bcrypt.lib provides BCryptGenRandom, used by SyOSCSPRNG in src/sx/sxrand.c.
+full_LDFLAGS = /nologo /link advapi32.lib bcrypt.lib ws2_32.lib $(PCRE2_LIBS) /subsystem:console /entry:mainCRTStartup
+tiny_LDFLAGS = /nologo /link advapi32.lib bcrypt.lib /subsystem:console /entry:mainCRTStartup
+coverage_LDFLAGS = /nologo /link advapi32.lib bcrypt.lib dbghelp.lib ws2_32.lib $(PCRE2_LIBS) /subsystem:console /entry:mainCRTStartup
 
 LDFLAGS = $(full_LDFLAGS)
 

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -11232,6 +11232,173 @@ static int vm_builtin_rand_str(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	ph7_result_string(pCtx,zString,iLen); /* Will make it's own copy */
 	return SXRET_OK;
 }
+/*
+ * Reject non-numeric values (array/object/resource and non-numeric strings)
+ * the same way intdiv() does. Returns SXRET_OK if the value is acceptable as
+ * an int (PHP coerces float and numeric string silently).
+ */
+static int VmRandomCheckIntArg(ph7_context *pCtx,ph7_value *pArg,const char *zFunc,int iArgPos,const char *zParamName)
+{
+	if( ph7_value_is_array(pArg) || ph7_value_is_object(pArg)
+		|| ph7_value_is_resource(pArg) ){
+		return PH7_VmThrowException(pCtx,
+			"TypeError",
+			"%s(): Argument #%d (%s) must be of type int, %s given",
+			zFunc,iArgPos,zParamName,
+			ph7_type_name(pArg)
+			);
+	}
+	if( ph7_value_is_string(pArg) ){
+		int len;
+		const char *zStr = ph7_value_to_string(pArg, &len);
+		if( SyStrIsNumeric(zStr, (sxu32)len, 0, 0) != SXRET_OK ){
+			return PH7_VmThrowException(pCtx,
+				"TypeError",
+				"%s(): Argument #%d (%s) must be of type int, string given",
+				zFunc,iArgPos,zParamName
+				);
+		}
+	}
+	return SXRET_OK;
+}
+/*
+ * int random_int(int $min, int $max)
+ *  Generate a cryptographically secure pseudo-random integer in [$min, $max].
+ *  Mirrors PHP 7.0+ random_int(). Uses the OS CSPRNG via SyOSCSPRNG().
+ *  Distribution is uniform via rejection sampling against the smallest
+ *  power-of-two mask covering the range.
+ */
+static int vm_builtin_random_int(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	sxi64 iMin,iMax;
+	sxu64 uRange,uMask,uResult;
+	unsigned int nAttempt;
+	int rc;
+	if( nArg != 2 ){
+		return PH7_VmThrowException(pCtx,
+			"ArgumentCountError",
+			"random_int() expects exactly 2 arguments, %d given",
+			nArg
+			);
+	}
+	rc = VmRandomCheckIntArg(pCtx,apArg[0],"random_int",1,"$min");
+	if( rc != SXRET_OK ){ return rc; }
+	rc = VmRandomCheckIntArg(pCtx,apArg[1],"random_int",2,"$max");
+	if( rc != SXRET_OK ){ return rc; }
+	iMin = ph7_value_to_int64(apArg[0]);
+	iMax = ph7_value_to_int64(apArg[1]);
+	if( iMin > iMax ){
+		return PH7_VmThrowException(pCtx,
+			"ValueError",
+			"random_int(): Argument #1 ($min) must be less than or equal to argument #2 ($max)"
+			);
+	}
+	if( iMin == iMax ){
+		ph7_result_int64(pCtx,iMin);
+		return SXRET_OK;
+	}
+	uRange = (sxu64)iMax - (sxu64)iMin;
+	uMask = uRange;
+	uMask |= uMask >> 1;
+	uMask |= uMask >> 2;
+	uMask |= uMask >> 4;
+	uMask |= uMask >> 8;
+	uMask |= uMask >> 16;
+	uMask |= uMask >> 32;
+	uResult = 0;
+	for( nAttempt = 0 ; nAttempt < 50 ; ++nAttempt ){
+		/* Always draw a full 8 bytes so endianness of the cast doesn't matter
+		 * (a 4-byte fill into a sxu64 would land in the high half on big-endian
+		 * and the low-half mask would always read 0). */
+		sxu64 uDraw;
+		if( SyOSCSPRNG(&uDraw,sizeof(uDraw)) != SXRET_OK ){
+			/* PHP 8.2+ would throw Random\RandomException here; that class
+			 * is not yet registered in PHL (see PLAN.md item 6.13). */
+			return PH7_VmThrowException(pCtx,
+				"Exception",
+				"Cannot gather sufficient random data"
+				);
+		}
+		uDraw &= uMask;
+		if( uDraw <= uRange ){
+			uResult = uDraw;
+			break;
+		}
+	}
+	if( nAttempt >= 50 ){
+		return PH7_VmThrowException(pCtx,
+			"Exception",
+			"Cannot gather sufficient random data"
+			);
+	}
+	ph7_result_int64(pCtx,(sxi64)((sxu64)iMin + uResult));
+	return SXRET_OK;
+}
+/*
+ * string random_bytes(int $length)
+ *  Generate $length cryptographically secure random bytes via SyOSCSPRNG().
+ *  Mirrors PHP 7.0+ random_bytes().
+ */
+static int vm_builtin_random_bytes(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	sxi64 iLen;
+	unsigned char zStack[256];
+	void *pBuf;
+	int rc;
+	int bHeap = 0;
+	if( nArg != 1 ){
+		return PH7_VmThrowException(pCtx,
+			"ArgumentCountError",
+			"random_bytes() expects exactly 1 argument, %d given",
+			nArg
+			);
+	}
+	rc = VmRandomCheckIntArg(pCtx,apArg[0],"random_bytes",1,"$length");
+	if( rc != SXRET_OK ){ return rc; }
+	iLen = ph7_value_to_int64(apArg[0]);
+	if( iLen < 1 ){
+		return PH7_VmThrowException(pCtx,
+			"ValueError",
+			"random_bytes(): Argument #1 ($length) must be greater than 0"
+			);
+	}
+	/* The PH7 allocator and ph7_result_string both take sxu32/int sizes,
+	 * so we can't honor a length above 2 GiB. Reject early rather than
+	 * silently truncating via the (sxu32) cast below. */
+	if( iLen > 0x7FFFFFFF ){
+		return PH7_VmThrowException(pCtx,
+			"ValueError",
+			"random_bytes(): Argument #1 ($length) is too large"
+			);
+	}
+	if( iLen <= (sxi64)sizeof(zStack) ){
+		pBuf = zStack;
+	}else{
+		pBuf = SyMemBackendAlloc(&pCtx->pVm->sAllocator,(sxu32)iLen);
+		if( pBuf == 0 ){
+			return PH7_VmThrowException(pCtx,
+				"Exception",
+				"random_bytes(): Failed to allocate %qd bytes",
+				iLen
+				);
+		}
+		bHeap = 1;
+	}
+	if( SyOSCSPRNG(pBuf,(sxu32)iLen) != SXRET_OK ){
+		if( bHeap ){
+			SyMemBackendFree(&pCtx->pVm->sAllocator,pBuf);
+		}
+		return PH7_VmThrowException(pCtx,
+			"Exception",
+			"Cannot gather sufficient random data"
+			);
+	}
+	ph7_result_string(pCtx,(const char *)pBuf,(int)iLen);
+	if( bHeap ){
+		SyMemBackendFree(&pCtx->pVm->sAllocator,pBuf);
+	}
+	return SXRET_OK;
+}
 #ifndef PH7_DISABLE_BUILTIN_FUNC
 #if !defined(PH7_DISABLE_HASH_FUNC)
 /* Unique ID private data */
@@ -14282,6 +14449,8 @@ static const ph7_builtin_func aVmFunc[] = {
 	{ "rand_str",      vm_builtin_rand_str        },
 	{ "getrandmax",    vm_builtin_getrandmax      },
 	{ "mt_getrandmax", vm_builtin_getrandmax      },
+	{ "random_int",    vm_builtin_random_int      },
+	{ "random_bytes",  vm_builtin_random_bytes    },
 #ifndef PH7_DISABLE_BUILTIN_FUNC
 #if !defined(PH7_DISABLE_HASH_FUNC)
 	{ "uniqid",        vm_builtin_uniqid          },

--- a/src/sx/sxrand.c
+++ b/src/sx/sxrand.c
@@ -20,6 +20,13 @@
 #define SXPRNG_MAGIC	0x13C4
 #ifdef __WINNT__
 #include <windows.h>
+#include <bcrypt.h>
+#ifndef BCRYPT_USE_SYSTEM_PREFERRED_RNG
+#define BCRYPT_USE_SYSTEM_PREFERRED_RNG 0x00000002
+#endif
+#ifndef BCRYPT_SUCCESS
+#define BCRYPT_SUCCESS(Status) (((NTSTATUS)(Status)) >= 0)
+#endif
 #endif
 #ifdef __UNIXES__
 #include <sys/types.h>
@@ -29,6 +36,14 @@
 #include <errno.h>
 #include <time.h>
 #include <sys/time.h>
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+#include <stdlib.h> /* arc4random_buf */
+#define SX_HAVE_ARC4RANDOM 1
+#endif
+#if defined(__linux__)
+#include <sys/random.h> /* getrandom */
+#define SX_HAVE_GETRANDOM 1
+#endif
 #endif
 static sxi32 SyOSUtilRandomSeed(void *pBuf,sxu32 nLen,void *pUnused)
 {
@@ -141,4 +156,70 @@ PH7_PRIVATE sxi32 SyRandomness(SyPRNGCtx *pCtx,void *pBuf,sxu32 nLen)
 		if( zBuf >= zEnd ){break;}	zBuf[0] = randomByte(pCtx);	zBuf++;
 	}
 	return SXRET_OK;
+}
+#if defined(__UNIXES__) && !defined(SX_HAVE_ARC4RANDOM)
+static sxi32 SyReadDevUrandom(unsigned char *zBuf,sxu32 nLen)
+{
+	int fd;
+	sxu32 nRead = 0;
+	fd = open("/dev/urandom",O_RDONLY);
+	if( fd < 0 ){
+		return SXERR_IO;
+	}
+	while( nRead < nLen ){
+		ssize_t n = read(fd,&zBuf[nRead],nLen - nRead);
+		if( n > 0 ){
+			nRead += (sxu32)n;
+			continue;
+		}
+		if( n < 0 && errno == EINTR ){
+			continue;
+		}
+		close(fd);
+		return SXERR_IO;
+	}
+	close(fd);
+	return SXRET_OK;
+}
+#endif
+PH7_PRIVATE sxi32 SyOSCSPRNG(void *pBuf,sxu32 nLen)
+{
+	unsigned char *zBuf = (unsigned char *)pBuf;
+#if defined(UNTRUST)
+	if( pBuf == 0 || nLen == 0 ){
+		return SXERR_EMPTY;
+	}
+#endif
+#ifdef __WINNT__
+	if( BCRYPT_SUCCESS(BCryptGenRandom(NULL,zBuf,(ULONG)nLen,BCRYPT_USE_SYSTEM_PREFERRED_RNG)) ){
+		return SXRET_OK;
+	}
+	return SXERR_IO;
+#elif defined(SX_HAVE_ARC4RANDOM)
+	arc4random_buf(zBuf,(size_t)nLen);
+	return SXRET_OK;
+#elif defined(SX_HAVE_GETRANDOM)
+	{
+		sxu32 nDone = 0;
+		while( nDone < nLen ){
+			ssize_t n = getrandom(&zBuf[nDone],nLen - nDone,0);
+			if( n > 0 ){
+				nDone += (sxu32)n;
+				continue;
+			}
+			if( n < 0 && errno == EINTR ){
+				continue;
+			}
+			/* getrandom unavailable (ENOSYS) or other error: fall back */
+			return SyReadDevUrandom(zBuf,nLen);
+		}
+		return SXRET_OK;
+	}
+#elif defined(__UNIXES__)
+	return SyReadDevUrandom(zBuf,nLen);
+#else
+	(void)zBuf;
+	(void)nLen;
+	return SXERR_IO;
+#endif
 }

--- a/src/sx/sxrand.h
+++ b/src/sx/sxrand.h
@@ -31,4 +31,13 @@ typedef sxi32 (*ProcRandomSeed)(void *,unsigned int,void *);
 PH7_PRIVATE sxi32 SyRandomnessInit(SyPRNGCtx *pCtx,ProcRandomSeed xSeed,void *pUserData);
 PH7_PRIVATE sxi32 SyRandomness(SyPRNGCtx *pCtx,void *pBuf,sxu32 nLen);
 
+/*
+ * Fill pBuf with nLen bytes drawn directly from the OS cryptographically
+ * secure RNG (arc4random_buf on macOS/BSD, getrandom/urandom on Linux,
+ * BCryptGenRandom on Windows). Returns SXRET_OK on full fill, SXERR_IO
+ * on failure. Never returns partial data. Under UNTRUST builds, also
+ * returns SXERR_EMPTY when pBuf is NULL or nLen is 0.
+ */
+PH7_PRIVATE sxi32 SyOSCSPRNG(void *pBuf,sxu32 nLen);
+
 #endif /* __SXRAND_H__ */

--- a/tests/ph7/001-smoke/function/random_bytes/random_bytes_arg_count.phpt
+++ b/tests/ph7/001-smoke/function/random_bytes/random_bytes_arg_count.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+random_bytes throws ArgumentCountError when called with wrong arity
+--SKIPIF--
+<?php
+if (!function_exists('random_bytes')) { echo 'skip: random_bytes not available'; }
+?>
+--FILE--
+<?php
+try { random_bytes(); echo "n0\n"; } catch (ArgumentCountError $e) { echo "ace0\n"; }
+try { random_bytes(8, 9); echo "n2\n"; } catch (ArgumentCountError $e) { echo "ace2\n"; }
+?>
+--EXPECT--
+ace0
+ace2
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/random_bytes/random_bytes_is_string.phpt
+++ b/tests/ph7/001-smoke/function/random_bytes/random_bytes_is_string.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+random_bytes returns a string
+--SKIPIF--
+<?php
+if (!function_exists('random_bytes')) { echo 'skip: random_bytes not available'; }
+?>
+--FILE--
+<?php
+echo is_string(random_bytes(8)) ? "str_ok\n" : "str_fail\n";
+?>
+--EXPECT--
+str_ok
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/random_bytes/random_bytes_length.phpt
+++ b/tests/ph7/001-smoke/function/random_bytes/random_bytes_length.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+random_bytes returns a string of the requested length
+--SKIPIF--
+<?php
+if (!function_exists('random_bytes')) { echo 'skip: random_bytes not available'; }
+?>
+--FILE--
+<?php
+$ok = true;
+foreach (array(1, 16, 32, 64) as $n) {
+    if (strlen(random_bytes($n)) !== $n) { $ok = false; break; }
+}
+echo $ok ? "len_ok\n" : "len_fail\n";
+?>
+--EXPECT--
+len_ok
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/random_bytes/random_bytes_negative.phpt
+++ b/tests/ph7/001-smoke/function/random_bytes/random_bytes_negative.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+random_bytes throws ValueError on negative length
+--SKIPIF--
+<?php
+if (!function_exists('random_bytes')) { echo 'skip: random_bytes not available'; }
+if (!class_exists('ValueError')) { echo 'skip: ValueError not available'; }
+?>
+--FILE--
+<?php
+try { random_bytes(-1); echo "no_throw\n"; } catch (ValueError $e) { echo "ve\n"; }
+?>
+--EXPECT--
+ve
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/random_bytes/random_bytes_nonzero.phpt
+++ b/tests/ph7/001-smoke/function/random_bytes/random_bytes_nonzero.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+random_bytes returns a buffer that was actually written (not all-NUL)
+--SKIPIF--
+<?php
+if (!function_exists('random_bytes')) { echo 'skip: random_bytes not available'; }
+?>
+--FILE--
+<?php
+$s = random_bytes(64);
+$zero = str_repeat("\0", 64);
+echo (is_string($s) && strlen($s) === 64 && $s !== $zero) ? "nonzero_ok\n" : "nonzero_fail\n";
+?>
+--EXPECT--
+nonzero_ok
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/random_bytes/random_bytes_type_error.phpt
+++ b/tests/ph7/001-smoke/function/random_bytes/random_bytes_type_error.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+random_bytes throws TypeError on non-int, non-numeric arguments
+--SKIPIF--
+<?php
+if (!function_exists('random_bytes')) { echo 'skip: random_bytes not available'; }
+?>
+--FILE--
+<?php
+$arr = array();
+try { random_bytes($arr); echo "n_arr\n"; } catch (TypeError $e) { echo "te_arr\n"; }
+try { random_bytes("abc"); echo "n_str\n"; } catch (TypeError $e) { echo "te_str\n"; }
+?>
+--EXPECT--
+te_arr
+te_str
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/random_bytes/random_bytes_zero.phpt
+++ b/tests/ph7/001-smoke/function/random_bytes/random_bytes_zero.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+random_bytes throws ValueError on length 0
+--SKIPIF--
+<?php
+if (!function_exists('random_bytes')) { echo 'skip: random_bytes not available'; }
+if (!class_exists('ValueError')) { echo 'skip: ValueError not available'; }
+?>
+--FILE--
+<?php
+try { random_bytes(0); echo "no_throw\n"; } catch (ValueError $e) { echo "ve\n"; }
+?>
+--EXPECT--
+ve
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/random_int/random_int_arg_count.phpt
+++ b/tests/ph7/001-smoke/function/random_int/random_int_arg_count.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+random_int throws ArgumentCountError when called with wrong arity
+--SKIPIF--
+<?php
+if (!function_exists('random_int')) { echo 'skip: random_int not available'; }
+?>
+--FILE--
+<?php
+try { random_int(); echo "n0\n"; } catch (ArgumentCountError $e) { echo "ace0\n"; }
+try { random_int(1); echo "n1\n"; } catch (ArgumentCountError $e) { echo "ace1\n"; }
+try { random_int(1, 2, 3); echo "n3\n"; } catch (ArgumentCountError $e) { echo "ace3\n"; }
+?>
+--EXPECT--
+ace0
+ace1
+ace3
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/random_int/random_int_basic.phpt
+++ b/tests/ph7/001-smoke/function/random_int/random_int_basic.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+random_int returns int values uniformly inside the requested closed range
+--SKIPIF--
+<?php
+if (!function_exists('random_int')) { echo 'skip: random_int not available'; }
+?>
+--FILE--
+<?php
+$ok = true;
+for ($i = 0; $i < 50; $i++) {
+    $v = random_int(0, 10);
+    if (!is_int($v) || $v < 0 || $v > 10) { $ok = false; break; }
+}
+echo $ok ? "range_ok\n" : "range_fail\n";
+?>
+--EXPECT--
+range_ok
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/random_int/random_int_min_equals_max.phpt
+++ b/tests/ph7/001-smoke/function/random_int/random_int_min_equals_max.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+random_int returns the bound when min equals max
+--SKIPIF--
+<?php
+if (!function_exists('random_int')) { echo 'skip: random_int not available'; }
+?>
+--FILE--
+<?php
+echo (random_int(7, 7) === 7) ? "eq_ok\n" : "eq_fail\n";
+echo (random_int(-3, -3) === -3) ? "eq_neg_ok\n" : "eq_neg_fail\n";
+?>
+--EXPECT--
+eq_ok
+eq_neg_ok
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/random_int/random_int_min_gt_max.phpt
+++ b/tests/ph7/001-smoke/function/random_int/random_int_min_gt_max.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+random_int throws ValueError when min is greater than max
+--SKIPIF--
+<?php
+if (!function_exists('random_int')) { echo 'skip: random_int not available'; }
+if (!class_exists('ValueError')) { echo 'skip: ValueError not available'; }
+?>
+--FILE--
+<?php
+try { random_int(10, 5); echo "no_throw\n"; } catch (ValueError $e) { echo "ve\n"; }
+?>
+--EXPECT--
+ve
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/random_int/random_int_negative_range.phpt
+++ b/tests/ph7/001-smoke/function/random_int/random_int_negative_range.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+random_int respects bounds when both min and max are negative
+--SKIPIF--
+<?php
+if (!function_exists('random_int')) { echo 'skip: random_int not available'; }
+?>
+--FILE--
+<?php
+$ok = true;
+for ($i = 0; $i < 30; $i++) {
+    $v = random_int(-5, -1);
+    if (!is_int($v) || $v < -5 || $v > -1) { $ok = false; break; }
+}
+echo $ok ? "neg_ok\n" : "neg_fail\n";
+?>
+--EXPECT--
+neg_ok
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/random_int/random_int_numeric_string.phpt
+++ b/tests/ph7/001-smoke/function/random_int/random_int_numeric_string.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+random_int accepts numeric strings as int arguments
+--SKIPIF--
+<?php
+if (!function_exists('random_int')) { echo 'skip: random_int not available'; }
+?>
+--FILE--
+<?php
+$v = random_int("0", "10");
+echo (is_int($v) && $v >= 0 && $v <= 10) ? "num_str_ok\n" : "num_str_fail\n";
+?>
+--EXPECT--
+num_str_ok
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/random_int/random_int_type_error.phpt
+++ b/tests/ph7/001-smoke/function/random_int/random_int_type_error.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+random_int throws TypeError on non-int, non-numeric arguments
+--SKIPIF--
+<?php
+if (!function_exists('random_int')) { echo 'skip: random_int not available'; }
+?>
+--FILE--
+<?php
+$arr = array();
+try { random_int($arr, 5); echo "n1\n"; } catch (TypeError $e) { echo "te1\n"; }
+try { random_int(0, $arr); echo "n2\n"; } catch (TypeError $e) { echo "te2\n"; }
+try { random_int("abc", 5); echo "ns\n"; } catch (TypeError $e) { echo "ts\n"; }
+?>
+--EXPECT--
+te1
+te2
+ts
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/random_int/random_int_wide_negative_range.phpt
+++ b/tests/ph7/001-smoke/function/random_int/random_int_wide_negative_range.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+random_int handles a wide range that straddles zero (exercises 64-bit + signed-add path)
+--SKIPIF--
+<?php
+if (!function_exists('random_int')) { echo 'skip: random_int not available'; }
+?>
+--FILE--
+<?php
+$min = -9999999999;
+$max =  9999999999;
+$ok = true;
+for ($i = 0; $i < 30; $i++) {
+    $v = random_int($min, $max);
+    if (!is_int($v) || $v < $min || $v > $max) { $ok = false; break; }
+}
+echo $ok ? "wide_neg_ok\n" : "wide_neg_fail\n";
+?>
+--EXPECT--
+wide_neg_ok
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/random_int/random_int_wide_range.phpt
+++ b/tests/ph7/001-smoke/function/random_int/random_int_wide_range.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+random_int handles a range wider than 32 bits
+--SKIPIF--
+<?php
+if (!function_exists('random_int')) { echo 'skip: random_int not available'; }
+?>
+--FILE--
+<?php
+$min = 0;
+$max = 9999999999; // 10^10, exceeds 2^32, exercises the 64-bit code path
+$v = random_int($min, $max);
+echo (is_int($v) && $v >= $min && $v <= $max) ? "wide_ok\n" : "wide_fail\n";
+?>
+--EXPECT--
+wide_ok
+--CLEAN--
+<?php


### PR DESCRIPTION
Add a SyOSCSPRNG helper in src/sx/sxrand.c that draws fresh OS entropy (arc4random_buf on macOS/BSD, getrandom with /dev/urandom fallback on Linux, BCryptGenRandom on Windows) — the existing RC4-seeded SyRandomness is not cryptographically secure and is not used here.

random_int uses uniform rejection sampling against a power-of-two mask. random_bytes uses a 256-byte stack buffer for small lengths and rejects lengths above 0x7FFFFFFF since the engine allocator is sxu32-bound.
