### PR TITLE
Make json_encode emit objects for non-list arrays

### DIFF
--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -7061,12 +7061,28 @@ static int ph7_hashmap_walk_recursive(ph7_context *pCtx,int nArg,ph7_value **apA
  * Return
  *  TRUE if the array is a list, FALSE otherwise.
  */
+/*
+ * Return TRUE if the given hashmap is a "list" [i.e: its keys are the
+ * consecutive integers 0,1,2,... with no gaps]. An empty map is a list.
+ * Shared by array_is_list() and the JSON encoder (vm_json.c).
+ */
+PH7_PRIVATE int PH7_HashmapIsList(ph7_hashmap *pMap)
+{
+	ph7_hashmap_node *pNode = pMap->pFirst;
+	sxi64 iExpect = 0;
+	sxu32 n;
+	for( n = 0 ; n < pMap->nEntry ; ++n ){
+		if( pNode->iType != HASHMAP_INT_NODE || pNode->xKey.iKey != iExpect ){
+			/* A non-integer key or a gap in the sequence: not a list */
+			return 0;
+		}
+		++iExpect;
+		pNode = pNode->pPrev; /* Reverse link */
+	}
+	return 1;
+}
 static int ph7_hashmap_is_list(ph7_context *pCtx,int nArg,ph7_value **apArg)
 {
-	ph7_hashmap_node *pNode;
-	ph7_hashmap *pMap;
-	sxi64 iExpect;
-	sxu32 n;
 	if( nArg < 1 ){
 		return PH7_VmThrowException(pCtx,
 			"ArgumentCountError",
@@ -7080,19 +7096,7 @@ static int ph7_hashmap_is_list(ph7_context *pCtx,int nArg,ph7_value **apArg)
 			ph7_type_name(apArg[0])
 			);
 	}
-	pMap = (ph7_hashmap *)apArg[0]->x.pOther;
-	pNode = pMap->pFirst;
-	iExpect = 0;
-	for( n = 0 ; n < pMap->nEntry ; ++n ){
-		if( pNode->iType != HASHMAP_INT_NODE || pNode->xKey.iKey != iExpect ){
-			/* A non-integer key or a gap in the sequence: not a list */
-			ph7_result_bool(pCtx,0);
-			return PH7_OK;
-		}
-		++iExpect;
-		pNode = pNode->pPrev; /* Reverse link */
-	}
-	ph7_result_bool(pCtx,1);
+	ph7_result_bool(pCtx,PH7_HashmapIsList((ph7_hashmap *)apArg[0]->x.pOther));
 	return PH7_OK;
 }
 /*

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1699,6 +1699,7 @@ PH7_PRIVATE void PH7_HashmapExtractNodeKey(ph7_hashmap_node *pNode,ph7_value *pK
 PH7_PRIVATE void PH7_RegisterHashmapFunctions(ph7_vm *pVm);
 PH7_PRIVATE sxi32 PH7_HashmapDump(SyBlob *pOut,ph7_hashmap *pMap,int ShowType,int nTab,int nDepth);
 PH7_PRIVATE sxi32 PH7_HashmapWalk(ph7_hashmap *pMap,int (*xWalk)(ph7_value *,ph7_value *,void *),void *pUserData);
+PH7_PRIVATE int PH7_HashmapIsList(ph7_hashmap *pMap);
 #ifndef PH7_DISABLE_DISK_IO
 PH7_PRIVATE int PH7_HashmapValuesToSet(ph7_hashmap *pMap,SySet *pOut);
 /* builtin.c function prototypes */

--- a/src/ph7/vm_json.c
+++ b/src/ph7/vm_json.c
@@ -22,6 +22,7 @@ struct json_private_data
 {
 	ph7_context *pCtx; /* Call context */
 	int isFirst;       /* True if first encoded entry */
+	int isObject;      /* True if the current array level is encoded as a JSON object */
 	int iFlags;        /* JSON encoding flags */
 	int nRecCount;     /* Recursion count */
 };
@@ -118,20 +119,24 @@ static sxi32 VmJsonEncode(
 				ph7_result_string(pCtx,"\"",(int)sizeof(char));
 			}
 		}else if( ph7_value_is_array(pIn) ){
-			int c = '[',d = ']';
+			/* An array encodes as a JSON array iff it is a "list" [consecutive
+			 * 0-based int keys]; otherwise [or under JSON_FORCE_OBJECT] as an
+			 * object with stringified keys (PHP semantics). */
+			int isObject = (iFlags & JSON_FORCE_OBJECT)
+				|| !PH7_HashmapIsList((ph7_hashmap *)pIn->x.pOther);
+			int savedObject = pData->isObject; /* restore for sibling entries after recursion */
+			int c = isObject ? '{' : '[';
+			int d = isObject ? '}' : ']';
 			/* Encode the array */
+			pData->isObject = isObject;
 			pData->isFirst = 1;
-			if( iFlags & JSON_FORCE_OBJECT ){
-				/* Outputs an object rather than an array */
-				c = '{';
-				d = '}';
-			}
 			/* Append the square bracket or curly braces */
 			ph7_result_string(pCtx,(const char *)&c,(int)sizeof(char));
 			/* Iterate throw array entries */
 			ph7_array_walk(pIn,VmJsonArrayEncode,pData);
 			/* Append the closing square bracket or curly braces */
 			ph7_result_string(pCtx,(const char *)&d,(int)sizeof(char));
+			pData->isObject = savedObject;
 		}else if( ph7_value_is_object(pIn) ){
 			/* Encode the class instance */
 			pData->isFirst = 1;
@@ -163,7 +168,7 @@ static int VmJsonArrayEncode(ph7_value *pKey,ph7_value *pValue,void *pUserData)
 		/* Append the colon first */
 		ph7_result_string(pJson->pCtx,",",(int)sizeof(char));
 	}
-	if( pJson->iFlags & JSON_FORCE_OBJECT ){
+	if( pJson->isObject ){
 		/* Outputs an object rather than an array */
 		const char *zKey;
 		int nByte;

--- a/tests/ph7/001-smoke/function/json_encode/json_encode_assoc_object.phpt
+++ b/tests/ph7/001-smoke/function/json_encode/json_encode_assoc_object.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+json_encode emits a JSON object for non-list arrays
+--SKIPIF--
+<?php if (!function_exists('json_encode')) { die('skip'); } ?>
+--FILE--
+<?php
+echo json_encode(["x" => 1]), "\n";          // string keys -> object
+echo json_encode([1 => "a", 2 => "b"]), "\n"; // int keys, non-zero start -> object
+echo json_encode([0 => "a", 2 => "b"]), "\n"; // gap in int keys -> object
+echo json_encode(["a" => 1, 0 => "x", 1 => "y"]), "\n"; // mixed -> object
+?>
+--EXPECT--
+{"x":1}
+{"1":"a","2":"b"}
+{"0":"a","2":"b"}
+{"a":1,"0":"x","1":"y"}

--- a/tests/ph7/001-smoke/function/json_encode/json_encode_list_array.phpt
+++ b/tests/ph7/001-smoke/function/json_encode/json_encode_list_array.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+json_encode keeps lists and empty arrays as JSON arrays
+--SKIPIF--
+<?php if (!function_exists('json_encode')) { die('skip'); } ?>
+--FILE--
+<?php
+echo json_encode([0 => "a", 1 => "b"]), "\n"; // consecutive 0-based keys -> array
+echo json_encode(["a", "b", "c"]), "\n";       // natural list -> array
+echo json_encode([]), "\n";                     // empty stays an array
+echo json_encode([[1, 2], [3, 4]]), "\n";       // list of lists
+?>
+--EXPECT--
+["a","b"]
+["a","b","c"]
+[]
+[[1,2],[3,4]]

--- a/tests/ph7/001-smoke/function/json_encode/json_encode_nested_mixed.phpt
+++ b/tests/ph7/001-smoke/function/json_encode/json_encode_nested_mixed.phpt
@@ -1,0 +1,25 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+json_encode handles object/list nesting and JSON_FORCE_OBJECT
+--SKIPIF--
+<?php if (!function_exists('json_encode') || !function_exists('json_decode')) { die('skip'); } ?>
+--FILE--
+<?php
+// object level whose values are a list then a nested object: exercises the
+// save/restore of the per-level object flag across sibling entries.
+echo json_encode(["a" => [1, 2], "b" => ["c" => 3]]), "\n";
+
+// JSON_FORCE_OBJECT still forces a list to be an object
+echo json_encode(["a", "b"], JSON_FORCE_OBJECT), "\n";
+
+// round-trip: an associative array decodes back associatively
+$src = ["id" => 7, "tags" => ["x", "y"]];
+$back = json_decode(json_encode($src), true);
+echo ($back["id"] === 7 && $back["tags"][1] === "y" ? "ok" : "fail"), "\n";
+?>
+--EXPECT--
+{"a":[1,2],"b":{"c":3}}
+{"0":"a","1":"b"}
+ok


### PR DESCRIPTION
json_encode always emitted a JSON array for any PHP array, dropping keys unless JSON_FORCE_OBJECT was passed: json_encode(["x"=>1]) returned [1] instead of {"x":1}. Silent wrong answer, high frequency in API payloads.

Apply PHP's rule: serialize as an array iff the array is a list (consecutive 0-based int keys; empty array -> []), otherwise as an object with stringified keys. JSON_FORCE_OBJECT still forces object form.

The list-detection logic that was inline in array_is_list is extracted into a shared PH7_HashmapIsList(); the builtin and the JSON encoder both call it. VmJsonEncode computes the per-array object-vs-array choice and saves/restores a new isObject flag on the encoder state around the array walk, so the key- emission callback stays correct across object->list->object nesting.
