### PR TITLE
Implement SPL Interfaces

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -347,14 +347,20 @@ Verified `get_declared_interfaces()`: **4 interfaces** (`Serializable`, `Iterato
 **Effort:** **M**
 
 ### 6.2 `ArrayAccess`, `Countable`, `Stringable`, `Traversable`, `UnitEnum`, `BackedEnum` interfaces
-**Status:** Missing. Verified `interface_exists("Countable")` and `interface_exists("ArrayAccess")` → false; `Stringable` also missing.
-**Scope:**
-- `ArrayAccess` — hook `[]` on objects into `offsetGet`/`offsetSet`/`offsetExists`/`offsetUnset`. Requires VM changes.
-- `Countable` — let `count()` call `->count()` when implemented.
-- `Stringable` (PHP 8.0) — auto-implemented when `__toString` present.
-- `Traversable` — empty interface used as type hint; extends `Iterator`/`IteratorAggregate`.
-- `UnitEnum`/`BackedEnum` — needed for enums (1.12).
-**Effort:** **M**
+**Status:** Implemented for the dispatch surface listed below. `interface_exists()` returns true for all six; `Iterator`/`IteratorAggregate` now `extends Traversable`; `Stringable` is auto-implemented for any class declaring `__toString` (including the built-in `Exception`/`Error` classes).
+**Implemented:**
+- `ArrayAccess` — `$obj[$k]` (offsetGet), `$obj[$k]=$v` and `$obj[]=$v` (offsetSet), `isset($obj[$k])` (offsetExists), `unset($obj[$k])` (offsetUnset). VM hooks live in `PH7_OP_LOAD_IDX`/`PH7_OP_STORE_IDX` (vm.c). Compiler routes `isset` and `unset` arguments via new iP2 codes 4 and 5.
+- `Countable` — `count($obj)` dispatches to `->count()`.
+- `Stringable` — auto-added to any class with `__toString`, at compile time.
+- `Traversable` — empty marker; `Iterator`/`IteratorAggregate` extend it; `instanceof Traversable` walks the parent-interface chain (`PH7_VmInstanceOf`).
+- `UnitEnum`/`BackedEnum` — declared as marker interfaces; full enum support is §1.12.
+**Out of scope (deferred):**
+- Nested ArrayAccess writes (`$obj['a']['b'] = 1`) — requires ref-semantic offsetGet return.
+- ArrayAccess `STORE_IDX_REF` (`$x =& $obj[$k]`) — runtime path is defended (throws "Cannot assign by reference to overloaded object") but the compiler rejects it earlier as "Reference operator require a variable not a constant", so the runtime guard is unreachable from valid PHP source.
+**Effort:** **M** (done).
+**Notes:**
+- `empty($obj[$k])` routes through `offsetExists` first, then `offsetGet` only when the key exists. New iP2=6 code added.
+- Subscripting a non-ArrayAccess object now throws a real `Error` (`Cannot use object of type X as array`) for read, write, isset, unset, and empty contexts — matches PHP. New `VmThrowFromVm` helper near `PH7_VmThrowException` factors the throw machinery (Error class lookup, instance construct, `VmThrowException`).
 
 ### 6.3 DateTime class family — PHP 5.2+
 **Status:** Missing. `new DateTime()` → "Class 'DateTime' is not defined".

--- a/build-aux/rules.mk
+++ b/build-aux/rules.mk
@@ -3,4 +3,10 @@
 
 $(BUILD_DIR)/$(MODE)/src/%.o: src/%.c
 	@mkdir -p $(@D)
-	$(CC) $(MODE_CFLAGS) -c $< -o $@
+	$(CC) $(MODE_CFLAGS) -MMD -MP -c $< -o $@
+
+# Auto-generated header dependencies (from -MMD -MP).
+# Each .d file lists the .c source plus every header it transitively includes,
+# so editing e.g. src/ph7/ph7int.h will rebuild every .o that pulls it in
+# instead of leaving stale objects with the wrong struct layout.
+-include $(MODE_OBJECTS:.o=.d)

--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -91,6 +91,9 @@ struct LangConstruct
 #define EXPR_FLAG_LOAD_IDX_STORE    0x001 /* Set the iP2 flag when dealing with the LOAD_IDX instruction */
 #define EXPR_FLAG_RDONLY_LOAD       0x002 /* Read-only load, refer to the 'PH7_OP_LOAD' VM instruction for more information */
 #define EXPR_FLAG_COMMA_STATEMENT   0x004 /* Treat comma expression as a single statement (used by class attributes) */
+#define EXPR_FLAG_LOAD_IDX_ISSET    0x008 /* LOAD_IDX argument is the LHS of isset() — emit iP2=4 (offsetExists) */
+#define EXPR_FLAG_LOAD_IDX_UNSET    0x010 /* LOAD_IDX argument is the LHS of unset() — emit iP2=5 (offsetUnset) */
+#define EXPR_FLAG_LOAD_IDX_EMPTY    0x020 /* LOAD_IDX argument is the LHS of empty() — emit iP2=6 (offsetExists+offsetGet) */
 /* Forward declaration */
 static sxi32 PH7_CompileExpr(ph7_gen_state *pGen,sxi32 iFlags,sxi32 (*xTreeValidator)(ph7_gen_state *,ph7_expr_node *));
 /*
@@ -8721,6 +8724,29 @@ static sxi32 GenStateCompileClass(ph7_gen_state *pGen,sxi32 iFlags)
 				break;
 			}
 		}
+		/* Auto-implement Stringable when class declares __toString (PHP 8.0+).
+		 * Skip interfaces/traits and classes that already implement it explicitly. */
+		if( rc == SXRET_OK
+		 && (pClass->iFlags & (PH7_CLASS_INTERFACE|PH7_CLASS_TRAIT)) == 0
+		 && SyHashGet(&pClass->hMethod,"__toString",sizeof("__toString")-1) != 0 ){
+			ph7_class *pStringable = PH7_VmExtractClass(pGen->pVm,
+				"Stringable",sizeof("Stringable")-1,FALSE,0);
+			if( pStringable ){
+				ph7_class **apImpl = (ph7_class **)SySetBasePtr(&pClass->aInterface);
+				sxu32 nImpl = SySetUsed(&pClass->aInterface);
+				sxu32 i;
+				int bAlready = 0;
+				for( i = 0 ; i < nImpl ; i++ ){
+					if( apImpl[i] == pStringable ){
+						bAlready = 1;
+						break;
+					}
+				}
+				if( !bAlready ){
+					PH7_ClassImplement(pClass,pStringable);
+				}
+			}
+		}
 		/* Validate interface method signatures (visibility and parameter count) */
 		if( rc == SXRET_OK ){
 			sxi32 rcCheck = GenStateCheckInterfaceSignatures(&(*pGen),pClass);
@@ -10039,6 +10065,20 @@ static sxi32 GenStateEmitExprCode(
 			}
 			/* Read-only load */
 			iFlags |= EXPR_FLAG_RDONLY_LOAD;
+			/* Route subscript-argument LOAD_IDX through a special iP2 code
+			 * for the language constructs `isset` and `empty` so ArrayAccess
+			 * objects dispatch to the right method (offsetExists for both;
+			 * empty also needs offsetGet to evaluate emptiness on hits). */
+			if( pNode->pLeft && pNode->pLeft->pStart ){
+				SyString *pCallName = &pNode->pLeft->pStart->sData;
+				if( pCallName->nByte == 5
+				 && SyStrnicmp(pCallName->zString,"isset",5) == 0 ){
+					iFlags |= EXPR_FLAG_LOAD_IDX_ISSET;
+				}else if( pCallName->nByte == 5
+				 && SyStrnicmp(pCallName->zString,"empty",5) == 0 ){
+					iFlags |= EXPR_FLAG_LOAD_IDX_EMPTY;
+				}
+			}
 			for( n = 0 ; n < nArgs ; ++n ){
 				sxu32 nArgNsBase = SySetUsed(&pGen->aNullsafeJmp);
 				rc = GenStateEmitExprCode(&(*pGen),apNode[n],iFlags&~EXPR_FLAG_LOAD_IDX_STORE);
@@ -10152,11 +10192,14 @@ static sxi32 GenStateEmitExprCode(
 		}else if( iVmOp == PH7_OP_LOAD_IDX ){
 			ph7_expr_node **apNode;
 			sxi32 n;
+			sxi32 iChildMask = ~(EXPR_FLAG_LOAD_IDX_STORE
+				|EXPR_FLAG_LOAD_IDX_ISSET|EXPR_FLAG_LOAD_IDX_UNSET
+				|EXPR_FLAG_LOAD_IDX_EMPTY);
 			/* Recurse and generate bytecodes for array index */
 			apNode = (ph7_expr_node **)SySetBasePtr(&pNode->aNodeArgs);
 			for( n = 0 ; n < (sxi32)SySetUsed(&pNode->aNodeArgs) ; ++n ){
 				sxu32 nIdxNsBase = SySetUsed(&pGen->aNullsafeJmp);
-				rc = GenStateEmitExprCode(&(*pGen),apNode[n],iFlags&~EXPR_FLAG_LOAD_IDX_STORE);
+				rc = GenStateEmitExprCode(&(*pGen),apNode[n],iFlags&iChildMask);
 				if( rc != SXRET_OK ){
 					return rc;
 				}
@@ -10166,7 +10209,19 @@ static sxi32 GenStateEmitExprCode(
 			if( SySetUsed(&pNode->aNodeArgs) > 0 ){
 				iP1 = 1; /* Node have an index associated with it */
 			}
-			if( iFlags & EXPR_FLAG_LOAD_IDX_STORE ){
+			if( iFlags & EXPR_FLAG_LOAD_IDX_ISSET ){
+				/* offsetExists for ArrayAccess; peek-only for arrays */
+				iP2 = 4;
+			}else if( iFlags & EXPR_FLAG_LOAD_IDX_UNSET ){
+				/* offsetUnset for ArrayAccess; auto-vivify+load for arrays
+				 * so the trailing unset() builtin can drop the slot. */
+				iP2 = 5;
+			}else if( iFlags & EXPR_FLAG_LOAD_IDX_EMPTY ){
+				/* offsetExists+offsetGet for ArrayAccess so empty() can
+				 * short-circuit on missing keys without invoking offsetGet
+				 * unnecessarily; peek-only for arrays (same as iP2=0). */
+				iP2 = 6;
+			}else if( iFlags & EXPR_FLAG_LOAD_IDX_STORE ){
 				/* Create an empty entry when the desired index is not found */
 				iP2 = 1;
 			}
@@ -10574,7 +10629,7 @@ static sxi32 PH7_CompileUnset(ph7_gen_state *pGen)
 		if( pGen->pIn < pNext ){
 			pGen->pEnd = pNext;
 			rc = PH7_CompileExpr(&(*pGen),
-				EXPR_FLAG_RDONLY_LOAD|EXPR_FLAG_LOAD_IDX_STORE,
+				EXPR_FLAG_RDONLY_LOAD|EXPR_FLAG_LOAD_IDX_UNSET,
 				GenStateUnsetValidator);
 			if( rc == SXERR_ABORT ){
 				return SXERR_ABORT;

--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -2650,13 +2650,9 @@ static int ph7_hashmap_count(ph7_context *pCtx,int nArg,ph7_value **apArg)
 			nArg
 			);
 	}
-	if( !ph7_value_is_array(apArg[0]) ){
-		return PH7_VmThrowException(pCtx,
-			"TypeError",
-			"count(): Argument #1 ($value) must be of type Countable|array, %s given",
-			ph7_type_name(apArg[0])
-			);
-	}
+	/* PHP validates $mode right after parsing, before the type dispatch, so
+	 * an invalid mode raises ValueError whether $value is an array or a
+	 * Countable object (the mode is then ignored for the Countable path). */
 	if( nArg > 1 ){
 		sxi32 iMode = ph7_value_to_int(apArg[1]);
 		if( iMode != 0 /* COUNT_NORMAL */ && iMode != 1 /* COUNT_RECURSIVE */ ){
@@ -2666,6 +2662,30 @@ static int ph7_hashmap_count(ph7_context *pCtx,int nArg,ph7_value **apArg)
 				);
 		}
 		bRecursive = iMode == 1;
+	}
+	if( !ph7_value_is_array(apArg[0]) ){
+		/* Countable object: dispatch to ->count() */
+		if( apArg[0]->iFlags & MEMOBJ_OBJ ){
+			ph7_class_instance *pInst = (ph7_class_instance *)apArg[0]->x.pOther;
+			ph7_class *pCountable = pCtx->pVm->pCountableClass;
+			if( pCountable && PH7_VmInstanceOf(pInst->pClass,pCountable) ){
+				ph7_class_method *pMeth = PH7_ClassExtractMethod(pInst->pClass,
+					"count",sizeof("count")-1);
+				if( pMeth ){
+					ph7_value sResult;
+					PH7_MemObjInit(pCtx->pVm,&sResult);
+					PH7_VmCallClassMethod(pCtx->pVm,pInst,pMeth,&sResult,0,0);
+					ph7_result_int64(pCtx,ph7_value_to_int64(&sResult));
+					PH7_MemObjRelease(&sResult);
+					return PH7_OK;
+				}
+			}
+		}
+		return PH7_VmThrowException(pCtx,
+			"TypeError",
+			"count(): Argument #1 ($value) must be of type Countable|array, %s given",
+			ph7_type_name(apArg[0])
+			);
 	}
 	/* Count */
 	iCount = HashmapCount((ph7_hashmap *)apArg[0]->x.pOther,bRecursive,&bCycleDetected);

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -905,6 +905,17 @@ struct ph7_vm
 	ph7_exec_ctx *pActiveCtx;  /* Currently executing fiber/generator context (NULL in normal code) */
 	ph7_class *pFiberClass;    /* Cached Fiber class pointer for fast dispatch */
 	ph7_class *pGeneratorClass; /* Cached Generator class pointer */
+	ph7_class *pArrayAccessClass; /* Cached ArrayAccess interface pointer */
+	ph7_class *pCountableClass;   /* Cached Countable interface pointer */
+	ph7_class *pStringableClass;  /* Cached Stringable interface pointer */
+	/* Pending null-coalesce-assign target on an ArrayAccess subscript.
+	 * Set by LOAD_IDX iP2=3 when the key is missing on an ArrayAccess
+	 * object; consumed by NULLC_STORE so it can dispatch to offsetSet
+	 * instead of writing through the (synthetic) pNos->nIdx. NULLC_STORE
+	 * always clears it, matched or not. */
+	ph7_class_instance *pCoalesceObj;
+	ph7_value sCoalesceKey;
+	int bCoalesceArmed;
 #ifdef PH7_ENABLE_PCRE
 	int iPcreLastError;        /* preg_last_error() return value */
 #endif

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -1046,6 +1046,26 @@ static int vm_builtin_Generator_destruct(ph7_context *pCtx, int nArg, ph7_value 
 	"public function getPrevious();"\
 	"public function __toString();"\
 	"}"\
+	"interface Traversable {}"\
+	"interface ArrayAccess {"\
+	"public function offsetExists($offset);"\
+	"public function offsetGet($offset);"\
+	"public function offsetSet($offset, $value);"\
+	"public function offsetUnset($offset);"\
+	"}"\
+	"interface Countable {"\
+	"public function count();"\
+	"}"\
+	"interface Stringable {"\
+	"public function __toString();"\
+	"}"\
+	"interface UnitEnum {"\
+	"public static function cases();"\
+	"}"\
+	"interface BackedEnum extends UnitEnum {"\
+	"public static function from($value);"\
+	"public static function tryFrom($value);"\
+	"}"\
 	"class Exception implements Throwable { "\
     "protected $message = '';"\
     "protected $code = 0;"\
@@ -1161,14 +1181,14 @@ static int vm_builtin_Generator_destruct(ph7_context *pCtx, int nArg, ph7_value 
 	"   return $this->severity;"\
     "}"\
 	"}"\
-	"interface Iterator {"\
+	"interface Iterator extends Traversable {"\
 	"public function current();"\
 	"public function key();"\
 	"public function next();"\
 	"public function rewind();"\
 	"public function valid();"\
 	"}"\
-	"interface IteratorAggregate {"\
+	"interface IteratorAggregate extends Traversable {"\
 	"public function getIterator();"\
 	"}"\
 	"interface Serializable {"\
@@ -1580,6 +1600,14 @@ PH7_PRIVATE sxi32 PH7_VmInit(
 	VmEvalChunk(&(*pVm),0,&sBuiltin,PH7_PHP_ONLY,FALSE);
 	/* Cache the Fiber class pointer for fast dispatch */
 	pVm->pFiberClass = PH7_VmExtractClass(pVm,"Fiber",5,0,0);
+	/* Cache built-in interface pointers used on hot dispatch paths */
+	pVm->pArrayAccessClass = PH7_VmExtractClass(pVm,"ArrayAccess",sizeof("ArrayAccess")-1,0,0);
+	pVm->pCountableClass   = PH7_VmExtractClass(pVm,"Countable",sizeof("Countable")-1,0,0);
+	pVm->pStringableClass  = PH7_VmExtractClass(pVm,"Stringable",sizeof("Stringable")-1,0,0);
+	/* Initialize null-coalesce-assign scratch slot */
+	pVm->pCoalesceObj = 0;
+	pVm->bCoalesceArmed = 0;
+	PH7_MemObjInit(pVm,&pVm->sCoalesceKey);
 	/* Register Fiber internal C functions */
 	ph7_create_function(pVm,"__fiber_suspend",vm_builtin_Fiber_suspend,0);
 	ph7_create_function(pVm,"__fiber_construct",vm_builtin_Fiber_construct,0);
@@ -3628,6 +3656,78 @@ static sxi32 VmReportUncaughtException(ph7_vm *pVm,const char *zClass,sxu32 nCla
 	return PH7_ABORT;
 }
 /*
+ * Disarm the null-coalesce-assign scratch slot armed by LOAD_IDX iP2=3.
+ *
+ * Arming holds a ref on the cached ArrayAccess instance so it survives the
+ * intervening RHS evaluation until NULLC_STORE consumes it. Anything that
+ * abandons that store path before NULLC_STORE runs — an exception thrown
+ * while evaluating the RHS, a re-arm for a different target — must disarm
+ * here, both to release the leaked instance ref/key and to stop a later
+ * unrelated NULLC_STORE from dispatching offsetSet() on the stale slot.
+ */
+static void VmCoalesceDisarm(ph7_vm *pVm)
+{
+	if( pVm->bCoalesceArmed ){
+		if( pVm->pCoalesceObj ){
+			PH7_ClassInstanceUnref(pVm->pCoalesceObj);
+		}
+		PH7_MemObjRelease(&pVm->sCoalesceKey);
+		pVm->pCoalesceObj = 0;
+		pVm->bCoalesceArmed = 0;
+	}
+}
+/*
+ * Throw a PHP-compatible exception of the named class from inside the VM
+ * bytecode dispatch loop (where no ph7_context is available). The message
+ * is a literal, non-formatted string; callers that need formatting should
+ * build the SyBlob themselves and pass its data + length.
+ *
+ * Returns SXERR_ABORT if the throw machinery itself fails, SXRET_OK on
+ * successful throw (the caller should typically `goto Abort` afterwards if
+ * the surrounding opcode cannot continue). Mirrors the inline pattern in
+ * PH7_OP_THROW (see "case PH7_OP_THROW").
+ */
+static sxi32 VmThrowFromVm(
+	ph7_vm *pVm,
+	const char *zClass,
+	const char *zMsg,
+	sxu32 nMsg
+){
+	ph7_class *pClass;
+	ph7_class_instance *pThis;
+	ph7_class_method *pCons;
+	VmFrame *pFrame;
+	sxi32 rc;
+	pClass = PH7_VmExtractClass(pVm,zClass,SyStrlen(zClass),TRUE,0);
+	if( pClass == 0 ){
+		return SXERR_ABORT;
+	}
+	pThis = PH7_NewClassInstance(pVm,pClass);
+	if( pThis == 0 ){
+		return SXERR_ABORT;
+	}
+	pCons = PH7_ClassExtractMethod(pClass,"__construct",sizeof("__construct")-1);
+	if( pCons ){
+		ph7_value sArg;
+		ph7_value *apArg[1];
+		SyString sMsgStr;
+		SyStringInitFromBuf(&sMsgStr,zMsg,nMsg);
+		PH7_MemObjInit(pVm,&sArg);
+		PH7_MemObjInitFromString(pVm,&sArg,&sMsgStr);
+		apArg[0] = &sArg;
+		PH7_VmCallClassMethod(pVm,pThis,pCons,0,1,apArg);
+		PH7_MemObjRelease(&sArg);
+	}
+	pFrame = pVm->pFrame;
+	if( pFrame ){
+		pFrame = VmSkipExceptionFrames(pFrame);
+		pFrame->iFlags |= VM_FRAME_THROW;
+	}
+	rc = VmThrowException(pVm,pThis);
+	PH7_ClassInstanceUnref(pThis);
+	return rc;
+}
+/*
  * Throw an internal exception instance that can be intercepted by try/catch.
  */
 PH7_PRIVATE sxi32 PH7_VmThrowException(ph7_context *pCtx,const char *zClass,const char *zFormat,...)
@@ -4704,7 +4804,168 @@ case PH7_OP_LOAD_IDX: {
 		}
 		break;
 	}
-	if( (pInstr->iP2 == 1 || pInstr->iP2 == 3) && (pTos->iFlags & MEMOBJ_HASHMAP) == 0 ){
+	if( pTos->iFlags & MEMOBJ_OBJ ){
+		/* Object subscript: ArrayAccess dispatch.
+		 * iP2 codes:
+		 *   0 = read       → offsetGet
+		 *   3 = ?? peek    → offsetExists; offsetGet on hit; arm coalesce
+		 *                    target on miss for the upcoming NULLC_STORE
+		 *   4 = isset()    → offsetExists
+		 *   5 = unset()    → offsetUnset
+		 *   6 = empty()    → offsetExists, then offsetGet on hit */
+		ph7_class_instance *pInst = (ph7_class_instance *)pTos->x.pOther;
+		ph7_class *pArrayAccess = pVm->pArrayAccessClass;
+		if( pArrayAccess && pInst && PH7_VmInstanceOf(pInst->pClass,pArrayAccess) ){
+			ph7_class_method *pMeth;
+			ph7_value sResult;
+			ph7_value *apArg[1];
+			if( (pInstr->iP2 == 0 || pInstr->iP2 == 3) && pIdx == 0 ){
+				/* `$obj[]` read — PHP rejects this. */
+				PH7_VmThrowError(&(*pVm),0,PH7_CTX_WARNING,
+					"Cannot use [] for reading");
+				PH7_MemObjRelease(pTos);
+				pTos->nIdx = SXU32_HIGH;
+				break;
+			}
+			PH7_MemObjInit(&(*pVm),&sResult);
+			if( pInstr->iP2 == 4 || pInstr->iP2 == 6 || pInstr->iP2 == 3 ){
+				/* isset, empty, and ??= all start with offsetExists. */
+				pMeth = PH7_ClassExtractMethod(pInst->pClass,
+					"offsetExists",sizeof("offsetExists")-1);
+				apArg[0] = pIdx;
+				if( pMeth ){
+					PH7_VmCallClassMethod(&(*pVm),pInst,pMeth,&sResult,pIdx ? 1 : 0,apArg);
+				}
+			}else if( pInstr->iP2 == 5 ){
+				pMeth = PH7_ClassExtractMethod(pInst->pClass,
+					"offsetUnset",sizeof("offsetUnset")-1);
+				apArg[0] = pIdx;
+				if( pMeth ){
+					PH7_VmCallClassMethod(&(*pVm),pInst,pMeth,&sResult,pIdx ? 1 : 0,apArg);
+				}
+			}else{
+				pMeth = PH7_ClassExtractMethod(pInst->pClass,
+					"offsetGet",sizeof("offsetGet")-1);
+				apArg[0] = pIdx;
+				if( pMeth ){
+					PH7_VmCallClassMethod(&(*pVm),pInst,pMeth,&sResult,pIdx ? 1 : 0,apArg);
+				}
+			}
+			if( pInstr->iP2 == 4 ){
+				/* isset: push MEMOBJ_BOOL so vm_builtin_isset reports the
+				 * right truth value AND skips its "Expecting a variable not
+				 * a constant" warning (keyed on MEMOBJ_BOOL). */
+				int bExists = ph7_value_to_bool(&sResult);
+				PH7_MemObjRelease(pTos);
+				pTos->nIdx = SXU32_HIGH;
+				if( bExists ){
+					MemObjSetType(pTos,MEMOBJ_BOOL);
+					pTos->x.iVal = 1;
+				}else{
+					MemObjSetType(pTos,MEMOBJ_NULL);
+				}
+			}else if( pInstr->iP2 == 5 ){
+				/* offsetUnset return is discarded; push NULL so the trailing
+				 * vm_builtin_unset is a harmless no-op. */
+				PH7_MemObjRelease(pTos);
+				pTos->nIdx = SXU32_HIGH;
+				MemObjSetType(pTos,MEMOBJ_NULL);
+			}else if( pInstr->iP2 == 6 ){
+				/* empty: if offsetExists is false, push NULL so empty=true
+				 * without calling offsetGet. If true, call offsetGet and
+				 * push the value so PH7_builtin_empty evaluates emptiness. */
+				int bExists = ph7_value_to_bool(&sResult);
+				PH7_MemObjRelease(&sResult);
+				PH7_MemObjRelease(pTos);
+				pTos->nIdx = SXU32_HIGH;
+				if( !bExists ){
+					MemObjSetType(pTos,MEMOBJ_NULL);
+				}else{
+					ph7_class_method *pGet = PH7_ClassExtractMethod(pInst->pClass,
+						"offsetGet",sizeof("offsetGet")-1);
+					ph7_value sValue;
+					PH7_MemObjInit(&(*pVm),&sValue);
+					apArg[0] = pIdx;
+					if( pGet ){
+						PH7_VmCallClassMethod(&(*pVm),pInst,pGet,&sValue,pIdx ? 1 : 0,apArg);
+					}
+					PH7_MemObjStore(&sValue,pTos);
+					PH7_MemObjRelease(&sValue);
+				}
+				if( pIdx ){ PH7_MemObjRelease(pIdx); }
+				break; /* skip the duplicate sResult release below */
+			}else if( pInstr->iP2 == 3 ){
+				/* ?? null-coalesce peek: emulate PHP semantics —
+				 *   if !offsetExists OR offsetGet() === null → arm
+				 *     coalesce slot (NULLC_STORE will call offsetSet)
+				 *     and push NULL.
+				 *   else → push offsetGet's value (NULLC_JMP skips). */
+				int bExists = ph7_value_to_bool(&sResult);
+				int bShouldArm = !bExists;
+				ph7_value sValue;
+				PH7_MemObjRelease(&sResult);
+				/* Reset any prior arming defensively */
+				VmCoalesceDisarm(pVm);
+				PH7_MemObjInit(&(*pVm),&sValue);
+				if( bExists ){
+					ph7_class_method *pGet = PH7_ClassExtractMethod(pInst->pClass,
+						"offsetGet",sizeof("offsetGet")-1);
+					apArg[0] = pIdx;
+					if( pGet ){
+						PH7_VmCallClassMethod(&(*pVm),pInst,pGet,&sValue,pIdx ? 1 : 0,apArg);
+					}
+					if( sValue.iFlags & MEMOBJ_NULL ){
+						bShouldArm = 1;
+					}
+				}
+				PH7_MemObjRelease(pTos);
+				pTos->nIdx = SXU32_HIGH;
+				if( bShouldArm ){
+					/* Arm: remember (object, key) so NULLC_STORE dispatches
+					 * to offsetSet. Hold a ref on the instance to survive
+					 * intervening expression evaluation. */
+					MemObjSetType(pTos,MEMOBJ_NULL);
+					if( pIdx ){
+						PH7_MemObjStore(pIdx,&pVm->sCoalesceKey);
+					}
+					pVm->pCoalesceObj = pInst;
+					pInst->iRef++;
+					pVm->bCoalesceArmed = 1;
+				}else{
+					PH7_MemObjStore(&sValue,pTos);
+				}
+				PH7_MemObjRelease(&sValue);
+				if( pIdx ){ PH7_MemObjRelease(pIdx); }
+				break;
+			}else{
+				/* offsetGet: replace pTos with the returned value. */
+				PH7_MemObjRelease(pTos);
+				PH7_MemObjStore(&sResult,pTos);
+				pTos->nIdx = SXU32_HIGH;
+			}
+			PH7_MemObjRelease(&sResult);
+			if( pIdx ){
+				PH7_MemObjRelease(pIdx);
+			}
+			break;
+		}
+		/* Object without ArrayAccess: PHP throws fatal Error in all subscript
+		 * contexts (read, isset, unset, empty). Match it. */
+		if( pInst ){
+			char zMsg[256];
+			SyString *pName = &pInst->pClass->sName;
+			sxu32 nMsg = SyBufferFormat(zMsg,sizeof(zMsg),
+				"Cannot use object of type %.*s as array",
+				(int)pName->nByte,pName->zString);
+			rc = VmThrowFromVm(pVm,"Error",zMsg,nMsg);
+			if( pIdx ){ PH7_MemObjRelease(pIdx); }
+			PH7_MemObjRelease(pTos);
+			pTos->nIdx = SXU32_HIGH;
+			if( rc == SXERR_ABORT ){ goto Abort; }
+			break;
+		}
+	}
+	if( (pInstr->iP2 == 1 || pInstr->iP2 == 3 || pInstr->iP2 == 5) && (pTos->iFlags & MEMOBJ_HASHMAP) == 0 ){
 		if( pTos->nIdx != SXU32_HIGH ){
 			ph7_value *pObj;
 			if( (pObj = (ph7_value *)SySetAt(&pVm->aMemObj,pTos->nIdx)) != 0 ){
@@ -4715,11 +4976,13 @@ case PH7_OP_LOAD_IDX: {
 	}
 	rc = SXERR_NOTFOUND; /* Assume the index is invalid */
 	if( pTos->iFlags & MEMOBJ_HASHMAP ){
-		if( pInstr->iP2 == 1 ){
+		if( pInstr->iP2 == 1 || pInstr->iP2 == 5 ){
 			/* Write-context access (iP2 = create-if-missing).  COW-separate
 			 * the parent so nested writes like $b[0][0] = 99 don't leak
 			 * through shared outer arrays.  Read-only loads (iP2 == 0) must
-			 * NOT separate — that would defeat COW on every element read. */
+			 * NOT separate — that would defeat COW on every element read.
+			 * iP2=5 is unset-context, treated like iP2=1 for arrays so the
+			 * trailing unset() builtin can drop the slot via pTos->nIdx. */
 			PH7_HashmapCowSeparate(&(*pVm),pTos);
 		}
 		/* Point to the hashmap */
@@ -4756,7 +5019,7 @@ case PH7_OP_LOAD_IDX: {
 				}
 			}
 		}
-		if( rc != SXRET_OK && (pInstr->iP2 == 1 || pInstr->iP2 == 3) ){
+		if( rc != SXRET_OK && (pInstr->iP2 == 1 || pInstr->iP2 == 3 || pInstr->iP2 == 5) ){
 			/* Create a new empty entry */
 			rc = PH7_HashmapInsert(pMap,pIdx,0);
 			if( rc == SXRET_OK ){
@@ -4971,6 +5234,73 @@ case PH7_OP_STORE_IDX_REF: {
 		pKey = 0;
 	}
 	nIdx = pTos->nIdx;
+	{
+		/* ArrayAccess::offsetSet dispatch.
+		 * Container may be on the stack as MEMOBJ_OBJ, or referenced via
+		 * the backing variable slot at nIdx. */
+		ph7_class_instance *pInst = 0;
+		if( pTos->iFlags & MEMOBJ_OBJ ){
+			pInst = (ph7_class_instance *)pTos->x.pOther;
+		}else if( nIdx != SXU32_HIGH ){
+			ph7_value *pBacking = (ph7_value *)SySetAt(&pVm->aMemObj,nIdx);
+			if( pBacking && (pBacking->iFlags & MEMOBJ_OBJ) ){
+				pInst = (ph7_class_instance *)pBacking->x.pOther;
+			}
+		}
+		if( pInst ){
+			ph7_class *pArrayAccess = pVm->pArrayAccessClass;
+			if( pArrayAccess && PH7_VmInstanceOf(pInst->pClass,pArrayAccess) ){
+				ph7_class_method *pMeth;
+				ph7_value sNullKey;
+				ph7_value *apArg[2];
+				if( pInstr->iOp == PH7_OP_STORE_IDX_REF ){
+					PH7_VmThrowError(&(*pVm),0,PH7_CTX_ERR,
+						"Cannot assign by reference to overloaded object");
+					if( pKey ){ PH7_MemObjRelease(pKey); }
+					VmPopOperand(&pTos,2); /* container + value */
+					break;
+				}
+				pMeth = PH7_ClassExtractMethod(pInst->pClass,
+					"offsetSet",sizeof("offsetSet")-1);
+				/* Pop container; pTos now points to the value */
+				VmPopOperand(&pTos,1);
+				if( pKey == 0 ){
+					PH7_MemObjInit(&(*pVm),&sNullKey);
+					apArg[0] = &sNullKey;
+				}else{
+					apArg[0] = pKey;
+				}
+				apArg[1] = pTos;
+				if( pMeth ){
+					PH7_VmCallClassMethod(&(*pVm),pInst,pMeth,0,2,apArg);
+				}
+				if( pKey ){
+					PH7_MemObjRelease(pKey);
+				}else{
+					PH7_MemObjRelease(&sNullKey);
+				}
+				/* Pop the value */
+				VmPopOperand(&pTos,1);
+				break;
+			}
+			/* Object without ArrayAccess: PHP throws a fatal Error rather
+			 * than silently coercing the object into a hashmap (which is
+			 * what the legacy PH7 fall-through would do via MemObjToHashmap
+			 * a few lines below). Match PHP. */
+			{
+				char zMsg[256];
+				SyString *pName = &pInst->pClass->sName;
+				sxu32 nMsg = SyBufferFormat(zMsg,sizeof(zMsg),
+					"Cannot use object of type %.*s as array",
+					(int)pName->nByte,pName->zString);
+				rc = VmThrowFromVm(pVm,"Error",zMsg,nMsg);
+				if( pKey ){ PH7_MemObjRelease(pKey); }
+				VmPopOperand(&pTos,2); /* container + value */
+				if( rc == SXERR_ABORT ){ goto Abort; }
+				break;
+			}
+		}
+	}
 	if( pTos->iFlags & MEMOBJ_HASHMAP ){
 		/* Hashmap already loaded on stack — COW separate the backing variable.
 		 * The stack holds a temporary ref (from LOAD), so undo it before
@@ -6182,6 +6512,26 @@ case PH7_OP_NULLC_STORE: {
 		goto Abort;
 	}
 #endif
+	/* ArrayAccess null-coalesce-assign target: the preceding LOAD_IDX iP2=3
+	 * armed pVm with the (object, key) on a missing key. Dispatch to
+	 * offsetSet instead of writing through the synthetic pNos->nIdx. */
+	if( pVm->bCoalesceArmed && pVm->pCoalesceObj ){
+		ph7_class_instance *pInst = pVm->pCoalesceObj;
+		ph7_class_method *pSet = PH7_ClassExtractMethod(pInst->pClass,
+			"offsetSet",sizeof("offsetSet")-1);
+		ph7_value *apArg[2];
+		apArg[0] = &pVm->sCoalesceKey;
+		apArg[1] = pTos;
+		if( pSet ){
+			PH7_VmCallClassMethod(&(*pVm),pInst,pSet,0,2,apArg);
+		}
+		/* Leave RHS as the expression result (replace pNos with pTos). */
+		PH7_MemObjStore(pTos,pNos);
+		VmPopOperand(&pTos,1);
+		/* Disarm and release the cached instance ref + key. */
+		VmCoalesceDisarm(pVm);
+		break;
+	}
 	nIdx = pNos->nIdx;
 	if( nIdx == SXU32_HIGH ){
 		PH7_VmThrowError(&(*pVm),0,PH7_CTX_ERR,
@@ -11948,7 +12298,10 @@ static int vm_builtin_isset(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	for( i = 0 ; i < nArg ; ++i ){
 		pObj = apArg[i];
 		if( pObj->nIdx == SXU32_HIGH ){
-			if( (pObj->iFlags & MEMOBJ_NULL) == 0 ){
+			/* Skip the "expecting a variable" warning for MEMOBJ_BOOL —
+			 * synthesized by LOAD_IDX iP2=4 (ArrayAccess::offsetExists) and
+			 * by anyone passing a bool literal (rare, harmless). */
+			if( (pObj->iFlags & (MEMOBJ_NULL|MEMOBJ_BOOL)) == 0 ){
 				/* Not so fatal,Throw a warning */
 				ph7_context_throw_error(pCtx,PH7_CTX_WARNING,"Expecting a variable not a constant");
 			}
@@ -13014,6 +13367,10 @@ static sxi32 VmThrowException(
 	ph7_exception_block *pCatch; /* Catch block to execute */
 	ph7_exception **apException;
 	ph7_exception *pException;
+	/* An in-flight throw abandons any pending null-coalesce-assign store:
+	 * disarm so the RHS-evaluation throw can't leave the slot live for a
+	 * later unrelated NULLC_STORE (stale offsetSet) or leak the instance ref. */
+	VmCoalesceDisarm(pVm);
 	/* Point to the stack of loaded exceptions */
 	apException = (ph7_exception **)SySetBasePtr(&pVm->aException);
 	pException = 0;

--- a/src/ph7/vm_builtin_class.c
+++ b/src/ph7/vm_builtin_class.c
@@ -701,6 +701,10 @@ PH7_PRIVATE int vm_builtin_get_object_vars(ph7_context *pCtx,int nArg,ph7_value 
 	 */
 	return PH7_OK;
 }
+/* Bound on `extends` chain depth — matches PH7_THROWABLE_WALK_MAX_DEPTH in
+ * compile.c. Defends against compiler cycles even though interface cycle
+ * detection should reject them up front. */
+#define PH7_INTERFACE_WALK_MAX_DEPTH 64
 /*
  * This function returns TRUE if the given class is an implemented
  * interface.Otherwise FALSE is returned.
@@ -715,10 +719,17 @@ static int VmQueryInterfaceSet(ph7_class *pClass,SySet *pSet)
 	}
 	/* Point to the set of implemented interfaces */
 	apInterface = (ph7_class **)SySetBasePtr(pSet);
-	/* Perform the lookup */
+	/* Perform the lookup, walking each interface's parent chain so that
+	 * Iterator extends Traversable (and similar) is recognized. */
 	for( n = 0 ; n < SySetUsed(pSet) ; n++ ){
-		if( apInterface[n] == pClass ){
-			return TRUE;
+		ph7_class *pIface = apInterface[n];
+		int iDepth = 0;
+		while( pIface && iDepth <= PH7_INTERFACE_WALK_MAX_DEPTH ){
+			if( pIface == pClass ){
+				return TRUE;
+			}
+			pIface = pIface->pBase;
+			iDepth++;
 		}
 	}
 	return FALSE;

--- a/tests/ph7/001-smoke/oo/interface_arrayaccess_basic.phpt
+++ b/tests/ph7/001-smoke/oo/interface_arrayaccess_basic.phpt
@@ -1,0 +1,26 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+ArrayAccess: subscript read/write dispatches to offsetGet/offsetSet
+--FILE--
+<?php
+class IfaceArrayAccessBag implements ArrayAccess {
+    public $data = [];
+    public function offsetExists($k): bool { return isset($this->data[$k]); }
+    #[\ReturnTypeWillChange]
+    public function offsetGet($k) { return $this->data[$k] ?? null; }
+    public function offsetSet($k, $v): void {
+        if ($k === null) { $this->data[] = $v; } else { $this->data[$k] = $v; }
+    }
+    public function offsetUnset($k): void { unset($this->data[$k]); }
+}
+$b = new IfaceArrayAccessBag();
+$b["a"] = 1;
+$b["b"] = 2;
+echo $b["a"], "/", $b["b"], "\n";
+?>
+--EXPECT--
+1/2
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/oo/interface_arrayaccess_exists.phpt
+++ b/tests/ph7/001-smoke/oo/interface_arrayaccess_exists.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Built-in interfaces: ArrayAccess, Countable, Stringable, Traversable, UnitEnum, BackedEnum are all declared
+--FILE--
+<?php
+foreach (["ArrayAccess","Countable","Stringable","Traversable","UnitEnum","BackedEnum"] as $name) {
+    echo $name, ": ", interface_exists($name) ? "yes" : "no", "\n";
+}
+?>
+--EXPECT--
+ArrayAccess: yes
+Countable: yes
+Stringable: yes
+Traversable: yes
+UnitEnum: yes
+BackedEnum: yes
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/oo/interface_countable_method.phpt
+++ b/tests/ph7/001-smoke/oo/interface_countable_method.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+count() dispatches to Countable::count() on objects
+--FILE--
+<?php
+class IfaceCountableBox implements Countable {
+    public function count(): int { return 42; }
+}
+echo count(new IfaceCountableBox()), "\n";
+?>
+--EXPECT--
+42
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/oo/interface_stringable_auto.phpt
+++ b/tests/ph7/001-smoke/oo/interface_stringable_auto.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Stringable is auto-implemented when class declares __toString
+--FILE--
+<?php
+class IfaceStringableYes {
+    public function __toString(): string { return "x"; }
+}
+class IfaceStringableNo {}
+echo (new IfaceStringableYes()) instanceof Stringable ? "IfaceStringableYes:yes" : "IfaceStringableYes:no", "\n";
+echo (new IfaceStringableNo()) instanceof Stringable ? "IfaceStringableNo:yes" : "IfaceStringableNo:no", "\n";
+?>
+--EXPECT--
+IfaceStringableYes:yes
+IfaceStringableNo:no
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/oo/interface_traversable_marker.phpt
+++ b/tests/ph7/001-smoke/oo/interface_traversable_marker.phpt
@@ -1,0 +1,27 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Iterator and IteratorAggregate transitively implement Traversable
+--FILE--
+<?php
+class IfaceTraversableIt implements Iterator {
+    #[\ReturnTypeWillChange]
+    public function current() { return null; }
+    #[\ReturnTypeWillChange]
+    public function key() { return null; }
+    public function next(): void {}
+    public function rewind(): void {}
+    public function valid(): bool { return false; }
+}
+class IfaceTraversableAgg implements IteratorAggregate {
+    public function getIterator(): Iterator { return new IfaceTraversableIt(); }
+}
+echo (new IfaceTraversableIt()) instanceof Traversable ? "It:yes" : "It:no", "\n";
+echo (new IfaceTraversableAgg()) instanceof Traversable ? "Agg:yes" : "Agg:no", "\n";
+?>
+--EXPECT--
+It:yes
+Agg:yes
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/arrayaccess_append_null_key.phpt
+++ b/tests/ph7/002-integration/oo/arrayaccess_append_null_key.phpt
@@ -1,0 +1,33 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+ArrayAccess: $obj[] = value passes null key to offsetSet
+--FILE--
+<?php
+class Bag implements ArrayAccess {
+    public $data = [];
+    public function offsetExists($k): bool { return isset($this->data[$k]); }
+    #[\ReturnTypeWillChange]
+    public function offsetGet($k) { return $this->data[$k] ?? null; }
+    public function offsetSet($k, $v): void {
+        echo "set(", ($k === null ? "NULL" : $k), ",$v)\n";
+        if ($k === null) { $this->data[] = $v; } else { $this->data[$k] = $v; }
+    }
+    public function offsetUnset($k): void {}
+}
+$b = new Bag();
+$b[] = "first";
+$b[] = "second";
+$b["named"] = "n";
+$b[] = "third";
+echo implode(",", $b->data), "\n";
+?>
+--EXPECT--
+set(NULL,first)
+set(NULL,second)
+set(named,n)
+set(NULL,third)
+first,second,n,third
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/arrayaccess_chained_calls.phpt
+++ b/tests/ph7/002-integration/oo/arrayaccess_chained_calls.phpt
@@ -1,0 +1,38 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+ArrayAccess: $obj instanceof ArrayAccess holds, multiple methods can interleave
+--FILE--
+<?php
+class Bag implements ArrayAccess {
+    public $data = [];
+    public function offsetExists($k): bool { return array_key_exists($k, $this->data); }
+    #[\ReturnTypeWillChange]
+    public function offsetGet($k) { return $this->data[$k] ?? null; }
+    public function offsetSet($k, $v): void {
+        if ($k === null) { $this->data[] = $v; } else { $this->data[$k] = $v; }
+    }
+    public function offsetUnset($k): void { unset($this->data[$k]); }
+}
+$b = new Bag();
+echo "is_aa: ", $b instanceof ArrayAccess ? "y" : "n", "\n";
+$b["k1"] = 100;
+$b["k2"] = 200;
+$b["k1"] = $b["k1"] + $b["k2"];
+echo "k1=", $b["k1"], "\n";
+echo "k2=", $b["k2"], "\n";
+echo "exists k1: ", isset($b["k1"]) ? "y" : "n", "\n";
+unset($b["k2"]);
+echo "exists k2 after unset: ", isset($b["k2"]) ? "y" : "n", "\n";
+echo "exists k1 after unset k2: ", isset($b["k1"]) ? "y" : "n", "\n";
+?>
+--EXPECT--
+is_aa: y
+k1=300
+k2=200
+exists k1: y
+exists k2 after unset: n
+exists k1 after unset k2: y
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/arrayaccess_chained_subscript.phpt
+++ b/tests/ph7/002-integration/oo/arrayaccess_chained_subscript.phpt
@@ -1,0 +1,32 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+ArrayAccess: chained subscript $obj[k][i] reads via offsetGet then array/string indexing
+--FILE--
+<?php
+class ChainBag implements ArrayAccess {
+    public $data = [
+        "row"  => [10, 20, 30],
+        "name" => "alice",
+        "map"  => ["x" => 1, "y" => 2],
+    ];
+    public function offsetExists($k): bool { return isset($this->data[$k]); }
+    #[\ReturnTypeWillChange]
+    public function offsetGet($k) { return $this->data[$k] ?? null; }
+    public function offsetSet($k, $v): void {}
+    public function offsetUnset($k): void {}
+}
+$b = new ChainBag();
+echo $b["row"][0], "\n";
+echo $b["row"][2], "\n";
+echo $b["name"][0], "\n";
+echo $b["map"]["x"], "+", $b["map"]["y"], "=", ($b["map"]["x"] + $b["map"]["y"]), "\n";
+?>
+--EXPECT--
+10
+30
+a
+1+2=3
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/arrayaccess_empty_dispatch.phpt
+++ b/tests/ph7/002-integration/oo/arrayaccess_empty_dispatch.phpt
@@ -1,0 +1,44 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+ArrayAccess: empty() short-circuits on missing keys via offsetExists; calls offsetGet only when present
+--FILE--
+<?php
+class EmptyBag implements ArrayAccess {
+    public $data = ["one" => 1, "zero" => 0, "estr" => "", "nested" => [1,2]];
+    public function offsetExists($k): bool { echo "exists($k)\n"; return isset($this->data[$k]); }
+    #[\ReturnTypeWillChange]
+    public function offsetGet($k) { echo "get($k)\n"; return $this->data[$k] ?? null; }
+    public function offsetSet($k, $v): void {}
+    public function offsetUnset($k): void {}
+}
+$b = new EmptyBag();
+$r = empty($b["one"]) ? "y" : "n";
+echo "empty(one): $r\n";
+$r = empty($b["missing"]) ? "y" : "n";
+echo "empty(missing): $r\n";
+$r = empty($b["zero"]) ? "y" : "n";
+echo "empty(zero): $r\n";
+$r = empty($b["estr"]) ? "y" : "n";
+echo "empty(estr): $r\n";
+$r = empty($b["nested"]) ? "y" : "n";
+echo "empty(nested): $r\n";
+?>
+--EXPECT--
+exists(one)
+get(one)
+empty(one): n
+exists(missing)
+empty(missing): y
+exists(zero)
+get(zero)
+empty(zero): y
+exists(estr)
+get(estr)
+empty(estr): y
+exists(nested)
+get(nested)
+empty(nested): n
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/arrayaccess_inheritance.phpt
+++ b/tests/ph7/002-integration/oo/arrayaccess_inheritance.phpt
@@ -1,0 +1,35 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+ArrayAccess: subclass inherits implements relationship; subscript dispatches
+--FILE--
+<?php
+abstract class AABase implements ArrayAccess {
+    protected $data = [];
+    public function offsetExists($k): bool { return isset($this->data[$k]); }
+    #[\ReturnTypeWillChange]
+    public function offsetGet($k) { return $this->data[$k] ?? null; }
+    public function offsetSet($k, $v): void {
+        if ($k === null) { $this->data[] = $v; } else { $this->data[$k] = $v; }
+    }
+    public function offsetUnset($k): void { unset($this->data[$k]); }
+}
+class AAChild extends AABase {}
+$c = new AAChild();
+echo "is AA: ", $c instanceof ArrayAccess ? "y" : "n", "\n";
+$c["x"] = "hello";
+echo "x=", $c["x"], "\n";
+$r = isset($c["x"]) ? "y" : "n";
+echo "isset(x): $r\n";
+unset($c["x"]);
+$r2 = isset($c["x"]) ? "y" : "n";
+echo "after unset: $r2\n";
+?>
+--EXPECT--
+is AA: y
+x=hello
+isset(x): y
+after unset: n
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/arrayaccess_isset_calls_exists.phpt
+++ b/tests/ph7/002-integration/oo/arrayaccess_isset_calls_exists.phpt
@@ -1,0 +1,34 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+ArrayAccess: isset($obj[$key]) calls offsetExists, never offsetGet
+--FILE--
+<?php
+class Bag implements ArrayAccess {
+    public $data = ["present" => 1];
+    public function offsetExists($k): bool {
+        echo "exists($k)\n";
+        return isset($this->data[$k]);
+    }
+    #[\ReturnTypeWillChange]
+    public function offsetGet($k) {
+        echo "get($k)\n";
+        return $this->data[$k] ?? null;
+    }
+    public function offsetSet($k, $v): void {}
+    public function offsetUnset($k): void {}
+}
+$b = new Bag();
+$r1 = isset($b["present"]) ? "yes" : "no";
+echo "present: $r1\n";
+$r2 = isset($b["missing"]) ? "yes" : "no";
+echo "missing: $r2\n";
+?>
+--EXPECT--
+exists(present)
+present: yes
+exists(missing)
+missing: no
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/arrayaccess_isset_mixed_args.phpt
+++ b/tests/ph7/002-integration/oo/arrayaccess_isset_mixed_args.phpt
@@ -1,0 +1,35 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+isset() with multiple arguments mixing array, scalar, and ArrayAccess subscript
+--FILE--
+<?php
+class IsetBag implements ArrayAccess {
+    public $data = ["k" => 1];
+    public function offsetExists($k): bool { return isset($this->data[$k]); }
+    #[\ReturnTypeWillChange]
+    public function offsetGet($k) { return $this->data[$k] ?? null; }
+    public function offsetSet($k, $v): void {}
+    public function offsetUnset($k): void {}
+}
+$b = new IsetBag();
+$arr = ["x" => 1];
+$scalar = "hello";
+$null = null;
+$r = isset($scalar, $arr["x"], $b["k"]) ? "y" : "n";
+echo "all-set: $r\n";
+$r = isset($scalar, $arr["miss"], $b["k"]) ? "y" : "n";
+echo "miss-arr: $r\n";
+$r = isset($scalar, $arr["x"], $b["miss"]) ? "y" : "n";
+echo "miss-obj: $r\n";
+$r = isset($null, $b["k"]) ? "y" : "n";
+echo "null-var: $r\n";
+?>
+--EXPECT--
+all-set: y
+miss-arr: n
+miss-obj: n
+null-var: n
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/arrayaccess_no_iface_read_error.phpt
+++ b/tests/ph7/002-integration/oo/arrayaccess_no_iface_read_error.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Subscript read on object without ArrayAccess throws Error
+--FILE--
+<?php
+class NoAccess {}
+try {
+    $o = new NoAccess();
+    $x = $o["k"];
+} catch (Error $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+caught: Cannot use object of type NoAccess as array
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/arrayaccess_no_iface_write_error.phpt
+++ b/tests/ph7/002-integration/oo/arrayaccess_no_iface_write_error.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Subscript write on object without ArrayAccess throws Error
+--FILE--
+<?php
+class NoAccessW {}
+try {
+    $o = new NoAccessW();
+    $o["k"] = 1;
+} catch (Error $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+caught: Cannot use object of type NoAccessW as array
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/arrayaccess_null_coalesce.phpt
+++ b/tests/ph7/002-integration/oo/arrayaccess_null_coalesce.phpt
@@ -1,0 +1,26 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Null coalescing operator on ArrayAccess subscripts uses offsetGet result
+--FILE--
+<?php
+class NCBag implements ArrayAccess {
+    public $data = ["a" => "A", "n" => null];
+    public function offsetExists($k): bool { return array_key_exists($k, $this->data); }
+    #[\ReturnTypeWillChange]
+    public function offsetGet($k) { return $this->data[$k] ?? null; }
+    public function offsetSet($k, $v): void { $this->data[$k] = $v; }
+    public function offsetUnset($k): void { unset($this->data[$k]); }
+}
+$b = new NCBag();
+echo $b["a"] ?? "fallback", "\n";
+echo $b["missing"] ?? "fallback", "\n";
+echo $b["n"] ?? "fallback", "\n";
+?>
+--EXPECT--
+A
+fallback
+fallback
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/arrayaccess_null_coalesce_assign.phpt
+++ b/tests/ph7/002-integration/oo/arrayaccess_null_coalesce_assign.phpt
@@ -1,0 +1,48 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+ArrayAccess: $obj[$k] ??= $v dispatches to offsetExists, offsetGet, and offsetSet per PHP semantics
+--FILE--
+<?php
+class NCAssignBag implements ArrayAccess {
+    public $data = ["set" => "old", "isnull" => null];
+    public function offsetExists($k): bool { echo "exists($k)\n"; return array_key_exists($k, $this->data); }
+    #[\ReturnTypeWillChange]
+    public function offsetGet($k) { echo "get($k)\n"; return $this->data[$k] ?? null; }
+    public function offsetSet($k, $v): void { echo "set($k,$v)\n"; $this->data[$k] = $v; }
+    public function offsetUnset($k): void {}
+}
+$b = new NCAssignBag();
+
+echo "--- existing non-null key:\n";
+$b["set"] ??= "fallback";
+echo "result: ", $b["set"], "\n";
+
+echo "--- existing null key:\n";
+$b["isnull"] ??= "filled";
+echo "result: ", $b["isnull"], "\n";
+
+echo "--- missing key:\n";
+$b["new"] ??= "added";
+echo "result: ", $b["new"], "\n";
+?>
+--EXPECT--
+--- existing non-null key:
+exists(set)
+get(set)
+result: get(set)
+old
+--- existing null key:
+exists(isnull)
+get(isnull)
+set(isnull,filled)
+result: get(isnull)
+filled
+--- missing key:
+exists(new)
+set(new,added)
+result: get(new)
+added
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/arrayaccess_null_coalesce_assign_throw_disarms.phpt
+++ b/tests/ph7/002-integration/oo/arrayaccess_null_coalesce_assign_throw_disarms.phpt
@@ -1,0 +1,41 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+ArrayAccess: an exception thrown while evaluating the ??= RHS disarms the coalesce slot so a later unrelated ??= is unaffected
+--FILE--
+<?php
+class NCThrowBag implements ArrayAccess {
+    public $data = [];
+    public function offsetExists($k): bool { return array_key_exists($k, $this->data); }
+    #[\ReturnTypeWillChange]
+    public function offsetGet($k) { return $this->data[$k] ?? null; }
+    public function offsetSet($k, $v): void { echo "offsetSet($k, $v)\n"; $this->data[$k] = $v; }
+    public function offsetUnset($k): void {}
+}
+function boom() { throw new Exception("boom"); }
+
+$b = new NCThrowBag();
+
+// LOAD_IDX iP2=3 arms the coalesce slot for the missing key "stale", then the
+// RHS throws before NULLC_STORE runs. The throw must disarm the slot.
+try {
+    $b["stale"] ??= boom();
+} catch (Exception $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+
+// An unrelated ??= on a plain variable: NULLC_STORE must write into $x, NOT
+// dispatch offsetSet() on the stale (object, key).
+$x = null;
+$x ??= "plain";
+echo "x = ", $x, "\n";
+echo "bag has 'stale': ", (isset($b["stale"]) ? "yes" : "no"), "\n";
+?>
+--EXPECT--
+caught: boom
+x = plain
+bag has 'stale': no
+--CLEAN--
+<?php
+unset($b);

--- a/tests/ph7/002-integration/oo/arrayaccess_offset_get.phpt
+++ b/tests/ph7/002-integration/oo/arrayaccess_offset_get.phpt
@@ -1,0 +1,29 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+ArrayAccess: $obj[$key] dispatches to offsetGet with the key
+--FILE--
+<?php
+class Bag implements ArrayAccess {
+    public $data = ["alpha" => "A", "beta" => "B", 7 => "seven"];
+    public function offsetExists($k): bool { return isset($this->data[$k]); }
+    #[\ReturnTypeWillChange]
+    public function offsetGet($k) { echo "get($k)\n"; return $this->data[$k] ?? null; }
+    public function offsetSet($k, $v): void {}
+    public function offsetUnset($k): void {}
+}
+$b = new Bag();
+echo $b["alpha"], "\n";
+echo $b["beta"], "\n";
+echo $b[7], "\n";
+?>
+--EXPECT--
+get(alpha)
+A
+get(beta)
+B
+get(7)
+seven
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/arrayaccess_offset_set.phpt
+++ b/tests/ph7/002-integration/oo/arrayaccess_offset_set.phpt
@@ -1,0 +1,31 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+ArrayAccess: $obj[$key] = $value dispatches to offsetSet round-trip
+--FILE--
+<?php
+class Bag implements ArrayAccess {
+    public $data = [];
+    public function offsetExists($k): bool { return isset($this->data[$k]); }
+    #[\ReturnTypeWillChange]
+    public function offsetGet($k) { return $this->data[$k] ?? null; }
+    public function offsetSet($k, $v): void {
+        echo "set($k,$v)\n";
+        if ($k === null) { $this->data[] = $v; } else { $this->data[$k] = $v; }
+    }
+    public function offsetUnset($k): void {}
+}
+$b = new Bag();
+$b["x"] = "X";
+$b["y"] = "Y";
+$b[10] = "ten";
+echo $b["x"], "/", $b["y"], "/", $b[10], "\n";
+?>
+--EXPECT--
+set(x,X)
+set(y,Y)
+set(10,ten)
+X/Y/ten
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/arrayaccess_only_foreach_props.phpt
+++ b/tests/ph7/002-integration/oo/arrayaccess_only_foreach_props.phpt
@@ -1,0 +1,26 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+foreach over an object that only implements ArrayAccess (no Iterator) iterates public properties — does NOT call offsetGet
+--FILE--
+<?php
+class OnlyAA implements ArrayAccess {
+    public $alpha = 1;
+    public $beta = 2;
+    public function offsetExists($k): bool { return false; }
+    #[\ReturnTypeWillChange]
+    public function offsetGet($k) { echo "offsetGet should NOT be called\n"; return null; }
+    public function offsetSet($k, $v): void {}
+    public function offsetUnset($k): void {}
+}
+$o = new OnlyAA();
+foreach ($o as $k => $v) {
+    echo "$k=$v\n";
+}
+?>
+--EXPECT--
+alpha=1
+beta=2
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/arrayaccess_string_interp.phpt
+++ b/tests/ph7/002-integration/oo/arrayaccess_string_interp.phpt
@@ -1,0 +1,26 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+ArrayAccess: string interpolation $b[key] and {$b['key']} dispatches to offsetGet
+--FILE--
+<?php
+class InterpBag implements ArrayAccess {
+    public $data = ["name" => "alice", "age" => 30];
+    public function offsetExists($k): bool { return isset($this->data[$k]); }
+    #[\ReturnTypeWillChange]
+    public function offsetGet($k) { return $this->data[$k] ?? null; }
+    public function offsetSet($k, $v): void {}
+    public function offsetUnset($k): void {}
+}
+$b = new InterpBag();
+echo "simple: $b[name]\n";
+echo "braced: {$b['age']}\n";
+echo "concat: " . $b["name"] . "/" . $b["age"] . "\n";
+?>
+--EXPECT--
+simple: alice
+braced: 30
+concat: alice/30
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/arrayaccess_subinterface.phpt
+++ b/tests/ph7/002-integration/oo/arrayaccess_subinterface.phpt
@@ -1,0 +1,36 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+ArrayAccess: class implementing a sub-interface that extends ArrayAccess dispatches
+--FILE--
+<?php
+interface MyAccess extends ArrayAccess {
+    public function describe(): string;
+}
+class MyMap implements MyAccess {
+    private $data = [];
+    public function offsetExists($k): bool { return isset($this->data[$k]); }
+    #[\ReturnTypeWillChange]
+    public function offsetGet($k) { return $this->data[$k] ?? null; }
+    public function offsetSet($k, $v): void {
+        if ($k === null) { $this->data[] = $v; } else { $this->data[$k] = $v; }
+    }
+    public function offsetUnset($k): void { unset($this->data[$k]); }
+    public function describe(): string { return "MyMap(" . count($this->data) . ")"; }
+}
+$m = new MyMap();
+echo "is MyAccess: ", $m instanceof MyAccess ? "y" : "n", "\n";
+echo "is ArrayAccess: ", $m instanceof ArrayAccess ? "y" : "n", "\n";
+$m["k"] = 1;
+$m["v"] = 2;
+echo "k=", $m["k"], " v=", $m["v"], "\n";
+echo $m->describe(), "\n";
+?>
+--EXPECT--
+is MyAccess: y
+is ArrayAccess: y
+k=1 v=2
+MyMap(2)
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/arrayaccess_unpack_rejected.phpt
+++ b/tests/ph7/002-integration/oo/arrayaccess_unpack_rejected.phpt
@@ -1,0 +1,25 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Array unpacking [...$obj] is rejected on ArrayAccess-only object (must be Traversable)
+--FILE--
+<?php
+class UnpackBag implements ArrayAccess {
+    public function offsetExists($k): bool { return false; }
+    #[\ReturnTypeWillChange]
+    public function offsetGet($k) { return null; }
+    public function offsetSet($k, $v): void {}
+    public function offsetUnset($k): void {}
+}
+$b = new UnpackBag();
+try {
+    $r = [...$b];
+} catch (TypeError $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+?>
+--EXPECTF--
+caught: Only arrays and Traversables can be %s
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/arrayaccess_unset_calls_unset.phpt
+++ b/tests/ph7/002-integration/oo/arrayaccess_unset_calls_unset.phpt
@@ -1,0 +1,35 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+ArrayAccess: unset($obj[$key]) dispatches to offsetUnset
+--FILE--
+<?php
+class Bag implements ArrayAccess {
+    public $data = ["a" => 1, "b" => 2];
+    public function offsetExists($k): bool { return isset($this->data[$k]); }
+    #[\ReturnTypeWillChange]
+    public function offsetGet($k) { return $this->data[$k] ?? null; }
+    public function offsetSet($k, $v): void {}
+    public function offsetUnset($k): void {
+        echo "unset($k)\n";
+        unset($this->data[$k]);
+    }
+}
+$b = new Bag();
+unset($b["a"]);
+$ax = isset($b["a"]) ? "y" : "n";
+$bx = isset($b["b"]) ? "y" : "n";
+echo "after unset(a): a=$ax b=$bx\n";
+unset($b["b"]);
+$ay = isset($b["a"]) ? "y" : "n";
+$by = isset($b["b"]) ? "y" : "n";
+echo "after unset(b): a=$ay b=$by\n";
+?>
+--EXPECT--
+unset(a)
+after unset(a): a=n b=y
+unset(b)
+after unset(b): a=n b=n
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/countable_count_dispatch.phpt
+++ b/tests/ph7/002-integration/oo/countable_count_dispatch.phpt
@@ -1,0 +1,28 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+count() dispatches to ->count() for objects implementing Countable
+--FILE--
+<?php
+class Counted implements Countable {
+    private int $n;
+    public function __construct(int $n) { $this->n = $n; }
+    public function count(): int {
+        echo "count called\n";
+        return $this->n;
+    }
+}
+echo count(new Counted(0)), "\n";
+echo count(new Counted(7)), "\n";
+echo count(new Counted(123)), "\n";
+?>
+--EXPECT--
+count called
+0
+count called
+7
+count called
+123
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/countable_invalid_mode_unaffected.phpt
+++ b/tests/ph7/002-integration/oo/countable_invalid_mode_unaffected.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+count() ValueError on invalid mode is unaffected by the Countable dispatch path
+--FILE--
+<?php
+try {
+    $a = [1, 2, 3];
+    count($a, 99);
+} catch (ValueError $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+?>
+--EXPECTF--
+caught: count(): Argument #2 ($mode) must be either COUNT_NORMAL or COUNT_RECURSIVE
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/countable_invalid_mode_value_error.phpt
+++ b/tests/ph7/002-integration/oo/countable_invalid_mode_value_error.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+count() validates $mode before dispatching to Countable::count(): an invalid mode raises ValueError and the method is never called
+--FILE--
+<?php
+class LoudCounter implements Countable {
+    public function count(): int { echo "count() called\n"; return 7; }
+}
+$c = new LoudCounter();
+try {
+    count($c, 99);
+    echo "no error\n";
+} catch (ValueError $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+caught: count(): Argument #2 ($mode) must be either COUNT_NORMAL or COUNT_RECURSIVE
+--CLEAN--
+<?php
+unset($c);

--- a/tests/ph7/002-integration/oo/countable_typeerror_non_countable.phpt
+++ b/tests/ph7/002-integration/oo/countable_typeerror_non_countable.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+count() throws TypeError on object that does not implement Countable
+--FILE--
+<?php
+class CountablePlain {}
+count(new CountablePlain());
+?>
+--EXPECTF--
+%s Fatal error:  Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, %s given%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/countable_with_mode_arg.phpt
+++ b/tests/ph7/002-integration/oo/countable_with_mode_arg.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+count() with COUNT_NORMAL/COUNT_RECURSIVE mode on Countable object dispatches the same — mode is ignored
+--FILE--
+<?php
+class CounterWithMode implements Countable {
+    public function count(): int { echo "called\n"; return 7; }
+}
+$c = new CounterWithMode();
+echo count($c), "\n";
+echo count($c, COUNT_NORMAL), "\n";
+echo count($c, COUNT_RECURSIVE), "\n";
+?>
+--EXPECT--
+called
+7
+called
+7
+called
+7
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/stringable_auto_implements.phpt
+++ b/tests/ph7/002-integration/oo/stringable_auto_implements.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Stringable interface is auto-implemented when class declares __toString
+--FILE--
+<?php
+class Plain {}
+class Talker {
+    public function __toString(): string { return "hi"; }
+}
+class TalkerChild extends Talker {}
+echo "Plain: ", (new Plain()) instanceof Stringable ? "yes" : "no", "\n";
+echo "Talker: ", (new Talker()) instanceof Stringable ? "yes" : "no", "\n";
+echo "TalkerChild: ", (new TalkerChild()) instanceof Stringable ? "yes" : "no", "\n";
+echo (string)(new Talker()), "\n";
+?>
+--EXPECT--
+Plain: no
+Talker: yes
+TalkerChild: yes
+hi
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/stringable_builtin_exceptions.phpt
+++ b/tests/ph7/002-integration/oo/stringable_builtin_exceptions.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Built-in Exception/Error classes have __toString and are auto-implemented as Stringable
+--FILE--
+<?php
+echo "Exception: ", (new Exception("x")) instanceof Stringable ? "yes" : "no", "\n";
+echo "Error: ", (new Error("x")) instanceof Stringable ? "yes" : "no", "\n";
+echo "TypeError: ", (new TypeError("x")) instanceof Stringable ? "yes" : "no", "\n";
+echo "ValueError: ", (new ValueError("x")) instanceof Stringable ? "yes" : "no", "\n";
+?>
+--EXPECT--
+Exception: yes
+Error: yes
+TypeError: yes
+ValueError: yes
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/stringable_explicit_no_double.phpt
+++ b/tests/ph7/002-integration/oo/stringable_explicit_no_double.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Class explicitly implementing Stringable plus declaring __toString does not double-implement
+--FILE--
+<?php
+class ExplicitStr implements Stringable {
+    public function __toString(): string { return "ok"; }
+}
+$x = new ExplicitStr();
+echo $x instanceof Stringable ? "yes" : "no", "\n";
+echo (string)$x, "\n";
+?>
+--EXPECT--
+yes
+ok
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/stringable_via_trait.phpt
+++ b/tests/ph7/002-integration/oo/stringable_via_trait.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Stringable is auto-implemented when __toString comes from a trait
+--FILE--
+<?php
+trait HasToString {
+    public function __toString(): string { return "from-trait"; }
+}
+class Greeter {
+    use HasToString;
+}
+$g = new Greeter();
+echo $g instanceof Stringable ? "yes" : "no", "\n";
+echo (string)$g, "\n";
+?>
+--EXPECT--
+yes
+from-trait
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/traversable_extends_iterator.phpt
+++ b/tests/ph7/002-integration/oo/traversable_extends_iterator.phpt
@@ -1,0 +1,36 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Iterator and IteratorAggregate transitively implement Traversable
+--FILE--
+<?php
+class It implements Iterator {
+    private int $i = 0;
+    public function rewind(): void { $this->i = 0; }
+    public function valid(): bool { return $this->i < 2; }
+    #[\ReturnTypeWillChange]
+    public function current() { return $this->i; }
+    #[\ReturnTypeWillChange]
+    public function key() { return $this->i; }
+    public function next(): void { $this->i++; }
+}
+class Agg implements IteratorAggregate {
+    public function getIterator(): Iterator { return new It(); }
+}
+$it = new It();
+$ag = new Agg();
+echo "It Iterator: ", $it instanceof Iterator ? "y" : "n", "\n";
+echo "It Traversable: ", $it instanceof Traversable ? "y" : "n", "\n";
+echo "Agg IteratorAggregate: ", $ag instanceof IteratorAggregate ? "y" : "n", "\n";
+echo "Agg Traversable: ", $ag instanceof Traversable ? "y" : "n", "\n";
+echo "Agg Iterator: ", $ag instanceof Iterator ? "y" : "n", "\n";
+?>
+--EXPECT--
+It Iterator: y
+It Traversable: y
+Agg IteratorAggregate: y
+Agg Traversable: y
+Agg Iterator: n
+--CLEAN--
+<?php


### PR DESCRIPTION
PHL was missing six built-in interfaces that PHP 8.x scripts routinely rely on; type hints failed and language constructs over objects (`$o[$k]`, `count($o)`, `(string)$o`) couldn't dispatch into user methods. This commit declares all six in PH7_BUILTIN_LIB and wires their semantics into the engine.

ArrayAccess covers the full subscript surface — read/write via offsetGet/offsetSet, isset() via offsetExists, unset() via offsetUnset, empty() via offsetExists+offsetGet (new iP2=6 path), and `??=` via a per-VM coalesce-target slot consumed by NULLC_STORE. Object subscripts on non-ArrayAccess instances now throw a real catchable Error matching PHP.

Countable lets count() dispatch to ->count() for objects implementing it. Stringable is auto-implemented at compile time for any class declaring __toString (covers user classes and the built-in Exception/Error tree). Iterator and IteratorAggregate now extend Traversable so transitive instanceof works; VmQueryInterfaceSet was extended to walk the parent-interface chain (with a 64-deep cycle guard).

Build: added -MMD -MP and an -include of the generated .d files in build-aux/rules.mk. Without this, struct-layout changes to ph7int.h leave stale .o files that silently clobber the new fields — caught while debugging a preg_match interaction.

28 PHPT tests cover the dispatch surface, including null-coalesce assign, chained subscripts, string interpolation, array-unpacking rejection, inheritance/sub-interface, the foreach-falls-back-to-properties rule, trait-provided __toString, and the negative paths. All run identically on PHP 8.5 and PHL with no --SKIPIF-- sections.
