### PR TITLE
Surface allocation failure (OOM) as a PHP fatal instead of a silent w…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,17 @@ TEST_INTEGRATION_PHP_CMD = "$(PHL_BIN)" "tests/phpt.php" \
 	--target-dir tests/ph7/002-integration \
 	--output-format dot
 
+# Stress / fault-injection tests (opt-in; NOT part of `make test`). These run in
+# child-process mode under a small per-allocation cap (PHL_MAX_ALLOC) so a
+# deliberately oversized allocation deterministically triggers the out-of-memory
+# paths. The cap is per-request (not cumulative), so the runner and the small
+# tests run normally while only the oversized allocations fail. Long-term these
+# migrate to per-test `--INI-- memory_limit=...` once php.ini lands.
+TEST_STRESS_CMD = PHL_MAX_ALLOC=1048576 "$(PHL_BIN)" "tests/phpt.php" \
+	--target-executable "$(PHL_BIN)" \
+	--target-dir tests/ph7/003-stress \
+	--output-format dot
+
 default: build
 
 # --- POLYGLOT MAGIC BEGINS
@@ -104,6 +115,7 @@ build: .ALWAYS $(PHL_BIN)
 clean: .ALWAYS $(BUILD_DIR)-clean
 test: .ALWAYS test-smoke test-integration
 test-compat: .ALWAYS test-smoke-compat test-integration-compat
+test-stress: .ALWAYS $(PHL_BIN) $(BUILD_DIR)-test-stress
 test-smoke: .ALWAYS $(PHL_BIN) $(BUILD_DIR)-test-smoke
 test-smoke-compat: .ALWAYS $(PHL_BIN) $(BUILD_DIR)-test-smoke-compat
 test-integration: .ALWAYS $(PHL_BIN) $(BUILD_DIR)-test-integration
@@ -124,7 +136,12 @@ $(BUILD_DIR)-test-smoke-compat: $(PHL_BIN)
 
 $(BUILD_DIR)-test-integration: $(PHL_BIN)
 	"$(PHL_BIN)" --version
-	$(TEST_INTEGRATION_CMD) 
+	$(TEST_INTEGRATION_CMD)
+
+# Opt-in stress/fault-injection suite (POSIX shell; sets PHL_MAX_ALLOC inline).
+$(BUILD_DIR)-test-stress: $(PHL_BIN)
+	"$(PHL_BIN)" --version
+	$(TEST_STRESS_CMD)
 
 $(BUILD_DIR)-test-integration-compat: $(PHL_BIN)
 	"$(PHP_BIN)" --version

--- a/src/ph7/api.c
+++ b/src/ph7/api.c
@@ -42,7 +42,7 @@ static struct Global_Data
 	ph7 *pEngines;                          /* List of active engine */
 	sxu32 nMagic;                           /* Sanity check against library misuse */
 }sMPGlobal = {
-	{0,0,0,0,0,0,0,0,{0}},
+	{0,0,0,0,0,0,0,0,0,{0}},
 #if defined(PH7_ENABLE_THREADS)
 	0,
 	0,
@@ -118,6 +118,14 @@ static sxi32 EngineConfig(ph7 *pEngine,sxi32 nOp,va_list ap)
 	case PH7_CONFIG_ERR_ABORT:
 		/* Reserved for future use */
 		break;
+	case PH7_CONFIG_MAX_ALLOC: {
+		/* Per-allocation cap in bytes (0 = unlimited). VMs created afterwards
+		 * inherit it via SyMemBackendInitFromParent. Primarily a test/embedding
+		 * knob to exercise out-of-memory paths deterministically. */
+		unsigned int nMax = va_arg(ap,unsigned int);
+		pEngine->sAllocator.nMaxRequest = (sxu32)nMax;
+		break;
+								}
 	default:
 		/* Unknown configuration verb */
 		rc = PH7_CORRUPT;
@@ -1907,7 +1915,9 @@ int ph7_value_string(ph7_value *pVal,const char *zString,int nLen)
 			/* Compute length automatically */
 			nLen = (int)SyStrlen(zString);
 		}
-		SyBlobAppend(&pVal->sBlob,(const void *)zString,(sxu32)nLen);
+		/* Propagate allocation failure (SXERR_MEM) instead of silently
+		 * fabricating a truncated success — callers can surface an OOM fatal. */
+		return SyBlobAppend(&pVal->sBlob,(const void *)zString,(sxu32)nLen);
 	}
 	return PH7_OK;
 }
@@ -1918,15 +1928,17 @@ int ph7_value_string(ph7_value *pVal,const char *zString,int nLen)
 int ph7_value_string_format(ph7_value *pVal,const char *zFormat,...)
 {
 	va_list ap;
+	int rc;
 	if((pVal->iFlags & MEMOBJ_STRING) == 0 ){
 		/* Invalidate any prior representation */
 		PH7_MemObjRelease(pVal);
 		MemObjSetType(pVal,MEMOBJ_STRING);
 	}
 	va_start(ap,zFormat);
-	(void)SyBlobFormatAp(&pVal->sBlob,zFormat,ap);
+	rc = SyBlobFormatAp(&pVal->sBlob,zFormat,ap);
 	va_end(ap);
-	return PH7_OK;
+	/* Propagate allocation failure rather than reporting a truncated success. */
+	return rc;
 }
 /*
  * [CAPIREF: ph7_value_reset_string_cursor()]

--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -3259,8 +3259,9 @@ static int PH7_builtin_str_repeat(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		/* Append the copy */
 		rc = ph7_result_string(pCtx,zIn,nLen);
 		if( rc != PH7_OK ){
-			/* Out of memory,break immediately */
-			break;
+			/* Allocation failed: surface a fatal instead of returning a
+			 * silently-truncated string with a success status. */
+			return PH7_ContextMemoryError(pCtx);
 		}
 		nMul--;
 	}
@@ -4439,9 +4440,8 @@ static int PH7_builtin_str_getcsv(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	/* Create our array */
 	pArray = ph7_context_new_array(pCtx);
 	if( pArray == 0 ){
-		ph7_context_throw_error(pCtx,PH7_CTX_ERR,"PH7 is running out of memory");
-		ph7_result_null(pCtx);
-		return PH7_OK;
+		/* Surface a fatal instead of silently returning null on OOM */
+		return PH7_ContextMemoryError(pCtx);
 	}
 	/* Parse the raw input */
 	PH7_ProcessCsv(zInput,nLen,delim,encl,escape,PH7_CsvConsumer,pArray);
@@ -5539,6 +5539,7 @@ struct str_replace_data
 	/* The following two fields are only used by the str_replace function */
 	SySet *pCollector;  /* Argument collector*/
 	ph7_context *pCtx;  /* Call context */
+	sxi32 rc;           /* Carries an allocation failure (SXERR_MEM) out of a walker */
 };
 /*
  * Remove a substring.
@@ -5591,8 +5592,9 @@ static int StringReplace(SyBlob *pWorker,sxu32 nOfft,int nLen,const char *zRepla
 		 */
 		rc = SyBlobAppend(pWorker,0/* Grow without an append operation*/,(sxu32)nReplen);
 		if( rc != SXRET_OK ){
-			/* Simply ignore any memory failure problem */
-			return SXRET_OK;
+			/* Propagate the allocation failure so the caller can raise a fatal
+			 * instead of returning a partially-replaced string as success. */
+			return rc;
 		}
 		/* Perform the insertion now */
 		zInput = (char *)SyBlobData(pWorker);
@@ -5637,7 +5639,12 @@ static int StringReplaceWalker(ph7_value *pKey,ph7_value *pData,void *pUserData)
 	/* Extract the replace string */
 	zReplace = ph7_value_to_string(pData,&nLen);
 	/* Perform the replace process */
-	StringReplace(pWorker,nOfft,tLen,zReplace,nLen);
+	rc = StringReplace(pWorker,nOfft,tLen,zReplace,nLen);
+	if( rc != SXRET_OK ){
+		/* Allocation failure: carry it out and stop the walk */
+		pRepData->rc = rc;
+		return rc;
+	}
 	/* All done */
 	return PH7_OK;
 }
@@ -5662,9 +5669,10 @@ static int StrReplaceWalker(ph7_value *pKey,ph7_value *pData,void *pUserData)
 			TRUE /* Release the chunk automatically,upon this context is destroyd */
 			);
 		if( zDup == 0 ){
-			/* Ignore any memory failure problem */
-			ph7_context_throw_error(pRep->pCtx,PH7_CTX_ERR,"PH7 is running out of memory");
-			return PH7_OK;
+			/* Allocation failure: carry it out and stop the walk so the caller
+			 * raises a fatal instead of silently dropping a search/replace term. */
+			pRep->rc = SXERR_MEM;
+			return SXERR_MEM;
 		}
 		SyMemcpy(zIn,zDup,(sxu32)nByte);
 		/* Save the chunk */
@@ -5765,6 +5773,13 @@ static int PH7_builtin_str_replace(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		/* Save for later processing */
 		SySetPut(&sReplace,(const void *)&sTemp);
 	}
+	/* Surface a collector allocation failure (StrReplaceWalker) as a fatal */
+	if( sRep.rc != SXRET_OK ){
+		SySetRelease(&sSearch);
+		SySetRelease(&sReplace);
+		SyBlobRelease(&sWorker);
+		return PH7_ContextMemoryError(pCtx);
+	}
 	/* Reset loop cursors */
 	SySetResetCursor(&sSearch);
 	SySetResetCursor(&sReplace);
@@ -5813,16 +5828,26 @@ static int PH7_builtin_str_replace(ph7_context *pCtx,int nArg,ph7_value **apArg)
 				break;
 			}
 			/* Perform the replace operation */
-			StringReplace(&sWorker,nCount+nOfft,(int)pSearch->nByte,pReplace->zString,(int)pReplace->nByte);
+			rc = StringReplace(&sWorker,nCount+nOfft,(int)pSearch->nByte,pReplace->zString,(int)pReplace->nByte);
+			if( rc != SXRET_OK ){
+				/* Allocation failure: surface a fatal instead of a partial result */
+				SySetRelease(&sSearch);
+				SySetRelease(&sReplace);
+				SyBlobRelease(&sWorker);
+				return PH7_ContextMemoryError(pCtx);
+			}
 			/* Increment offset counter */
 			nCount += nOfft + pReplace->nByte;
 		}
 	}
 	/* All done,clean-up the mess left behind */
-	ph7_result_string(pCtx,(const char *)SyBlobData(&sWorker),(int)SyBlobLength(&sWorker));
+	rc = ph7_result_string(pCtx,(const char *)SyBlobData(&sWorker),(int)SyBlobLength(&sWorker));
 	SySetRelease(&sSearch);
 	SySetRelease(&sReplace);
 	SyBlobRelease(&sWorker);
+	if( rc != PH7_OK ){
+		return PH7_ContextMemoryError(pCtx);
+	}
 	return PH7_OK;
 }
 /*
@@ -5861,6 +5886,7 @@ static int PH7_builtin_strtr(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	if( nArg == 2 && ph7_value_is_array(apArg[1]) ){
 		str_replace_data sRepData;
 		SyBlob sWorker;
+		sxi32 rc;
 		/* Initilaize the working buffer */
 		SyBlobInit(&sWorker,&pCtx->pVm->sAllocator);
 		/* Copy raw string */
@@ -5868,13 +5894,22 @@ static int PH7_builtin_strtr(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		/* Init our replace data instance */
 		sRepData.pWorker = &sWorker;
 		sRepData.xMatch = SyBlobSearch;
+		sRepData.rc = SXRET_OK;
 		/* Iterate throw array entries and perform the replace operation.*/
 		ph7_array_walk(apArg[1],StringReplaceWalker,&sRepData);
+		if( sRepData.rc != SXRET_OK ){
+			/* Allocation failure during replacement: surface a fatal */
+			SyBlobRelease(&sWorker);
+			return PH7_ContextMemoryError(pCtx);
+		}
 		/* All done, return the result string */
-		ph7_result_string(pCtx,(const char *)SyBlobData(&sWorker),
+		rc = ph7_result_string(pCtx,(const char *)SyBlobData(&sWorker),
 			(int)SyBlobLength(&sWorker)); /* Will make it's own copy */
 		/* Clean-up */
 		SyBlobRelease(&sWorker);
+		if( rc != PH7_OK ){
+			return PH7_ContextMemoryError(pCtx);
+		}
 	}else{
 		int i,flen,tlen,c,iOfft;
 		const char *zFrom,*zTo;
@@ -5943,11 +5978,8 @@ PH7_PRIVATE sxi32 PH7_ParseIniString(ph7_context *pCtx,const char *zIn,sxu32 nBy
 	pWorker = ph7_context_new_scalar(pCtx);
 	pValue = ph7_context_new_scalar(pCtx);
 	if( pArray == 0 || pWorker == 0 || pValue == 0){
-		/* Out of memory */
-		ph7_context_throw_error(pCtx,PH7_CTX_ERR,"PH7 is running out of memory");
-		/* Return FALSE */
-		ph7_result_bool(pCtx,0);
-		return PH7_OK;
+		/* Out of memory: surface a fatal instead of returning FALSE */
+		return PH7_ContextMemoryError(pCtx);
 	}
 	SyHashInit(&sHash,&pCtx->pVm->sAllocator,0,0);
 	pCur = pArray;
@@ -6135,9 +6167,8 @@ static int PH7_builtin_parse_ini_string(ph7_context *pCtx,int nArg,ph7_value **a
 	}
 	/* Extract the raw INI buffer */
 	zIni = ph7_value_to_string(apArg[0],&nByte);
-	/* Process the INI buffer*/
-	PH7_ParseIniString(pCtx,zIni,(sxu32)nByte,(nArg > 1) ? ph7_value_to_bool(apArg[1]) : 0);
-	return PH7_OK;
+	/* Process the INI buffer; propagate an OOM abort so the fatal actually halts */
+	return PH7_ParseIniString(pCtx,zIni,(sxu32)nByte,(nArg > 1) ? ph7_value_to_bool(apArg[1]) : 0);
 }
 #endif /* PH7_NEED_FMT_AND_INI */
 

--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -3341,14 +3341,16 @@ static int ph7_hashmap_range(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	/* Create the new array */
 	pArray = ph7_context_new_array(pCtx);
 	if( pArray == 0 ){
-		ph7_result_null(pCtx);
-		return PH7_OK;
+		return PH7_ContextMemoryError(pCtx);
 	}
 	/* Start filling */
 	while( iOfft <= iLimit ){
 		ph7_value_int64(pValue,iOfft);
 		/* Perform the insertion */
-		ph7_array_add_elem(pArray,0/* Automatic index assign*/,pValue);
+		if( ph7_array_add_elem(pArray,0/* Automatic index assign*/,pValue) != SXRET_OK ){
+			/* Allocation failure: surface a fatal instead of a partial array */
+			return PH7_ContextMemoryError(pCtx);
+		}
 		/* Increment */
 		iOfft += iStep;
 	}
@@ -5402,15 +5404,19 @@ static int ph7_hashmap_fill(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	/* Create a new array */
 	pArray = ph7_context_new_array(pCtx);
 	if( pArray == 0 ){
-		ph7_result_null(pCtx);
-		return PH7_OK;
+		return PH7_ContextMemoryError(pCtx);
 	}
 
 	/* Insert the first entry alone because it has its own key */
-	ph7_array_add_intkey_elem(pArray, ph7_value_to_int(apArg[0]), apArg[2]);
+	if( ph7_array_add_intkey_elem(pArray, ph7_value_to_int(apArg[0]), apArg[2]) != SXRET_OK ){
+		return PH7_ContextMemoryError(pCtx);
+	}
 	/* Repeat insertion of the desired value */
 	for( i = 1 ; i < nEntry ; i++ ){
-		ph7_array_add_elem(pArray, 0/*Automatic index assign */, apArg[2]);
+		if( ph7_array_add_elem(pArray, 0/*Automatic index assign */, apArg[2]) != SXRET_OK ){
+			/* Allocation failure: surface a fatal instead of a partial array */
+			return PH7_ContextMemoryError(pCtx);
+		}
 	}
 	/* Return the filled array */
 	ph7_result_value(pCtx, pArray);
@@ -6346,8 +6352,7 @@ static int ph7_hashmap_pad(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	/* Create a new array */
 	pArray = ph7_context_new_array(pCtx);
 	if( pArray == 0 ){
-		ph7_result_null(pCtx);
-		return PH7_OK;
+		return PH7_ContextMemoryError(pCtx);
 	}
 	/* Point to the internal representation of the input hashmap */
 	pMap = (ph7_hashmap *)apArg[0]->x.pOther;
@@ -6359,7 +6364,9 @@ static int ph7_hashmap_pad(ph7_context *pCtx,int nArg,ph7_value **apArg)
 			nEntry -= (int)pMap->nEntry;
 			/* Insert given items first */
 			while( nEntry > 0 ){
-				ph7_array_add_elem(pArray,0,apArg[2]);
+				if( ph7_array_add_elem(pArray,0,apArg[2]) != SXRET_OK ){
+					return PH7_ContextMemoryError(pCtx);
+				}
 				nEntry--;
 			}
 			/* Merge the two arrays */
@@ -6374,7 +6381,9 @@ static int ph7_hashmap_pad(ph7_context *pCtx,int nArg,ph7_value **apArg)
 			HashmapMerge(pMap,(ph7_hashmap *)pArray->x.pOther);
 			/* Insert given items */
 			while( nEntry > 0 ){
-				ph7_array_add_elem(pArray,0,apArg[2]);
+				if( ph7_array_add_elem(pArray,0,apArg[2]) != SXRET_OK ){
+					return PH7_ContextMemoryError(pCtx);
+				}
 				nEntry--;
 			}
 		}else{

--- a/src/ph7/ph7.h
+++ b/src/ph7/ph7.h
@@ -171,6 +171,7 @@ typedef sxi64 ph7_int64;
 #define PH7_CONFIG_ERR_OUTPUT    1  /* TWO ARGUMENTS: int (*xConsumer)(const void *pOut,unsigned int nLen,void *pUserData),void *pUserData */
 #define PH7_CONFIG_ERR_ABORT     2  /* RESERVED FOR FUTURE USE */
 #define PH7_CONFIG_ERR_LOG       3  /* TWO ARGUMENTS: const char **pzBuf,int *pLen */
+#define PH7_CONFIG_MAX_ALLOC     4  /* ONE ARGUMENT: unsigned int nMaxByte (per-allocation cap in bytes; 0 = unlimited). Inherited by VMs created afterwards. */
 /*
  * Virtual Machine Configuration Commands.
  *

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1431,6 +1431,8 @@ PH7_PRIVATE sxi32 PH7_VmOutputConsume(ph7_vm *pVm,SyString *pString);
 PH7_PRIVATE sxi32 PH7_VmOutputConsumeAp(ph7_vm *pVm,const char *zFormat,va_list ap);
 PH7_PRIVATE sxi32 PH7_VmThrowErrorAp(ph7_vm *pVm,SyString *pFuncName,sxi32 iErr,const char *zFormat,va_list ap);
 PH7_PRIVATE sxi32 PH7_VmThrowError(ph7_vm *pVm,SyString *pFuncName,sxi32 iErr,const char *zMessage);
+PH7_PRIVATE sxi32 PH7_VmMemoryError(ph7_vm *pVm);
+PH7_PRIVATE sxi32 PH7_ContextMemoryError(ph7_context *pCtx);
 PH7_PRIVATE sxi32 PH7_VmThrowException(ph7_context *pCtx,const char *zClass,const char *zFormat,...);
 PH7_PRIVATE sxi32 PH7_VmThrowExceptionTrace(ph7_context *pCtx,const char *zClass,const char *zFormat,...);
 PH7_PRIVATE void  PH7_VmExpandConstantValue(ph7_value *pVal,void *pUserData);

--- a/src/ph7/vfs.c
+++ b/src/ph7/vfs.c
@@ -5069,6 +5069,7 @@ static int PH7_builtin_parse_ini_file(ph7_context *pCtx,int nArg,ph7_value **apA
 	SyBlob sContents;
 	void *pHandle;
 	int nLen;
+	sxi32 rc = PH7_OK;
 	if( nArg < 1 || !ph7_value_is_string(apArg[0]) ){
 		/* Missing/Invalid arguments,return FALSE */
 		ph7_context_throw_error(pCtx,PH7_CTX_WARNING,"Expecting a file path");
@@ -5098,15 +5099,16 @@ static int PH7_builtin_parse_ini_file(ph7_context *pCtx,int nArg,ph7_value **apA
 		/* Empty buffer,return FALSE */
 		ph7_result_bool(pCtx,0);
 	}else{
-		/* Process the raw INI buffer */
-		PH7_ParseIniString(pCtx,(const char *)SyBlobData(&sContents),SyBlobLength(&sContents),
+		/* Process the raw INI buffer; capture an OOM abort to propagate below */
+		rc = PH7_ParseIniString(pCtx,(const char *)SyBlobData(&sContents),SyBlobLength(&sContents),
 			nArg > 1 ? ph7_value_to_bool(apArg[1]) : 0);
 	}
 	/* Close the stream */
 	PH7_StreamCloseHandle(pStream,pHandle);
 	/* Release the working buffer */
 	SyBlobRelease(&sContents);
-	return PH7_OK;
+	/* Propagate an OOM abort so the fatal actually halts the VM */
+	return rc;
 }
 /* ZIP archive processing moved to vfs_zip.c */
 #endif /* PH7_DISABLE_BUILTIN_FUNC || PH7_DISABLE_DISK_IO */

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -2655,6 +2655,33 @@ PH7_PRIVATE sxi32 PH7_VmThrowError(
 	return rc;
 }
 /*
+ * Raise an out-of-memory fatal and request a clean VM halt.
+ *
+ * This is the single choke point for surfacing an allocation failure that would
+ * otherwise produce a silently-wrong result (a truncated string/array returned
+ * with a success status). It mirrors PHP's non-catchable OOM fatal: it emits a
+ * fatal-level diagnostic, sets a nonzero process exit status, and requests a
+ * VM-wide halt that unwinds via the OP_CALL/abort path — which still runs
+ * register_shutdown_function() callbacks (see PH7_VmByteCodeExec). Callers
+ * return the value of this function (PH7_ABORT) directly, or `goto Abort` after
+ * calling it from a VM op.
+ */
+PH7_PRIVATE sxi32 PH7_VmMemoryError(ph7_vm *pVm)
+{
+	PH7_VmThrowError(&(*pVm),0,PH7_CTX_ERR,"PH7 is running out of memory");
+	/* Non-catchable, terminate with a PHP-like fatal exit status */
+	pVm->iExitStatus = 255;
+	pVm->bHaltRequested = 1;
+	return PH7_ABORT;
+}
+/*
+ * Context wrapper around PH7_VmMemoryError() for foreign/builtin functions.
+ */
+PH7_PRIVATE sxi32 PH7_ContextMemoryError(ph7_context *pCtx)
+{
+	return PH7_VmMemoryError(pCtx->pVm);
+}
+/*
  * Format and throw a run-time error and invoke the supplied VM output consumer callback.
  * Refer to the implementation of [ph7_context_throw_error_format()] for additional
  * information.
@@ -6409,7 +6436,11 @@ case PH7_OP_CAT:{
 		}
 		/* Perform the concatenation */
 		if( SyBlobLength(&pCur->sBlob) > 0 ){
-			PH7_MemObjStringAppend(pNos,(const char *)SyBlobData(&pCur->sBlob),SyBlobLength(&pCur->sBlob));
+			if( PH7_MemObjStringAppend(pNos,(const char *)SyBlobData(&pCur->sBlob),SyBlobLength(&pCur->sBlob)) != SXRET_OK ){
+				/* Allocation failure: raise a fatal instead of a truncated concat */
+				PH7_VmMemoryError(&(*pVm));
+				goto Abort;
+			}
 		}
 		SyBlobRelease(&pCur->sBlob);
 		pCur++;
@@ -6440,7 +6471,12 @@ case PH7_OP_CAT_STORE:{
 	}
 	/* Perform the concatenation (Reverse order) */
 	if( SyBlobLength(&pNos->sBlob) > 0 ){
-		PH7_MemObjStringAppend(pTos,(const char *)SyBlobData(&pNos->sBlob),SyBlobLength(&pNos->sBlob));
+		if( PH7_MemObjStringAppend(pTos,(const char *)SyBlobData(&pNos->sBlob),SyBlobLength(&pNos->sBlob)) != SXRET_OK ){
+			/* Allocation failure: raise a fatal before committing the store so
+			 * no partially-concatenated value is written to the lvalue. */
+			PH7_VmMemoryError(&(*pVm));
+			goto Abort;
+		}
 	}
 	/* Perform the store operation */
 	if( pTos->nIdx == SXU32_HIGH ){
@@ -9491,6 +9527,10 @@ SkipFuncBody:
 		/* Release the call context */
 		VmReleaseCallContext(&sCtx);
 		if( rc == PH7_ABORT ){
+			/* Release the (possibly partially-built) result slot before unwinding;
+			 * the Abort: label only frees the operand stack, not this local
+			 * (mirrors the PH7_EXCEPTION branch below). */
+			PH7_MemObjRelease(&sRet);
 			goto Abort;
 		}else if( rc == PH7_EXCEPTION ){
 			VmFrame *pFrm = pVm->pFrame;

--- a/src/phl/phl.c
+++ b/src/phl/phl.c
@@ -284,6 +284,25 @@ int main(int argc,char **argv)
 		Output_Consumer, /* Error log consumer */
 		0 /* NULL: Callback Private data */
 		);
+	/* Optional per-allocation memory cap (PHL_MAX_ALLOC=bytes). Used to
+	 * deterministically exercise out-of-memory paths (see tests/ph7/003-stress).
+	 * Clamp to a floor above the pool bucket size (SXMEM_POOL_MAXALLOC, 32 KB)
+	 * so the engine can still start; VMs inherit it at creation. */
+	{
+		const char *zMaxAlloc = getenv("PHL_MAX_ALLOC");
+		if( zMaxAlloc ){
+			unsigned long uMax = strtoul(zMaxAlloc,0,10);
+			if( uMax > 0 ){
+				if( uMax < 65536UL ){
+					uMax = 65536UL; /* floor: keep above the pool bucket size */
+				}
+				if( uMax > 0xFFFFFFFFUL ){
+					uMax = 0xFFFFFFFFUL; /* clamp: nMaxRequest is a 32-bit byte count */
+				}
+				ph7_config(pEngine,PH7_CONFIG_MAX_ALLOC,(unsigned int)uMax);
+			}
+		}
+	}
 	/* Now,it's time to compile our PHP file */
 	if( run_code ){
 		/* Compile inline PHP code string (PHP only - no tags needed) */

--- a/src/sx/sxmem.c
+++ b/src/sx/sxmem.c
@@ -143,6 +143,12 @@ static void * MemBackendAlloc(SyMemBackend *pBackend,sxu32 nByte)
 	 * leaks.
 	 */
 	nByte += sizeof(SyMemBlock);
+	/* Enforce the optional per-allocation cap (0 = unlimited). A capped failure
+	 * returns NULL just like a genuine OS failure, driving the normal SXERR_MEM
+	 * propagation; the retry callback is intentionally skipped (hard limit). */
+	if( pBackend->nMaxRequest && nByte > pBackend->nMaxRequest ){
+		return 0;
+	}
 	for(;;){
 		pBlock = (SyMemBlock *)pBackend->pMethods->xAlloc(nByte);
 		if( pBlock != 0 || pBackend->xMemError == 0 || nRetry > SXMEM_BACKEND_RETRY
@@ -195,6 +201,10 @@ static void * MemBackendRealloc(SyMemBackend *pBackend,void * pOld,sxu32 nByte)
 	}
 #endif
 	nByte += sizeof(SyMemBlock);
+	/* Enforce the optional per-allocation cap (0 = unlimited); see MemBackendAlloc. */
+	if( pBackend->nMaxRequest && nByte > pBackend->nMaxRequest ){
+		return 0;
+	}
 	pPrev = pBlock->pPrev;
 	pNext = pBlock->pNext;
 	for(;;){
@@ -570,6 +580,7 @@ PH7_PRIVATE sxi32 SyMemBackendInitFromParent(SyMemBackend *pBackend,SyMemBackend
 	pBackend->pMethods  = pParent->pMethods;
 	pBackend->xMemError = pParent->xMemError;
 	pBackend->pUserData = pParent->pUserData;
+	pBackend->nMaxRequest = pParent->nMaxRequest;
 	bInheritMutex = pParent->pMutexMethods ? TRUE : FALSE;
 	if( bInheritMutex ){
 		pBackend->pMutexMethods = pParent->pMutexMethods;

--- a/src/sx/sxmem.h
+++ b/src/sx/sxmem.h
@@ -48,6 +48,9 @@ struct SyMemBackend
 	void *pUserData;               /* First arg to xMemError() */
 	SyMutex *pMutex;               /* Per instance mutex */
 	sxu32 nMagic;                  /* Sanity check against misuse */
+	sxu32 nMaxRequest;             /* Per-allocation cap in bytes (0 = unlimited); fails
+	                                * any single alloc/realloc larger than this. Used to
+	                                * exercise out-of-memory paths deterministically. */
 	SyMemHeader *apPool[SXMEM_POOL_NBUCKETS+SXMEM_POOL_INCR]; /* Pool of memory chunks */
 };
 

--- a/tests/ph7/003-stress/memory/array_fill_oom.phpt
+++ b/tests/ph7/003-stress/memory/array_fill_oom.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+array_fill surfaces an out-of-memory fatal instead of a partial array
+--DESCRIPTION--
+Run under a small per-allocation cap (PHL_MAX_ALLOC, set by `make test-stress`).
+The bucket-table growth fails; the engine must raise a fatal, not return a
+silently-truncated array with a success status.
+--SKIPIF--
+<?php if (!getenv('PHL_MAX_ALLOC')) { echo "skip needs PHL_MAX_ALLOC cap (run: make test-stress)"; } ?>
+--FILE--
+<?php
+$a = array_fill(0, 4000000, 0);
+echo "UNREACHABLE count=" . count($a) . "\n";
+?>
+--EXPECTF--
+%s Error:  PH7 is running out of memory
+--CLEAN--
+<?php

--- a/tests/ph7/003-stress/memory/concat_oom.phpt
+++ b/tests/ph7/003-stress/memory/concat_oom.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+String concatenation surfaces an out-of-memory fatal instead of a truncated result
+--DESCRIPTION--
+Run under a small per-allocation cap (PHL_MAX_ALLOC, set by `make test-stress`).
+Each operand builds under the cap; concatenating them needs a buffer past the
+cap, so the OP_CAT path must raise a fatal, not produce a truncated string.
+--SKIPIF--
+<?php if (!getenv('PHL_MAX_ALLOC')) { echo "skip needs PHL_MAX_ALLOC cap (run: make test-stress)"; } ?>
+--FILE--
+<?php
+$a = str_repeat('A', 500000);
+$b = str_repeat('B', 500000);
+$c = $a . $b;
+echo "UNREACHABLE len=" . strlen($c) . "\n";
+?>
+--EXPECTF--
+%s Error:  PH7 is running out of memory
+--CLEAN--
+<?php

--- a/tests/ph7/003-stress/memory/shutdown_on_oom.phpt
+++ b/tests/ph7/003-stress/memory/shutdown_on_oom.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+An out-of-memory fatal still runs registered shutdown functions (PHP semantics)
+--DESCRIPTION--
+Run under a small per-allocation cap (PHL_MAX_ALLOC, set by `make test-stress`).
+The OOM fatal is non-catchable and halts execution, but register_shutdown_function
+callbacks must still run, mirroring PHP.
+--SKIPIF--
+<?php if (!getenv('PHL_MAX_ALLOC')) { echo "skip needs PHL_MAX_ALLOC cap (run: make test-stress)"; } ?>
+--FILE--
+<?php
+register_shutdown_function(function(){ echo "SHUTDOWN\n"; });
+$s = str_repeat('A', 8000000);
+echo "UNREACHABLE\n";
+?>
+--EXPECTF--
+%s Error:  PH7 is running out of memory
+SHUTDOWN
+--CLEAN--
+<?php

--- a/tests/ph7/003-stress/memory/str_repeat_oom.phpt
+++ b/tests/ph7/003-stress/memory/str_repeat_oom.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+str_repeat surfaces an out-of-memory fatal instead of a truncated string
+--DESCRIPTION--
+Run under a small per-allocation cap (PHL_MAX_ALLOC, set by `make test-stress`).
+The allocation fails mid-build; the engine must raise a fatal, not return a
+silently-truncated string with a success status.
+--SKIPIF--
+<?php if (!getenv('PHL_MAX_ALLOC')) { echo "skip needs PHL_MAX_ALLOC cap (run: make test-stress)"; } ?>
+--FILE--
+<?php
+$s = str_repeat('A', 8000000);
+echo "UNREACHABLE len=" . strlen($s) . "\n";
+?>
+--EXPECTF--
+%s Error:  PH7 is running out of memory
+--CLEAN--
+<?php


### PR DESCRIPTION
…rong answer

A failed allocation inside a string/array builtin fabricated an empty or truncated value with a SUCCESS status (e.g. str_repeat('A', 2_000_000) returned "" with HTTP 200 on the ESP32 profile). Any allocation-heavy code under memory pressure silently got a wrong answer.

Root cause: the API layer discarded the allocator's SXERR_MEM. ph7_value_string and ph7_value_string_format always returned PH7_OK, and builtins ignored even propagated codes (str_repeat broke its loop but returned PH7_OK; StringReplace explicitly swallowed SXERR_MEM; OP_CAT/OP_CAT_STORE dropped the append rc).

Fixes:
- Keystone: ph7_value_string / ph7_value_string_format now propagate the underlying SyBlobAppend / SyBlobFormatAp return code.
- New shared helper PH7_VmMemoryError / PH7_ContextMemoryError (vm.c) emits a non-catchable OOM fatal (matching PHP), sets iExitStatus=255 and bHaltRequested, and returns PH7_ABORT — which unwinds via the existing abort path and still runs register_shutdown_function callbacks.
- Wired into str_repeat, OP_CAT/OP_CAT_STORE, StringReplace (+str_replace/ str_ireplace/strtr), str_getcsv, PH7_ParseIniString, and the array-growth builtins array_fill/array_pad/range. parse_ini_string and parse_ini_file now propagate PH7_ParseIniString's abort instead of swallowing it.
- Fixed an abort-path leak: the OP_CALL PH7_ABORT branch now releases the partial result slot (sRet), mirroring the exception branch.

Testability: a per-allocation cap (SyMemBackend.nMaxRequest) is exposed via the new PH7_CONFIG_MAX_ALLOC engine verb and the PHL_MAX_ALLOC env var in phl.c (parsed unsigned, clamped to [65536, 0xFFFFFFFF]). Default is unlimited (nMaxRequest=0), so behavior is unchanged unless an allocation genuinely fails.

A new opt-in test tier (tests/ph7/003-stress, `make test-stress`) runs in child-process mode under the cap and asserts the fatal — not a wrong answer — and that shutdown functions still run on OOM. The default `make test` is unaffected. Deferred (same helper, follow-up): the broader audit of other allocation-ignoring sites (implode, str_pad, sprintf, json_encode, general hashmap-insert callers), which degrade gracefully today but do not yet raise.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
