### PR TITLE
Propagate exit status, add PHP_BINARY, guard against silent test trun…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,13 @@ composer.json
 composer.lock
 php
 .tmp
+*.phpt.file
+*.phpt.skipif
+*.phpt.clean
+*.phpt.output
+*.phpt.expect
+*.diag.file
+*.diag.skipif
+*.diag.clean
+*.diag.output
+*.diag.expect

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,10 @@ OBJECTS = \
 
 
 # --- Test commands ---
+# Smoke tests omit --target-executable so they run in-process (fast). That is
+# safe only because the smoke corpus never calls exit/die or pollutes the
+# interpreter; tests that need process isolation live in 002-integration and
+# pass --target-executable below.
 TEST_SMOKE_CMD = "$(PHL_BIN)" "tests/phpt.php" \
 	--target-dir tests/ph7/001-smoke \
 	--output-format dot

--- a/src/phl/phl.c
+++ b/src/phl/phl.c
@@ -84,6 +84,7 @@ static void Version(void)
 #else
 /* Assume UNIX */
 #include <unistd.h>
+#include <limits.h>
 #endif
 /*
  * The following define is used by the UNIX built and have
@@ -92,6 +93,37 @@ static void Version(void)
 #ifndef STDOUT_FILENO
 #define STDOUT_FILENO	1
 #endif
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+static char zPhlBinaryPath[PATH_MAX];
+/*
+ * Expand callback for the PHP_BINARY constant.
+ * pUserData points to the resolved binary path.
+ */
+static void PHL_PhpBinaryConst(ph7_value *pVal,void *pUserData)
+{
+	ph7_value_string(pVal,(const char *)pUserData,-1);
+}
+/*
+ * Resolve the absolute path of the running interpreter.
+ * Falls back to argv[0] verbatim (e.g. bare PATH invocation):
+ * consumers spawning it again go through the shell, which re-resolves it.
+ */
+static const char * PHL_ResolveBinaryPath(const char *zArgv0)
+{
+#ifdef __WINNT__
+	DWORD nLen = GetModuleFileNameA(0,zPhlBinaryPath,(DWORD)sizeof(zPhlBinaryPath));
+	if( nLen > 0 && nLen < sizeof(zPhlBinaryPath) ){
+		return zPhlBinaryPath;
+	}
+#else
+	if( realpath(zArgv0,zPhlBinaryPath) != 0 ){
+		return zPhlBinaryPath;
+	}
+#endif
+	return zArgv0;
+}
 /*
  * VM output consumer callback.
  * Each time the virtual machine generates some outputs,the following
@@ -301,6 +333,9 @@ int main(int argc,char **argv)
 	if( rc != PH7_OK ){
 		Fatal("Error while installing the VM output consumer callback");
 	}
+	/* Define PHP_BINARY: absolute path of this interpreter */
+	ph7_create_constant(pVm,"PHP_BINARY",PHL_PhpBinaryConst,
+		(void *)PHL_ResolveBinaryPath(argv[0]));
 	/* Register script arguments so we can access them later using the $argv[]
 	 * array from the compiled PHP program. For regular file execution we need
 	 * to register the arguments after the script file, while for inline code
@@ -328,10 +363,14 @@ int main(int argc,char **argv)
 	 * And finally, execute our program. Note that your output (STDOUT in our case)
 	 * should display the result.
 	 */
-	ph7_vm_exec(pVm,0);
-	/* All done, cleanup the mess left behind.
-	*/
-	ph7_vm_release(pVm);
-	ph7_release(pEngine);
-	return 0;
+	{
+		int iExitStatus = 0;
+		ph7_vm_exec(pVm,&iExitStatus);
+		/* All done, cleanup the mess left behind.
+		*/
+		ph7_vm_release(pVm);
+		ph7_release(pEngine);
+		/* Propagate the script exit status (set via exit()/die()) */
+		return iExitStatus;
+	}
 }

--- a/tests/ph7/001-smoke/constants/php_binary.phpt
+++ b/tests/ph7/001-smoke/constants/php_binary.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PHP_BINARY is defined and non-empty
+--FILE--
+<?php
+echo (defined('PHP_BINARY') && PHP_BINARY !== '') ? "defined" : "missing", "\n";
+?>
+--EXPECT--
+defined
+--CLEAN--
+<?php
+?>

--- a/tests/phpt.php
+++ b/tests/phpt.php
@@ -79,7 +79,10 @@ while (!empty($phpt_args)) {
             echo "Usage: " . $phpt_script_name . " [options]\n";
             echo "\n";
             echo "Options:\n";
-            echo "  --target-executable <exe>  Path to the executable being tested (mandatory)\n";
+            echo "  --target-executable <exe>  Path to the executable being tested. Omit to run\n";
+            echo "                             tests in-process (fast); the in-process corpus must\n";
+            echo "                             not call exit/die or pollute the interpreter\n";
+            echo "                             (see tests/phptrunner/README.md).\n";
             echo "  --target-timeout <sec>     Timeout for each test in seconds (default: 1)\n";
             echo "  --target-dir <dir>         Directory containing test files (default: directory of this script)\n";
             echo "  --file-extension <ext>     File extension for test files (default: phpt)\n";
@@ -114,6 +117,28 @@ if ($phpt_output_format != "tap" && $phpt_output_format != "dot") {
 if ($phpt_output_format == "tap") {
     echo "Tap Version 13\n";
 }
+
+// Abort guard. Tests run in-process by default (fast; the smoke corpus is
+// curated to never exit/die or pollute the interpreter). If a test does kill
+// the interpreter, this shutdown function turns the otherwise-silent
+// truncation into a loud TAP "Bail out!" with a nonzero exit status.
+$phpt_run_complete = false;
+$phpt_current_test = '';
+function phpt_abort_guard() {
+    global $phpt_run_complete, $phpt_current_test, $phpt_count;
+    if (!$phpt_run_complete) {
+        // The aborted test left its ob_start() buffer open; discard it so the
+        // Bail out! line reaches stdout instead of the dangling buffer.
+        while (ob_get_level() > 0) {
+            ob_end_clean();
+        }
+        echo "\nBail out! Test run aborted at test #$phpt_count ($phpt_current_test).\n";
+        echo "# A test terminated the interpreter (exit/die?). In-process tests must not\n";
+        echo "# do that; move it to tests/ph7/002-integration and run with --target-executable.\n";
+        exit(1);
+    }
+}
+register_shutdown_function('phpt_abort_guard');
 
 function parse_phpt_sections($phpt_path, $phpt_valid_sections) {
     // Read file and normalize line endings to LF
@@ -346,6 +371,7 @@ foreach ($phpt_files as $phpt_file) {
     }
 
     $phpt_test_name = $phpt_file;
+    $phpt_current_test = $phpt_file;
 
     // SKIPIF check
     $phpt_skip = false;
@@ -491,6 +517,9 @@ foreach ($phpt_files as $phpt_file) {
     @unlink($phpt_file . '.output');
     @unlink($phpt_file . '.expect');
 }
+
+// The loop completed normally; tell the abort guard not to fire.
+$phpt_run_complete = true;
 
 if ($phpt_output_format == "tap") {
     echo "# Incomplete Tests\n";

--- a/tests/phptrunner/007-handler_format_test.diag
+++ b/tests/phptrunner/007-handler_format_test.diag
@@ -1,0 +1,13 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Wrapper mode normalizes error output across engines
+--FILE--
+<?php
+trigger_error("diag message", E_USER_WARNING);
+echo "after_error\n";
+?>
+--EXPECTF--
+Error [%d]: diag message in %s on line %d
+after_error

--- a/tests/phptrunner/008-exit_test.diag
+++ b/tests/phptrunner/008-exit_test.diag
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+die() inside a test must not terminate the runner
+--FILE--
+<?php
+echo "before_die\n";
+die("died\n");
+echo "never printed\n";
+?>
+--EXPECT--
+before_die
+died

--- a/tests/phptrunner/README.md
+++ b/tests/phptrunner/README.md
@@ -1,10 +1,35 @@
 # phpt.php diagnostics tests
 
 These are not part of the PHL test suite, and only exist to diagnose
-the `phpt.php` test runner. As so, they are marked as disabled.
+the `phpt.php` test runner. As so, they use the `diag` extension that
+the runner does not pick up by default.
 
 You can run those diagnostics using:
 
 ```sh
-phl tests/phpt.php --target-dir tests/ph7/phptrunner --file-extension disabled
+phl tests/phpt.php --target-dir tests/phptrunner --file-extension diag
 ```
+
+## The two runner modes
+
+- **In-process (default, no `--target-executable`):** each test's `--FILE--`
+  is `include()`d in the runner's own process. This is fast, so the smoke
+  corpus uses it — but an in-process test must never call `exit`/`die` or
+  otherwise pollute the interpreter. A test that kills the interpreter is
+  caught by a shutdown guard that prints a TAP `Bail out!` and exits nonzero,
+  instead of silently truncating the run.
+- **External (`--target-executable <bin>`):** each test runs in its own child
+  process. Required for tests that exit/die or mutate global interpreter state;
+  the integration corpus runs this way.
+
+## Per-diagnostic notes
+
+- `002-fail_test.diag` — output mismatch; reports as a failure by design.
+- `004-unimplemented_test.diag` — unsupported section; reports as a failure by design.
+- `007-handler_format_test.diag` — verifies the in-process `handle_error`
+  normalization (`Error [%d]: …`). It only passes **in-process**; under
+  `--target-executable` the engine emits its native warning format, so it fails
+  there. An in-process-mode diagnostic.
+- `008-exit_test.diag` — calls `die()`. In the default in-process run it triggers
+  the `Bail out!` guard and aborts the run, so it is intentionally LAST. Under
+  `--target-executable` it runs in a child process and passes.


### PR DESCRIPTION
…cation

phl discarded the script exit status (ph7_vm_exec(pVm, 0)); 'phl -r exit(3)' returned 0. main() now captures and returns it.

A test calling die() used to silently kill the in-process test harness (exit 0, no summary, remaining tests skipped). With shutdown callbacks now running after exit-from-include (see engine fix), the harness installs an abort guard via register_shutdown_function: if the run did not complete it flushes the aborted test's open ob_start() buffer, prints TAP "Bail out!", and exits 1. The fast in-process default for the smoke corpus is kept; the loud bail-out replaces the silent truncation.

Also adds the PHP_BINARY constant (absolute interpreter path via realpath / GetModuleFileNameA), a framework-compat win. New smoke test for PHP_BINARY, harness self-diagnostics (007 normalized format, 008 die->Bail out!), updated phptrunner README, Makefile comment, and gitignored harness artifacts.
