### PR TITLE
Fix float type identity and decrement semantics

### DIFF
--- a/src/ph7/api.c
+++ b/src/ph7/api.c
@@ -1966,6 +1966,11 @@ int ph7_value_release(ph7_value *pVal)
  */
 int ph7_value_is_int(ph7_value *pVal)
 {
+	/* TRUE whenever an integer representation is available, including an
+	 * integer-valued real (which caches its int in MEMOBJ_INT; see
+	 * PH7_MemObjTryInteger). Internal arg-extraction relies on this lenient form to
+	 * accept a float where PHP would coerce. PHP's strict is_int() — which must
+	 * reject floats — lives in the is_int() builtin (PH7_builtin_is_int). */
 	return (pVal->iFlags & MEMOBJ_INT) ? TRUE : FALSE;
 }
 /*

--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -63,7 +63,10 @@ static int PH7_builtin_is_int(ph7_context *pCtx,int nArg,ph7_value **apArg)
 {
 	int res = 0; /* Assume false by default */
 	if( nArg > 0 ){
-		res = ph7_value_is_int(apArg[0]);
+		/* Strict PHP identity: a float is never an int, even when it holds an
+		 * integer value (1.0). An integer-valued real carries both MEMOBJ_INT
+		 * (cached) and MEMOBJ_REAL, so REAL must be excluded here. */
+		res = ph7_value_is_int(apArg[0]) && !ph7_value_is_float(apArg[0]);
 	}
 	/* Query result */
 	ph7_result_bool(pCtx,res);

--- a/src/ph7/memobj.c
+++ b/src/ph7/memobj.c
@@ -1341,10 +1341,12 @@ PH7_PRIVATE const char * PH7_MemObjTypeDump(ph7_value *pVal)
 	const char *zType = "";
 	if( pVal->iFlags & MEMOBJ_NULL ){
 		zType = "null";
+	}else if( pVal->iFlags & MEMOBJ_REAL ){
+		/* REAL is authoritative over a cached MEMOBJ_INT: an integer-valued
+		 * real (e.g. 1.0) is reported as "double", matching PHP's gettype(). */
+		zType = "double";
 	}else if( pVal->iFlags & MEMOBJ_INT ){
 		zType = "int";
-	}else if( pVal->iFlags & MEMOBJ_REAL ){
-		zType = "double";
 	}else if( pVal->iFlags & MEMOBJ_STRING ){
 		zType = "string";
 	}else if( pVal->iFlags & MEMOBJ_BOOL ){
@@ -1381,8 +1383,13 @@ PH7_PRIVATE sxi32 PH7_MemObjDump(
 		if( isRef ){
 			SyBlobAppend(&(*pOut),"&",sizeof(char));
 		}
-		/* Get value type first */
-		zType = PH7_MemObjTypeDump(pObj);
+		/* Get value type first. var_dump() labels reals "float" (PHP), whereas
+		 * gettype()/PH7_MemObjTypeDump use the legacy "double" spelling. */
+		if( (pObj->iFlags & MEMOBJ_REAL) && (pObj->iFlags & MEMOBJ_NULL) == 0 ){
+			zType = "float";
+		}else{
+			zType = PH7_MemObjTypeDump(pObj);
+		}
 		SyBlobAppend(&(*pOut),zType,SyStrlen(zType));
 	}
 	if((pObj->iFlags & MEMOBJ_NULL) == 0 ){

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -5448,6 +5448,11 @@ case PH7_OP_INCR:
 					PH7_MemObjToNumeric(pObj);
 					if( pObj->iFlags & MEMOBJ_REAL ){
 						pObj->rVal++;
+						/* Refresh the cached integer (x.iVal/MEMOBJ_INT) so it
+						 * stays consistent with the new rVal; otherwise (int)$a,
+						 * ===, intdiv() etc. read a stale int for an
+						 * integer-valued real. */
+						PH7_MemObjTryInteger(pObj);
 					}else{
 						pObj->x.iVal++;
 					}
@@ -5493,37 +5498,62 @@ case PH7_OP_DECR:
 		goto Abort;
 	}
 #endif
+	/* NULL stays excluded: PHP leaves `--` on null untouched (no-op). */
 	if( (pTos->iFlags & (MEMOBJ_HASHMAP|MEMOBJ_OBJ|MEMOBJ_RES|MEMOBJ_NULL)) == 0 ){
-		/* Force a numeric cast */
-		PH7_MemObjToNumeric(pTos);
 		if( pTos->nIdx != SXU32_HIGH ){
 			ph7_value *pObj;
 			if( (pObj = (ph7_value *)SySetAt(&pVm->aMemObj,pTos->nIdx)) != 0 ){
-				/* Force a numeric cast */
-				PH7_MemObjToNumeric(pObj);
-				if( pObj->iFlags & MEMOBJ_REAL ){
-					pObj->rVal--;
-					/* Try to get an integer representation */
-					PH7_MemObjTryInteger(pTos);
+				if( VmStringWantsPerlIncr(pObj) ){
+					/* PHP has no string decrement: `--` on a non-numeric string
+					 * is a no-op (unlike `++`, which is Perl-style). Leave pObj
+					 * unchanged; the result is simply that unchanged value. */
+					if( pInstr->iP1 ){
+						/* Pre-decrement: result is the (unchanged) value. */
+						PH7_MemObjStore(pObj,pTos);
+					}
+					/* Post-decrement: pTos already holds the old value. */
 				}else{
-					pObj->x.iVal--;
-					MemObjSetType(pTos,MEMOBJ_INT);
-				}
-				if( pInstr->iP1 ){
-					/* Pre-icrement */
-					PH7_MemObjStore(pObj,pTos);
+					/* Numeric coercion. Mirror INCR's aliasing care: a
+					 * post-decrement must preserve pTos's original value, which
+					 * may alias pObj's blob via SXBLOB_RDONLY (PH7_MemObjLoad).
+					 * Force pTos to own its blob before coercing pObj. */
+					if( pInstr->iP1 == 0 && (pTos->iFlags & MEMOBJ_STRING) ){
+						SyBlobNullAppend(&pTos->sBlob);
+					}
+					PH7_MemObjToNumeric(pObj);
+					if( pObj->iFlags & MEMOBJ_REAL ){
+						pObj->rVal--;
+						/* Refresh the cached integer (x.iVal/MEMOBJ_INT) so it
+						 * stays consistent with the new rVal; otherwise (int)$a,
+						 * ===, intdiv() etc. read a stale int for an
+						 * integer-valued real. */
+						PH7_MemObjTryInteger(pObj);
+					}else{
+						pObj->x.iVal--;
+					}
+					if( pInstr->iP1 ){
+						/* Pre-decrement: result is the new value. */
+						PH7_MemObjStore(pObj,pTos);
+					}
+					/* Post-decrement: pTos retains the old value. */
 				}
 			}
 		}else{
 			if( pInstr->iP1 ){
-				/* Pre-increment */
-				if( pTos->iFlags & MEMOBJ_REAL ){
-					pTos->rVal--;
-					/* Try to get an integer representation */
-					PH7_MemObjTryInteger(pTos);
+				if( VmStringWantsPerlIncr(pTos) ){
+					/* Non-numeric string, no lvalue: no-op (value unchanged). */
 				}else{
-					pTos->x.iVal--;
-					MemObjSetType(pTos,MEMOBJ_INT);
+					/* Force a numeric cast */
+					PH7_MemObjToNumeric(pTos);
+					/* Pre-decrement */
+					if( pTos->iFlags & MEMOBJ_REAL ){
+						pTos->rVal--;
+						/* Keep the cached int consistent with the new rVal. */
+						PH7_MemObjTryInteger(pTos);
+					}else{
+						pTos->x.iVal--;
+						MemObjSetType(pTos,MEMOBJ_INT);
+					}
 				}
 			}
 		}

--- a/tests/ph7/001-smoke/lang/decrement_noop.phpt
+++ b/tests/ph7/001-smoke/lang/decrement_noop.phpt
@@ -1,0 +1,30 @@
+--TEST--
+-- on a non-numeric string or null is a no-op (value unchanged)
+--DESCRIPTION--
+Regression: PH7_OP_DECR lacked the non-numeric-string guard, so "abc"-- coerced
+to int(-1) instead of leaving the string unchanged. PHP has no string decrement,
+so "abc"--, "5x"-- and null-- are no-ops. This guards the VALUE behavior.
+
+PHL-only: on PHP 8.3+ each of these operations additionally emits a deprecation
+("Decrement on non-numeric string has no effect and is deprecated") / warning
+("Decrement on type null has no effect"). PHL does not yet emit engine
+deprecation notices (tracked separately in the roadmap, §3.7; PHL's "abc"++
+likewise emits no notice), so the combined output diverges from PHP only by those
+notices. Skipped on real PHP rather than suppressing them, until PHL mirrors them.
+--SKIPIF--
+<?php if (function_exists('zend_version')) echo 'skip'; ?>
+--FILE--
+<?php
+$s="abc"; $s--; echo "[$s]\n";
+$s="a";   $s--; echo "[$s]\n";
+$s="5x";  $s--; echo "[$s]\n";
+$n=null;  $n--; echo ($n===null?'null-noop':'CHANGED'),"\n";
+?>
+--EXPECT--
+[abc]
+[a]
+[5x]
+null-noop
+--CLEAN--
+<?php
+?>

--- a/tests/ph7/001-smoke/lang/expression_edge_cases.phpt
+++ b/tests/ph7/001-smoke/lang/expression_edge_cases.phpt
@@ -41,7 +41,7 @@ $func_result = strlen($str1 . $str2);
 var_dump($func_result);
 ?>
 --EXPECT--
-double(4.5)
+float(4.5)
 int(-2)
 int(3)
 string(15) "hello world 223"

--- a/tests/ph7/001-smoke/lang/float_type_identity.phpt
+++ b/tests/ph7/001-smoke/lang/float_type_identity.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Integer-valued reals keep float type identity (not int)
+--DESCRIPTION--
+Regression: PHL stored an integer-valued real (e.g. 1.0, or the result of float
+arithmetic) with both MEMOBJ_REAL and a cached MEMOBJ_INT, and is_int() reported
+it as an int. The REAL flag is now authoritative: a float stays a float. Probed
+with is_int()/is_float() (not var_dump, whose float label Xdebug renders as
+"double") so output is identical on PHL and real PHP.
+--FILE--
+<?php
+// Closure in a variable, not a named function: the compat harness @includes
+// every FILE into one PHP process, so a top-level function would collide.
+$show = function($v){ echo (is_int($v)?'int':'-'),' ',(is_float($v)?'float':'-'),' val=',$v,"\n"; };
+$show(1.0);
+$show(1.0 + 1.0);
+$show(3.0 - 1.0);
+$show(2.0 * 1.0);
+$show(4.0 / 2.0);
+$show(2.0 ** 2);
+$show(5);
+$show(1.5 + 1.5);
+$show(7 / 2);
+?>
+--EXPECT--
+- float val=1
+- float val=2
+- float val=2
+- float val=2
+- float val=2
+- float val=4
+int - val=5
+- float val=3
+- float val=3.5
+--CLEAN--
+<?php
+?>

--- a/tests/ph7/001-smoke/lang/increment_decrement_semantics.phpt
+++ b/tests/ph7/001-smoke/lang/increment_decrement_semantics.phpt
@@ -1,0 +1,46 @@
+--TEST--
+++/-- preserve float type and numeric-string semantics
+--DESCRIPTION--
+Regression: PH7_OP_DECR operated on the wrong ph7_value (pTos vs pObj) and
+collapsed real results to int. DECR now mirrors the hardened INCR. This test
+covers the cases that are byte-for-byte identical on PHL and real PHP: float
+++/-- (pre and post) keep float type, and numeric strings increment/decrement to
+int. Probed with is_int()/is_float()/is_string() (not var_dump, which Xdebug
+overloads). The non-numeric-string / null no-op cases live in
+decrement_noop.phpt (PHP emits a deprecation there that PHL does not yet mirror).
+--FILE--
+<?php
+// Closure in a variable, not a named function: the compat harness @includes
+// every FILE into one PHP process, so a top-level function would collide.
+$show = function($v){ echo (is_int($v)?'int':'-'),' ',(is_float($v)?'float':'-'),' ',(is_string($v)?'str':'-'),' val=',$v,"\n"; };
+$a=1.0; $a++; $show($a);
+$a=1.0; $a--; $show($a);
+$a=1.0; $r=$a--; $show($r); $show($a);
+$a=1.0; $show(--$a);
+$s="5"; $s++; $show($s);
+$s="5"; $s--; $show($s);
+$s="5"; $r=$s--; $show($r);
+$i=5; $i--; $show($i);
+$i=5; $show($i--);
+// Cache consistency: after --/++ on an integer-valued real, the cached int
+// (x.iVal/MEMOBJ_INT) must be refreshed, else (int), ===, intdiv() read a stale
+// integer.
+$a=2.0; $a--; echo (int)$a,' ',($a===1.0?'eq':'ne'),' ',intdiv($a,1),"\n";
+$a=2.0; $a++; echo (int)$a,' ',($a===3.0?'eq':'ne'),"\n";
+?>
+--EXPECT--
+- float - val=2
+- float - val=0
+- float - val=1
+- float - val=0
+- float - val=0
+int - - val=6
+int - - val=4
+- - str val=5
+int - - val=4
+int - - val=5
+1 eq 1
+3 eq
+--CLEAN--
+<?php
+?>


### PR DESCRIPTION
Integer-valued reals (1.0, float arithmetic results, $f++/$f--) were stored dual-flagged REAL|INT and reported as int by is_int/gettype/var_dump, because type-identity consumers checked MEMOBJ_INT before MEMOBJ_REAL. Make REAL authoritative so a float stays a float, matching PHP:

- PH7_MemObjTypeDump: check REAL before INT (gettype(1.0) -> "double").
- PH7_MemObjDump: var_dump labels reals "float" (PHP) while gettype keeps the legacy "double" spelling.
- is_int() builtin: strict identity (is_int && !is_float) so 1.0 is not an int. ph7_value_is_int() stays lenient (an integer representation is available) so internal arg-extraction (date timestamps, sleep, exit code, json flags, ...) still accepts a float where PHP coerces.

Also rewrite PH7_OP_DECR to mirror the hardened PH7_OP_INCR: add the VmStringWantsPerlIncr guard so "--" on a non-numeric string is a no-op (PHP has no string decrement), and drop a pTos/pObj aliasing bug that operated on the wrong value. null-- no-op preserved.

Tests: add float_type_identity.phpt and increment_decrement_semantics.phpt (byte-for-byte parity with PHP 8.5); update expression_edge_cases.phpt which hard-coded the old non-PHP "double(4.5)" var_dump label.
