### PR TITLE
Fix aMemObj use-after-free in array inserts, COW separate, fibers

### DIFF
--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -270,6 +270,17 @@ static sxi32 HashmapInsertIntKey(ph7_hashmap *pMap,sxi64 iKey,ph7_value *pValue,
 	sxi32 rc;
 	if( !isForeign ){
 		ph7_value *pObj;
+		ph7_value sSafeVal;
+		/* Snapshot the source BEFORE reserving: PH7_ReserveMemObj can grow (move)
+		 * pVm->aMemObj, which would dangle pValue when it points into the pool
+		 * (e.g. get_defined_vars/func_get_args/get_class_vars/get_object_vars pass
+		 * a pool slot). A shallow copy is a safe PH7_MemObjStore source — the
+		 * referent and the heap-resident blob data survive the move; only the
+		 * ph7_value struct relocates (same sSafeVal idiom used by PH7_HashmapDup). */
+		if( pValue ){
+			sSafeVal = *pValue;
+			pValue = &sSafeVal;
+		}
 		/* Reserve a ph7_value for the value */
 		pObj = PH7_ReserveMemObj(pMap->pVm);
 		if( pObj == 0 ){
@@ -319,6 +330,17 @@ static sxi32 HashmapInsertBlobKey(ph7_hashmap *pMap,const void *pKey,sxu32 nKeyL
 	sxi32 rc;
 	if( !isForeign ){
 		ph7_value *pObj;
+		ph7_value sSafeVal;
+		/* Snapshot the source BEFORE reserving: PH7_ReserveMemObj can grow (move)
+		 * pVm->aMemObj, which would dangle pValue when it points into the pool
+		 * (e.g. get_defined_vars/func_get_args/get_class_vars/get_object_vars pass
+		 * a pool slot). A shallow copy is a safe PH7_MemObjStore source — the
+		 * referent and the heap-resident blob data survive the move; only the
+		 * ph7_value struct relocates (same sSafeVal idiom used by PH7_HashmapDup). */
+		if( pValue ){
+			sSafeVal = *pValue;
+			pValue = &sSafeVal;
+		}
 		/* Reserve a ph7_value for the value */
 		pObj = PH7_ReserveMemObj(pMap->pVm);
 		if( pObj == 0 ){
@@ -1260,6 +1282,8 @@ PH7_PRIVATE ph7_hashmap * PH7_HashmapCowSeparate(ph7_vm *pVm,ph7_value *pValue)
 	ph7_hashmap *pMap = (ph7_hashmap *)pValue->x.pOther;
 	ph7_hashmap *pNew;
 	ph7_value *pBacking;
+	sxu32 nValIdx;
+	int bValueInPool;
 	if( pMap->iRef < 2 ){
 		/* Sole owner, no separation needed */
 		return pMap;
@@ -1313,6 +1337,16 @@ PH7_PRIVATE ph7_hashmap * PH7_HashmapCowSeparate(ph7_vm *pVm,ph7_value *pValue)
 			return pNew;
 		}
 	}
+	/* Some callers (e.g. OP_STORE_IDX, by-ref foreach) pass a pValue that points
+	 * directly into pVm->aMemObj. PH7_HashmapDup below reserves a memory object
+	 * per duplicated entry, which can grow — and therefore reallocate (move) —
+	 * pVm->aMemObj, leaving such a pValue dangling. Capture its slot identity now,
+	 * before the dup, so the write-back can re-resolve from the (stable) index
+	 * rather than dereference the captured pointer (the same hazard handled for
+	 * pBacking in the backing-variable branch above). */
+	nValIdx = pValue->nIdx;
+	bValueInPool = ( nValIdx != SXU32_HIGH
+		&& (ph7_value *)SySetAt(&pVm->aMemObj,nValIdx) == pValue );
 	pNew = PH7_NewHashmap(pVm,0,0);
 	if( pNew == 0 ){
 		/* Allocation failure — fall through with shared map */
@@ -1325,6 +1359,13 @@ PH7_PRIVATE ph7_hashmap * PH7_HashmapCowSeparate(ph7_vm *pVm,ph7_value *pValue)
 	}
 	pNew->iNextIdx = pMap->iNextIdx;
 	pMap->iRef--;
+	if( bValueInPool ){
+		/* aMemObj may have moved during the dup — re-resolve pValue's slot. */
+		pValue = (ph7_value *)SySetAt(&pVm->aMemObj,nValIdx);
+		if( pValue == 0 ){
+			return pNew;
+		}
+	}
 	pValue->x.pOther = pNew;
 	return pNew;
 }

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -7754,8 +7754,10 @@ case PH7_OP_FOREACH_INIT: {
 						 * the stack value. */
 						if( pBacking->x.pOther == (void *)pCur ){
 							pCur->iRef--;
-							PH7_HashmapCowSeparate(&(*pVm),pBacking);
-							pTos->x.pOther = pBacking->x.pOther;
+							/* Use the returned map, not pBacking->x.pOther: PH7_HashmapDup
+							 * inside CowSeparate can reallocate (move) pVm->aMemObj and leave
+							 * pBacking dangling. The return value is the post-separation map. */
+							pTos->x.pOther = PH7_HashmapCowSeparate(&(*pVm),pBacking);
 							((ph7_hashmap *)pTos->x.pOther)->iRef++;
 						}
 					}
@@ -10593,6 +10595,7 @@ static int vm_builtin_Fiber_start(ph7_context *pCtx, int nArg, ph7_value **apArg
 	/* Unpack the args array and install into the frame */
 	{
 		ph7_value **apValues = 0;
+		ph7_value *aStore = 0;
 		int nActual = 0;
 		if( nArg >= 2 && (apArg[1]->iFlags & MEMOBJ_HASHMAP) ){
 			ph7_hashmap *pMap = (ph7_hashmap *)apArg[1]->x.pOther;
@@ -10602,10 +10605,24 @@ static int vm_builtin_Fiber_start(ph7_context *pCtx, int nArg, ph7_value **apArg
 				sxu32 idx = 0;
 				apValues = (ph7_value **)SyMemBackendAlloc(&pVm->sAllocator,
 					nCount * sizeof(ph7_value *));
-				if( apValues ){
+				aStore = (ph7_value *)SyMemBackendAlloc(&pVm->sAllocator,
+					nCount * sizeof(ph7_value));
+				if( apValues && aStore ){
 					pNode = pMap->pFirst;
 					while( pNode && idx < nCount ){
-						apValues[idx] = (ph7_value *)SySetAt(&pVm->aMemObj, pNode->nValIdx);
+						/* Snapshot each source into stable storage: VmFiberSetupFrame reserves
+						 * memory objects (VmExtractMemObj) before reading the args, which can
+						 * reallocate (move) pVm->aMemObj and dangle a raw pool pointer. A
+						 * shallow copy is a safe source — the referent and the heap-resident
+						 * blob data survive the move (same sSafeVal idiom the hashmap inserters
+						 * use); it owns nothing independently, so it needs no release. */
+						ph7_value *pSrc = (ph7_value *)SySetAt(&pVm->aMemObj, pNode->nValIdx);
+						if( pSrc ){
+							aStore[idx] = *pSrc;
+						}else{
+							PH7_MemObjInit(pVm, &aStore[idx]);
+						}
+						apValues[idx] = &aStore[idx];
 						idx++;
 						pNode = pNode->pPrev;
 					}
@@ -10614,6 +10631,9 @@ static int vm_builtin_Fiber_start(ph7_context *pCtx, int nArg, ph7_value **apArg
 			}
 		}
 		rc = VmFiberSetupFrame(pVm, pExecCtx, pClosureThis, nActual, apValues);
+		if( aStore ){
+			SyMemBackendFree(&pVm->sAllocator, aStore);
+		}
 		if( apValues ){
 			SyMemBackendFree(&pVm->sAllocator, apValues);
 		}
@@ -12948,7 +12968,9 @@ static sxi32 VmHashVarWalker(SyHashEntry *pEntry,void *pUserData)
 			if( pEntry->nKeyLen > 0 ){
 				SyString sName;
 				ph7_value sKey;
-				/* Perform the insertion */
+				/* Perform the insertion (pObj may point into pVm->aMemObj; the
+				 * inserter snapshots the source before reserving, so the pool may
+				 * safely move underneath it — see HashmapInsertIntKey/BlobKey). */
 				SyStringInitFromBuf(&sName,pEntry->pKey,pEntry->nKeyLen);
 				PH7_MemObjInitFromString(pVm,&sKey,&sName);
 				ph7_array_add_elem(pArray,&sKey/*Will make it's own copy*/,pObj);


### PR DESCRIPTION
A ph7_value* obtained from SySetAt(&pVm->aMemObj, idx) points into the memory-object pool's backing array, which is reallocated (moved) whenever a new memory object is reserved. Holding such a pointer across a reserving call and then dereferencing it is a use-after-free: a hard SIGSEGV on glibc/x86_64 (large pools are mmap-backed and the old mapping is munmap'd on move) and a silent corruption elsewhere.

Root cause for the array-insert family: HashmapInsertIntKey/HashmapInsertBlobKey call PH7_ReserveMemObj (which can move the pool) and only afterward read the caller's source via PH7_MemObjStore. Snapshot the source with the existing sSafeVal = *pValue idiom before reserving, so the pool may move underneath it. This fixes every non-foreign insert caller at once, including get_defined_vars, func_get_args, get_class_vars and get_object_vars, all of which passed a pool slot straight into the insert.

Also fix the remaining distinct reserve-then-read paths:
- PH7_HashmapCowSeparate: re-resolve pValue from its stable slot index after PH7_HashmapDup when the caller passed a pool slot (OP_STORE_IDX, by-ref foreach); the prior fix only covered the backing-variable branch.
- PH7_OP_FOREACH_INIT: use CowSeparate's return value instead of re-reading pBacking->x.pOther after the call.
- Fiber start: snapshot the unpacked argument values into stable storage before VmFiberSetupFrame reserves the frame's memory objects.
