### PR TITLE
Auto-vivify by-ref builtin out-params so preg_match populates undefin…

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -9888,6 +9888,80 @@ static void GenStatePatchNullsafeJumps(ph7_gen_state *pGen, sxu32 nBaseline)
 }
 
 /*
+ * By-reference out-parameters of builtin functions.
+ *
+ * PH7 foreign/builtin functions carry no parameter signature, so the call
+ * compiler cannot otherwise know that e.g. preg_match()'s 3rd argument
+ * ($matches) is passed by reference. Without that knowledge an *undefined*
+ * variable argument is compiled as a read-only load (EXPR_FLAG_RDONLY_LOAD)
+ * and reaches the builtin tagged nIdx == SXU32_HIGH, so the builtin's write-
+ * back is a silent no-op — the caller's variable stays null unless it was
+ * pre-initialised. This table maps a builtin name to a bitmask of the argument
+ * positions it writes back through, letting the caller auto-vivify just those
+ * argument variables (PHP's exact "passing an undefined var by reference
+ * creates it" behaviour).
+ *
+ * Bit N (1u<<N) set => the argument at position N is by reference. Out-params
+ * live at low indices, so a 32-bit mask is sufficient.
+ */
+static sxu32 GenStateByRefBuiltinMask(SyString *pName)
+{
+	static const struct {
+		const char *zName;
+		sxu32 nByte;
+		sxu32 mask;
+	} aByRef[] = {
+		{ "preg_match",            10, 1u<<2 },  /* $matches (apArg[2]) */
+		{ "preg_match_all",        14, 1u<<2 },  /* $matches (apArg[2]) */
+		{ "preg_replace",          12, 1u<<4 },  /* &$count  (apArg[4]) */
+		{ "preg_replace_callback", 21, 1u<<4 },  /* &$count  (apArg[4]) */
+	};
+	sxu32 i;
+	if( pName == 0 || pName->zString == 0 || pName->nByte == 0 ){
+		return 0;
+	}
+	for( i = 0 ; i < SX_ARRAYSIZE(aByRef) ; ++i ){
+		if( pName->nByte == aByRef[i].nByte
+		 && SyStrnicmp(pName->zString, aByRef[i].zName, pName->nByte) == 0 ){
+			return aByRef[i].mask;
+		}
+	}
+	return 0;
+}
+/*
+ * Recover the bare global-builtin name from a call's callee node.
+ *
+ * Handles the unqualified form `preg_match(...)` (a single PH7_TK_ID token) and
+ * the absolute single-component form `\preg_match(...)` (a leading PH7_TK_NSSEP
+ * then one identifier) — both resolve to the global builtin. A deeper-qualified
+ * name (`Foo\preg_match`, `\Foo\bar`) is a *different* function, so no name is
+ * returned for it. pEnd is exclusive (one past the last name token). Returns
+ * {NULL,0} in *pOut when the callee is not a plain global function name.
+ */
+static void GenStateCallBuiltinName(ph7_expr_node *pLeft, SyString *pOut)
+{
+	SyToken *p, *pEnd;
+	pOut->zString = 0;
+	pOut->nByte = 0;
+	if( pLeft == 0 || pLeft->pStart == 0 || pLeft->pEnd == 0 ){
+		return;
+	}
+	p = pLeft->pStart;
+	pEnd = pLeft->pEnd;
+	/* Optional single leading namespace separator (absolute path). */
+	if( p < pEnd && (p->nType & PH7_TK_NSSEP) ){
+		p++;
+	}
+	if( p >= pEnd || (p->nType & (PH7_TK_ID|PH7_TK_KEYWORD)) == 0 ){
+		return;
+	}
+	/* Must be a single component: nothing follows the name token. */
+	if( p + 1 != pEnd ){
+		return;
+	}
+	*pOut = p->sData;
+}
+/*
  * Generate bytecode for a given expression tree.
  * If something goes wrong while generating bytecode
  * for the expression tree (A very unlikely scenario)
@@ -10044,6 +10118,8 @@ static sxi32 GenStateEmitExprCode(
 			ph7_expr_node **apNode;
 			int hasSpread = 0;
 			int hasNamed = 0;
+			int bAnySpread = 0;
+			sxu32 byRefMask = 0;
 			sxi32 nArgs;
 			sxi32 n;
 			/* Recurse and generate bytecodes for function arguments */
@@ -10056,7 +10132,9 @@ static sxi32 GenStateEmitExprCode(
 					if( apNode[n]->iFlags & EXPR_NODE_NAMED_ARG ){
 						seenNamed = 1;
 						hasNamed = 1;
-					}else if( seenNamed && !(apNode[n]->iFlags & EXPR_NODE_SPREAD) ){
+					}else if( apNode[n]->iFlags & EXPR_NODE_SPREAD ){
+						bAnySpread = 1;
+					}else if( seenNamed ){
 						rc = PH7_GenCompileError(&(*pGen),E_ERROR,apNode[n]->pStart->nLine,
 							"Cannot use positional argument after named argument");
 						return SXERR_SYNTAX;
@@ -10078,10 +10156,27 @@ static sxi32 GenStateEmitExprCode(
 				 && SyStrnicmp(pCallName->zString,"empty",5) == 0 ){
 					iFlags |= EXPR_FLAG_LOAD_IDX_EMPTY;
 				}
+				/* Auto-vivify by-reference out-params of known builtins so an
+				 * undefined variable argument (e.g. preg_match($p,$s,$m) with
+				 * $m never assigned) gets a real memobj slot for the builtin to
+				 * write back through. Skipped when spread/named args are present:
+				 * the compile-time positional index no longer maps to the
+				 * runtime apArg[] slot (and spread elements can't be by-ref). */
+				if( !bAnySpread && !hasNamed ){
+					SyString sBuiltin;
+					GenStateCallBuiltinName(pNode->pLeft, &sBuiltin);
+					byRefMask = GenStateByRefBuiltinMask(&sBuiltin);
+				}
 			}
 			for( n = 0 ; n < nArgs ; ++n ){
 				sxu32 nArgNsBase = SySetUsed(&pGen->aNullsafeJmp);
-				rc = GenStateEmitExprCode(&(*pGen),apNode[n],iFlags&~EXPR_FLAG_LOAD_IDX_STORE);
+				sxi32 iArgFlags = iFlags & ~EXPR_FLAG_LOAD_IDX_STORE;
+				/* For a by-ref argument position, drop the read-only flag so the
+				 * variable is created if absent (PH7_OP_LOAD iP1=0 => bCreate). */
+				if( n < 31 && (byRefMask & (1u<<n)) ){
+					iArgFlags &= ~EXPR_FLAG_RDONLY_LOAD;
+				}
+				rc = GenStateEmitExprCode(&(*pGen),apNode[n],iArgFlags);
 				if( rc != SXRET_OK ){
 					return rc;
 				}

--- a/src/ph7/vm_pcre.c
+++ b/src/ph7/vm_pcre.c
@@ -250,11 +250,18 @@ static pcre2_code *PcreCompile(
 /*
  * Write a value back to the caller's variable through the stack slot's nIdx.
  *
- * PHL limitation: if the caller passes an undefined variable (e.g. bare $m
- * without prior assignment), nIdx is SXU32_HIGH and the write-back is a
- * no-op — the caller's variable stays null.  Workaround: initialize the
- * variable before the call ($m = null;).  PHP does not have this limitation
- * because it creates the variable via the & reference mechanism.
+ * For a plain positional variable argument the call compiler auto-vivifies
+ * known by-reference out-params (see GenStateByRefBuiltinMask in compile.c),
+ * so even a bare undefined variable (e.g. preg_match($p,$s,$m) with $m never
+ * assigned) arrives with a real nIdx and is written back here, matching PHP's
+ * reference semantics.
+ *
+ * nIdx stays SXU32_HIGH and the write-back to the caller is skipped (the value
+ * still lands in the local stack slot) when the argument is not a plain lvalue
+ * variable: a literal, a function-call result, an array/property subscript
+ * (element vivification is not wired), or any variable in a call that also uses
+ * named or spread arguments (compile-time positions no longer map to the
+ * runtime arg slots, so the compiler conservatively does not vivify).
  */
 static void PcreStoreByRef(ph7_vm *pVm, ph7_value *pArg, ph7_value *pNewVal)
 {

--- a/tests/ph7/001-smoke/function/preg_match/preg_match_undefined_absolute_name.phpt
+++ b/tests/ph7/001-smoke/function/preg_match/preg_match_undefined_absolute_name.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+preg_match auto-vivifies $matches via the absolute \preg_match() form inside a namespace
+--FILE--
+<?php
+namespace App;
+// The fully-qualified \preg_match resolves to the global builtin and must
+// still auto-vivify the undefined $m.
+\preg_match('/(\d+)/', 'a12', $m);
+echo $m[0] . "\n";
+echo $m[1] . "\n";
+?>
+--EXPECT--
+12
+12
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/preg_match/preg_match_undefined_matches.phpt
+++ b/tests/ph7/001-smoke/function/preg_match/preg_match_undefined_matches.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+preg_match populates $matches when the variable is undefined (auto-vivify by-ref)
+--FILE--
+<?php
+// $m is never assigned before the call; PHP creates it via the by-ref param.
+$r = preg_match('/(\w+)\s(\w+)/', 'Hello World', $m);
+echo $r . "\n";
+echo $m[0] . "\n";
+echo $m[1] . "\n";
+echo $m[2] . "\n";
+?>
+--EXPECT--
+1
+Hello World
+Hello
+World
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/preg_match/preg_match_undefined_named_groups.phpt
+++ b/tests/ph7/001-smoke/function/preg_match/preg_match_undefined_named_groups.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+preg_match populates named groups into an undefined $matches
+--FILE--
+<?php
+preg_match('/(?<year>\d{4})-(?<month>\d{2})/', '2026-06', $m);
+echo $m['year'] . "\n";
+echo $m['month'] . "\n";
+echo $m[1] . "\n";
+echo $m[2] . "\n";
+?>
+--EXPECT--
+2026
+06
+2026
+06
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/preg_match/preg_match_undefined_no_match.phpt
+++ b/tests/ph7/001-smoke/function/preg_match/preg_match_undefined_no_match.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+preg_match sets an undefined $matches to an empty array on no match
+--FILE--
+<?php
+// On no match, an undefined $m must become an empty array (not stay null).
+$r = preg_match('/(\d+)/', 'abc', $m);
+echo $r . "\n";
+echo (is_array($m) ? "array" : gettype($m)) . "\n";
+echo count($m) . "\n";
+?>
+--EXPECT--
+0
+array
+0
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/preg_match_all/preg_match_all_undefined_matches.phpt
+++ b/tests/ph7/001-smoke/function/preg_match_all/preg_match_all_undefined_matches.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+preg_match_all populates $matches when the variable is undefined (auto-vivify by-ref)
+--FILE--
+<?php
+$r = preg_match_all('/\d/', 'a1b2c3', $m);
+echo $r . "\n";
+echo implode(',', $m[0]) . "\n";
+?>
+--EXPECT--
+3
+1,2,3
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/preg_replace/preg_replace_undefined_count.phpt
+++ b/tests/ph7/001-smoke/function/preg_replace/preg_replace_undefined_count.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+preg_replace populates the &$count out-param when the variable is undefined
+--FILE--
+<?php
+$s = preg_replace('/\d/', 'x', 'a1b2c3', -1, $count);
+echo $s . "\n";
+echo $count . "\n";
+?>
+--EXPECT--
+axbxcx
+3
+--CLEAN--
+<?php


### PR DESCRIPTION
…ed $matches

preg_match()/preg_match_all() returned 1 but left $matches null when the variable was undefined; the capture-population logic existed but only wrote back when the caller pre-initialised the variable ($m = null;). Root cause is engine-wide: PH7 foreign/builtin functions carry no parameter signature, so the call compiler emitted read-only argument loads (EXPR_FLAG_RDONLY_LOAD) for every argument. An undefined variable therefore reached the builtin tagged nIdx == SXU32_HIGH and the by-ref write-back was a silent no-op.

Fix is compiler-side: a small by-ref builtin registry (GenStateByRefBuiltinMask) maps a builtin name to a bitmask of its by-ref argument positions (preg_match/preg_match_all $matches at arg 2; preg_replace/preg_replace_callback &$count at arg 4). At call-argument compile time, a matched position is compiled with EXPR_FLAG_RDONLY_LOAD cleared, so OP_LOAD auto-vivifies the variable to a real memobj slot (bCreate=TRUE) and the existing write-back targets a valid nIdx. This is PHP's exact "passing an undefined var by reference creates it" behaviour; on no match $matches becomes []. The bare name is recovered via GenStateCallBuiltinName, which handles the unqualified preg_match and the absolute single-component \preg_match forms while rejecting Foo\preg_match and method/static calls. Auto-vivify is skipped when the call uses spread or named arguments, where the compile-time positional index no longer maps to the runtime arg slot.

Known limitation (unchanged): a subscript/property by-ref target (preg_match($p,$s,$a['k'])) still does not populate the element; that path needs EXPR_FLAG_LOAD_IDX_STORE.

Byte-for-byte parity with PHP 8.5.7. Regression: preg_match undefined matches / no-match / named groups / absolute \preg_match form, preg_match_all undefined matches, preg_replace undefined count.
