### PR TITLE
Add microsecond microtime()/gettimeofday() + PH7_CONFIG_CLOCK hook

### DIFF
--- a/examples/ph7_clock_hook.c
+++ b/examples/ph7_clock_hook.c
@@ -1,0 +1,65 @@
+/*
+ * Embedding example: overriding the engine clock via PH7_CONFIG_CLOCK.
+ *
+ * microtime()/gettimeofday() normally read the platform wall clock
+ * (gettimeofday() on Unix). An embedder with no usable sub-second system
+ * clock — e.g. the ESP32 port, which has esp_timer but builds with
+ * -DOS_OTHER — can install a callback that supplies "now" instead, so
+ * standard PHP timing works without re-registering microtime() in PHP.
+ *
+ * Build (from the repo root), linking against the split engine sources in
+ * src/sx and src/ph7 (everything except net.c), e.g.:
+ *   cc -Isrc/sx -Isrc/ph7 -D__UNIXES__ -o /tmp/ph7_clock_hook \
+ *      examples/ph7_clock_hook.c src/sx/[a-z]*.c \
+ *      $(ls src/ph7/[a-z]*.c | grep -v net.c) -lm -lpthread
+ *   then run /tmp/ph7_clock_hook  -> 1700000000.123456 / usec=123456 / OK
+ */
+#include <stdio.h>
+#include "ph7.h"
+
+/* Deterministic clock: a fixed instant, so the test output is stable. */
+static int fixed_clock(void *pUserData, ph7_int64 *pSec, ph7_int64 *pUsec)
+{
+	(void)pUserData;
+	*pSec  = 1700000000;
+	*pUsec = 123456;
+	return PH7_OK;
+}
+
+static int Consumer(const void *pOut, unsigned int nLen, void *pUserData)
+{
+	(void)pUserData;
+	fwrite(pOut, 1, nLen, stdout);
+	return PH7_OK;
+}
+
+static const char *zScript =
+	"<?php\n"
+	"printf(\"%.6f\\n\", microtime(true));\n"
+	"$g = gettimeofday();\n"
+	"echo 'usec=', $g['usec'], \"\\n\";\n"
+	"echo (abs(microtime(true) - 1700000000.123456) < 1e-3) ? \"OK\\n\" : \"FAIL\\n\";\n";
+
+int main(void)
+{
+	ph7 *pEngine;
+	ph7_vm *pVm;
+	if (ph7_init(&pEngine) != PH7_OK) {
+		fprintf(stderr, "ph7_init failed\n");
+		return 1;
+	}
+	/* Install the clock override before compiling/running. */
+	if (ph7_config(pEngine, PH7_CONFIG_CLOCK, fixed_clock, (void *)0) != PH7_OK) {
+		fprintf(stderr, "PH7_CONFIG_CLOCK failed\n");
+		return 1;
+	}
+	if (ph7_compile_v2(pEngine, zScript, -1, &pVm, 0) != PH7_OK) {
+		fprintf(stderr, "compile failed\n");
+		return 1;
+	}
+	ph7_vm_config(pVm, PH7_VM_CONFIG_OUTPUT, Consumer, (void *)0);
+	ph7_vm_exec(pVm, 0);
+	ph7_vm_release(pVm);
+	ph7_release(pEngine);
+	return 0;
+}

--- a/src/ph7/api.c
+++ b/src/ph7/api.c
@@ -126,6 +126,16 @@ static sxi32 EngineConfig(ph7 *pEngine,sxi32 nOp,va_list ap)
 		pEngine->sAllocator.nMaxRequest = (sxu32)nMax;
 		break;
 								}
+	case PH7_CONFIG_CLOCK: {
+		/* Optional embedder clock used by microtime()/gettimeofday(). The
+		 * callback fills epoch seconds + microseconds; NULL restores the
+		 * platform default. Inherited by VMs created afterwards. */
+		ph7_clock xClock = va_arg(ap,ph7_clock);
+		void *pUserData  = va_arg(ap,void *);
+		pEngine->xConf.xClock     = xClock;
+		pEngine->xConf.pClockData = pUserData;
+		break;
+							}
 	default:
 		/* Unknown configuration verb */
 		rc = PH7_CORRUPT;

--- a/src/ph7/builtin_date.c
+++ b/src/ph7/builtin_date.c
@@ -57,6 +57,55 @@ struct tm *__cdecl localtime(const time_t *t)
 #elif defined(__UNIXES__)
 #include <sys/time.h>
 #endif /* __WINNT__*/
+/*
+ * Resolve the current wall-clock time (epoch seconds + sub-second microseconds).
+ *
+ * An embedder may override the platform clock via PH7_CONFIG_CLOCK (e.g. the
+ * ESP32 port routes this through esp_timer); when no hook is registered we use
+ * gettimeofday() on Unix and fall back to a second-resolution time() elsewhere.
+ * Centralising this here gives microtime()/gettimeofday() a single sub-second
+ * source instead of the old nonsensical `tt % SX_USEC_PER_SEC` off-Unix path.
+ */
+static void DateNow(ph7_vm *pVm,sytime *pOut)
+{
+	if( pVm && pVm->pEngine->xConf.xClock ){
+		ph7_int64 sec = 0,usec = 0;
+		if( pVm->pEngine->xConf.xClock(pVm->pEngine->xConf.pClockData,&sec,&usec) == PH7_OK ){
+			pOut->tm_sec  = (long)sec;
+			pOut->tm_usec = (long)usec;
+			return;
+		}
+	}
+#if defined(__UNIXES__)
+	{
+		struct timeval tv;
+		gettimeofday(&tv,0);
+		pOut->tm_sec  = (long)tv.tv_sec;
+		pOut->tm_usec = (long)tv.tv_usec;
+	}
+#elif defined(__WINNT__)
+	{
+		/* FILETIME is 100-ns ticks since 1601-01-01 UTC; convert to the Unix
+		 * epoch with microsecond resolution (GetSystemTime() only carries
+		 * milliseconds, and time() has no sub-second part at all). */
+		FILETIME ft;
+		ph7_int64 t;
+		GetSystemTimeAsFileTime(&ft);
+		t  = (ph7_int64)ft.dwHighDateTime << 32;
+		t += ft.dwLowDateTime;
+		t -= 116444736000000000LL; /* 100-ns ticks between 1601 and 1970 */
+		pOut->tm_sec  = (long)(t / 10000000);
+		pOut->tm_usec = (long)((t % 10000000) / 10);
+	}
+#else
+	{
+		time_t tt;
+		time(&tt);
+		pOut->tm_sec  = (long)tt;
+		pOut->tm_usec = 0; /* no sub-second source; embedders supply one via PH7_CONFIG_CLOCK */
+	}
+#endif /* __UNIXES__ */
+}
  /*
   * int64 time(void)
   *  Current Unix timestamp
@@ -96,26 +145,19 @@ PH7_PRIVATE int PH7_builtin_microtime(ph7_context *pCtx,int nArg,ph7_value **apA
 {
 	int bFloat = 0;
 	sytime sTime;
-#if defined(__UNIXES__)
-	struct timeval tv;
-	gettimeofday(&tv,0);
-	sTime.tm_sec  = (long)tv.tv_sec;
-	sTime.tm_usec = (long)tv.tv_usec;
-#else
-	time_t tt;
-	time(&tt);
-	sTime.tm_sec  = (long)tt;
-	sTime.tm_usec = (long)(tt%SX_USEC_PER_SEC);
-#endif /* __UNIXES__ */
+	DateNow(pCtx->pVm,&sTime);
 	if( nArg > 0 ){
 		bFloat = ph7_value_to_bool(apArg[0]);
 	}
 	if( bFloat ){
-		/* Return as float */
-		ph7_result_double(pCtx,(double)sTime.tm_sec);
+		/* Return as float: seconds accurate to the nearest microsecond */
+		ph7_result_double(pCtx,(double)sTime.tm_sec + (double)sTime.tm_usec/(double)SX_USEC_PER_SEC);
 	}else{
-		/* Return as string */
-		ph7_result_string_format(pCtx,"%ld %ld",sTime.tm_usec,sTime.tm_sec);
+		/* Return PHP's "msec sec" form: the sub-second part as fractional
+		 * seconds to 8 decimals, e.g. "0.50667100 1700000000". tm_usec is in
+		 * microseconds (0..999999), so scaling by 100 yields the 8-digit
+		 * fraction — matching PHP's "%.8F" output exactly. */
+		ph7_result_string_format(pCtx,"0.%08ld %ld",sTime.tm_usec*100,sTime.tm_sec);
 	}
 	return PH7_OK;
 }
@@ -227,23 +269,13 @@ PH7_PRIVATE int PH7_builtin_gettimeofday(ph7_context *pCtx,int nArg,ph7_value **
 {
 	int bFloat = 0;
 	sytime sTime;
-#if defined(__UNIXES__)
-	struct timeval tv;
-	gettimeofday(&tv,0);
-	sTime.tm_sec  = (long)tv.tv_sec;
-	sTime.tm_usec = (long)tv.tv_usec;
-#else
-	time_t tt;
-	time(&tt);
-	sTime.tm_sec  = (long)tt;
-	sTime.tm_usec = (long)(tt%SX_USEC_PER_SEC);
-#endif /* __UNIXES__ */
+	DateNow(pCtx->pVm,&sTime);
 	if( nArg > 0 ){
 		bFloat = ph7_value_to_bool(apArg[0]);
 	}
 	if( bFloat ){
-		/* Return as float */
-		ph7_result_double(pCtx,(double)sTime.tm_sec);
+		/* Return as float: seconds accurate to the nearest microsecond */
+		ph7_result_double(pCtx,(double)sTime.tm_sec + (double)sTime.tm_usec/(double)SX_USEC_PER_SEC);
 	}else{
 		/* Return an associative array */
 		ph7_value *pValue,*pArray;

--- a/src/ph7/ph7.h
+++ b/src/ph7/ph7.h
@@ -153,6 +153,13 @@ typedef sxi64 ph7_real;
 typedef double ph7_real;
 #endif
 typedef sxi64 ph7_int64;
+/*
+ * Optional embedder clock callback (see PH7_CONFIG_CLOCK).
+ * Fill *pSec with the current Unix epoch seconds and *pUsec with the
+ * sub-second microseconds (0..999999). Return PH7_OK on success; any
+ * other value makes the engine fall back to the platform default clock.
+ */
+typedef int (*ph7_clock)(void *pUserData, ph7_int64 *pSec, ph7_int64 *pUsec);
 #define PH7_APIEXPORT SX_APIEXPORT
 /*
  * Engine Configuration Commands.
@@ -172,6 +179,7 @@ typedef sxi64 ph7_int64;
 #define PH7_CONFIG_ERR_ABORT     2  /* RESERVED FOR FUTURE USE */
 #define PH7_CONFIG_ERR_LOG       3  /* TWO ARGUMENTS: const char **pzBuf,int *pLen */
 #define PH7_CONFIG_MAX_ALLOC     4  /* ONE ARGUMENT: unsigned int nMaxByte (per-allocation cap in bytes; 0 = unlimited). Inherited by VMs created afterwards. */
+#define PH7_CONFIG_CLOCK         5  /* TWO ARGUMENTS: ph7_clock xClock, void *pUserData. Overrides the platform wall/sub-second clock used by microtime()/gettimeofday(); xClock fills *pSec (epoch seconds) and *pUsec (0..999999). NULL restores the default. Inherited by VMs created afterwards. */
 /*
  * Virtual Machine Configuration Commands.
  *

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -139,6 +139,8 @@ struct ph7_conf
 	ProcConsumer xErr;   /* Compile-time error consumer callback */
 	void *pErrData;      /* Third argument to xErr() */
 	SyBlob sErrConsumer; /* Default error consumer */
+	ph7_clock xClock;    /* Optional embedder clock [PH7_CONFIG_CLOCK]; NULL => platform default */
+	void *pClockData;    /* Third argument to xClock() */
 };
 /*
  * Signature of the C function responsible of expanding constant values.

--- a/tests/ph7/001-smoke/function/gettimeofday/gettimeofday_subsecond.phpt
+++ b/tests/ph7/001-smoke/function/gettimeofday/gettimeofday_subsecond.phpt
@@ -1,0 +1,32 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+gettimeofday(true) carries sub-second resolution; usec is in range
+--SKIPIF--
+<?php
+if (!function_exists('gettimeofday')) { echo 'skip: gettimeofday not available'; }
+?>
+--FILE--
+<?php
+// gettimeofday(true) must carry sub-second resolution: across a handful of
+// reads at least one has a non-zero fractional part (was always 0 before the
+// fix, which dropped tm_usec). Sampling keeps this robust on coarse clocks.
+$frac = false;
+for ($i = 0; $i < 1000 && !$frac; $i++) {
+    $t = gettimeofday(true);
+    if ($t - floor($t) > 0) { $frac = true; }
+}
+echo $frac ? "SUBSEC_OK\n" : "SUBSEC_FAIL\n";
+
+// The array form's usec field must be a valid microsecond count.
+$arr = gettimeofday();
+$u = $arr['usec'];
+echo ($u >= 0 && $u < 1000000) ? "USEC_RANGE_OK\n" : "USEC_RANGE_FAIL\n";
+?>
+--EXPECT--
+SUBSEC_OK
+USEC_RANGE_OK
+--CLEAN--
+<?php
+unset($frac, $i, $t, $arr, $u);

--- a/tests/ph7/001-smoke/function/microtime/microtime_subsecond.phpt
+++ b/tests/ph7/001-smoke/function/microtime/microtime_subsecond.phpt
@@ -1,0 +1,36 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: microtime(true) carries sub-second (microsecond) resolution
+--FILE--
+<?php
+// microtime(true) must carry sub-second resolution: across a handful of reads
+// at least one has a non-zero fractional part. The pre-fix engine dropped the
+// microsecond part, so every read was an exact integer second -> never OK.
+// (Sampling instead of a sleep-delta keeps this robust on coarse-grained
+// clocks such as Windows' system timer.)
+$frac = false;
+for ($i = 0; $i < 1000 && !$frac; $i++) {
+    $t = microtime(true);
+    if ($t - floor($t) > 0) { $frac = true; }
+}
+echo $frac ? "SUBSEC_OK\n" : "SUBSEC_FAIL\n";
+
+// The string form is PHP's "0.dddddddd sec" (fractional seconds, 8 decimals).
+$parts = explode(' ', microtime());
+echo (strlen($parts[0]) === 10 && $parts[0][0] === '0' && $parts[0][1] === '.'
+      && ctype_digit($parts[1])) ? "FORMAT_OK\n" : "FORMAT_FAIL: {$parts[0]}\n";
+
+// ...and the float form must agree with that string form to ~ms.
+$as_float = (float)$parts[1] + (float)$parts[0];
+$now = microtime(true);
+echo (abs($now - $as_float) < 1) ? "AGREE_OK\n" : "AGREE_FAIL\n";
+?>
+--EXPECT--
+SUBSEC_OK
+FORMAT_OK
+AGREE_OK
+--CLEAN--
+<?php
+unset($frac, $i, $t, $parts, $as_float, $now);


### PR DESCRIPTION
The float branch of both microtime(true) and gettimeofday(true) returned (double)tm_sec, computing tm_usec and then discarding it, so sub-second timing was useless on every platform. The non-__UNIXES__ path also faked microseconds as `tt % SX_USEC_PER_SEC`, leaving the ESP32 build (-DOS_OTHER) with no real sub-second clock. And microtime()'s string form printed raw integer microseconds ("506671 ...") instead of PHP's fractional-seconds "0.50667100 ...".

Fixes:
- Float branch now returns sec + usec/1e6.
- microtime() string is PHP-exact "0.dddddddd sec".
- A shared DateNow() helper centralises "now", consulting an optional embedder clock first, then gettimeofday() on Unix / time() (usec=0) elsewhere.
- New engine-level config verb PH7_CONFIG_CLOCK (ph7.h) installs the hook (ph7_clock: fill epoch sec + usec, return PH7_OK). Stored on ph7_conf, reached from builtins via pCtx->pVm->pEngine; NULL restores the default; inherited by VMs, mirroring PH7_CONFIG_MAX_ALLOC.

This lets embedders (the ESP32 port via esp_timer) supply time so standard microtime(true) works without re-registering PHP functions.

Byte-for-byte parity with PHP 8.5.7; full suite green under phl and php. Tests: function/microtime/microtime_subsecond.phpt, function/gettimeofday/gettimeofday_subsecond.phpt; the C hook is exercised by examples/ph7_clock_hook.c.
