### PR TITLE
vfs: make popen/pclose pipe code build on non-Unix (OS_OTHER) targets

### DIFF
--- a/src/ph7/vfs.c
+++ b/src/ph7/vfs.c
@@ -5659,7 +5659,7 @@ static pipe_private * PipeOpen(ph7_vm *pVm, const char *zCommand, const char *zM
 		pPipe->pVm = pVm;
 		pPipe->iMode = zMode[0];
 	}
-#else /* Unix */
+#elif defined(__UNIXES__) /* Unix */
 	pFile = popen(zCommand, zMode);
 	if( pFile == 0 ){
 		return 0;
@@ -5675,6 +5675,9 @@ static pipe_private * PipeOpen(ph7_vm *pVm, const char *zCommand, const char *zM
 	pPipe->pFile = pFile;
 	pPipe->pVm = pVm;
 	pPipe->iMode = zMode[0];
+#else /* OS_OTHER: no process pipes on this platform */
+	(void)pFile;
+	return 0;
 #endif
 	return pPipe;
 }
@@ -5694,7 +5697,7 @@ static int PipeClose(pipe_private *pPipe)
 #ifdef __WINNT__
 	/* Use our custom WinPclose that properly waits for process completion */
 	status = WinPclose(pPipe->pFile, pPipe->hProcess);
-#else
+#elif defined(__UNIXES__)
 	status = pclose(pPipe->pFile);
 	/* On Unix, pclose returns the status from waitpid, need to extract exit code */
 	if( status != -1 ){
@@ -5708,6 +5711,8 @@ static int PipeClose(pipe_private *pPipe)
 			status = -1;
 		}
 	}
+#else /* OS_OTHER: no process pipes on this platform */
+	status = -1;
 #endif
 	/* Free the structure */
 	SyMemBackendFree(&pVm->sAllocator, pPipe);


### PR DESCRIPTION
PipeOpen()/PipeClose() had only a Windows branch and a fallthrough Unix branch (#ifdef __WINNT__ ... #else). On a non-Unix, non-Windows build (OS_OTHER, e.g. an embedded/newlib target with no process APIs) the Unix branch was compiled, referencing popen/pclose and the WIFEXITED/WTERMSIG macros from <sys/wait.h> — which do not exist there, breaking the build.

Guard the Unix branch with __UNIXES__ and add an OS_OTHER fallback that fails gracefully: PipeOpen() returns NULL (PHP popen() yields false) and PipeClose() returns -1. No behavior change on Unix or Windows.
