### PR TITLE
Make exit/die unwind the VM and run shutdown callbacks

### DIFF
--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -909,6 +909,10 @@ struct ph7_vm
 								* array_uintersect families) can abort and propagate
 								* PH7_EXCEPTION. */
 	sxi32 iExitStatus;         /* Script exit status */
+	sxu8 bHaltRequested;       /* Set by exit/die (OP_HALT or the builtin) so the halt
+								* cascades out of nested execution units (include/require/
+								* eval chunks) instead of hard-exiting the process; the
+								* top-level executor then runs shutdown callbacks normally. */
 	ph7_gen_state sCodeGen;    /* Code generator module */
 	ph7_exec_ctx *pActiveCtx;  /* Currently executing fiber/generator context (NULL in normal code) */
 	ph7_class *pFiberClass;    /* Cached Fiber class pointer for fast dispatch */

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -4130,11 +4130,11 @@ case PH7_OP_HALT:
 		/* Nothing referenced */
 		*pLastRef = SXU32_HIGH;
 	}
-	/* Check if we're in an included file context */
-	if( SySetUsed(&pVm->aFiles) > 0 ){
-		/* Terminate the entire process */
-		exit(pVm->iExitStatus);
-	}
+	/* Request a VM-wide halt so the abort cascades out of any enclosing
+	 * include/require/eval execution unit; shutdown callbacks then run
+	 * at the top level (PHP semantics) instead of hard-exiting here.
+	 */
+	pVm->bHaltRequested = 1;
 	goto Abort;
 /*
  * JMP: * P2 *
@@ -9616,6 +9616,11 @@ static void VmInvokeShutdownCallbacks(ph7_vm *pVm)
 	for( i = 0 ; i < (int)SX_ARRAYSIZE(apArg) ; i++ ){
 		apArg[i] = 0;
 	}
+	/* A halt that led us here is consumed; a fresh one set by a callback
+	 * (i.e. exit() inside a shutdown function) skips the remaining
+	 * callbacks, mirroring PHP.
+	 */
+	pVm->bHaltRequested = 0;
 	for( n = 0 ; n < nEntry ; ++n ){
 		pEntry = (VmShutdownCB *)SySetAt(&pVm->aShutdown,n);
 		if( pEntry ){
@@ -9638,6 +9643,10 @@ static void VmInvokeShutdownCallbacks(ph7_vm *pVm)
 				for( i = 0 ; i < pEntry->nArg ; ++i ){
 					PH7_MemObjRelease(apArg[i]);
 				}
+			}
+			if( pVm->bHaltRequested ){
+				/* exit() inside the callback: skip the remaining callbacks */
+				break;
 			}
 		}
 	}
@@ -12380,12 +12389,10 @@ static int vm_builtin_exit(ph7_context *pCtx,int nArg,ph7_value **apArg)
 			pCtx->pVm->iExitStatus = iExitStatus;
 		}
 	}
-	/* Check if we are in an included file */
-	if( SySetUsed(&pCtx->pVm->aFiles) > 0 ){
-		/* Exit the entire process */
-		exit(pCtx->pVm->iExitStatus);
-	}
-	/* Abort processing immediately */
+	/* Request a VM-wide halt (see PH7_OP_HALT) and abort processing
+	 * immediately; the abort unwinds enclosing frames and execution units.
+	 */
+	pCtx->pVm->bHaltRequested = 1;
 	return PH7_ABORT;
 }
 /*
@@ -14560,6 +14567,10 @@ static int vm_builtin_eval(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	}
 	/* Eval the chunk */
 	VmEvalChunk(pCtx->pVm,&(*pCtx),&sChunk,PH7_PHP_ONLY,FALSE);
+	if( pCtx->pVm->bHaltRequested ){
+		/* exit/die inside the evaluated chunk: cascade the halt */
+		return PH7_ABORT;
+	}
 	return SXRET_OK;
 }
 /*
@@ -14840,6 +14851,10 @@ static int vm_builtin_include(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		ph7_context_throw_error_format(pCtx,PH7_CTX_WARNING,"IO error while importing: '%z'",&sFile);
 		ph7_result_bool(pCtx,0);
 	}
+	if( pCtx->pVm->bHaltRequested ){
+		/* exit/die inside the included file: cascade the halt */
+		return PH7_ABORT;
+	}
 	return SXRET_OK;
 }
 /*
@@ -14879,6 +14894,10 @@ static int vm_builtin_include_once(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		ph7_context_throw_error_format(pCtx,PH7_CTX_WARNING,"IO error while importing: '%z'",&sFile);
 		ph7_result_bool(pCtx,0);
  	}
+	if( pCtx->pVm->bHaltRequested ){
+		/* exit/die inside the included file: cascade the halt */
+		return PH7_ABORT;
+	}
 	return SXRET_OK;
 }
 /*
@@ -14911,6 +14930,10 @@ static int vm_builtin_require(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		/* Fatal,abort VM execution immediately */
 		ph7_context_throw_error_format(pCtx,PH7_CTX_ERR,"Fatal IO error while importing: '%z'",&sFile);
 		ph7_result_bool(pCtx,0);
+		return PH7_ABORT;
+	}
+	if( pCtx->pVm->bHaltRequested ){
+		/* exit/die inside the included file: cascade the halt */
 		return PH7_ABORT;
 	}
 	return SXRET_OK;
@@ -14950,6 +14973,10 @@ static int vm_builtin_require_once(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		/* Fatal,abort VM execution immediately */
 		ph7_context_throw_error_format(pCtx,PH7_CTX_ERR,"Fatal IO error while importing: '%z'",&sFile);
 		ph7_result_bool(pCtx,0);
+		return PH7_ABORT;
+	}
+	if( pCtx->pVm->bHaltRequested ){
+		/* exit/die inside the included file: cascade the halt */
 		return PH7_ABORT;
 	}
 	return SXRET_OK;

--- a/tests/ph7/002-integration/function/exit/exit_in_eval_halts.phpt
+++ b/tests/ph7/002-integration/function/exit/exit_in_eval_halts.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+die() inside eval() halts the whole script
+--DESCRIPTION--
+Regression: VmEvalChunk swallowed an abort from the evaluated chunk, so execution
+continued past eval() after a die(). The halt now cascades out of eval().
+--FILE--
+<?php
+echo "before\n";
+eval('die("died\n");');
+echo "after\n";
+?>
+--EXPECT--
+before
+died
+--CLEAN--
+<?php
+?>

--- a/tests/ph7/002-integration/function/exit/exit_in_function_in_include.phpt
+++ b/tests/ph7/002-integration/function/exit/exit_in_function_in_include.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+die() in a function called from an included file halts the script and runs shutdown
+--FILE--
+<?php
+$target = __DIR__ . '/exit_in_fn_target.php';
+file_put_contents($target, "<?php\nfunction inc_die() { die(\"died\\n\"); }\necho \"in_include\\n\";\ninc_die();\necho \"never\\n\";\n");
+register_shutdown_function(function () { echo "shutdown ran\n"; });
+echo "before\n";
+include $target;
+echo "after_include\n";
+?>
+--EXPECT--
+before
+in_include
+died
+shutdown ran
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/exit_in_fn_target.php');
+?>

--- a/tests/ph7/002-integration/function/exit/exit_in_include_runs_shutdown.phpt
+++ b/tests/ph7/002-integration/function/exit/exit_in_include_runs_shutdown.phpt
@@ -1,0 +1,27 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+die() inside an included file halts the script but still runs shutdown callbacks
+--DESCRIPTION--
+Regression: exit/die inside an included file used to hard-exit the C process
+(skipping shutdown callbacks and discarding the exit status). It now requests a
+VM-wide halt that cascades out of the include, so shutdown callbacks run as in PHP.
+--FILE--
+<?php
+$target = __DIR__ . '/exit_in_include_target.php';
+file_put_contents($target, "<?php\necho \"in_include\\n\";\ndie(\"died\\n\");\necho \"never\\n\";\n");
+register_shutdown_function(function () { echo "shutdown ran\n"; });
+echo "before\n";
+include $target;
+echo "after_include\n";
+?>
+--EXPECT--
+before
+in_include
+died
+shutdown ran
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/exit_in_include_target.php');
+?>


### PR DESCRIPTION
Three PHP-fidelity bugs in exit/die:

1. exit/die inside an included file called exit() on the C process directly (OP_HALT and vm_builtin_exit: if SySetUsed(&aFiles) exit(...)), hard-killing the process and skipping shutdown callbacks.
2. exit/die inside eval() did not halt at all: VmEvalChunk swallowed the chunk's abort, so execution continued past the eval().

Both are fixed with a new bHaltRequested flag on the VM. OP_HALT and vm_builtin_exit set it and abort unconditionally (goto Abort / PH7_ABORT) instead of exit()ing; the include/require/eval builtins cascade PH7_ABORT while the flag is set, so the halt unwinds to the top level where shutdown callbacks run normally. exit() inside a shutdown callback re-sets the flag and short-circuits the remaining callbacks, matching PHP.
