### PR TITLE
Add PHP version constants + phpversion() + php_sapi_name()

### DIFF
--- a/src/ph7/constant.c
+++ b/src/ph7/constant.c
@@ -15,6 +15,41 @@ static void PH7_VER_Const(ph7_value *pVal,void *pUnused)
 	SXUNUSED(pUnused);
 	ph7_value_string(pVal,ph7_lib_signature(),-1/*Compute length automatically*/);
 }
+/*
+ * PHP_VERSION, PHP_MAJOR_VERSION, PHP_MINOR_VERSION, PHP_RELEASE_VERSION,
+ * PHP_EXTRA_VERSION, PHP_VERSION_ID
+ *   Expand the PHP-compatibility version PHL advertises (see PHP_COMPAT_* in ph7.h).
+ */
+static void PH7_PHPVerConst(ph7_value *pVal,void *pUnused)
+{
+	SXUNUSED(pUnused);
+	ph7_value_string(pVal,PHP_COMPAT_VERSION,(int)sizeof(PHP_COMPAT_VERSION)-1);
+}
+static void PH7_PHPMajorConst(ph7_value *pVal,void *pUnused)
+{
+	SXUNUSED(pUnused);
+	ph7_value_int64(pVal,PHP_COMPAT_MAJOR_VERSION);
+}
+static void PH7_PHPMinorConst(ph7_value *pVal,void *pUnused)
+{
+	SXUNUSED(pUnused);
+	ph7_value_int64(pVal,PHP_COMPAT_MINOR_VERSION);
+}
+static void PH7_PHPReleaseConst(ph7_value *pVal,void *pUnused)
+{
+	SXUNUSED(pUnused);
+	ph7_value_int64(pVal,PHP_COMPAT_RELEASE_VERSION);
+}
+static void PH7_PHPExtraConst(ph7_value *pVal,void *pUnused)
+{
+	SXUNUSED(pUnused);
+	ph7_value_string(pVal,PHP_COMPAT_EXTRA_VERSION,(int)sizeof(PHP_COMPAT_EXTRA_VERSION)-1);
+}
+static void PH7_PHPVerIdConst(ph7_value *pVal,void *pUnused)
+{
+	SXUNUSED(pUnused);
+	ph7_value_int64(pVal,PHP_COMPAT_VERSION_ID);
+}
 #ifdef __WINNT__
 #include <Windows.h>
 #elif defined(__UNIXES__)
@@ -1885,6 +1920,12 @@ static const ph7_builtin_constant aBuiltIn[] = {
 	{"PH7_VERSION",          PH7_VER_Const      },
 	{"PH7_ENGINE",           PH7_VER_Const      },
 	{"__PH7__",              PH7_VER_Const      },
+	{"PHP_VERSION",          PH7_PHPVerConst    },
+	{"PHP_MAJOR_VERSION",    PH7_PHPMajorConst  },
+	{"PHP_MINOR_VERSION",    PH7_PHPMinorConst  },
+	{"PHP_RELEASE_VERSION",  PH7_PHPReleaseConst},
+	{"PHP_EXTRA_VERSION",    PH7_PHPExtraConst  },
+	{"PHP_VERSION_ID",       PH7_PHPVerIdConst  },
 	{"PHP_OS",               PH7_OS_Const       },
 	{"PHP_EOL",              PH7_EOL_Const      },
 	{"PHP_INT_MAX",          PH7_INTMAX_Const   },

--- a/src/ph7/ph7.h
+++ b/src/ph7/ph7.h
@@ -37,6 +37,17 @@
  */
 #define PH7_SIG "PH7/2.1.4"
 /*
+ * PHP-compatibility version reported to scripts (PHP_VERSION, phpversion(), ...).
+ * PHL targets PHP 8.x semantics; these advertise that target so framework version
+ * gates take the right branch. Keep the string and the numeric pieces in sync.
+ */
+#define PHP_COMPAT_VERSION         "8.5.0"
+#define PHP_COMPAT_MAJOR_VERSION   8
+#define PHP_COMPAT_MINOR_VERSION   5
+#define PHP_COMPAT_RELEASE_VERSION 0
+#define PHP_COMPAT_EXTRA_VERSION   ""
+#define PHP_COMPAT_VERSION_ID      80500
+/*
  * PH7 identification in the Symisc source tree:
  * Each particular check-in of a particular software released
  * by symisc systems have an unique identifier associated with it.

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -13683,6 +13683,41 @@ static int vm_builtin_ph7_version(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	return PH7_OK;
 }
 /*
+ * string phpversion([ string $extension ])
+ *  Returns the PHP-compatibility version PHL advertises (see PHP_COMPAT_VERSION).
+ * Parameters
+ *  $extension (optional): an extension name. PHL has no extension registry, so any
+ *  argument yields NULL (PHP returns FALSE for an unknown extension).
+ * Return
+ *  The PHP-compat version string, or NULL when called with an extension argument.
+ */
+static int vm_builtin_phpversion(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	SXUNUSED(apArg); /* cc warning */
+	if( nArg > 0 ){
+		ph7_result_null(pCtx);
+		return PH7_OK;
+	}
+	ph7_result_string(pCtx,PHP_COMPAT_VERSION,(int)sizeof(PHP_COMPAT_VERSION) - 1);
+	return PH7_OK;
+}
+/*
+ * string php_sapi_name(void)
+ *  Returns the type of interface (SAPI) PHL is running under.
+ * Parameters
+ *  None
+ * Return
+ *  "cli-server" while serving an HTTP request via the built-in -S server, "cli" otherwise.
+ */
+static int vm_builtin_php_sapi_name(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	const char *zSapi = pCtx->pVm->bHttpContext ? "cli-server" : "cli";
+	SXUNUSED(nArg);
+	SXUNUSED(apArg); /* cc warning */
+	ph7_result_string(pCtx,zSapi,-1);
+	return PH7_OK;
+}
+/*
  * PH7 release information HTML page used by the ph7info() and ph7credits() functions.
  */
  #define PH7_HTML_PAGE_HEADER "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">"\
@@ -15329,6 +15364,8 @@ static const ph7_builtin_func aVmFunc[] = {
 	{ "debug_string_backtrace",vm_builtin_debug_string_backtrace },
 	  /* Release info */
 	{"ph7version",       vm_builtin_ph7_version  },
+	{"phpversion",       vm_builtin_phpversion    },
+	{"php_sapi_name",    vm_builtin_php_sapi_name },
 	{"ph7credits",       vm_builtin_ph7_credits  },
 	{"ph7info",          vm_builtin_ph7_credits  },
 	{"ph7_info",         vm_builtin_ph7_credits  },

--- a/tests/ph7/001-smoke/constants/php_version.phpt
+++ b/tests/ph7/001-smoke/constants/php_version.phpt
@@ -1,0 +1,29 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PHP version constants are defined and internally consistent
+--FILE--
+<?php
+// Presence and types (hold under any PHP-compat version, so unskipped).
+echo defined('PHP_VERSION') ? "defined\n" : "missing\n";
+echo preg_match('/^\d+\.\d+\.\d+/', PHP_VERSION) ? "format-ok\n" : "format-bad\n";
+echo is_int(PHP_VERSION_ID) ? "id-int\n" : "id-notint\n";
+echo (is_int(PHP_MAJOR_VERSION) && is_int(PHP_MINOR_VERSION)
+      && is_int(PHP_RELEASE_VERSION)) ? "parts-int\n" : "parts-notint\n";
+echo is_string(PHP_EXTRA_VERSION) ? "extra-string\n" : "extra-notstring\n";
+
+// The identity PHP guarantees between the numeric pieces and the ID.
+$expected = PHP_MAJOR_VERSION * 10000 + PHP_MINOR_VERSION * 100 + PHP_RELEASE_VERSION;
+echo (PHP_VERSION_ID === $expected) ? "id-consistent\n" : "id-inconsistent\n";
+?>
+--EXPECT--
+defined
+format-ok
+id-int
+parts-int
+extra-string
+id-consistent
+--CLEAN--
+<?php
+?>

--- a/tests/ph7/001-smoke/function/php_sapi_name/php_sapi_name.phpt
+++ b/tests/ph7/001-smoke/function/php_sapi_name/php_sapi_name.phpt
@@ -1,0 +1,15 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+php_sapi_name() returns "cli" under the command-line interface
+--FILE--
+<?php
+// Both PHL and the real php CLI report "cli" here.
+echo php_sapi_name(), "\n";
+?>
+--EXPECT--
+cli
+--CLEAN--
+<?php
+?>

--- a/tests/ph7/001-smoke/function/phpversion/phpversion.phpt
+++ b/tests/ph7/001-smoke/function/phpversion/phpversion.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+phpversion() reports the PHP-compat version and agrees with PHP_VERSION
+--FILE--
+<?php
+// The no-arg form matches PHP_VERSION on every engine, so this is unskipped.
+echo (phpversion() === PHP_VERSION) ? "matches\n" : "mismatch\n";
+echo is_string(phpversion()) ? "string\n" : "notstring\n";
+?>
+--EXPECT--
+matches
+string
+--CLEAN--
+<?php
+?>


### PR DESCRIPTION
Framework version gates (version_compare(phpversion(), ...), PHP_VERSION_ID < 80000) previously crashed or branched wrong: the whole PHP-compat version surface was undefined (only ph7version() existed).

A single source of truth -- PHP_COMPAT_* macros in ph7.h (8.5.0 / 80500, matching the engine's stated PHP-8.5 parity target) -- now feeds:
- six constants in constant.c (PHP_VERSION, PHP_MAJOR/MINOR/RELEASE_VERSION, PHP_EXTRA_VERSION, PHP_VERSION_ID), registered in aBuiltIn[];
- phpversion() in vm.c: no-arg -> version string, extension-arg -> NULL (no extension registry);
- php_sapi_name() in vm.c: "cli" / "cli-server" via pVm->bHttpContext.

Regression: constants/php_version.phpt (asserts the ID = major*10000+minor*100+release identity, so it validates structurally under real PHP too), function/phpversion/phpversion.phpt, function/php_sapi_name/php_sapi_name.phpt -- all byte-for-byte under phl and real PHP 8.5.7.
