### PR TITLE
Fix  correctness bugs: by-ref merge, multi-array array_map, exception…

### DIFF
--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -1058,9 +1058,36 @@ static sxi32 HashmapDuplicateNode(
 	int iAction /* 0: Merge, 1: Overwrite, 2: Dup */
 	)
 {
-	ph7_value sSafeVal = *pVal;
+	ph7_value sSafeVal;
 	ph7_value sKey;
 	sxi32 rc;
+
+	if( pEntry->iFlags & HASHMAP_NODE_FOREIGN_OBJ ){
+		/* The source node holds a reference to a foreign ph7_value (e.g: [&$x]).
+		 * Re-insert it by reference so the reference survives the duplication
+		 * instead of being flattened to a value copy. This keeps spread
+		 * ([...$a]), array_merge(), array_replace() and array copies in sync
+		 * with PHP semantics. */
+		sxu32 nRefIdx = pEntry->nValIdx;
+		if( pEntry->iType == HASHMAP_BLOB_NODE ){
+			PH7_MemObjInitFromString(pDest->pVm,&sKey,0);
+			PH7_MemObjStringAppend(&sKey,(const char *)SyBlobData(&pEntry->xKey.sKey),SyBlobLength(&pEntry->xKey.sKey));
+			rc = HashmapInsertByRef(pDest,&sKey,nRefIdx);
+			PH7_MemObjRelease(&sKey);
+		}else{
+			if( iAction == 0 ){ /* Merge: automatic index assign */
+				rc = HashmapInsertByRef(pDest,0,nRefIdx);
+			}else if( iAction == 1 ){ /* Overwrite: keep the int key */
+				PH7_MemObjInitFromInt(pDest->pVm,&sKey,pEntry->xKey.iKey);
+				rc = HashmapInsertByRef(pDest,&sKey,nRefIdx);
+				PH7_MemObjRelease(&sKey);
+			}else{ /* Dup: preserve the int key */
+				rc = HashmapInsertIntKey(pDest,pEntry->xKey.iKey,0,nRefIdx,TRUE);
+			}
+		}
+		return rc;
+	}
+	sSafeVal = *pVal;
 
 	if( pEntry->iType == HASHMAP_BLOB_NODE ){
 		/* Blob key insertion */
@@ -1985,6 +2012,11 @@ static sxi32 HashmapCmpCallback4(ph7_hashmap_node *pA,ph7_hashmap_node *pB,void 
 	sxi32 rc;
 	/* Point to the desired callback */
 	pCallback = (ph7_value *)pCmpData;
+	if( pA->pMap->pVm->iCmpCallbackExc ){
+		/* A previous comparison already raised: stop invoking the callback so
+		 * the exception is not thrown again, and let the sort wind down. */
+		return 0;
+	}
 	/* initialize the result value */
 	PH7_MemObjInit(pA->pMap->pVm,&sResult);
 	/* Extract nodes values */
@@ -1994,7 +2026,12 @@ static sxi32 HashmapCmpCallback4(ph7_hashmap_node *pA,ph7_hashmap_node *pB,void 
 	apArg[1] = pV2;
 	/* Invoke the callback */
 	rc = PH7_VmCallUserFunction(pA->pMap->pVm,pCallback,2,apArg,&sResult);
-	if( rc != SXRET_OK ){
+	if( rc == PH7_EXCEPTION ){
+		/* The comparator raised: flag it so the sort driver aborts and
+		 * propagates, and order this pair arbitrarily for the rest of the run. */
+		pA->pMap->pVm->iCmpCallbackExc = 1;
+		rc = 0;
+	}else if( rc != SXRET_OK ){
 		/* An error occured while calling user defined function [i.e: not defined] */
 		rc = -1; /* Set a dummy result */
 	}else{
@@ -2062,6 +2099,11 @@ static sxi32 HashmapCmpCallback6(ph7_hashmap_node *pA,ph7_hashmap_node *pB,void 
 	sxi32 rc;
 	/* Point to the desired callback */
 	pCallback = (ph7_value *)pCmpData;
+	if( pA->pMap->pVm->iCmpCallbackExc ){
+		/* A previous comparison already raised: stop invoking the callback so
+		 * the exception is not thrown again, and let the sort wind down. */
+		return 0;
+	}
 	/* initialize the result value */
 	PH7_MemObjInit(pA->pMap->pVm,&sResult);
 	PH7_MemObjInit(pA->pMap->pVm,&sK1);
@@ -2076,7 +2118,12 @@ static sxi32 HashmapCmpCallback6(ph7_hashmap_node *pA,ph7_hashmap_node *pB,void 
 	sK2.nIdx = SXU32_HIGH;
 	/* Invoke the callback */
 	rc = PH7_VmCallUserFunction(pA->pMap->pVm,pCallback,2,apArg,&sResult);
-	if( rc != SXRET_OK ){
+	if( rc == PH7_EXCEPTION ){
+		/* The comparator raised: flag it so the sort driver aborts and
+		 * propagates, and order this pair arbitrarily for the rest of the run. */
+		pA->pMap->pVm->iCmpCallbackExc = 1;
+		rc = 0;
+	}else if( rc != SXRET_OK ){
 		/* An error occured while calling user defined function [i.e: not defined] */
 		rc = -1; /* Set a dummy result */
 	}else{
@@ -2479,9 +2526,15 @@ static int ph7_hashmap_usort(ph7_context *pCtx,int nArg,ph7_value **apArg)
 			xCmp = HashmapCmpCallback1;
 		}
 		/* Do the merge sort */
+		pCtx->pVm->iCmpCallbackExc = 0;
 		HashmapMergeSort(pMap,xCmp,pCallback);
 		/* Rehash [Do not maintain index association as requested by the PHP specification] */
 		HashmapSortRehash(pMap);
+		if( pCtx->pVm->iCmpCallbackExc ){
+			/* The comparison callback raised: propagate so the dispatcher unwinds. */
+			pCtx->pVm->iCmpCallbackExc = 0;
+			return PH7_EXCEPTION;
+		}
 	}
 	/* All done,return TRUE */
 	ph7_result_bool(pCtx,1);
@@ -2526,10 +2579,16 @@ static int ph7_hashmap_uasort(ph7_context *pCtx,int nArg,ph7_value **apArg)
 			xCmp = HashmapCmpCallback1;
 		}
 		/* Do the merge sort */
+		pCtx->pVm->iCmpCallbackExc = 0;
 		HashmapMergeSort(pMap,xCmp,pCallback);
 		/* Fix the last link broken by the merge */
 		while(pMap->pLast->pPrev){
 			pMap->pLast = pMap->pLast->pPrev;
+		}
+		if( pCtx->pVm->iCmpCallbackExc ){
+			/* The comparison callback raised: propagate so the dispatcher unwinds. */
+			pCtx->pVm->iCmpCallbackExc = 0;
+			return PH7_EXCEPTION;
 		}
 	}
 	/* All done,return TRUE */
@@ -2575,10 +2634,16 @@ static int ph7_hashmap_uksort(ph7_context *pCtx,int nArg,ph7_value **apArg)
 			xCmp = HashmapCmpCallback2;
 		}
 		/* Do the merge sort */
+		pCtx->pVm->iCmpCallbackExc = 0;
 		HashmapMergeSort(pMap,xCmp,pCallback);
 		/* Fix the last link broken by the merge */
 		while(pMap->pLast->pPrev){
 			pMap->pLast = pMap->pLast->pPrev;
+		}
+		if( pCtx->pVm->iCmpCallbackExc ){
+			/* The comparison callback raised: propagate so the dispatcher unwinds. */
+			pCtx->pVm->iCmpCallbackExc = 0;
+			return PH7_EXCEPTION;
 		}
 	}
 	/* All done,return TRUE */
@@ -6414,6 +6479,11 @@ static int ph7_hashmap_filter(ph7_context *pCtx,int nArg,ph7_value **apArg)
 			}
 			keep = FALSE;
 			rc = PH7_VmCallUserFunction(pMap->pVm,apArg[1],1,&pValue,&sResult);
+			if( rc == PH7_EXCEPTION ){
+				/* The callback raised: propagate so the dispatcher unwinds. */
+				PH7_MemObjRelease(&sResult);
+				return PH7_EXCEPTION;
+			}
 			if( rc == SXRET_OK ){
 				/* Perform a boolean cast */
 				keep = ph7_value_to_bool(&sResult);
@@ -6437,37 +6507,39 @@ static int ph7_hashmap_filter(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	return PH7_OK;
 }
 /*
- * array array_map(?callable $callback, array $array)
- *  Applies the callback to the elements of the given array.
+ * array array_map(?callable $callback, array $array, array ...$arrays)
+ *  Applies the callback to the elements of the given arrays.
  * Parameters
  *  $callback
- *   A callable to run for each element in the array, or NULL for the
- *   identity function (returns the array unchanged).
+ *   A callable to run for each element in each array, or NULL. With a single
+ *   array and a NULL callback this is the identity function (the array is
+ *   returned unchanged); with several arrays and a NULL callback the arrays
+ *   are zipped together.
  *  $array
- *   An array to run through the callback function.
+ *   The first array to run through the callback function.
+ *  $arrays
+ *   Zero or more additional arrays to process in parallel.
  * Return
- *  Returns an array containing the results of applying the callback
- *  function to each element of $array.
+ *  Returns an array containing the results of applying the callback function.
+ *  With a single array the keys are preserved; with several arrays the result
+ *  is re-indexed and the iteration runs to the length of the longest array,
+ *  padding shorter arrays with NULL.
  */
 static int ph7_hashmap_map(ph7_context *pCtx,int nArg,ph7_value **apArg)
 {
 	ph7_value *pArray,*pValue,sKey,sResult;
 	ph7_hashmap_node *pEntry;
 	ph7_hashmap *pMap;
+	ph7_vm *pVm;
 	int bNullCallback;
+	sxi32 rc;
+	int i;
 	sxu32 n;
 	if( nArg < 2 ){
 		return PH7_VmThrowException(pCtx,
 			"ArgumentCountError",
 			"array_map() expects at least 2 arguments, %d given",
 			nArg
-			);
-	}
-	if( !ph7_value_is_array(apArg[1]) ){
-		return PH7_VmThrowException(pCtx,
-			"TypeError",
-			"array_map(): Argument #2 ($array) must be of type array, %s given",
-			ph7_type_name(apArg[1])
 			);
 	}
 	bNullCallback = ph7_value_is_null(apArg[0]);
@@ -6487,41 +6559,140 @@ static int ph7_hashmap_map(ph7_context *pCtx,int nArg,ph7_value **apArg)
 			"no array or string given"
 			);
 	}
+	/* Every remaining argument must be an array */
+	for( i = 1 ; i < nArg ; i++ ){
+		if( !ph7_value_is_array(apArg[i]) ){
+			if( i == 1 ){
+				return PH7_VmThrowException(pCtx,
+					"TypeError",
+					"array_map(): Argument #2 ($array) must be of type array, %s given",
+					ph7_type_name(apArg[1])
+					);
+			}
+			return PH7_VmThrowException(pCtx,
+				"TypeError",
+				"array_map(): Argument #%d must be of type array, %s given",
+				i+1,ph7_type_name(apArg[i])
+				);
+		}
+	}
+	pVm = pCtx->pVm;
 	/* Create a new array */
 	pArray = ph7_context_new_array(pCtx);
 	if( pArray == 0 ){
 		ph7_result_null(pCtx);
 		return PH7_OK;
 	}
-	/* Point to the internal representation of the input hashmap */
-	pMap = (ph7_hashmap *)apArg[1]->x.pOther;
-	PH7_MemObjInit(pMap->pVm,&sResult);
-	PH7_MemObjInit(pMap->pVm,&sKey);
+	PH7_MemObjInit(pVm,&sResult);
+	PH7_MemObjInit(pVm,&sKey);
 	sResult.nIdx = SXU32_HIGH; /* Mark as constant */
 	sKey.nIdx    = SXU32_HIGH; /* Mark as constant */
-	/* Perform the requested operation */
-	pEntry = pMap->pFirst;
-	for( n = 0 ; n < pMap->nEntry ; n++ ){
-		/* Extract the node value */
-		pValue = HashmapExtractNodeValue(pEntry);
-		if( pValue ){
-			/* Extract the node key */
-			PH7_HashmapExtractNodeKey(pEntry,&sKey);
-			if( bNullCallback ){
-				/* NULL callback: identity function, keep original value */
-				ph7_array_add_elem(pArray,&sKey,pValue);
-			}else{
-				/* Invoke the supplied callback */
-				PH7_VmCallUserFunction(pMap->pVm,apArg[0],1,&pValue,&sResult);
-				/* Insert the callback return value */
-				ph7_array_add_elem(pArray,&sKey,&sResult);
+	if( nArg == 2 ){
+		/* Single-array mode: keys are preserved (PHP semantics). */
+		pMap = (ph7_hashmap *)apArg[1]->x.pOther;
+		pEntry = pMap->pFirst;
+		for( n = 0 ; n < pMap->nEntry ; n++ ){
+			/* Extract the node value */
+			pValue = HashmapExtractNodeValue(pEntry);
+			if( pValue ){
+				/* Extract the node key */
+				PH7_HashmapExtractNodeKey(pEntry,&sKey);
+				if( bNullCallback ){
+					/* NULL callback: identity function, keep original value */
+					ph7_array_add_elem(pArray,&sKey,pValue);
+				}else{
+					/* Invoke the supplied callback */
+					rc = PH7_VmCallUserFunction(pVm,apArg[0],1,&pValue,&sResult);
+					if( rc == PH7_EXCEPTION ){
+						/* Callback raised: abort and let the foreign-function
+						 * dispatcher unwind through the nearest try/catch. */
+						PH7_MemObjRelease(&sKey);
+						PH7_MemObjRelease(&sResult);
+						return PH7_EXCEPTION;
+					}
+					/* Insert the callback return value */
+					ph7_array_add_elem(pArray,&sKey,&sResult);
+				}
+				PH7_MemObjRelease(&sKey);
+				PH7_MemObjRelease(&sResult);
 			}
+			/* Point to the next entry */
+			pEntry = pEntry->pPrev; /* Reverse link */
+		}
+	}else{
+		/* Multi-array mode: walk every array in parallel to the length of the
+		 * longest one, pad shorter arrays with NULL, and re-index the result. */
+		int nArrays = nArg - 1;
+		ph7_hashmap_node **apCur;
+		ph7_value **apCallArg;
+		ph7_value sNull;
+		sxu32 nMax = 0;
+		apCur     = (ph7_hashmap_node **)SyMemBackendAlloc(&pVm->sAllocator,(sxu32)(nArrays*sizeof(ph7_hashmap_node *)));
+		apCallArg = (ph7_value **)SyMemBackendAlloc(&pVm->sAllocator,(sxu32)(nArrays*sizeof(ph7_value *)));
+		if( apCur == 0 || apCallArg == 0 ){
+			if( apCur ){ SyMemBackendFree(&pVm->sAllocator,apCur); }
+			if( apCallArg ){ SyMemBackendFree(&pVm->sAllocator,apCallArg); }
 			PH7_MemObjRelease(&sKey);
 			PH7_MemObjRelease(&sResult);
+			ph7_result_value(pCtx,pArray);
+			return PH7_OK;
 		}
-		/* Point to the next entry */
-		pEntry = pEntry->pPrev; /* Reverse link */
+		PH7_MemObjInit(pVm,&sNull); /* shared NULL pad for short arrays */
+		sNull.nIdx = SXU32_HIGH;
+		for( i = 0 ; i < nArrays ; i++ ){
+			pMap = (ph7_hashmap *)apArg[i+1]->x.pOther;
+			apCur[i] = pMap->pFirst;
+			if( pMap->nEntry > nMax ){
+				nMax = pMap->nEntry;
+			}
+		}
+		for( n = 0 ; n < nMax ; n++ ){
+			ph7_value *pZip = 0;
+			if( bNullCallback ){
+				/* zip: each result element is an array of the i-th values */
+				pZip = ph7_context_new_array(pCtx);
+			}
+			for( i = 0 ; i < nArrays ; i++ ){
+				ph7_value *pv = &sNull;
+				if( apCur[i] ){
+					ph7_value *pNodeVal = HashmapExtractNodeValue(apCur[i]);
+					if( pNodeVal ){
+						pv = pNodeVal;
+					}
+					apCur[i] = apCur[i]->pPrev; /* Reverse link */
+				}
+				if( bNullCallback ){
+					if( pZip ){
+						ph7_array_add_elem(pZip,0,pv);
+					}
+				}else{
+					apCallArg[i] = pv;
+				}
+			}
+			if( bNullCallback ){
+				if( pZip ){
+					ph7_array_add_elem(pArray,0,pZip);
+				}
+			}else{
+				rc = PH7_VmCallUserFunction(pVm,apArg[0],nArrays,apCallArg,&sResult);
+				if( rc == PH7_EXCEPTION ){
+					SyMemBackendFree(&pVm->sAllocator,apCur);
+					SyMemBackendFree(&pVm->sAllocator,apCallArg);
+					PH7_MemObjRelease(&sNull);
+					PH7_MemObjRelease(&sKey);
+					PH7_MemObjRelease(&sResult);
+					return PH7_EXCEPTION;
+				}
+				ph7_array_add_elem(pArray,0,&sResult);
+				PH7_MemObjRelease(&sResult);
+			}
+		}
+		SyMemBackendFree(&pVm->sAllocator,apCur);
+		SyMemBackendFree(&pVm->sAllocator,apCallArg);
+		PH7_MemObjRelease(&sNull);
 	}
+	PH7_MemObjRelease(&sKey);
+	PH7_MemObjRelease(&sResult);
 	ph7_result_value(pCtx,pArray);
 	return PH7_OK;
 }
@@ -6546,6 +6717,7 @@ static int ph7_hashmap_reduce(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	ph7_hashmap *pMap;
 	ph7_value *pValue;
 	ph7_value sResult;
+	sxi32 rc;
 	sxu32 n;
 	if( nArg < 2 ){
 		return PH7_VmThrowException(pCtx,
@@ -6606,7 +6778,12 @@ static int ph7_hashmap_reduce(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		/* Extract the node value */
 		pValue = HashmapExtractNodeValue(pEntry);
 		/* Invoke the supplied callback */
-		PH7_VmCallUserFunctionAp(pMap->pVm,apArg[1],&sResult,&sResult,pValue,0);
+		rc = PH7_VmCallUserFunctionAp(pMap->pVm,apArg[1],&sResult,&sResult,pValue,0);
+		if( rc == PH7_EXCEPTION ){
+			/* The callback raised: propagate so the dispatcher unwinds. */
+			PH7_MemObjRelease(&sResult);
+			return PH7_EXCEPTION;
+		}
 		/* Point to the next entry */
 		pEntry = pEntry->pPrev; /* Reverse link */
 	}
@@ -6695,11 +6872,16 @@ static int ph7_hashmap_walk(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		/* Extract the node value */
 		pValue = HashmapExtractNodeValue(pEntry);
 		if( pValue ){
+			sxi32 rcW;
 			/* Extract the entry key */
 			PH7_HashmapExtractNodeKey(pEntry,&sKey);
 			/* Invoke the supplied callback */
-			PH7_VmCallUserFunctionAp(pMap->pVm,apArg[1],0,pValue,&sKey,pUserData,0);
+			rcW = PH7_VmCallUserFunctionAp(pMap->pVm,apArg[1],0,pValue,&sKey,pUserData,0);
 			PH7_MemObjRelease(&sKey);
+			if( rcW == PH7_EXCEPTION ){
+				/* The callback raised: propagate so the dispatcher unwinds. */
+				return PH7_EXCEPTION;
+			}
 		}
 		/* Point to the next entry */
 		pEntry = pEntry->pPrev; /* Reverse link */
@@ -6712,7 +6894,7 @@ static int ph7_hashmap_walk(ph7_context *pCtx,int nArg,ph7_value **apArg)
  * Apply a user function to every member of an array.(Recurse on array's).
  * Refer to the [array_walk_recursive()] implementation for more information.
  */
-static void HashmapWalkRecursive(
+static sxi32 HashmapWalkRecursive(
 	ph7_hashmap *pMap,    /* Target hashmap */
 	ph7_value *pCallback, /* User callback */
 	ph7_value *pUserData, /* Callback private data */
@@ -6721,6 +6903,7 @@ static void HashmapWalkRecursive(
 {
 	ph7_hashmap_node *pEntry;
 	ph7_value *pValue,sKey;
+	sxi32 rc;
 	sxu32 n;
 	/* Iterate through hashmap entries */
 	PH7_MemObjInit(pMap->pVm,&sKey);
@@ -6734,20 +6917,28 @@ static void HashmapWalkRecursive(
 				if( iNest < 32 ){
 					/* Recurse */
 					iNest++;
-					HashmapWalkRecursive((ph7_hashmap *)pValue->x.pOther,pCallback,pUserData,iNest);
+					rc = HashmapWalkRecursive((ph7_hashmap *)pValue->x.pOther,pCallback,pUserData,iNest);
 					iNest--;
+					if( rc == PH7_EXCEPTION ){
+						return PH7_EXCEPTION;
+					}
 				}
 			}else{
 				/* Extract the node key */
 				PH7_HashmapExtractNodeKey(pEntry,&sKey);
 				/* Invoke the supplied callback */
-				PH7_VmCallUserFunctionAp(pMap->pVm,pCallback,0,pValue,&sKey,pUserData,0);
+				rc = PH7_VmCallUserFunctionAp(pMap->pVm,pCallback,0,pValue,&sKey,pUserData,0);
 				PH7_MemObjRelease(&sKey);
+				if( rc == PH7_EXCEPTION ){
+					/* The callback raised: propagate so the dispatcher unwinds. */
+					return PH7_EXCEPTION;
+				}
 			}
 		}
 		/* Point to the next entry */
 		pEntry = pEntry->pPrev; /* Reverse link */
 	}
+	return PH7_OK;
 }
 /*
  * bool array_walk_recursive(array &$array, callback $funcname [, mixed $userdata])
@@ -6819,7 +7010,10 @@ static int ph7_hashmap_walk_recursive(ph7_context *pCtx,int nArg,ph7_value **apA
 	PH7_HashmapCowSeparate(pCtx->pVm, apArg[0]);
 	pMap = (ph7_hashmap *)apArg[0]->x.pOther;
 	/* Perform the desired operation */
-	HashmapWalkRecursive(pMap,apArg[1],nArg > 2 ? apArg[2] : 0,0);
+	if( HashmapWalkRecursive(pMap,apArg[1],nArg > 2 ? apArg[2] : 0,0) == PH7_EXCEPTION ){
+		/* A callback raised: propagate so the dispatcher unwinds. */
+		return PH7_EXCEPTION;
+	}
 	/* All done, return TRUE */
 	ph7_result_bool(pCtx,1);
 	return PH7_OK;

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -36,6 +36,10 @@ PH7_PRIVATE const char *ph7_type_name(ph7_value *pVal);
 /* Value of PI */
 #define PH7_PI 3.1415926535898
 #endif
+/* Uncaught/in-flight exception code value. A foreign function (built-in) that
+ * propagates a callback-raised exception returns this so the OP_CALL dispatcher
+ * unwinds through the nearest try/catch. */
+#define PH7_EXCEPTION -255
 /*
  * Constants for the largest and smallest possible 64-bit signed integers.
  * These macros are designed to work correctly on both 32-bit and 64-bit
@@ -900,6 +904,9 @@ struct ph7_vm
 	/* Index of the shared empty-string literal reserved at VM init */
 	sxu32 nEmptyStringIdx;
 	sxi32 iSpreadExtra;        /* Cumulative extra args from PH7_OP_SPREAD (reset by CALL) */
+	sxi32 iCmpCallbackExc;     /* Set when a sort comparison callback raised an exception
+								* so the sort driver (usort/uasort/uksort) can abort and
+								* propagate PH7_EXCEPTION. */
 	sxi32 iExitStatus;         /* Script exit status */
 	ph7_gen_state sCodeGen;    /* Code generator module */
 	ph7_exec_ctx *pActiveCtx;  /* Currently executing fiber/generator context (NULL in normal code) */

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -133,8 +133,6 @@ struct VmAutoloadCB
 {
 	ph7_value sCallback; /* Autoload callback (string or [obj,method] array) */
 };
-/* Uncaught exception code value */
-#define PH7_EXCEPTION -255
 
 /*
  * Return TRUE if either operand is a NaN real value.
@@ -649,6 +647,25 @@ static VmFrame * VmSkipExceptionFrames(VmFrame *pFrame)
 		pFrame = pFrame->pParent;
 	}
 	return pFrame;
+}
+/*
+ * After a callee invoked from an OP_CALL site (object __invoke, an array
+ * callable, or a NEW constructor) returns PH7_EXCEPTION, decide how the current
+ * frame unwinds. The catch body, if any, already ran in-place inside
+ * VmThrowException. Returns TRUE and sets *pResumePc to the post-try resume
+ * point when THIS frame's own try caught the exception; returns FALSE to signal
+ * the caller to propagate (goto Exception) so the exception unwinds through
+ * intermediate frames that have no local handler.
+ */
+static int VmCalleeExceptionResume(ph7_vm *pVm,sxi32 *pResumePc)
+{
+	VmFrame *pFrame = pVm->pFrame;
+	if( (pFrame->iFlags & VM_FRAME_EXCEPTION) && pFrame->iExceptionJump > 0
+	 && !(pFrame->iFlags & VM_FRAME_THROW) ){
+		*pResumePc = (sxi32)pFrame->iExceptionJump - 1;
+		return TRUE;
+	}
+	return FALSE;
 }
 /*
  * Compare two functions signature and return the comparison result.
@@ -8004,6 +8021,7 @@ case PH7_OP_NEW: {
 			 * receiving OP_CALL path runs its named-argument matching
 			 * (including variadic string-key packing). */
 			VmCallArgMap *pNewMap = (VmCallArgMap *)pInstr->p3;
+			sxi32 rcCons;
 			SySetReset(&aArg);
 			while( pArg < pTos ){
 				SySetPut(&aArg,(const void *)&pArg);
@@ -8027,10 +8045,32 @@ case PH7_OP_NEW: {
 					n++;
 				}
 			}
-			VmCallClassMethodWithMap(&(*pVm),pNew,pCons,0,(int)SySetUsed(&aArg),(ph7_value **)SySetBasePtr(&aArg),pNewMap);
+			rcCons = VmCallClassMethodWithMap(&(*pVm),pNew,pCons,0,(int)SySetUsed(&aArg),(ph7_value **)SySetBasePtr(&aArg),pNewMap);
 			/* TICKET 1433-52: Unsetting $this in the constructor body */
 			if( pNew->iRef < 1 ){
 				pNew->iRef = 1;
+			}
+			if( rcCons == PH7_ABORT || rcCons == PH7_EXCEPTION ){
+				/* The constructor raised: the half-constructed object must not
+				 * become the NEW result. Drop our reference so it is destroyed.
+				 * The class-name operand (and any leftover args) are released by
+				 * the Abort/Exception unwind, or explicitly on the resume path. */
+				sxi32 iResumePc;
+				PH7_ClassInstanceUnref(pNew);
+				if( rcCons == PH7_ABORT ){
+					goto Abort;
+				}
+				if( VmCalleeExceptionResume(pVm,&iResumePc) ){
+					/* This frame's own try caught it in-place: tidy the stack
+					 * (pop ctor args + release the class-name slot) and resume. */
+					if( pInstr->iP1 > 0 ){
+						VmPopOperand(&pTos,pInstr->iP1);
+					}
+					PH7_MemObjRelease(pTos);
+					pc = iResumePc;
+					break;
+				}
+				goto Exception;
 			}
 		}
 		if( pInstr->iP1 > 0 ){
@@ -8278,6 +8318,7 @@ case PH7_OP_CALL: {
 	if( (pTos->iFlags & MEMOBJ_STRING) == 0 ){
 		if( pTos->iFlags & MEMOBJ_HASHMAP ){
 			ph7_value sResult;
+			sxi32 rcArr;
 			SySetReset(&aArg);
 			while( pArg < pTos ){
 				SySetPut(&aArg,(const void *)&pArg);
@@ -8285,11 +8326,27 @@ case PH7_OP_CALL: {
 			}
 			PH7_MemObjInit(pVm,&sResult);
 			/* May be a class instance and it's static method */
-			PH7_VmCallUserFunction(pVm,pTos,(int)SySetUsed(&aArg),(ph7_value **)SySetBasePtr(&aArg),&sResult);
+			rcArr = PH7_VmCallUserFunction(pVm,pTos,(int)SySetUsed(&aArg),(ph7_value **)SySetBasePtr(&aArg),&sResult);
 			SySetReset(&aArg);
 			/* Pop given arguments */
 			if( nCallArgs > 0 ){
 				VmPopOperand(&pTos,nCallArgs);
+			}
+			if( rcArr == PH7_ABORT ){
+				PH7_MemObjRelease(&sResult);
+				goto Abort;
+			}
+			if( rcArr == PH7_EXCEPTION ){
+				/* An array callable ([$obj,'m']()) raised: resume after this frame's
+				 * try if it caught the exception in-place, otherwise propagate. */
+				sxi32 iResumePc;
+				PH7_MemObjRelease(&sResult);
+				if( VmCalleeExceptionResume(pVm,&iResumePc) ){
+					PH7_MemObjRelease(pTos);
+					pc = iResumePc;
+					break;
+				}
+				goto Exception;
 			}
 			/* Copy result */
 			PH7_MemObjStore(&sResult,pTos);
@@ -8333,6 +8390,24 @@ case PH7_OP_CALL: {
 						pc = pFrm2->iExceptionJump - 1;
 						break;
 					}
+				}
+				goto Exception;
+			}
+			if( rcInv == PH7_ABORT ){
+				PH7_MemObjRelease(&sResult);
+				goto Abort;
+			}
+			if( rcInv == PH7_EXCEPTION ){
+				/* __invoke raised. The catch body (if any) already ran in-place
+				 * inside VmThrowException. If THIS frame's own try caught it,
+				 * resume after the try/catch; otherwise propagate so the
+				 * exception unwinds through intermediate frames with no handler. */
+				sxi32 iResumePc;
+				PH7_MemObjRelease(&sResult);
+				if( VmCalleeExceptionResume(pVm,&iResumePc) ){
+					PH7_MemObjRelease(pTos);
+					pc = iResumePc;
+					break;
 				}
 				goto Exception;
 			}
@@ -11311,6 +11386,7 @@ static sxi32 VmCallClassMethodWithMap(
 	VmInstr aInstr[2];
 	int iCursor;
 	int i;
+	sxi32 rc;
 	aStack = VmNewOperandStack(&(*pVm),2+nArg);
 	if( aStack == 0 ){
 		PH7_VmThrowError(&(*pVm),0,PH7_CTX_ERR,
@@ -11341,9 +11417,11 @@ static sxi32 VmCallClassMethodWithMap(
 	aInstr[1].iP1 = 1;
 	aInstr[1].iP2 = 0;
 	aInstr[1].p3  = 0;
-	VmByteCodeExec(&(*pVm),aInstr,aStack,iCursor,pResult,0,TRUE,0,0);
+	rc = VmByteCodeExec(&(*pVm),aInstr,aStack,iCursor,pResult,0,TRUE,0,0);
 	SyMemBackendFree(&pVm->sAllocator,aStack);
-	return PH7_OK;
+	/* Propagate the real exec status (PH7_EXCEPTION / PH7_ABORT) so callers
+	 * can unwind instead of continuing past a method that raised. */
+	return rc;
 }
 PH7_PRIVATE sxi32 PH7_VmCallClassMethod(
 	ph7_vm *pVm,               /* Target VM */
@@ -11572,10 +11650,14 @@ PH7_PRIVATE sxi32 PH7_VmCallUserFunction(
 	aInstr[1].iP2 = 0;
 	aInstr[1].p3  = 0;
 	/* Execute the function body (if available) */
-	VmByteCodeExec(&(*pVm),aInstr,aStack,nArg,pResult,0,TRUE,0,0);
-	/* Clean up the mess left behind */
-	SyMemBackendFree(&pVm->sAllocator,aStack);
-	return PH7_OK;
+	{
+		sxi32 rcExec;
+		rcExec = VmByteCodeExec(&(*pVm),aInstr,aStack,nArg,pResult,0,TRUE,0,0);
+		/* Clean up the mess left behind */
+		SyMemBackendFree(&pVm->sAllocator,aStack);
+		/* Propagate PH7_EXCEPTION/PH7_ABORT so a callback that raised unwinds. */
+		return rcExec;
+	}
 }
 /*
  * Call a user defined or foreign function whith a varibale number

--- a/src/ph7/vm_builtin_class.c
+++ b/src/ph7/vm_builtin_class.c
@@ -868,6 +868,12 @@ PH7_PRIVATE int vm_builtin_call_user_func(ph7_context *pCtx,int nArg,ph7_value *
 	sResult.nIdx = SXU32_HIGH; /* Mark as constant */
 	/* Try to invoke the callback */
 	rc = PH7_VmCallUserFunction(pCtx->pVm,apArg[0],nArg - 1,&apArg[1],&sResult);
+	if( rc == PH7_EXCEPTION ){
+		/* The callback raised: propagate so the OP_CALL dispatcher unwinds
+		 * through the nearest try/catch instead of returning FALSE. */
+		PH7_MemObjRelease(&sResult);
+		return PH7_EXCEPTION;
+	}
 	if( rc != SXRET_OK ){
 		/* An error occured while invoking the given callback [i.e: not defined] */
 		ph7_result_bool(pCtx,0); /* return false */
@@ -919,6 +925,12 @@ PH7_PRIVATE int vm_builtin_call_user_func_array(ph7_context *pCtx,int nArg,ph7_v
 	}
 	/* Try to invoke the callback */
 	rc = PH7_VmCallUserFunction(pCtx->pVm,apArg[0],(int)SySetUsed(&aArg),(ph7_value **)SySetBasePtr(&aArg),&sResult);
+	if( rc == PH7_EXCEPTION ){
+		/* The callback raised: propagate so the OP_CALL dispatcher unwinds. */
+		PH7_MemObjRelease(&sResult);
+		SySetRelease(&aArg);
+		return PH7_EXCEPTION;
+	}
 	if( rc != SXRET_OK ){
 		/* An error occured while invoking the given callback [i.e: not defined] */
 		ph7_result_bool(pCtx,0); /* return false */

--- a/src/ph7/vm_pcre.c
+++ b/src/ph7/vm_pcre.c
@@ -1038,7 +1038,14 @@ static int PH7_builtin_preg_replace_callback(ph7_context *pCtx, int nArg, ph7_va
 		/* Call the callback */
 		PH7_MemObjInit(pCtx->pVm, &sResult);
 		apCbArg[0] = pMatchArr;
-		PH7_VmCallUserFunction(pCtx->pVm, apArg[1], 1, apCbArg, &sResult);
+		if( PH7_VmCallUserFunction(pCtx->pVm, apArg[1], 1, apCbArg, &sResult) == PH7_EXCEPTION ){
+			/* The callback raised: propagate so the dispatcher unwinds. */
+			PH7_MemObjRelease(&sResult);
+			ph7_context_release_value(pCtx, pMatchArr);
+			SyBlobRelease(&sOut);
+			pcre2_match_data_free(pMatchData);
+			return PH7_EXCEPTION;
+		}
 		/* Get replacement string from callback result */
 		zReplacement = ph7_value_to_string(&sResult, &nReplLen);
 		SyBlobAppend(&sOut, zReplacement, (sxu32)nReplLen);

--- a/tests/ph7/001-smoke/function/array_map/array_map_callback_exception.phpt
+++ b/tests/ph7/001-smoke/function/array_map/array_map_callback_exception.phpt
@@ -1,0 +1,40 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Exceptions raised by array callback builtins unwind
+--DESCRIPTION--
+A callback that throws inside array_map / array_filter / array_reduce /
+array_walk / usort must propagate the exception out of the builtin instead of
+swallowing it and continuing.
+--FILE--
+<?php
+$a = [3, 1, 2];
+
+try { array_map(function ($v) { throw new Exception("map"); }, $a); echo "no\n"; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+
+try { array_filter($a, function ($v) { throw new Exception("filter"); }); echo "no\n"; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+
+try { array_reduce($a, function ($c, $v) { throw new Exception("reduce"); }); echo "no\n"; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+
+try { array_walk($a, function ($v) { throw new Exception("walk"); }); echo "no\n"; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+
+try { usort($a, function ($x, $y) { throw new Exception("usort"); }); echo "no\n"; }
+catch (Exception $e) { echo $e->getMessage(), "\n"; }
+
+echo "done\n";
+?>
+--EXPECT--
+map
+filter
+reduce
+walk
+usort
+done
+--CLEAN--
+<?php
+unset($a);

--- a/tests/ph7/001-smoke/function/array_map/array_map_multi_arrays.phpt
+++ b/tests/ph7/001-smoke/function/array_map/array_map_multi_arrays.phpt
@@ -1,0 +1,25 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+array_map with several arrays applies the callback in parallel
+--DESCRIPTION--
+Regression: array_map ignored every array after the first, calling the callback
+with a single argument. PHP walks the arrays in parallel, passing one element
+from each per iteration and re-indexing the result with sequential integer keys.
+--FILE--
+<?php
+$a = [1, 2, 3];
+$b = [10, 20, 30];
+$c = [100, 200, 300];
+$r = array_map(function ($x, $y) { return $x + $y; }, $a, $b);
+echo $r[0], ',', $r[1], ',', $r[2], PHP_EOL;
+$s = array_map(function ($x, $y, $z) { return $x + $y + $z; }, $a, $b, $c);
+echo $s[0], ',', $s[1], ',', $s[2], PHP_EOL;
+?>
+--EXPECT--
+11,22,33
+111,222,333
+--CLEAN--
+<?php
+unset($a, $b, $c, $r, $s);

--- a/tests/ph7/001-smoke/function/array_map/array_map_multi_pad_null.phpt
+++ b/tests/ph7/001-smoke/function/array_map/array_map_multi_pad_null.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+array_map iterates to the longest array, padding short ones with NULL
+--FILE--
+<?php
+$a = [1];
+$b = [10, 20];
+$r = array_map(function ($x, $y) { return [$x, $y]; }, $a, $b);
+echo count($r), PHP_EOL;          // 2 (length of the longest array)
+echo $r[0][0], ',', $r[0][1], PHP_EOL;                          // 1,10
+echo (is_null($r[1][0]) ? 'NULL' : $r[1][0]), ',', $r[1][1], PHP_EOL; // NULL,20
+?>
+--EXPECT--
+2
+1,10
+NULL,20
+--CLEAN--
+<?php
+unset($a, $b, $r);

--- a/tests/ph7/001-smoke/function/array_map/array_map_multi_reindex.phpt
+++ b/tests/ph7/001-smoke/function/array_map/array_map_multi_reindex.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+array_map re-indexes the result when several arrays are given
+--DESCRIPTION--
+A single array keeps its keys; with several arrays the result is re-indexed with
+sequential integers even when an input array is associative.
+--FILE--
+<?php
+$assoc = ['x' => 1, 'y' => 2];
+$other = [10, 20];
+$r = array_map(function ($a, $b) { return $a . ':' . $b; }, $assoc, $other);
+echo implode(',', array_keys($r)), PHP_EOL;   // 0,1
+echo $r[0], ',', $r[1], PHP_EOL;               // 1:10,2:20
+?>
+--EXPECT--
+0,1
+1:10,2:20
+--CLEAN--
+<?php
+unset($assoc, $other, $r);

--- a/tests/ph7/001-smoke/function/array_map/array_map_null_zip.phpt
+++ b/tests/ph7/001-smoke/function/array_map/array_map_null_zip.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+array_map with a NULL callback and several arrays zips them together
+--DESCRIPTION--
+With more than one array and a NULL callback, PHP builds an array whose i-th
+element is an array of the i-th element of every input array.
+--FILE--
+<?php
+$n = [1, 2];
+$s = ['a', 'b'];
+$r = array_map(null, $n, $s);
+echo $r[0][0], ',', $r[0][1], PHP_EOL;   // 1,a
+echo $r[1][0], ',', $r[1][1], PHP_EOL;   // 2,b
+?>
+--EXPECT--
+1,a
+2,b
+--CLEAN--
+<?php
+unset($n, $s, $r);

--- a/tests/ph7/001-smoke/function/array_merge/array_merge_preserves_references.phpt
+++ b/tests/ph7/001-smoke/function/array_merge/array_merge_preserves_references.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+array_merge preserves by-reference entries
+--DESCRIPTION--
+Regression: array_merge routed every entry through HashmapDuplicateNode, which
+value-copied references and lost the by-reference binding. PHP keeps references
+live through the merge.
+--FILE--
+<?php
+$x = 5;
+$a = [&$x];
+$b = array_merge($a, [7]);
+$x = 99;
+echo $b[0], ',', $b[1], "\n";   // 99,7
+?>
+--EXPECT--
+99,7
+--CLEAN--
+<?php
+unset($x, $a, $b);

--- a/tests/ph7/001-smoke/lang/short_array_spread_reference.phpt
+++ b/tests/ph7/001-smoke/lang/short_array_spread_reference.phpt
@@ -1,0 +1,38 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Array spread preserves by-reference entries
+--DESCRIPTION--
+Regression: HashmapDuplicateNode value-copied every entry during a merge, so a
+reference held by the source array (e.g: [&$x]) was flattened to a plain value.
+PHP keeps the reference live across the spread, so mutating the original target
+is visible through the new array. Both int-keyed and string-keyed references are
+covered, plus a non-reference control that must stay independent.
+--FILE--
+<?php
+$x = 5;
+$a = [&$x];
+$b = [...$a];
+$x = 99;
+echo $b[0], "\n";        // 99: reference preserved
+
+$y = 1;
+$c = ['k' => &$y];
+$d = [...$c];
+$y = 7;
+echo $d['k'], "\n";      // 7: string-keyed reference preserved
+
+$z = 5;
+$e = [$z];               // no reference
+$f = [...$e];
+$z = 99;
+echo $f[0], "\n";        // 5: value copy stays independent
+?>
+--EXPECT--
+99
+7
+5
+--CLEAN--
+<?php
+unset($x, $a, $b, $y, $c, $d, $z, $e, $f);

--- a/tests/ph7/001-smoke/oo/exception_in_array_callable.phpt
+++ b/tests/ph7/001-smoke/oo/exception_in_array_callable.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+An exception thrown by an array-callable [$obj,'m']() unwinds the call
+--FILE--
+<?php
+class ExcArrCallable_C {
+    public function m() { throw new Exception("arr"); }
+}
+$o = new ExcArrCallable_C();
+$c = [$o, 'm'];
+try {
+    $c();
+    echo "after\n"; // must NOT run
+} catch (Exception $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+caught: arr
+--CLEAN--
+<?php
+unset($o, $c);

--- a/tests/ph7/001-smoke/oo/exception_in_constructor_strict_types.phpt
+++ b/tests/ph7/001-smoke/oo/exception_in_constructor_strict_types.phpt
@@ -1,0 +1,26 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A strict_types TypeError on a constructor argument unwinds the NEW
+--FILE--
+<?php
+declare(strict_types=1);
+class ExcStrictCtor_T {
+    public function __construct(int $n) {}
+}
+$o = null;
+try {
+    $o = new ExcStrictCtor_T("not-an-int");
+    echo "after\n"; // must NOT run
+} catch (TypeError $e) {
+    echo "type error caught\n";
+}
+echo ($o === null ? "o-is-null" : "o-set"), "\n";
+?>
+--EXPECT--
+type error caught
+o-is-null
+--CLEAN--
+<?php
+unset($o);

--- a/tests/ph7/001-smoke/oo/magic/invoke_exception_call_user_func.phpt
+++ b/tests/ph7/001-smoke/oo/magic/invoke_exception_call_user_func.phpt
@@ -1,0 +1,33 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Exceptions from callables invoked via call_user_func unwind
+--DESCRIPTION--
+call_user_func()/call_user_func_array() on a throwing callable (an __invoke
+object, an array [obj, method] callable, or a closure) must propagate the
+exception instead of returning FALSE and continuing.
+--FILE--
+<?php
+class InvokeCuf_Boom {
+    public function __invoke() { throw new Exception("invoke"); }
+    public function m()        { throw new Exception("method"); }
+}
+$b = new InvokeCuf_Boom();
+
+try { call_user_func($b); echo "no\n"; }
+catch (Exception $e) { echo "a: ", $e->getMessage(), "\n"; }
+
+try { call_user_func([$b, 'm']); echo "no\n"; }
+catch (Exception $e) { echo "b: ", $e->getMessage(), "\n"; }
+
+try { call_user_func_array(function ($x) { throw new Exception("cf-$x"); }, ['z']); echo "no\n"; }
+catch (Exception $e) { echo "c: ", $e->getMessage(), "\n"; }
+?>
+--EXPECT--
+a: invoke
+b: method
+c: cf-z
+--CLEAN--
+<?php
+unset($b);

--- a/tests/ph7/001-smoke/oo/magic/invoke_exception_nested.phpt
+++ b/tests/ph7/001-smoke/oo/magic/invoke_exception_nested.phpt
@@ -1,0 +1,30 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+An exception unwinds through a nested __invoke that has no handler
+--DESCRIPTION--
+The inner __invoke throws; the outer __invoke has no try/catch, so the exception
+must unwind through it (its trailing code must not run) up to the caller's catch.
+--FILE--
+<?php
+class InvokeNested_Inner {
+    public function __invoke() { throw new Exception("deep"); }
+}
+class InvokeNested_Outer {
+    public function __invoke($f) {
+        $f();
+        echo "outer-after\n"; // must NOT run
+    }
+}
+try {
+    (new InvokeNested_Outer())(new InvokeNested_Inner());
+    echo "call-after\n"; // must NOT run
+} catch (Exception $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+caught: deep
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/oo/magic/invoke_exception_unwinds.phpt
+++ b/tests/ph7/001-smoke/oo/magic/invoke_exception_unwinds.phpt
@@ -1,0 +1,32 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+An exception thrown inside __invoke unwinds the call
+--DESCRIPTION--
+Regression: an exception raised inside __invoke ran the catch block but then
+continued past the failed call with a bogus result. The call must unwind: code
+after $obj() must not run when __invoke throws.
+--FILE--
+<?php
+class InvokeUnwind_Boom {
+    public function __invoke() {
+        throw new Exception("boom");
+        echo "after-throw\n"; // unreachable
+    }
+}
+$b = new InvokeUnwind_Boom();
+try {
+    $r = $b();
+    echo "after-call\n"; // must NOT run
+} catch (Exception $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+echo "after-try\n";
+?>
+--EXPECT--
+caught: boom
+after-try
+--CLEAN--
+<?php
+unset($b);

--- a/tests/ph7/001-smoke/oo/throw_in_constructor.phpt
+++ b/tests/ph7/001-smoke/oo/throw_in_constructor.phpt
@@ -3,12 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 PH7: Throw from a class constructor and catch it
---SKIPIF--
-<?php
-if (function_exists('zend_version')) {
-    echo "skip";
-}
-?>
 --FILE--
 <?php
 class TestCtorThrow {
@@ -19,15 +13,13 @@ class TestCtorThrow {
 
 try {
     $o = new TestCtorThrow();
-    echo "no\n"; // This will execute, incorrectly in PH7
+    echo "no\n"; // must NOT run: the constructor threw and unwound
 } catch (Exception $e) {
     echo "caught: " . $e->getMessage() . "\n";
 }
 ?>
 --EXPECT--
 caught: ctor fail
-no
 --CLEAN--
 <?php
-// PH7 does not properly catch exceptions in constructors, it keeps going on
-unset($o);
+// $o was never assigned because the constructor threw.


### PR DESCRIPTION
… unwind

Three silent-wrong-answer bugs, shipped together with regression coverage and byte-for-byte parity against PHP 8.5.

1. Array spread / array_merge / array_replace / copies dropped by-reference entries. HashmapDuplicateNode value-copied every node, flattening references ([&$x]); it now re-inserts foreign (HASHMAP_NODE_FOREIGN_OBJ) nodes by reference via HashmapInsertByRef.

2. Multi-array array_map($cb,$a,$b,...) ignored every array after the first. ph7_hashmap_map now walks all arrays in parallel to the longest (padding short arrays with null), re-indexes the result, and zips on a null callback; the single-array path keeps keys.

3. Exceptions raised inside __invoke, an array callable, a NEW constructor, or a call_user_func / array-builtin callback ran the catch block but then continued past the failed call. VmCallClassMethodWithMap and PH7_VmCallUserFunction now propagate VmByteCodeExec's return code; each OP_CALL site resumes after the frame's own try when the catch ran in-place, else propagates so the exception unwinds through intermediate frames (shared VmCalleeExceptionResume helper). Callback builtins (call_user_func[_array], array_map/filter/reduce/walk/ walk_recursive, usort/uasort/uksort via a new pVm->iCmpCallbackExc flag, preg_replace_callback) now return PH7_EXCEPTION. PH7_EXCEPTION was promoted from a vm.c-local macro to ph7int.h.

Updated throw_in_constructor.phpt (it encoded the old buggy "keeps going" output).
