### PR TITLE
Fix multiple array-literal call args collapsing to the last

### DIFF
--- a/src/ph7/parse.c
+++ b/src/ph7/parse.c
@@ -1200,7 +1200,15 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 			if( apNode[iCur] ){
 				if( (apNode[iCur]->pStart->nType & PH7_TK_COMMA) && apNode[iCur]->pLeft == 0 && iNest <= 0 ){
 					break;
-				}else if( apNode[iCur]->pStart->nType & (PH7_TK_LPAREN|PH7_TK_OSB|PH7_TK_OCB) ){
+				}else if( (apNode[iCur]->pStart->nType & (PH7_TK_LPAREN|PH7_TK_OSB|PH7_TK_OCB))
+					&& apNode[iCur]->xCode != PH7_CompileShortArray
+					&& apNode[iCur]->xCode != PH7_CompileShortList ){
+					/* A short-array/short-list literal ([...]) is extracted as a single
+					 * self-contained node that already consumed its matching ']', so its
+					 * opening '[' has no separate closing node to balance iNest. Treat it
+					 * as a term, not an opening bracket, otherwise iNest stays >0 and the
+					 * following comma is never seen as an argument separator (collapsing
+					 * e.g. array_merge([1],[2]) to just [2]). */
 					iNest++;
 				}else if( apNode[iCur]->pStart->nType & (PH7_TK_RPAREN|PH7_TK_CCB|PH7_TK_CSB) ){
 					iNest--;

--- a/tests/ph7/001-smoke/function/array_merge/array_merge_short_array_literal_args.phpt
+++ b/tests/ph7/001-smoke/function/array_merge/array_merge_short_array_literal_args.phpt
@@ -1,0 +1,48 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+array_merge merges multiple short-array literal arguments
+--DESCRIPTION--
+Regression: a short-array literal [...] is extracted as a single self-contained
+node whose opening '[' had no balancing close-bracket node, so the argument
+splitter's nesting counter never returned to zero. Every comma after the first
+literal was hidden, folding all arguments into one and leaving only the last
+literal (array_merge([1],[2]) wrongly returned [2]). Using array() or variables
+masked the bug. PHP merges every argument.
+--FILE--
+<?php
+$two = array_merge([1], [2]);
+echo count($two), ':', implode(',', $two), "\n";
+
+$three = array_merge([1], [2], [3]);
+echo count($three), ':', implode(',', $three), "\n";
+
+$keys = array_merge(['a' => 1], ['b' => 2]);
+echo $keys['a'], $keys['b'], "\n";
+
+// Inner literal must stay nested, not be flattened by the splitter.
+$nested = array_merge([1, [9]], [2]);
+echo count($nested), ':', $nested[0], ',', $nested[1][0], ',', $nested[2], "\n";
+
+// Mixed literal + variable, both orders, must still work.
+$v = [2];
+echo implode(',', array_merge([1], $v)), "\n";
+echo implode(',', array_merge($v, [1])), "\n";
+
+// No regression for a single literal or an empty literal.
+echo implode(',', array_merge([1])), "\n";
+echo implode(',', array_merge([], [1])), "\n";
+?>
+--EXPECT--
+2:1,2
+3:1,2,3
+12
+3:1,9,2
+1,2
+2,1
+1
+1
+--CLEAN--
+<?php
+unset($two, $three, $keys, $nested, $v);

--- a/tests/ph7/001-smoke/parse/call_arg_short_array_literals.phpt
+++ b/tests/ph7/001-smoke/parse/call_arg_short_array_literals.phpt
@@ -1,0 +1,39 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Short-array literals as call arguments stay separate arguments
+--DESCRIPTION--
+Regression for the argument splitter (ExprProcessFuncArguments): a short-array
+literal [...] consumes its own ']', so its '[' had no balancing node and the
+nesting counter stayed positive, collapsing every subsequent argument into the
+last literal. This affected any call, not just array builtins. Each parameter
+must receive its own literal.
+--FILE--
+<?php
+function call_arg_lit_three($a, $b, $c) {
+    echo count($a), count($b), count($c), ' ', $a[0], $b[0], $c[0], "\n";
+}
+call_arg_lit_three([1], [2], [3]);
+
+// A literal followed by an array subscript argument: the subscript's '['/']'
+// are separate balancing nodes and must keep working alongside the fix.
+$arr = [9, 8];
+function call_arg_lit_subscript($x, $y) {
+    echo $x[0], ',', $y, "\n";
+}
+call_arg_lit_subscript([1], $arr[0]);
+
+// Nested literal as one argument is one argument.
+function call_arg_lit_nested($x, $y) {
+    echo count($x), ',', $x[1][0], ',', $y, "\n";
+}
+call_arg_lit_nested([1, [7]], 5);
+?>
+--EXPECT--
+111 123
+1,9
+2,7,5
+--CLEAN--
+<?php
+unset($arr);


### PR DESCRIPTION
ExprProcessFuncArguments split a call's argument list by tracking bracket nesting via each node's start token, incrementing iNest on '(' / '[' / '{'. A short-array literal [...] is extracted as a single self-contained node that already consumed its matching ']', so its opening '[' had no balancing close-bracket node: iNest never returned to 0, every comma after the first literal was hidden, and the comma operator left only the last array (array_merge([1],[2]) wrongly returned [2]; f([1],[2],[3]) reached the callee as one arg). array() and variables masked the bug, which affected any call.

Treat self-contained short-array / short-list nodes as terms, not opening brackets, so iNest stays balanced and comma-based arg separation is restored.

Regression: function/array_merge/array_merge_short_array_literal_args.phpt, parse/call_arg_short_array_literals.phpt.
