### PR TITLE
Fix use-after-free in PH7_HashmapCowSeparate (coverage report segfault)

### DIFF
--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -1296,7 +1296,17 @@ PH7_PRIVATE ph7_hashmap * PH7_HashmapCowSeparate(ph7_vm *pVm,ph7_value *pValue)
 			}
 			pNew->iNextIdx = pMap->iNextIdx;
 			pMap->iRef--;  /* Backing variable no longer references old map */
-			pBacking->x.pOther = pNew;
+			/* PH7_HashmapDup reserves a memory object per duplicated entry, which
+			 * can grow — and therefore reallocate (move) — pVm->aMemObj. That
+			 * invalidates the pBacking pointer captured above, so re-resolve it
+			 * from the (stable) slot index before writing. Using the stale pointer
+			 * dereferences the freed old buffer, which is a hard SIGSEGV on
+			 * glibc/x86_64 once aMemObj is large enough to be mmap-backed (the old
+			 * mapping is munmap'd on move) and a silent use-after-free elsewhere. */
+			pBacking = (ph7_value *)SySetAt(&pVm->aMemObj,pValue->nIdx);
+			if( pBacking ){
+				pBacking->x.pOther = pNew;
+			}
 			/* Update the stack value to match */
 			pValue->x.pOther = pNew;
 			pNew->iRef++;  /* +1 for stack (pValue); iRef=1 from NewHashmap covers pBacking */


### PR DESCRIPTION
PH7_HashmapCowSeparate captured pBacking = SySetAt(&pVm->aMemObj, pValue->nIdx) — a pointer INTO the aMemObj object pool — and then called PH7_HashmapDup(), which reserves a memory object per duplicated entry and can therefore grow and reallocate (move) aMemObj. The subsequent `pBacking->x.pOther = pNew` then wrote through the stale pointer into the freed old buffer.

On most allocators (macOS, arm64-linux, qemu) the old buffer stays mapped, so this is a silent use-after-free. On glibc/x86_64 a large aMemObj is mmap-backed, so the realloc munmap's the old mapping and the stale write hits an unmapped page — a hard SIGSEGV. This is exactly what the CI coverage `report` job hit running build-aux/lcov_to_markdown.php (ksort() of a ~16k-entry per-line array for a large source file): SIGSEGV at hashmap.c:1299, pBacking pointing into an unmapped region. Pre-existing since the COW work (bc925b8); surfaced once the aMemObj high-water during that ksort grew past the mmap threshold.

Fix: re-resolve pBacking from the (stable) slot index after PH7_HashmapDup, so the write targets the current aMemObj buffer rather than a freed one.
