### PR TITLE
Implement __invoke magic method dispatch

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -982,6 +982,9 @@ static sxi32 VmFiberSetupFrame(ph7_vm *pVm, ph7_exec_ctx *pExecCtx,
 static sxi32 VmCallClassMethodWithMap(ph7_vm *pVm, ph7_class_instance *pThis,
 	ph7_class_method *pMethod, ph7_value *pResult, int nArg,
 	ph7_value **apArg, VmCallArgMap *pMap);
+static sxi32 VmCallObjectInvoke(ph7_vm *pVm, ph7_class_instance *pThis,
+	int nArg, ph7_value **apArg, ph7_value *pResult, VmCallArgMap *pMap);
+static sxi32 VmRaiseNotCallable(ph7_vm *pVm, ph7_class_instance *pThis);
 /* Forward declarations for Generator helpers and C functions */
 static ph7_generator * VmNewGenerator(ph7_vm *pVm, ph7_exec_ctx *pCtx);
 static void VmReleaseGenerator(ph7_vm *pVm, ph7_generator *pGen);
@@ -7723,15 +7726,53 @@ case PH7_OP_CALL: {
 			/* Copy result */
 			PH7_MemObjStore(&sResult,pTos);
 			PH7_MemObjRelease(&sResult);
-		}else{
-			if( pTos->iFlags & MEMOBJ_OBJ ){
-				ph7_class_instance *pThis = (ph7_class_instance *)pTos->x.pOther;
-				/* Call the magic method '__invoke' if available */
-				PH7_ClassInstanceCallMagicMethod(&(*pVm),pThis->pClass,pThis,"__invoke",sizeof("__invoke")-1,0);
-			}else{
-				/* Raise exception: Invalid function name */
-				VmErrorFormat(&(*pVm),PH7_CTX_WARNING,"Invalid function name,NULL will be returned");
+		}else if( pTos->iFlags & MEMOBJ_OBJ ){
+			ph7_class_instance *pThis = (ph7_class_instance *)pTos->x.pOther;
+			ph7_value sResult;
+			sxi32 rcInv;
+			SySetReset(&aArg);
+			while( pArg < pTos ){
+				SySetPut(&aArg,(const void *)&pArg);
+				pArg++;
 			}
+			PH7_MemObjInit(pVm,&sResult);
+			rcInv = VmCallObjectInvoke(&(*pVm),pThis,
+				(int)SySetUsed(&aArg),
+				(ph7_value **)SySetBasePtr(&aArg),
+				&sResult,
+				(VmCallArgMap *)pInstr->p3);
+			SySetReset(&aArg);
+			if( nCallArgs > 0 ){
+				VmPopOperand(&pTos,nCallArgs);
+			}
+			if( rcInv == SXERR_INVALID ){
+				/* No __invoke: raise a catchable Error and route through try/catch.
+				 * sResult was already released by VmCallObjectInvoke.
+				 * Pin pThis: the release below would otherwise drop the last ref
+				 * to a temporary callable like (new Plain())(...), freeing the
+				 * instance before VmRaiseNotCallable reads its class name. */
+				pThis->iRef++;
+				PH7_MemObjRelease(pTos);
+				rc = VmRaiseNotCallable(&(*pVm),pThis);
+				PH7_ClassInstanceUnref(pThis);
+				if( rc == SXERR_ABORT ){
+					goto Abort;
+				}
+				{
+					VmFrame *pFrm2 = pVm->pFrame;
+					if( pFrm2 && (pFrm2->iFlags & VM_FRAME_EXCEPTION)
+					 && pFrm2->iExceptionJump > 0 ){
+						pc = pFrm2->iExceptionJump - 1;
+						break;
+					}
+				}
+				goto Exception;
+			}
+			PH7_MemObjStore(&sResult,pTos);
+			PH7_MemObjRelease(&sResult);
+		}else{
+			/* Raise exception: Invalid function name */
+			VmErrorFormat(&(*pVm),PH7_CTX_WARNING,"Invalid function name,NULL will be returned");
 			/* Pop given arguments */
 			if( nCallArgs > 0 ){
 				VmPopOperand(&pTos,nCallArgs);
@@ -10421,21 +10462,15 @@ PH7_PRIVATE int PH7_VmIsCallable(ph7_vm *pVm,ph7_value *pValue,int CallInvoke)
 {
 	int res = 0;
 	if( pValue->iFlags & MEMOBJ_OBJ ){
-		/* Call the magic method __invoke if available */
+		/* PHP semantics: an object is callable iff its class declares __invoke
+		 * (inherited methods count). The CallInvoke flag is unused — it
+		 * formerly invoked __invoke as a runtime predicate, which is not
+		 * standard PHP behavior. */
 		ph7_class_instance *pThis = (ph7_class_instance *)pValue->x.pOther;
-		ph7_class_method *pMethod;
-		pMethod = PH7_ClassExtractMethod(pThis->pClass,"__invoke",sizeof("__invoke")-1);
-		if( pMethod && CallInvoke ){
-			ph7_value sResult;
-			sxi32 rc;
-			/* Invoke the magic method and extract the result */
-			PH7_MemObjInit(pVm,&sResult);
-			rc = PH7_VmCallClassMethod(pVm,pThis,pMethod,&sResult,0,0);
-			if( rc == SXRET_OK && (sResult.iFlags & (MEMOBJ_BOOL|MEMOBJ_INT)) ){
-				res = sResult.x.iVal != 0;
-			}
-			PH7_MemObjRelease(&sResult);
+		if( PH7_ClassExtractMethod(pThis->pClass,"__invoke",sizeof("__invoke")-1) ){
+			res = 1;
 		}
+		(void)CallInvoke;
 	}else if( pValue->iFlags & MEMOBJ_HASHMAP ){
 		ph7_hashmap *pMap = (ph7_hashmap *)pValue->x.pOther;
 		if( pMap->nEntry == 2 ){
@@ -10753,6 +10788,103 @@ PH7_PRIVATE sxi32 PH7_VmCallClassMethod(
 	return VmCallClassMethodWithMap(pVm,pThis,pMethod,pResult,nArg,apArg,0);
 }
 /*
+ * Dispatch a call to an object's __invoke magic method, forwarding arguments
+ * and the return value. Used by the PH7_OP_CALL object-callable branch and by
+ * PH7_VmCallUserFunction so that $obj(...), call_user_func($obj, ...) and
+ * call_user_func_array($obj, [...]) all reach __invoke uniformly.
+ *
+ * Visibility is intentionally not checked: PHP allows private/protected
+ * __invoke to be invoked via $obj() from any scope, and PHL's existing
+ * is_callable / closure-invoke paths follow the same rule.
+ *
+ * pMap forwards the call-site VmCallArgMap so named-argument resolution and
+ * strict_types coercion work for $obj(...) the same way they do for normal
+ * function calls. Pass 0 from C-API call sites (call_user_func and friends),
+ * which receive arguments positionally and don't carry a strict-types context.
+ *
+ * Returns SXRET_OK on success, SXERR_INVALID if __invoke is missing.
+ */
+static sxi32 VmCallObjectInvoke(
+	ph7_vm *pVm,
+	ph7_class_instance *pThis,
+	int nArg,
+	ph7_value **apArg,
+	ph7_value *pResult,
+	VmCallArgMap *pMap
+	)
+{
+	ph7_class_method *pMethod;
+	pMethod = PH7_ClassExtractMethod(pThis->pClass,"__invoke",sizeof("__invoke")-1);
+	if( pMethod == 0 ){
+		if( pResult ){
+			PH7_MemObjRelease(pResult);
+		}
+		return SXERR_INVALID;
+	}
+	return VmCallClassMethodWithMap(pVm,pThis,pMethod,pResult,nArg,apArg,pMap);
+}
+/*
+ * Raise a catchable Error("Object of type X is not callable") when an object
+ * is invoked as a function but lacks __invoke. Mirrors the OP_THROW pattern
+ * (vm.c PH7_OP_THROW): build the Error instance, mark the current frame as
+ * throwing, dispatch via VmThrowException so the nearest try/catch can handle
+ * it. Caller is responsible for the post-throw control flow (iExceptionJump
+ * lookup or 'goto Exception').
+ *
+ * Returns the result of VmThrowException (SXRET_OK on handled exception,
+ * SXERR_ABORT on abort), or SXERR_ABORT if the Error class itself cannot
+ * be bootstrapped — in which case an uncaught fatal has already been
+ * reported.
+ */
+static sxi32 VmRaiseNotCallable(ph7_vm *pVm, ph7_class_instance *pThis)
+{
+	ph7_class *pErrorClass;
+	ph7_class_instance *pErrInst = 0;
+	ph7_class_method *pCons;
+	VmFrame *pThrowFrame;
+	char zMsg[256];
+	int nMsg;
+	sxi32 rc;
+	nMsg = SyBufferFormat(zMsg,sizeof(zMsg),
+		"Object of type %.*s is not callable",
+		(int)pThis->pClass->sName.nByte,
+		pThis->pClass->sName.zString);
+	pErrorClass = PH7_VmExtractClass(pVm,"Error",sizeof("Error")-1,TRUE,0);
+	if( pErrorClass ){
+		pErrInst = PH7_NewClassInstance(pVm,pErrorClass);
+	}
+	if( pErrInst == 0 ){
+		/* Bootstrap failure: Error class is part of the built-in library and
+		 * should always be available, so this branch is effectively unreachable.
+		 * Degrade to an uncaught fatal report so the failure is at least
+		 * visible to the user. */
+		VmReportUncaughtException(pVm,"Error",5,zMsg,(sxu32)nMsg,0,0);
+		return SXERR_ABORT;
+	}
+	pCons = PH7_ClassExtractMethod(pErrorClass,"__construct",sizeof("__construct")-1);
+	if( pCons ){
+		ph7_value sArg;
+		ph7_value *apMsg[1];
+		SyString sMsgStr;
+		SyStringInitFromBuf(&sMsgStr,zMsg,(sxu32)nMsg);
+		PH7_MemObjInit(pVm,&sArg);
+		PH7_MemObjInitFromString(pVm,&sArg,&sMsgStr);
+		apMsg[0] = &sArg;
+		PH7_VmCallClassMethod(pVm,pErrInst,pCons,0,1,apMsg);
+		PH7_MemObjRelease(&sArg);
+	}
+	/* Else: Error::__construct is part of the built-in library and should
+	 * always be present; if it isn't, the thrown exception still surfaces
+	 * with an empty getMessage() rather than crashing. */
+	pThrowFrame = VmSkipExceptionFrames(pVm->pFrame);
+	if( pThrowFrame ){
+		pThrowFrame->iFlags |= VM_FRAME_THROW;
+	}
+	rc = VmThrowException(pVm,pErrInst);
+	PH7_ClassInstanceUnref(pErrInst);
+	return rc;
+}
+/*
  * Call a user defined or foreign function where the name of the function
  * is stored in the pFunc parameter and the given arguments are stored
  * in the apArg[] array.
@@ -10770,6 +10902,14 @@ PH7_PRIVATE sxi32 PH7_VmCallUserFunction(
 	ph7_value *aStack;
 	VmInstr aInstr[2];
 	int i;
+	if( pFunc->iFlags & MEMOBJ_OBJ ){
+		/* Object callable: dispatch through __invoke when available.
+		 * No VmCallArgMap: call_user_func / array_map / usort and the C API
+		 * pass arguments positionally and inherit no strict-types context. */
+		return VmCallObjectInvoke(&(*pVm),
+			(ph7_class_instance *)pFunc->x.pOther,
+			nArg,apArg,pResult,0);
+	}
 	if((pFunc->iFlags & (MEMOBJ_STRING|MEMOBJ_HASHMAP)) == 0 ){
 		/* Don't bother processing,it's invalid anyway */
 		if( pResult ){

--- a/tests/ph7/001-smoke/oo/magic/invoke.phpt
+++ b/tests/ph7/001-smoke/oo/magic/invoke.phpt
@@ -2,7 +2,7 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-Magic method __invoke (PH7 does not support arguments)
+Magic method __invoke
 --FILE--
 <?php
 class FooInvoke {

--- a/tests/ph7/001-smoke/oo/magic/invoke_args.phpt
+++ b/tests/ph7/001-smoke/oo/magic/invoke_args.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Magic method __invoke forwards positional arguments and return value
+--FILE--
+<?php
+class Adder {
+    public function __invoke($x, $y) {
+        return $x + $y;
+    }
+}
+$a = new Adder();
+echo $a(2, 3), "\n";
+echo $a(40, 2), "\n";
+?>
+--EXPECT--
+5
+42
+--CLEAN--
+<?php
+unset($a);

--- a/tests/ph7/001-smoke/oo/magic/invoke_byref.phpt
+++ b/tests/ph7/001-smoke/oo/magic/invoke_byref.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Magic method __invoke handles by-reference parameters
+--FILE--
+<?php
+class Bumper {
+    public function __invoke(&$x) {
+        $x++;
+    }
+}
+$b = new Bumper();
+$v = 10;
+$b($v);
+$b($v);
+echo $v, "\n";
+?>
+--EXPECT--
+12
+--CLEAN--
+<?php
+unset($b, $v);

--- a/tests/ph7/001-smoke/oo/magic/invoke_call_user_func.phpt
+++ b/tests/ph7/001-smoke/oo/magic/invoke_call_user_func.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+call_user_func dispatches to __invoke on objects
+--FILE--
+<?php
+class Mul {
+    public function __invoke($x, $y) {
+        return $x * $y;
+    }
+}
+$m = new Mul();
+echo call_user_func($m, 6, 7), "\n";
+?>
+--EXPECT--
+42
+--CLEAN--
+<?php
+unset($m);

--- a/tests/ph7/001-smoke/oo/magic/invoke_call_user_func_array.phpt
+++ b/tests/ph7/001-smoke/oo/magic/invoke_call_user_func_array.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+call_user_func_array dispatches to __invoke on objects
+--FILE--
+<?php
+class Concat {
+    public function __invoke($a, $b, $c) {
+        return $a . $b . $c;
+    }
+}
+$obj = new Concat();
+echo call_user_func_array($obj, ["foo", "-", "bar"]), "\n";
+?>
+--EXPECT--
+foo-bar
+--CLEAN--
+<?php
+unset($obj);

--- a/tests/ph7/001-smoke/oo/magic/invoke_default.phpt
+++ b/tests/ph7/001-smoke/oo/magic/invoke_default.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Magic method __invoke honors default parameter values
+--FILE--
+<?php
+class InvokeGreeter {
+    public function __invoke($name, $greeting = "hello") {
+        return "$greeting, $name";
+    }
+}
+$g = new InvokeGreeter();
+echo $g("world"), "\n";
+echo $g("world", "hi"), "\n";
+?>
+--EXPECT--
+hello, world
+hi, world
+--CLEAN--
+<?php
+unset($g);

--- a/tests/ph7/001-smoke/oo/magic/invoke_inherited.phpt
+++ b/tests/ph7/001-smoke/oo/magic/invoke_inherited.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Magic method __invoke inherited from a parent class
+--FILE--
+<?php
+class Base {
+    public function __invoke($n) {
+        return $n * 3;
+    }
+}
+class Child extends Base {}
+$c = new Child();
+echo $c(7), "\n";
+?>
+--EXPECT--
+21
+--CLEAN--
+<?php
+unset($c);

--- a/tests/ph7/001-smoke/oo/magic/invoke_is_callable.phpt
+++ b/tests/ph7/001-smoke/oo/magic/invoke_is_callable.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+is_callable returns true for objects with __invoke regardless of return value
+--FILE--
+<?php
+class WithInvoke {
+    public function __invoke() { return 1; }
+}
+class InvokeReturnsFalse {
+    public function __invoke() { return false; }
+}
+class WithoutInvoke {}
+echo is_callable(new WithInvoke()) ? "yes\n" : "no\n";
+echo is_callable(new InvokeReturnsFalse()) ? "yes\n" : "no\n";
+echo is_callable(new WithoutInvoke()) ? "yes\n" : "no\n";
+?>
+--EXPECT--
+yes
+yes
+no
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/oo/magic/invoke_missing.phpt
+++ b/tests/ph7/001-smoke/oo/magic/invoke_missing.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Calling an object without __invoke throws a catchable Error
+--FILE--
+<?php
+class Plain {}
+try {
+    (new Plain())(1, 2, 3);
+    echo "no throw\n";
+} catch (Error $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+caught: Object of type Plain is not callable
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/oo/magic/invoke_missing_temporary.phpt
+++ b/tests/ph7/001-smoke/oo/magic/invoke_missing_temporary.phpt
@@ -1,0 +1,25 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Calling a temporary object without __invoke raises a catchable Error
+--FILE--
+<?php
+class PlainTemp {}
+for ($i = 0; $i < 5; $i++) {
+    try {
+        (new PlainTemp())(1, 2, 3);
+        echo "no throw\n";
+    } catch (Error $e) {
+        echo $e->getMessage(), "\n";
+    }
+}
+?>
+--EXPECT--
+Object of type PlainTemp is not callable
+Object of type PlainTemp is not callable
+Object of type PlainTemp is not callable
+Object of type PlainTemp is not callable
+Object of type PlainTemp is not callable
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/oo/magic/invoke_named_args.phpt
+++ b/tests/ph7/001-smoke/oo/magic/invoke_named_args.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+__invoke resolves named arguments
+--FILE--
+<?php
+class Pair {
+    public function __invoke($x, $y) {
+        return "$x:$y";
+    }
+}
+$p = new Pair();
+echo $p(y: "Y", x: "X"), "\n";
+echo $p(x: 1, y: 2), "\n";
+echo $p(1, y: 2), "\n";
+?>
+--EXPECT--
+X:Y
+1:2
+1:2
+--CLEAN--
+<?php
+unset($p);

--- a/tests/ph7/001-smoke/oo/magic/invoke_variadic.phpt
+++ b/tests/ph7/001-smoke/oo/magic/invoke_variadic.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Magic method __invoke supports variadic parameters
+--FILE--
+<?php
+class Summer {
+    public function __invoke(...$xs) {
+        return array_sum($xs);
+    }
+}
+$s = new Summer();
+echo $s(1, 2, 3, 4), "\n";
+echo $s(), "\n";
+echo $s(99), "\n";
+?>
+--EXPECT--
+10
+0
+99
+--CLEAN--
+<?php
+unset($s);

--- a/tests/ph7/002-integration/oo/magic/invoke_array_map.phpt
+++ b/tests/ph7/002-integration/oo/magic/invoke_array_map.phpt
@@ -1,0 +1,27 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+array_map accepts an object with __invoke as its callback
+--FILE--
+<?php
+class Doubler {
+    public function __invoke($x) {
+        return $x * 2;
+    }
+}
+class WithKey {
+    private string $prefix;
+    public function __construct(string $prefix) { $this->prefix = $prefix; }
+    public function __invoke($x) {
+        return $this->prefix . ":" . $x;
+    }
+}
+echo implode(",", array_map(new Doubler(), [1, 2, 3, 4])), "\n";
+echo implode(",", array_map(new WithKey("v"), [10, 20, 30])), "\n";
+?>
+--EXPECT--
+2,4,6,8
+v:10,v:20,v:30
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/magic/invoke_closure_sanity.phpt
+++ b/tests/ph7/002-integration/oo/magic/invoke_closure_sanity.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Closure invocation is unaffected by the __invoke object-callable path
+--FILE--
+<?php
+$f = function ($a, $b) { return $a * $b; };
+echo $f(3, 4), "\n";
+
+$arrow = fn($x) => $x + 1;
+echo $arrow(41), "\n";
+
+$captured = 100;
+$closure = function ($x) use ($captured) { return $x + $captured; };
+echo $closure(5), "\n";
+?>
+--EXPECT--
+12
+42
+105
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/magic/invoke_preg_replace_callback.phpt
+++ b/tests/ph7/002-integration/oo/magic/invoke_preg_replace_callback.phpt
@@ -1,0 +1,27 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+preg_replace_callback accepts an object with __invoke as its callback
+--FILE--
+<?php
+class Upper {
+    public function __invoke($m) {
+        return strtoupper($m[0]);
+    }
+}
+class Tagged {
+    private string $tag;
+    public function __construct(string $tag) { $this->tag = $tag; }
+    public function __invoke($m) {
+        return "<{$this->tag}>{$m[0]}</{$this->tag}>";
+    }
+}
+echo preg_replace_callback("/[a-z]+/", new Upper(), "hello world"), "\n";
+echo preg_replace_callback("/[0-9]+/", new Tagged("n"), "a1 b22 c333"), "\n";
+?>
+--EXPECT--
+HELLO WORLD
+a<n>1</n> b<n>22</n> c<n>333</n>
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/magic/invoke_recursion.phpt
+++ b/tests/ph7/002-integration/oo/magic/invoke_recursion.phpt
@@ -1,0 +1,27 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Magic method __invoke supports self-recursion via $this()
+--FILE--
+<?php
+class Sumdown {
+    public function __invoke($n) {
+        if ($n <= 0) {
+            return 0;
+        }
+        return $n + ($this)($n - 1);
+    }
+}
+$s = new Sumdown();
+echo $s(5), "\n";
+echo $s(10), "\n";
+echo $s(0), "\n";
+?>
+--EXPECT--
+15
+55
+0
+--CLEAN--
+<?php
+unset($s);

--- a/tests/ph7/002-integration/oo/magic/invoke_usort.phpt
+++ b/tests/ph7/002-integration/oo/magic/invoke_usort.phpt
@@ -1,0 +1,31 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+usort accepts an object with __invoke as its comparator
+--FILE--
+<?php
+class Ascending {
+    public function __invoke($a, $b) {
+        return $a - $b;
+    }
+}
+class Descending {
+    public function __invoke($a, $b) {
+        return $b - $a;
+    }
+}
+$asc = [3, 1, 4, 1, 5, 9, 2, 6];
+usort($asc, new Ascending());
+echo implode(",", $asc), "\n";
+
+$desc = [3, 1, 4, 1, 5, 9, 2, 6];
+usort($desc, new Descending());
+echo implode(",", $desc), "\n";
+?>
+--EXPECT--
+1,1,2,3,4,5,6,9
+9,6,5,4,3,2,1,1
+--CLEAN--
+<?php
+unset($asc, $desc);


### PR DESCRIPTION
Wire up object-as-callable so $obj($args), call_user_func, call_user_func_array, usort, array_map, preg_replace_callback, and any other site funnelling through PH7_VmCallUserFunction or ph7_value_is_callable now reach __invoke with arguments and return value. Missing __invoke raises a catchable Error.

Also fix PH7_VmIsCallable to match PHP semantics: an object is callable iff its class declares __invoke; the previous behavior of invoking __invoke as a runtime predicate during is_callable silently rejected object callables in usort/array_map/preg_replace_callback.
