### PR TITLE
Propagate callback exceptions from array_udiff/uintersect/diff_uassoc

### DIFF
--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -898,6 +898,11 @@ static int HashmapFindValueByCallback(
 	ph7_value *apArg[2];    /* Callback arguments */
 	sxi32 rc;
 	sxu32 n;
+	if( pMap->pVm->iCmpCallbackExc ){
+		/* A previous comparison already raised: stop invoking the callback so the
+		 * exception is not thrown again, and let the caller wind down. */
+		return SXERR_NOTFOUND;
+	}
 	/* Perform a linear search since we cannot sort the array based on values */
 	pEntry = pMap->pFirst;
 	n = pMap->nEntry;
@@ -915,6 +920,13 @@ static int HashmapFindValueByCallback(
 			/* Invoke the user callback */
 			apArg[1] = pVal; /* Second argument to the callback */
 			rc = PH7_VmCallUserFunction(pMap->pVm,pCallback,2,apArg,&sResult);
+			if( rc == PH7_EXCEPTION ){
+				/* The callback raised: flag it so the caller aborts and propagates,
+				 * and report no match for the rest of the run. */
+				pMap->pVm->iCmpCallbackExc = 1;
+				PH7_MemObjRelease(&sResult);
+				return SXERR_NOTFOUND;
+			}
 			if( rc == SXRET_OK ){
 				/* Extract callback result */
 				if( (sResult.iFlags & MEMOBJ_INT) == 0 ){
@@ -4337,6 +4349,7 @@ static int ph7_hashmap_udiff(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	/* Perform the diff */
 	pEntry = pSrc->pFirst;
 	n = pSrc->nEntry;
+	pCtx->pVm->iCmpCallbackExc = 0;
 	for(;;){
 		if( n < 1 ){
 			break;
@@ -4353,6 +4366,12 @@ static int ph7_hashmap_udiff(ph7_context *pCtx,int nArg,ph7_value **apArg)
 					/* Value exist */
 					break;
 				}
+			}
+			if( pCtx->pVm->iCmpCallbackExc ){
+				/* The comparison callback raised: propagate so the dispatcher
+				 * unwinds, before any spurious insertion into the result. */
+				pCtx->pVm->iCmpCallbackExc = 0;
+				return PH7_EXCEPTION;
 			}
 			if( i >= (nArg - 1)){
 				/* Perform the insertion */
@@ -4625,6 +4644,17 @@ static int ph7_hashmap_diff_uassoc(ph7_context *pCtx,int nArg,ph7_value **apArg)
 					apK[0] = &key1;
 					apK[1] = &key2;
 					rc = PH7_VmCallUserFunction(pMap->pVm,pCallback,2,apK,&result);
+				}
+				if( rc == PH7_EXCEPTION ){
+					/* The key comparison callback raised. Unlike array_udiff/
+					 * array_uintersect (which signal back from
+					 * HashmapFindValueByCallback via pVm->iCmpCallbackExc), this
+					 * function invokes the callback inline, so it cleans up its own
+					 * temporaries and propagates the exception directly. */
+					PH7_MemObjRelease(&result);
+					PH7_MemObjRelease(&key1);
+					PH7_MemObjRelease(&key2);
+					return PH7_EXCEPTION;
 				}
 				if( rc == SXRET_OK ){
 					if( (result.iFlags & MEMOBJ_INT) == 0 ){
@@ -5214,6 +5244,7 @@ static int ph7_hashmap_uintersect(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	/* Perform the intersection */
 	pEntry = pSrc->pFirst;
 	n = pSrc->nEntry;
+	pCtx->pVm->iCmpCallbackExc = 0;
 	for(;;){
 		if( n < 1 ){
 			break;
@@ -5239,6 +5270,11 @@ static int ph7_hashmap_uintersect(ph7_context *pCtx,int nArg,ph7_value **apArg)
 				/* Perform the insertion */
 				HashmapInsertNode((ph7_hashmap *)pArray->x.pOther,pEntry,TRUE);
 			}
+		}
+		if( pCtx->pVm->iCmpCallbackExc ){
+			/* The comparison callback raised: propagate so the dispatcher unwinds. */
+			pCtx->pVm->iCmpCallbackExc = 0;
+			return PH7_EXCEPTION;
 		}
 		/* Point to the next entry */
 		pEntry = pEntry->pPrev; /* Reverse link */

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -904,9 +904,10 @@ struct ph7_vm
 	/* Index of the shared empty-string literal reserved at VM init */
 	sxu32 nEmptyStringIdx;
 	sxi32 iSpreadExtra;        /* Cumulative extra args from PH7_OP_SPREAD (reset by CALL) */
-	sxi32 iCmpCallbackExc;     /* Set when a sort comparison callback raised an exception
-								* so the sort driver (usort/uasort/uksort) can abort and
-								* propagate PH7_EXCEPTION. */
+	sxi32 iCmpCallbackExc;     /* Set when a comparison callback raised an exception so the
+								* driver (usort/uasort/uksort and the array_udiff/
+								* array_uintersect families) can abort and propagate
+								* PH7_EXCEPTION. */
 	sxi32 iExitStatus;         /* Script exit status */
 	ph7_gen_state sCodeGen;    /* Code generator module */
 	ph7_exec_ctx *pActiveCtx;  /* Currently executing fiber/generator context (NULL in normal code) */

--- a/tests/ph7/001-smoke/function/array_diff_uassoc/array_diff_uassoc_callback_exception.phpt
+++ b/tests/ph7/001-smoke/function/array_diff_uassoc/array_diff_uassoc_callback_exception.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+array_diff_uassoc propagates an exception thrown by the key-comparison callback and unwinds
+--FILE--
+<?php
+try {
+    array_diff_uassoc(['a' => 1, 'b' => 2], ['a' => 1], function ($a, $b) {
+        throw new Exception('boom');
+    });
+    echo 'NOT REACHED' . PHP_EOL;
+} catch (Exception $e) {
+    echo 'caught: ' . $e->getMessage() . PHP_EOL;
+}
+echo 'after' . PHP_EOL;
+?>
+--EXPECT--
+caught: boom
+after

--- a/tests/ph7/001-smoke/function/array_udiff/array_udiff_callback_exception.phpt
+++ b/tests/ph7/001-smoke/function/array_udiff/array_udiff_callback_exception.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+array_udiff propagates an exception thrown by the comparison callback and unwinds
+--FILE--
+<?php
+try {
+    array_udiff([1, 2, 3], [2, 3], function ($a, $b) {
+        throw new Exception('boom');
+    });
+    echo 'NOT REACHED' . PHP_EOL;
+} catch (Exception $e) {
+    echo 'caught: ' . $e->getMessage() . PHP_EOL;
+}
+echo 'after' . PHP_EOL;
+?>
+--EXPECT--
+caught: boom
+after

--- a/tests/ph7/001-smoke/function/array_uintersect/array_uintersect_callback_exception.phpt
+++ b/tests/ph7/001-smoke/function/array_uintersect/array_uintersect_callback_exception.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+array_uintersect propagates an exception thrown by the comparison callback and unwinds
+--FILE--
+<?php
+try {
+    array_uintersect([1, 2, 3], [2, 3], function ($a, $b) {
+        throw new Exception('boom');
+    });
+    echo 'NOT REACHED' . PHP_EOL;
+} catch (Exception $e) {
+    echo 'caught: ' . $e->getMessage() . PHP_EOL;
+}
+echo 'after' . PHP_EOL;
+?>
+--EXPECT--
+caught: boom
+after


### PR DESCRIPTION
array_udiff, array_uintersect and array_diff_uassoc discarded an exception thrown by their user-comparison callback (the same comparator-returns-int pattern previously fixed for the usort family): the catch block ran but execution continued past the call, yielding silent wrong answers.

HashmapFindValueByCallback (shared by array_udiff/array_uintersect) now sets pVm->iCmpCallbackExc on PH7_EXCEPTION and short-circuits further callback invocations; both builtins check the flag after their diff/intersect loop and return PH7_EXCEPTION (before any spurious insertion into the discarded result). array_diff_uassoc invokes the key comparator inline, so it releases its temporaries and propagates the exception directly.
