### PR TITLE
Add the 13 SPL exception classes (RuntimeException, LogicException, …)

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -1201,6 +1201,20 @@ static int vm_builtin_Generator_destruct(ph7_context *pCtx, int nArg, ph7_value 
 	"   return $this->severity;"\
     "}"\
 	"}"\
+	"/* SPL exceptions: thin tree, inherit Exception's ctor+getters. Roots first. */"\
+	"class LogicException extends Exception { }"\
+	"class RuntimeException extends Exception { }"\
+	"class BadFunctionCallException extends LogicException { }"\
+	"class BadMethodCallException extends BadFunctionCallException { }"\
+	"class DomainException extends LogicException { }"\
+	"class InvalidArgumentException extends LogicException { }"\
+	"class LengthException extends LogicException { }"\
+	"class OutOfRangeException extends LogicException { }"\
+	"class OutOfBoundsException extends RuntimeException { }"\
+	"class OverflowException extends RuntimeException { }"\
+	"class RangeException extends RuntimeException { }"\
+	"class UnderflowException extends RuntimeException { }"\
+	"class UnexpectedValueException extends RuntimeException { }"\
 	"interface Iterator extends Traversable {"\
 	"public function current();"\
 	"public function key();"\

--- a/tests/ph7/001-smoke/lang/spl_exception_catch_by_base.phpt
+++ b/tests/ph7/001-smoke/lang/spl_exception_catch_by_base.phpt
@@ -1,0 +1,29 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+SPL exceptions: caught by a base type, inherited ctor/getMessage/getCode
+--FILE--
+<?php
+try {
+  throw new InvalidArgumentException("bad", 3);
+} catch (LogicException $e) {
+  echo "caught LogicException ", get_class($e), ":", $e->getMessage(), ":", $e->getCode(), "\n";
+}
+try {
+  throw new RangeException("r");
+} catch (Exception $e) {
+  echo "caught Exception ", get_class($e), "\n";
+}
+try {
+  throw new OverflowException("o");
+} catch (Throwable $e) {
+  echo "caught Throwable ", get_class($e), "\n";
+}
+?>
+--EXPECT--
+caught LogicException InvalidArgumentException:bad:3
+caught Exception RangeException
+caught Throwable OverflowException
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/spl_exception_class_exists.phpt
+++ b/tests/ph7/001-smoke/lang/spl_exception_class_exists.phpt
@@ -1,0 +1,32 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+SPL exception classes are declared (class_exists)
+--FILE--
+<?php
+$classes = ['LogicException','RuntimeException','BadFunctionCallException',
+  'BadMethodCallException','DomainException','InvalidArgumentException',
+  'LengthException','OutOfRangeException','OutOfBoundsException',
+  'OverflowException','RangeException','UnderflowException','UnexpectedValueException'];
+foreach ($classes as $c) {
+  echo $c, '=', class_exists($c) ? '1' : '0', "\n";
+}
+?>
+--EXPECT--
+LogicException=1
+RuntimeException=1
+BadFunctionCallException=1
+BadMethodCallException=1
+DomainException=1
+InvalidArgumentException=1
+LengthException=1
+OutOfRangeException=1
+OutOfBoundsException=1
+OverflowException=1
+RangeException=1
+UnderflowException=1
+UnexpectedValueException=1
+--CLEAN--
+<?php
+unset($classes);

--- a/tests/ph7/001-smoke/lang/spl_exception_hierarchy.phpt
+++ b/tests/ph7/001-smoke/lang/spl_exception_hierarchy.phpt
@@ -1,0 +1,32 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+SPL exception parent chain matches PHP (get_parent_class)
+--FILE--
+<?php
+$classes = ['LogicException','RuntimeException','BadFunctionCallException',
+  'BadMethodCallException','DomainException','InvalidArgumentException',
+  'LengthException','OutOfRangeException','OutOfBoundsException',
+  'OverflowException','RangeException','UnderflowException','UnexpectedValueException'];
+foreach ($classes as $c) {
+  echo $c, '->', get_parent_class($c), "\n";
+}
+?>
+--EXPECT--
+LogicException->Exception
+RuntimeException->Exception
+BadFunctionCallException->LogicException
+BadMethodCallException->BadFunctionCallException
+DomainException->LogicException
+InvalidArgumentException->LogicException
+LengthException->LogicException
+OutOfRangeException->LogicException
+OutOfBoundsException->RuntimeException
+OverflowException->RuntimeException
+RangeException->RuntimeException
+UnderflowException->RuntimeException
+UnexpectedValueException->RuntimeException
+--CLEAN--
+<?php
+unset($classes);

--- a/tests/ph7/001-smoke/lang/spl_exception_instanceof.phpt
+++ b/tests/ph7/001-smoke/lang/spl_exception_instanceof.phpt
@@ -1,0 +1,31 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+SPL exceptions: instanceof across the hierarchy
+--FILE--
+<?php
+// Inline checks (no global helper) to avoid in-process name clashes.
+echo (new InvalidArgumentException() instanceof LogicException) ? "yes\n" : "no\n";
+echo (new InvalidArgumentException() instanceof Exception) ? "yes\n" : "no\n";
+echo (new InvalidArgumentException() instanceof Throwable) ? "yes\n" : "no\n";
+echo (new BadMethodCallException() instanceof BadFunctionCallException) ? "yes\n" : "no\n";
+echo (new BadMethodCallException() instanceof LogicException) ? "yes\n" : "no\n";
+echo (new RangeException() instanceof RuntimeException) ? "yes\n" : "no\n";
+echo (new RangeException() instanceof Exception) ? "yes\n" : "no\n";
+// OutOfBoundsException is a RuntimeException in PHP, NOT a LogicException
+echo (new OutOfBoundsException() instanceof RuntimeException) ? "yes\n" : "no\n";
+echo (new OutOfBoundsException() instanceof LogicException) ? "yes\n" : "no\n";
+?>
+--EXPECT--
+yes
+yes
+yes
+yes
+yes
+yes
+yes
+yes
+no
+--CLEAN--
+<?php


### PR DESCRIPTION
The SPL exception hierarchy was undeclared — class_exists("RuntimeException") returned false, so any framework or library code that throws or catches these (extremely common) types died with "Call to undefined class".

Added all 13 as embedded PHP source in the PH7_BUILTIN_LIB macro (vm.c, after ErrorException), following the existing `class X extends Error { }` template — no C required. They use PHP's exact two-root hierarchy so catch / instanceof / get_parent_class match PHP:
  LogicException, RuntimeException        extends Exception
  BadFunctionCallException, DomainException, InvalidArgumentException,
  LengthException, OutOfRangeException    extends LogicException
  BadMethodCallException                  extends BadFunctionCallException
  OutOfBoundsException, OverflowException, RangeException, UnderflowException,
  UnexpectedValueException                extends RuntimeException

Each is an empty body inheriting Exception's constructor and getMessage/getCode/getPrevious/... Declaration order places the two roots before their subclasses so the compile-time parent resolution succeeds. Declared-class count: 14 -> 27.

Byte-for-byte parity with PHP 8.5.7 (catch-by-base, instanceof chains, get_parent_class, inherited ctor/getMessage/getCode all match). Regression: lang/spl_exception_{class_exists,hierarchy,instanceof,catch_by_base}.phpt (pass under both phl and real php). make test / test-compat green.
