### PR TITLE
Implement Perl-style string increment (PHP 4)

### DIFF
--- a/src/ph7/memobj.c
+++ b/src/ph7/memobj.c
@@ -726,6 +726,97 @@ PH7_PRIVATE sxi32 PH7_MemObjToNumeric(ph7_value *pObj)
 	return SXRET_OK;
 }
 /*
+ * Apply Perl-style increment to a string ph7_value in place.
+ * Walks the bytes right-to-left: digits 0-8 / letters a-y, A-Y bump in
+ * place; '9' wraps to '0' with carry; 'z' to 'a'; 'Z' to 'A'. A non-
+ * alphanumeric byte stops the walk without prepending. If carry survives
+ * past index 0, prepend '1', 'a', or 'A' depending on the class of the
+ * last carried character. Empty strings become "1".
+ *
+ * Caller must ensure pObj is MEMOBJ_STRING and not a numeric string;
+ * this routine never reclassifies the type, so a result like "e0" stays
+ * a string even though it looks numeric.
+ */
+PH7_PRIVATE sxi32 PH7_MemObjStringIncrement(ph7_value *pObj)
+{
+	enum CarryClass { CARRY_NONE = 0, CARRY_LOWER, CARRY_UPPER, CARRY_DIGIT };
+	enum CarryClass last_class = CARRY_NONE;
+	sxu32 nLen, pos;
+	sxu8 *zStr;
+	int carry = 1;
+	int ch;
+	/* Force ownership: the blob may be SXBLOB_RDONLY (e.g., from
+	 * PH7_MemObjLoad), in which case BlobPrepareGrow copies on demand
+	 * and clears the flag.  On an already-owned blob with spare capacity
+	 * (the common case under PHL's growth allocator), this is a no-op
+	 * append; on an exact-fit owned blob it triggers a single realloc. */
+	if( SyBlobLength(&pObj->sBlob) > 0 ){
+		SyBlobNullAppend(&pObj->sBlob);
+	}
+	nLen = SyBlobLength(&pObj->sBlob);
+	if( nLen == 0 ){
+		SyBlobAppend(&pObj->sBlob,"1",sizeof(char));
+		return SXRET_OK;
+	}
+	zStr = (sxu8 *)SyBlobData(&pObj->sBlob);
+	pos = nLen;
+	while( pos > 0 ){
+		pos--;
+		ch = zStr[pos];
+		if( ch >= 'a' && ch <= 'z' ){
+			if( ch == 'z' ){
+				zStr[pos] = 'a';
+				last_class = CARRY_LOWER;
+				continue;
+			}
+			zStr[pos]++;
+			carry = 0;
+			break;
+		}else if( ch >= 'A' && ch <= 'Z' ){
+			if( ch == 'Z' ){
+				zStr[pos] = 'A';
+				last_class = CARRY_UPPER;
+				continue;
+			}
+			zStr[pos]++;
+			carry = 0;
+			break;
+		}else if( ch >= '0' && ch <= '9' ){
+			if( ch == '9' ){
+				zStr[pos] = '0';
+				last_class = CARRY_DIGIT;
+				continue;
+			}
+			zStr[pos]++;
+			carry = 0;
+			break;
+		}else{
+			/* non-alphanumeric: stop without prepending */
+			carry = 0;
+			break;
+		}
+	}
+	if( carry ){
+		sxu8 prepend;
+		sxu32 i;
+		switch( last_class ){
+			case CARRY_LOWER: prepend = (sxu8)'a'; break;
+			case CARRY_UPPER: prepend = (sxu8)'A'; break;
+			default:          prepend = (sxu8)'1'; break;
+		}
+		/* Append a sentinel byte to grow nByte by 1 (capacity grows too). */
+		SyBlobAppend(&pObj->sBlob,"\0",sizeof(char));
+		zStr = (sxu8 *)SyBlobData(&pObj->sBlob);
+		nLen = SyBlobLength(&pObj->sBlob);
+		/* Shift right by 1, walking from the end so overlapping is safe. */
+		for( i = nLen - 1; i > 0; i-- ){
+			zStr[i] = zStr[i - 1];
+		}
+		zStr[0] = prepend;
+	}
+	return SXRET_OK;
+}
+/*
  * Try a get an integer representation of the given ph7_value.
  * If the ph7_value is not of type real,this function is a no-op.
  */

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1368,6 +1368,7 @@ PH7_PRIVATE sxi32 PH7_MemObjStore(ph7_value *pSrc,ph7_value *pDest);
 PH7_PRIVATE sxi32 PH7_MemObjLoad(ph7_value *pSrc,ph7_value *pDest);
 PH7_PRIVATE sxi32 PH7_MemObjRelease(ph7_value *pObj);
 PH7_PRIVATE sxi32 PH7_MemObjToNumeric(ph7_value *pObj);
+PH7_PRIVATE sxi32 PH7_MemObjStringIncrement(ph7_value *pObj);
 PH7_PRIVATE sxi32 PH7_MemObjTryInteger(ph7_value *pObj);
 PH7_PRIVATE ProcMemObjCast PH7_MemObjCastMethod(sxi32 iFlags);
 PH7_PRIVATE sxi32 PH7_MemObjIsNumeric(ph7_value *pObj);

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -149,6 +149,40 @@ static sxi32 VmIsUnorderedCmp(ph7_value *pLeft,ph7_value *pRight)
 	}
 	return FALSE;
 }
+/*
+ * Return TRUE if the value should take the Perl-style string-increment path:
+ * any MEMOBJ_STRING that is empty, or whose contents are not a complete
+ * number (matching PHP's is_numeric semantics — the whole string must parse
+ * as a number, with optional surrounding whitespace).  Strings with a
+ * numeric prefix followed by non-whitespace bytes (e.g. "5foo") take the
+ * Perl path, like PHP.  Strict numeric strings ("5", "1.5", "5e2", "  5  ")
+ * still go through the existing numeric coercion.
+ */
+static int VmStringWantsPerlIncr(ph7_value *pVal)
+{
+	SyString sStr;
+	sxu8 bReal = FALSE;
+	const char *zTail = 0;
+	const char *zEnd;
+	if( (pVal->iFlags & MEMOBJ_STRING) == 0 ){
+		return FALSE;
+	}
+	SyStringInitFromBuf(&sStr,SyBlobData(&pVal->sBlob),SyBlobLength(&pVal->sBlob));
+	if( sStr.nByte == 0 ){
+		return TRUE;
+	}
+	if( SyStrIsNumeric(sStr.zString,sStr.nByte,&bReal,&zTail) != SXRET_OK ){
+		return TRUE;
+	}
+	/* SyStrIsNumeric accepts a leading numeric prefix; require the
+	 * remainder to be whitespace only so leading-numeric junk like "5foo"
+	 * still takes the Perl path. */
+	zEnd = sStr.zString + sStr.nByte;
+	while( zTail < zEnd && (unsigned char)*zTail < 0xc0 && SyisSpace(*zTail) ){
+		zTail++;
+	}
+	return zTail < zEnd;
+}
 /* SyhttpUri, SyhttpHeader and HTTP method/protocol defines moved to ph7int.h */
 /*
  * Register a constant and it's associated expansion callback so that
@@ -4944,33 +4978,60 @@ case PH7_OP_INCR:
 		if( pTos->nIdx != SXU32_HIGH ){
 			ph7_value *pObj;
 			if( (pObj = (ph7_value *)SySetAt(&pVm->aMemObj,pTos->nIdx)) != 0 ){
-				/* Force a numeric cast */
-				PH7_MemObjToNumeric(pObj);
-				if( pObj->iFlags & MEMOBJ_REAL ){
-					pObj->rVal++;
-					/* Try to get an integer representation */
-					PH7_MemObjTryInteger(pTos);
+				if( VmStringWantsPerlIncr(pObj) ){
+					/* Perl-style string increment.
+					 * Post-increment: pTos may alias pObj's buffer via SXBLOB_RDONLY
+					 * (set by PH7_MemObjLoad).  Force ownership so the upcoming
+					 * mutation of pObj doesn't bleed into pTos's old-value view. */
+					if( pInstr->iP1 == 0 ){
+						SyBlobNullAppend(&pTos->sBlob);
+					}
+					PH7_MemObjStringIncrement(pObj);
+					if( pInstr->iP1 ){
+						/* Pre-increment: deep-copy pObj into pTos. */
+						PH7_MemObjStore(pObj,pTos);
+					}
 				}else{
-					pObj->x.iVal++;
-					MemObjSetType(pTos,MEMOBJ_INT);
-				}
-				if( pInstr->iP1 ){
-					/* Pre-icrement */
-					PH7_MemObjStore(pObj,pTos);
+					/* Numeric coercion. Post-increment must preserve pTos's
+					 * original value: pTos may alias pObj's blob via
+					 * SXBLOB_RDONLY (set by PH7_MemObjLoad), and
+					 * PH7_MemObjToNumeric calls SyBlobRelease on a STRING
+					 * pObj. Force pTos to take ownership of its blob first
+					 * so its old-value view survives the coercion. */
+					if( pInstr->iP1 == 0 && (pTos->iFlags & MEMOBJ_STRING) ){
+						SyBlobNullAppend(&pTos->sBlob);
+					}
+					/* Force a numeric cast on the variable */
+					PH7_MemObjToNumeric(pObj);
+					if( pObj->iFlags & MEMOBJ_REAL ){
+						pObj->rVal++;
+					}else{
+						pObj->x.iVal++;
+					}
+					if( pInstr->iP1 ){
+						/* Pre-increment: result is the new value. */
+						PH7_MemObjStore(pObj,pTos);
+					}
+					/* Post-increment: pTos retains the old value (a string
+					 * for "5"++, an int/float for direct numeric operands). */
 				}
 			}
 		}else{
 			if( pInstr->iP1 ){
-				/* Force a numeric cast */
-				PH7_MemObjToNumeric(pTos);
-				/* Pre-increment */
-				if( pTos->iFlags & MEMOBJ_REAL ){
-					pTos->rVal++;
-					/* Try to get an integer representation */
-					PH7_MemObjTryInteger(pTos);
+				if( VmStringWantsPerlIncr(pTos) ){
+					PH7_MemObjStringIncrement(pTos);
 				}else{
-					pTos->x.iVal++;
-					MemObjSetType(pTos,MEMOBJ_INT);
+					/* Force a numeric cast */
+					PH7_MemObjToNumeric(pTos);
+					/* Pre-increment */
+					if( pTos->iFlags & MEMOBJ_REAL ){
+						pTos->rVal++;
+						/* Try to get an integer representation */
+						PH7_MemObjTryInteger(pTos);
+					}else{
+						pTos->x.iVal++;
+						MemObjSetType(pTos,MEMOBJ_INT);
+					}
 				}
 			}
 		}

--- a/tests/ph7/001-smoke/lang/string_increment.phpt
+++ b/tests/ph7/001-smoke/lang/string_increment.phpt
@@ -1,0 +1,156 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Perl-style string increment ($a = "a"; $a++; -> "b")
+--FILE--
+<?php
+function s_inc_silence_dep() { return true; }
+
+// PHP 8.3+ raises E_DEPRECATED for non-numeric string increment.  Install
+// a swallow-only handler for that level so the runner's default error hook
+// doesn't echo deprecation lines and break our EXPECT match.  Other error
+// levels fall through to whatever handler was previously installed.
+if (defined('E_DEPRECATED')) {
+    set_error_handler('s_inc_silence_dep', E_DEPRECATED);
+}
+
+function s_inc_check(string $label, $expected, $actual): void {
+    if ($actual === $expected) {
+        echo "$label OK\n";
+    } else {
+        echo "$label FAIL: expected ";
+        var_export($expected);
+        echo " got ";
+        var_export($actual);
+        echo "\n";
+    }
+}
+
+// Empty string increments to "1".
+$a = ""; $a++;
+s_inc_check("empty", "1", $a);
+
+// Single letters and uppercase chains.
+$a = "a"; $a++; s_inc_check("a->b", "b", $a);
+$a = "z"; $a++; s_inc_check("z->aa", "aa", $a);
+$a = "Z"; $a++; s_inc_check("Z->AA", "AA", $a);
+$a = "Zz"; $a++; s_inc_check("Zz->AAa", "AAa", $a);
+
+// Long carry chains exercise the prepend path and the right-shift loop.
+$a = "zzzz"; $a++; s_inc_check("zzzz->aaaaa", "aaaaa", $a);
+$a = "ZZZZ"; $a++; s_inc_check("ZZZZ->AAAAA", "AAAAA", $a);
+
+// Mixed-case carry: the interior carry walks across class boundaries until
+// it hits an incrementable char.
+$a = "ZzZ"; $a++; s_inc_check("ZzZ->AAaA", "AAaA", $a);
+
+// Carry stops at a non-edge letter without prepending.
+$a = "yz"; $a++; s_inc_check("yz->za", "za", $a);
+$a = "az"; $a++; s_inc_check("az->ba", "ba", $a);
+
+// Carry through digits and across letter classes.
+$a = "a9"; $a++; s_inc_check("a9->b0", "b0", $a);
+$a = "Z9"; $a++; s_inc_check("Z9->AA0", "AA0", $a);
+$a = "Az"; $a++; s_inc_check("Az->Ba", "Ba", $a);
+$a = "abc"; $a++; s_inc_check("abc->abd", "abd", $a);
+
+// Numeric strings still go through numeric increment.
+$a = "5"; $a++; s_inc_check("\"5\"->6", 6, $a);
+$a = "1.5"; $a++; s_inc_check("\"1.5\"->2.5", 2.5, $a);
+
+// Non-alphanumeric stops the carry without prepending.
+$a = "!"; $a++; s_inc_check("!->!", "!", $a);
+$a = "a-z"; $a++; s_inc_check("a-z->a-a", "a-a", $a);
+
+// UTF-8 / high-bit bytes (>= 0x80) are non-alphanumeric to the byte-wise
+// walker.  An ASCII char following them still increments normally; a 'z'
+// preceded by them carries to 'a' but the carry stops at the high byte
+// without prepending (matches PHP's byte-level increment semantics).
+$a = "\xc3\xa1";  $a++; s_inc_check("á->á",   "\xc3\xa1",     $a);
+$a = "\xc3\xa1b"; $a++; s_inc_check("áb->ác", "\xc3\xa1c",    $a);
+$a = "\xc3\xa1z"; $a++; s_inc_check("áz->áa", "\xc3\xa1\x61", $a);
+
+// Result of carry through letters can look numeric ("e0") but must stay a string.
+$a = "d9"; $a++;
+s_inc_check("d9->e0", "e0", $a);
+s_inc_check("d9 stays string", true, is_string($a));
+
+// Post-increment must preserve the OLD value (regression test for COW guard).
+$a = "z"; $b = $a++;
+s_inc_check("post: a", "aa", $a);
+s_inc_check("post: b", "z", $b);
+
+// Pre-increment yields the NEW value.
+$a = "z"; $b = ++$a;
+s_inc_check("pre:  a", "aa", $a);
+s_inc_check("pre:  b", "aa", $b);
+
+// Pre-increment of an empty string also yields "1" (helper's empty branch
+// is reached whether or not the iP1 deep-copy fires).
+$a = ""; $b = ++$a;
+s_inc_check("pre-empty: a", "1", $a);
+s_inc_check("pre-empty: b", "1", $b);
+
+// Numeric-string post-increment must preserve the OLD string value.
+// Regression test for the COW guard in the numeric-coercion branch:
+// without it pTos still aliased pObj's blob and read freed memory.
+$a = "5"; $b = $a++;
+s_inc_check("post-num int: a", 6, $a);
+s_inc_check("post-num int: b", "5", $b);
+
+$a = "1.5"; $b = $a++;
+s_inc_check("post-num float: a", 2.5, $a);
+s_inc_check("post-num float: b", "1.5", $b);
+
+// Leading-numeric junk must take the Perl path (matches PHP's is_numeric).
+$a = "5foo"; $b = $a++;
+s_inc_check("post-prefix: a", "5fop", $a);
+s_inc_check("post-prefix: b", "5foo", $b);
+
+// Whitespace-padded numeric strings still take the numeric path.
+$a = "  5  "; $b = $a++;
+s_inc_check("post-pad: a", 6, $a);
+s_inc_check("post-pad: b", "  5  ", $b);
+?>
+--EXPECT--
+empty OK
+a->b OK
+z->aa OK
+Z->AA OK
+Zz->AAa OK
+zzzz->aaaaa OK
+ZZZZ->AAAAA OK
+ZzZ->AAaA OK
+yz->za OK
+az->ba OK
+a9->b0 OK
+Z9->AA0 OK
+Az->Ba OK
+abc->abd OK
+"5"->6 OK
+"1.5"->2.5 OK
+!->! OK
+a-z->a-a OK
+á->á OK
+áb->ác OK
+áz->áa OK
+d9->e0 OK
+d9 stays string OK
+post: a OK
+post: b OK
+pre:  a OK
+pre:  b OK
+pre-empty: a OK
+pre-empty: b OK
+post-num int: a OK
+post-num int: b OK
+post-num float: a OK
+post-num float: b OK
+post-prefix: a OK
+post-prefix: b OK
+post-pad: a OK
+post-pad: b OK
+--CLEAN--
+<?php
+unset($a, $b);


### PR DESCRIPTION
$a = "a"; $a++; now produces "b" instead of int(1). PH7_OP_INCR detects non-numeric MEMOBJ_STRING values via VmStringWantsPerlIncr (reusing SyStrIsNumeric) and dispatches to a new helper, PH7_MemObjStringIncrement, which walks bytes right-to-left in place: 'a'..'y' / 'A'..'Y' / '0'..'8' bump and stop; 'z' wraps to 'a' with carry, 'Z' to 'A', '9' to '0'. A non-alphanumeric byte (including UTF-8 high bytes) stops the carry without prepending. If carry survives past index 0, prepend '1', 'a', or 'A' based on the class of the last carried character. Empty strings become "1".

Numeric strings ("5", "1.5") still flow through the existing numeric-coercion path. The helper does not reclassify the result, so "d9"++ stays the string "e0" instead of becoming numeric.

Post-increment correctness depends on a copy-on-write guard: pTos aliases pObj's blob via SXBLOB_RDONLY after PH7_MemObjLoad, so a SyBlobNullAppend on pTos forces ownership before pObj is mutated. Pre-increment writes the result back to pTos via PH7_MemObjStore, which deep-copies. The helper itself also runs SyBlobNullAppend on pObj because pObj's blob may itself be RDONLY (loaded constants).
