### PR TITLE
Make .= string concatenation amortized O(1) (in-place append)

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -6768,18 +6768,68 @@ case PH7_OP_CAT:{
 case PH7_OP_CAT_STORE:{
 	ph7_value *pNos = &pTos[-1];
 	ph7_value *pObj;
+	sxu32 nIdx;
 #ifdef UNTRUST
 	if( pNos < pStack ){
 		goto Abort;
 	}
 #endif
+	/* The right operand must be a string to append it */
+	if((pNos->iFlags & MEMOBJ_STRING) == 0 ){
+		PH7_MemObjToString(pNos);
+	}
+	nIdx = pTos->nIdx;
+	/* Fast path: append straight into the lvalue's own (geometrically grown) buffer
+	 * instead of copy-on-write-dup'ing the read-only-aliased stack value and then
+	 * storing the whole buffer back twice. This turns `$s .= ...` (and the
+	 * $a[$i] .= / $obj->prop .= forms) from O(n^2) into amortized O(1).
+	 * Guards: a real owned slot; the right operand must NOT alias that same slot
+	 * (`$s .= $s`, or a reference to it, would realloc the buffer out from under
+	 * the source we copy from — references share the slot index, so one check
+	 * covers both); and not a typed property, whose store-time type check/coercion
+	 * must run before any mutation (left to the slow path).
+	 * NOTE: the explicit `$s = $s . x` form (OP_CAT + OP_STORE) is not covered here
+	 * and remains O(n^2) by design. */
+	if( nIdx != SXU32_HIGH
+	 && nIdx != pNos->nIdx
+	 && (pObj = (ph7_value *)SySetAt(&pVm->aMemObj,nIdx)) != 0
+	 && (SyHashTotalEntry(&pVm->hTypedSlot) == 0
+	     || SyHashGet(&pVm->hTypedSlot,(const void *)&nIdx,sizeof(sxu32)) == 0) ){
+		if( (pObj->iFlags & MEMOBJ_STRING) == 0 ){
+			/* e.g. $x = 5; $x .= "a";  ->  "5a" */
+			PH7_MemObjToString(pObj);
+		}
+		if( SyBlobLength(&pNos->sBlob) > 0 ){
+			if( PH7_MemObjStringAppend(pObj,(const char *)SyBlobData(&pNos->sBlob),SyBlobLength(&pNos->sBlob)) != SXRET_OK ){
+				/* Allocation failure: the grow happens before the copy, so pObj
+				 * keeps its prior valid contents — raise the fatal uncorrupted. */
+				PH7_VmMemoryError(&(*pVm));
+				goto Abort;
+			}
+		}
+		/* Produce the expression result. A `.=` result is a temporary, never an
+		 * addressable lvalue, so nIdx is SXU32_HIGH (otherwise `f($s .= "x")` with a
+		 * by-ref param, or `&($s .= "x")`, would alias the live variable).
+		 * In the dominant statement form `$s .= "x";` the result is discarded by the
+		 * very next opcode (OP_POP), so we skip building it and leave the (harmless)
+		 * RHS operand for the POP to drop — keeping the hot path allocation-free.
+		 * Otherwise the result is consumed, so materialize an INDEPENDENT owned copy
+		 * of the updated value: a read-only alias into pObj's buffer would dangle if
+		 * the same slot is appended to again later in the statement
+		 * (e.g. `($s .= "a") . ($s .= "b")` reallocs the buffer the first result
+		 * still points at). Peeking pInstr+1 is safe: the compiler always emits a
+		 * terminating OP_DONE, so it is in-bounds inside any non-DONE opcode. */
+		if( (pInstr+1)->iOp != PH7_OP_POP ){
+			PH7_MemObjStore(pObj,pNos);
+		}
+		pNos->nIdx = SXU32_HIGH;
+		VmPopOperand(&pTos,1);
+		break;
+	}
+	/* Slow path: read-only/typed/constant-attribute/self-aliasing lvalues. */
 	if((pTos->iFlags & MEMOBJ_STRING) == 0 ){
 		/* Force a string cast */
 		PH7_MemObjToString(pTos);
-	}
-	if((pNos->iFlags & MEMOBJ_STRING) == 0 ){
-		/* Force a string cast */
-		PH7_MemObjToString(pNos);
 	}
 	/* Perform the concatenation (Reverse order) */
 	if( SyBlobLength(&pNos->sBlob) > 0 ){

--- a/tests/ph7/001-smoke/lang/concat_assign_inplace.phpt
+++ b/tests/ph7/001-smoke/lang/concat_assign_inplace.phpt
@@ -1,0 +1,67 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+.= appends in place (amortized O(1)) while preserving exact concat semantics
+--DESCRIPTION--
+OP_CAT_STORE gained an in-place fast path that appends directly to the lvalue's
+owned buffer (turning $s .= ... from O(n^2) into amortized O(1)) for plain
+variable / array-element / object-property lvalues, falling back to the copy
+path for typed properties and self-aliasing RHS. This pins the observable
+semantics so the optimization stays byte-for-byte identical to PHP. Uses unique
+class names + a closure printer because the compat harness @includes every FILE
+into one PHP process (top-level names must not collide).
+--FILE--
+<?php
+$p = function($label,$v){ echo $label,'=',$v,"\n"; };
+
+$s="ab"; $s.="cd";                 $p('basic',$s);
+$x=5; $x.="a";                     $p('int_lvalue',$x);      // non-string lvalue stringifies
+$a=["k"=>"x"]; $a["k"].="y";       $p('array_elem',$a["k"]);
+
+class ConcatAssignInplaceA { public $prop="a"; }
+$o=new ConcatAssignInplaceA; $o->prop.="b"; $p('obj_prop',$o->prop);
+
+$s="a"; $y=($s.="b");              $p('result_value',$y.'|'.$s);
+$s="a"; echo 'echo_result=' . ($s .= "bc") . "\n";
+
+$s="a"; $s.=$s; $s.=$s; $s.=$s;    $p('self_append',$s.'|'.strlen($s));  // slow-path fallback
+$s="ab"; $s.="X".$s;               $p('self_in_concat',$s);              // computed RHS, fast path
+$s="a"; $cc=($s.="b").($s.="c");   $p('chained_results',$cc.'|'.$s);     // two .= results co-live: must be owned copies, not dangling aliases
+
+$ra="x"; $rb=&$ra; $ra.=$rb;       $p('ref_self',$ra);                   // slow-path fallback
+$rc="x"; $rd=&$rc; $rc.="y";       $p('ref_propagate',$rd);              // shared slot visible via ref
+$va="x"; $vb=$va; $vb.="y";        $p('value_copy',$va.'|'.$vb);         // copy isolated from $va
+
+$s="ab"; $s.="";                   $p('empty_rhs',$s.'|'.strlen($s));    // no-op
+
+$s=""; for($i=0;$i<3;$i++) $s.="[".$i."]"; $p('chain',$s);
+
+class ConcatAssignInplaceTyped { public string $sp="a"; public int $ip=1; }
+$t=new ConcatAssignInplaceTyped; $t->sp.="b"; $p('typed_str',$t->sp);   // typed slot -> slow path
+$t2=new ConcatAssignInplaceTyped;
+// echo (not the $p closure) inside catch: invoking a closure as the first call
+// in a catch block trips a separate pre-existing VM bug, unrelated to concat.
+try { $t2->ip.="x"; echo "typed_int=NO_THROW\n"; }
+catch(TypeError $e){ echo "typed_int=TypeError\n"; }                    // type enforced, no corruption
+?>
+--EXPECT--
+basic=abcd
+int_lvalue=5a
+array_elem=xy
+obj_prop=ab
+result_value=ab|ab
+echo_result=abc
+self_append=aaaaaaaa|8
+self_in_concat=abXab
+chained_results=ababc|abc
+ref_self=xx
+ref_propagate=xy
+value_copy=x|xy
+empty_rhs=ab|2
+chain=[0][1][2]
+typed_str=ab
+typed_int=TypeError
+--CLEAN--
+<?php
+unset($p, $s, $x, $a, $o, $y, $cc, $i, $t, $t2, $ra, $rb, $rc, $rd, $va, $vb);

--- a/tests/ph7/003-stress/memory/concat_assign_oom.phpt
+++ b/tests/ph7/003-stress/memory/concat_assign_oom.phpt
@@ -1,0 +1,26 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+.= in-place append surfaces an out-of-memory fatal instead of a truncated result
+--DESCRIPTION--
+Run under a small per-allocation cap (PHL_MAX_ALLOC, set by `make test-stress`).
+The OP_CAT_STORE in-place fast path appends directly into the lvalue's buffer;
+when that buffer must grow past the cap the append must raise a fatal, not
+silently truncate. Companion to concat_oom.phpt (which covers the OP_CAT `.`
+path).
+--SKIPIF--
+<?php if (!getenv('PHL_MAX_ALLOC')) { echo "skip needs PHL_MAX_ALLOC cap (run: make test-stress)"; } ?>
+--FILE--
+<?php
+$s = '';
+$chunk = str_repeat('A', 100000);
+/* Each chunk fits under the cap, but the accumulator's geometric growth soon
+ * needs a single buffer larger than the cap -> the in-place append must fatal. */
+for ($i = 0; $i < 100; $i++) { $s .= $chunk; }
+echo "UNREACHABLE len=" . strlen($s) . "\n";
+?>
+--EXPECTF--
+%s Error:  PH7 is running out of memory
+--CLEAN--
+<?php


### PR DESCRIPTION
Building a string with `$s .= "..."` in a loop was O(n^2) (host n=80k = 11.57 s; on-chip 64 KB = 79 s), the biggest blocker to using PHL for PHP templating. The cause was not the SyBlob growth (BlobPrepareGrow already reallocs nByte+mByte*2+16, super-geometric) and str_repeat/implode/output buffers were already linear; it was three full O(n) buffer copies per `.=` in OP_CAT_STORE: the loaded lvalue is a read-only alias of the variable's buffer, so the append copy-on-write-dups it, then two PH7_MemObjStore/ SyBlobDup calls copy the result to the slot and the stack.

Add an in-place fast path to OP_CAT_STORE that appends the RHS straight into the lvalue's own (geometrically grown) slot buffer -> amortized O(1), for plain-variable, array-element and object-property lvalues. Guards fall back to the unchanged slow path when the slot is constant/typed or the RHS aliases the same slot (`$s .= $s`); typed properties keep slow-path type enforcement.

The `.=` expression result is a temporary (nIdx = SXU32_HIGH), never an addressable lvalue, so `f($s .= "x")` by-ref / `&($s .= "x")` no longer alias the variable. The result is only materialized when actually consumed: in the dominant `$s .= "x";` statement form the next opcode is OP_POP, so the result is left unbuilt (hot path stays allocation-free); otherwise an independent owned copy is made so it can't dangle when the same slot is appended to again later in the statement (e.g. `($s .= "a") . ($s .= "b")`). The typed-slot probe is skipped entirely when no typed properties exist.

Result: n=80k `.=` 11.57 s -> 0.01 s (array-element / object-property forms too), byte-for-byte parity with PHP 8.5.7. The explicit `$s = $s . x` form (OP_CAT + OP_STORE) remains O(n^2) by design.

Regression: tests/ph7/001-smoke/lang/concat_assign_inplace.phpt (semantics: var/array/property/int-lvalue, result value, chained .= results, self-append, references, value-copy isolation, empty RHS, typed-property fallback), tests/ph7/003-stress/memory/concat_assign_oom.phpt (in-place append surfaces the OOM fatal). make test / test-compat / test-stress green under phl and php 8.5.7; full corpus unchanged.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
