### PR TITLE
Skip #[...] attribute groups instead of swallowing the line

### DIFF
--- a/src/ph7/lex.c
+++ b/src/ph7/lex.c
@@ -102,7 +102,72 @@ static sxi32 TokenizePHP(SyStream *pStream,SyToken *pToken,void *pUserData,void 
 	}else{
 		sxi32 c;
 		/* Non-alpha stream */
-		if( pStream->zText[0] == '#' ||
+		if( pStream->zText[0] == '#' && &pStream->zText[1] < pStream->zEnd && pStream->zText[1] == '[' ){
+			sxu32 nDepth = 1;
+			/* PHP 8 attribute group '#[ ... ]': skip the whole balanced group as
+			 * trivia (attributes are not stored yet). Brackets inside string
+			 * literals and comments must not affect the depth count. An
+			 * unterminated group is silently consumed up to EOF, consistent
+			 * with unterminated block comments below.
+			 */
+			pStream->zText += 2;
+			while( pStream->zText < pStream->zEnd && nDepth > 0 ){
+				sxi32 d = pStream->zText[0];
+				if( d == '[' ){
+					nDepth++;
+				}else if( d == ']' ){
+					nDepth--;
+				}else if( d == '\'' || d == '"' ){
+					/* String literal: scan for the matching unescaped quote */
+					pStream->zText++;
+					while( pStream->zText < pStream->zEnd ){
+						if( pStream->zText[0] == '\\' && &pStream->zText[1] < pStream->zEnd ){
+							if( pStream->zText[1] == '\n' ){
+								pStream->nLine++;
+							}
+							pStream->zText += 2;
+							continue;
+						}
+						if( pStream->zText[0] == d ){
+							break;
+						}
+						if( pStream->zText[0] == '\n' ){
+							pStream->nLine++;
+						}
+						pStream->zText++;
+					}
+					if( pStream->zText >= pStream->zEnd ){
+						break; /* Unterminated string literal */
+					}
+					/* Fall through: consume the closing quote below */
+				}else if( d == '#' || (d == '/' && &pStream->zText[1] < pStream->zEnd && pStream->zText[1] == '/') ){
+					/* Inline comment inside the group */
+					while( pStream->zText < pStream->zEnd && pStream->zText[0] != '\n' ){
+						pStream->zText++;
+					}
+					continue; /* Let the outer loop count the newline */
+				}else if( d == '/' && &pStream->zText[1] < pStream->zEnd && pStream->zText[1] == '*' ){
+					/* Block comment inside the group */
+					pStream->zText += 2;
+					while( pStream->zText < pStream->zEnd ){
+						if( pStream->zText[0] == '*' && &pStream->zText[1] < pStream->zEnd && pStream->zText[1] == '/' ){
+							pStream->zText += 2;
+							break;
+						}
+						if( pStream->zText[0] == '\n' ){
+							pStream->nLine++;
+						}
+						pStream->zText++;
+					}
+					continue;
+				}else if( d == '\n' ){
+					pStream->nLine++;
+				}
+				pStream->zText++;
+			}
+			/* Tell the upper-layer to ignore this token */
+			return SXERR_CONTINUE;
+		}else if( pStream->zText[0] == '#' ||
 			( pStream->zText[0] == '/' &&  &pStream->zText[1] < pStream->zEnd && pStream->zText[1] == '/') ){
 				pStream->zText++;
 				/* Inline comments */

--- a/tests/ph7/001-smoke/lang/attribute_args_strings.phpt
+++ b/tests/ph7/001-smoke/lang/attribute_args_strings.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Brackets and escapes inside attribute argument strings do not unbalance the group
+--FILE--
+<?php
+#[Route("/a]b", 'c[d')] function attr_args_str_f(){ return "both quotes"; }
+echo attr_args_str_f(), "\n";
+#[Pattern("esc\"quote]still[inside")] function attr_args_esc_f(){ return "escaped"; }
+echo attr_args_esc_f(), "\n";
+?>
+--EXPECT--
+both quotes
+escaped
+--CLEAN--
+<?php
+?>

--- a/tests/ph7/001-smoke/lang/attribute_class_members.phpt
+++ b/tests/ph7/001-smoke/lang/attribute_class_members.phpt
@@ -1,0 +1,27 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Attributes on class, const, property, method and promoted param are inert
+--FILE--
+<?php
+#[Entity] class AttrMembers {
+    #[Marker] const TAG = "tag";
+    #[Column] public $prop = "prop";
+    public function __construct(#[Inject] public $promoted = "promoted") {}
+    #[Route] public function method(){ return "method"; }
+}
+$o = new AttrMembers();
+echo AttrMembers::TAG, "\n";
+echo $o->prop, "\n";
+echo $o->promoted, "\n";
+echo $o->method(), "\n";
+?>
+--EXPECT--
+tag
+prop
+promoted
+method
+--CLEAN--
+<?php
+?>

--- a/tests/ph7/001-smoke/lang/attribute_multiline_line_count.phpt
+++ b/tests/ph7/001-smoke/lang/attribute_multiline_line_count.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Multi-line attribute groups keep the line counter accurate
+--FILE--
+<?php
+#[Config(
+    "multi]line",
+    [1, 2],
+)]
+function attr_multiline_f(){ return __LINE__; }
+echo attr_multiline_f(), "\n";
+echo __LINE__, "\n";
+?>
+--EXPECT--
+6
+8
+--CLEAN--
+<?php
+?>

--- a/tests/ph7/001-smoke/lang/attribute_nested_brackets.phpt
+++ b/tests/ph7/001-smoke/lang/attribute_nested_brackets.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nested arrays and grouped attributes are skipped as one balanced group
+--FILE--
+<?php
+#[ListOf([1, [2, 3], ["k" => [4]]])] function attr_nested_f(){ return "nested"; }
+echo attr_nested_f(), "\n";
+#[First, Second(1), Third(name: "x")] function attr_grouped_f(){ return "grouped"; }
+echo attr_grouped_f(), "\n";
+?>
+--EXPECT--
+nested
+grouped
+--CLEAN--
+<?php
+?>

--- a/tests/ph7/001-smoke/lang/attribute_same_line_code.phpt
+++ b/tests/ph7/001-smoke/lang/attribute_same_line_code.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Code on the same line as a #[Attr] attribute is not swallowed
+--DESCRIPTION--
+Regression: the lexer treated '#' unconditionally as a line comment, so
+'#[MyAttr] function f(){}' silently discarded the function declaration.
+The balanced '#[ ... ]' group alone must be skipped, not the whole line.
+--FILE--
+<?php
+#[MyAttr] function attr_same_line_f(){ return "ok"; }
+echo attr_same_line_f(), "\n";
+$attr_same_line_c = #[MyAttr] function(){ return "closure"; };
+echo $attr_same_line_c(), "\n";
+?>
+--EXPECT--
+ok
+closure
+--CLEAN--
+<?php
+?>

--- a/tests/ph7/001-smoke/lang/hash_comment_unchanged.phpt
+++ b/tests/ph7/001-smoke/lang/hash_comment_unchanged.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Plain # and // comments still consume to end of line
+--FILE--
+<?php
+# comment with [ bracket and ] more
+echo "hash ok\n";
+#plain comment
+echo "plain ok\n";
+// comment with [ bracket
+echo "slash ok\n";
+$x = 1; # [ trailing comment with bracket
+echo $x, "\n";
+?>
+--EXPECT--
+hash ok
+plain ok
+slash ok
+1
+--CLEAN--
+<?php
+?>

--- a/tests/ph7/001-smoke/lang/string_hash_bracket_literal.phpt
+++ b/tests/ph7/001-smoke/lang/string_hash_bracket_literal.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+The #[ sequence inside string literals stays literal
+--FILE--
+<?php
+echo "#[not an attribute]\n";
+echo '#[single quoted]', "\n";
+$s = "prefix #[inner] suffix";
+echo $s, "\n";
+?>
+--EXPECT--
+#[not an attribute]
+#[single quoted]
+prefix #[inner] suffix
+--CLEAN--
+<?php
+?>


### PR DESCRIPTION
The lexer treated '#' unconditionally as a line comment, so a single-line PHP 8 attribute like '#[Attr] function f(){}' silently discarded the rest of the line (the function declaration), losing code with no diagnostic.

TokenizePHP now recognizes '#[' and skips the balanced attribute group as inert trivia: bracket depth is counted, brackets inside string literals (escape-aware) and inline/block comments are ignored, and nLine is kept accurate across multi-line groups. An unterminated group is consumed to EOF, consistent with the existing unterminated block-comment behavior. Attributes are still not stored; parse+store remains future work.
