### PR TITLE
Add JsonSerializable and fix mixed return type / throw enforcement

### DIFF
--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -920,6 +920,7 @@ struct ph7_vm
 	ph7_class *pArrayAccessClass; /* Cached ArrayAccess interface pointer */
 	ph7_class *pCountableClass;   /* Cached Countable interface pointer */
 	ph7_class *pStringableClass;  /* Cached Stringable interface pointer */
+	ph7_class *pJsonSerializableClass; /* Cached JsonSerializable interface pointer */
 	/* Pending null-coalesce-assign target on an ArrayAccess subscript.
 	 * Set by LOAD_IDX iP2=3 when the key is missing on an ArrayAccess
 	 * object; consumed by NULLC_STORE so it can dispatch to offsetSet

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -1076,6 +1076,9 @@ static int vm_builtin_Generator_destruct(ph7_context *pCtx, int nArg, ph7_value 
 	"interface Stringable {"\
 	"public function __toString();"\
 	"}"\
+	"interface JsonSerializable {"\
+	"public function jsonSerialize();"\
+	"}"\
 	"interface UnitEnum {"\
 	"public static function cases();"\
 	"}"\
@@ -1621,6 +1624,7 @@ PH7_PRIVATE sxi32 PH7_VmInit(
 	pVm->pArrayAccessClass = PH7_VmExtractClass(pVm,"ArrayAccess",sizeof("ArrayAccess")-1,0,0);
 	pVm->pCountableClass   = PH7_VmExtractClass(pVm,"Countable",sizeof("Countable")-1,0,0);
 	pVm->pStringableClass  = PH7_VmExtractClass(pVm,"Stringable",sizeof("Stringable")-1,0,0);
+	pVm->pJsonSerializableClass = PH7_VmExtractClass(pVm,"JsonSerializable",sizeof("JsonSerializable")-1,0,0);
 	/* Initialize null-coalesce-assign scratch slot */
 	pVm->pCoalesceObj = 0;
 	pVm->bCoalesceArmed = 0;
@@ -3447,13 +3451,23 @@ static sxi32 VmEnforceReturnType(ph7_vm *pVm, ph7_vm_func *pFunc, ph7_value *pVa
 		return VmThrowTypeErrorForReturn(pVm,&pFunc->sName,"void",zGiven);
 	}
 	/* Function fell off the end without an explicit return: PHP implicitly
-	 * returns null. For a typed non-nullable return, that's a TypeError. */
+	 * returns null. For a typed non-nullable return (including `mixed`, which
+	 * requires an explicit returned value), that's a TypeError. */
 	if( pValue == 0 ){
 		const char *zExpected = "value";
 		if( SyStringLength(&pFunc->sReturnTypeName) > 0 ){
 			zExpected = VmSyStringToCStr(&pFunc->sReturnTypeName, zTypeBuf, sizeof(zTypeBuf));
 		}
 		return VmThrowTypeErrorForReturn(pVm,&pFunc->sName,zExpected,"null");
+	}
+	/* `mixed` accepts any explicitly returned value, including null. It is
+	 * parsed as a class-name atom (SXU32_HIGH, sReturnClass = "mixed") since
+	 * it is not a scalar keyword, so short-circuit it here before the null /
+	 * class-type checks below — which would otherwise demand an object. */
+	if( pFunc->nReturnType == SXU32_HIGH
+	 && pFunc->sReturnClass.nByte == 5
+	 && SyStrnicmp(pFunc->sReturnClass.zString,"mixed",5) == 0 ){
+		return SXRET_OK;
 	}
 	/* Union return type — delegate. The function has no flag for nullable
 	 * unions; a null alternative is represented inside aReturnUnion, so pass
@@ -4037,7 +4051,14 @@ case PH7_OP_DONE:
 	 * the fiber start/resume paths) set pEnforceRetFunc, so this branch is
 	 * skipped for default-value bytecode, class-method mini-programs,
 	 * callback trampolines, and the main script. */
-	if( pEnforceRetFunc && pEnforceRetFunc->nReturnType > 0 ){
+	if( pEnforceRetFunc && pEnforceRetFunc->nReturnType > 0
+	 && !(VmSkipExceptionFrames(pVm->pFrame)->iFlags & VM_FRAME_THROW) ){
+		/* The VM_FRAME_THROW guard skips enforcement when the function is
+		 * unwinding because an exception was thrown (the compiler routes an
+		 * uncaught throw to this terminal OP_DONE): PHP does not type-check a
+		 * value the function never actually returned, so enforcing here would
+		 * raise a spurious "Return value must be of type X" over the real
+		 * exception. */
 		ph7_value *pRetVal = 0;
 		if( pInstr->iP1 && pTos >= pStack ){
 			pRetVal = pTos;

--- a/src/ph7/vm_json.c
+++ b/src/ph7/vm_json.c
@@ -25,6 +25,7 @@ struct json_private_data
 	int isObject;      /* True if the current array level is encoded as a JSON object */
 	int iFlags;        /* JSON encoding flags */
 	int nRecCount;     /* Recursion count */
+	int exc;           /* True if a jsonSerialize() callback threw an exception */
 };
 /*
  * Returns the JSON representation of a value.In other word perform a JSON encoding operation.
@@ -138,14 +139,44 @@ static sxi32 VmJsonEncode(
 			ph7_result_string(pCtx,(const char *)&d,(int)sizeof(char));
 			pData->isObject = savedObject;
 		}else if( ph7_value_is_object(pIn) ){
-			/* Encode the class instance */
-			pData->isFirst = 1;
-			/* Append the curly braces */
-			ph7_result_string(pCtx,"{",(int)sizeof(char));
-			/* Iterate throw class attribute */
-			ph7_object_walk(pIn,VmJsonObjectEncode,pData);
-			/* Append the closing curly braces  */
-			ph7_result_string(pCtx,"}",(int)sizeof(char));
+			ph7_class_instance *pThis = (ph7_class_instance *)pIn->x.pOther;
+			ph7_vm *pVm = pIn->pVm;
+			ph7_class_method *pMethod = 0;
+			/* If the object implements JsonSerializable, encode the value
+			 * returned by jsonSerialize() instead of its public properties. */
+			if( pVm->pJsonSerializableClass
+				&& PH7_VmInstanceOf(pThis->pClass,pVm->pJsonSerializableClass) ){
+				pMethod = PH7_ClassExtractMethod(pThis->pClass,"jsonSerialize",sizeof("jsonSerialize")-1);
+			}
+			if( pMethod ){
+				ph7_value sResult;
+				sxi32 rc;
+				PH7_MemObjInit(pVm,&sResult);
+				rc = PH7_VmCallClassMethod(pVm,pThis,pMethod,&sResult,0,0);
+				if( rc == PH7_EXCEPTION ){
+					/* Let jsonSerialize()'s throw propagate */
+					PH7_MemObjRelease(&sResult);
+					pData->exc = 1;
+					return PH7_EXCEPTION;
+				}
+				/* Encode the returned value [scalar/array/object] */
+				pData->nRecCount++;
+				VmJsonEncode(&sResult,pData);
+				pData->nRecCount--;
+				PH7_MemObjRelease(&sResult);
+				if( pData->exc ){
+					return PH7_EXCEPTION;
+				}
+			}else{
+				/* Encode the class instance */
+				pData->isFirst = 1;
+				/* Append the curly braces */
+				ph7_result_string(pCtx,"{",(int)sizeof(char));
+				/* Iterate throw class attribute */
+				ph7_object_walk(pIn,VmJsonObjectEncode,pData);
+				/* Append the closing curly braces  */
+				ph7_result_string(pCtx,"}",(int)sizeof(char));
+			}
 		}else{
 			/* Can't happen */
 			ph7_result_string(pCtx,"null",(int)sizeof("null")-1);
@@ -160,8 +191,8 @@ static sxi32 VmJsonEncode(
 static int VmJsonArrayEncode(ph7_value *pKey,ph7_value *pValue,void *pUserData)
 {
 	json_private_data *pJson = (json_private_data *)pUserData;
-	if( pJson->nRecCount > 31 ){
-		/* Recursion limit reached,return immediately */
+	if( pJson->nRecCount > 31 || pJson->exc ){
+		/* Recursion limit reached or a callback threw,return immediately */
 		return PH7_OK;
 	}
 	if( !pJson->isFirst ){
@@ -191,8 +222,8 @@ static int VmJsonArrayEncode(ph7_value *pKey,ph7_value *pValue,void *pUserData)
 static int VmJsonObjectEncode(const char *zAttr,ph7_value *pValue,void *pUserData)
 {
 	json_private_data *pJson = (json_private_data *)pUserData;
-	if( pJson->nRecCount > 31 ){
-		/* Recursion limit reached,return immediately */
+	if( pJson->nRecCount > 31 || pJson->exc ){
+		/* Recursion limit reached or a callback threw,return immediately */
 		return PH7_OK;
 	}
 	if( !pJson->isFirst ){
@@ -232,6 +263,7 @@ static int VmJsonObjectEncode(const char *zAttr,ph7_value *pValue,void *pUserDat
 PH7_PRIVATE int vm_builtin_json_encode(ph7_context *pCtx,int nArg,ph7_value **apArg)
 {
 	json_private_data sJson;
+	sxi32 rc;
 	if( nArg < 1 ){
 		/* Missing arguments,return FALSE */
 		ph7_result_bool(pCtx,0);
@@ -242,12 +274,17 @@ PH7_PRIVATE int vm_builtin_json_encode(ph7_context *pCtx,int nArg,ph7_value **ap
 	sJson.pCtx = pCtx;
 	sJson.isFirst = 1;
 	sJson.iFlags = 0;
+	sJson.exc = 0;
 	if( nArg > 1 && ph7_value_is_int(apArg[1]) ){
 		/* Extract option flags */
 		sJson.iFlags = ph7_value_to_int(apArg[1]);
 	}
 	/* Perform the encoding operation */
-	VmJsonEncode(apArg[0],&sJson);
+	rc = VmJsonEncode(apArg[0],&sJson);
+	if( rc == PH7_EXCEPTION || sJson.exc ){
+		/* A jsonSerialize() callback threw — propagate so the exception unwinds */
+		return PH7_EXCEPTION;
+	}
 	/* All done */
 	return PH7_OK;
 }

--- a/tests/ph7/001-smoke/function/json_encode/json_encode_jsonserializable.phpt
+++ b/tests/ph7/001-smoke/function/json_encode/json_encode_jsonserializable.phpt
@@ -1,0 +1,48 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+json_encode consults JsonSerializable::jsonSerialize()
+--SKIPIF--
+<?php if (!function_exists('json_encode') || !interface_exists('JsonSerializable')) { die('skip'); } ?>
+--FILE--
+<?php
+class JsonSerMoney implements JsonSerializable {
+    private $amount;
+    private $currency;
+    public function __construct($a, $c) { $this->amount = $a; $this->currency = $c; }
+    public function jsonSerialize(): mixed {
+        return ['amount' => $this->amount, 'currency' => $this->currency];
+    }
+}
+class JsonSerScalar implements JsonSerializable {
+    public function jsonSerialize(): mixed { return 42; }
+}
+class JsonSerNested implements JsonSerializable {
+    public function jsonSerialize(): mixed {
+        return ['m' => new JsonSerMoney(5, 'USD'), 'list' => [1, 2, 3]];
+    }
+}
+class JsonSerPlain {
+    public $a = 1;
+    public $b = 2;
+}
+
+echo json_encode(new JsonSerMoney(100, 'EUR')), "\n"; // assoc array -> JSON object
+echo json_encode(new JsonSerScalar()), "\n";          // scalar passthrough
+echo json_encode(new JsonSerNested()), "\n";          // nested object + list
+echo json_encode(['wrap' => new JsonSerMoney(1, 'GBP')]), "\n"; // nested inside array
+echo json_encode(new JsonSerPlain()), "\n";           // non-implementer: public props
+echo (new JsonSerMoney(1, 'X') instanceof JsonSerializable) ? "yes\n" : "no\n";
+echo interface_exists('JsonSerializable') ? "iface\n" : "no\n";
+?>
+--EXPECT--
+{"amount":100,"currency":"EUR"}
+42
+{"m":{"amount":5,"currency":"USD"},"list":[1,2,3]}
+{"wrap":{"amount":1,"currency":"GBP"}}
+{"a":1,"b":2}
+yes
+iface
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/json_encode/json_encode_jsonserializable_throws.phpt
+++ b/tests/ph7/001-smoke/function/json_encode/json_encode_jsonserializable_throws.phpt
@@ -1,0 +1,36 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+An exception thrown inside jsonSerialize() propagates out of json_encode
+--SKIPIF--
+<?php if (!function_exists('json_encode') || !interface_exists('JsonSerializable')) { die('skip'); } ?>
+--FILE--
+<?php
+class JsonSerBoom implements JsonSerializable {
+    public function jsonSerialize(): mixed { throw new Exception("boom"); }
+}
+class JsonSerInner implements JsonSerializable {
+    public function jsonSerialize(): mixed { throw new Exception("inner"); }
+}
+
+try {
+    json_encode(new JsonSerBoom());
+    echo "no-throw\n";
+} catch (Exception $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+
+// Thrown while nested inside an array being encoded.
+try {
+    json_encode(['k' => new JsonSerInner()]);
+    echo "no-throw\n";
+} catch (Exception $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+caught: boom
+caught: inner
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/mixed_return_type.phpt
+++ b/tests/ph7/001-smoke/lang/mixed_return_type.phpt
@@ -1,0 +1,28 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+mixed return type accepts any explicitly returned value, including null
+--FILE--
+<?php
+class MixedRetBox {}
+function mixedRetArray(): mixed { return [1, 2]; }
+function mixedRetString(): mixed { return "x"; }
+function mixedRetInt(): mixed { return 7; }
+function mixedRetNull(): mixed { return null; }
+function mixedRetObject(): mixed { return new MixedRetBox(); }
+
+echo implode(",", mixedRetArray()), "\n";
+echo mixedRetString(), "\n";
+echo mixedRetInt(), "\n";
+echo mixedRetNull() === null ? "null\n" : "notnull\n";
+echo mixedRetObject() instanceof MixedRetBox ? "obj\n" : "notobj\n";
+?>
+--EXPECT--
+1,2
+x
+7
+null
+obj
+--CLEAN--
+<?php


### PR DESCRIPTION
Declare the JsonSerializable interface (embedded PHP source) and make json_encode consult jsonSerialize() for objects that implement it, encoding the returned value (scalar/array/object) instead of the public properties. A throw inside jsonSerialize() propagates: VmJsonEncode returns PH7_EXCEPTION and a new `exc` flag on json_private_data short-circuits the array/object walk callbacks (same discipline as iCmpCallbackExc), so vm_builtin_json_encode returns PH7_EXCEPTION.

Two pre-existing engine bugs surfaced while making idiomatic `jsonSerialize(): mixed` usable, and are fixed here:

- `mixed` return type rejected all non-object values. It parses as a class-name atom (SXU32_HIGH, "mixed") since it is not a scalar keyword, so the class-return branch demanded an object. VmEnforceReturnType now short-circuits `mixed` to accept any explicitly returned value (including null) — after the no-value check, so a fell-off-end `: mixed` still errors like PHP.

- A typed function that throws raised a spurious second TypeError. The compiler routes an uncaught throw to the terminal OP_DONE, which then ran return-type enforcement over the real exception (reproduces with a plain `function f(): int { throw ...; }`). OP_DONE now skips enforcement when the frame is unwinding (VM_FRAME_THROW).
