### PR TITLE
Support true/false, standalone null, iterable & mixed types end-to-end

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -6243,9 +6243,17 @@ static sxi32 GenStateParseUnionTypeDecl(
 			}
 		}
 		if( !bHasNonNull && bExplicitNull ){
-			PH7_GenCompileError(pGen, E_ERROR, nLine,
-				"Null can not be used as a standalone type");
-			return SXERR_SYNTAX;
+			if( bShortNullable ){
+				/* `?null` is not a valid type — PHP rejects the shorthand. */
+				PH7_GenCompileError(pGen, E_ERROR, nLine,
+					"Null can not be used as a standalone type");
+				return SXERR_SYNTAX;
+			}
+			/* Bare `null` standalone type (PHP 8.2): represent it as the null
+			 * type flag so enforcement accepts only null. The single-type fast
+			 * path below leaves *pnType untouched when there is no non-null
+			 * atom, so set it here. */
+			*pnType = MEMOBJ_NULL;
 		}
 	}
 	/* Compute nullability flag */
@@ -6923,12 +6931,9 @@ static int GenStateIsDisallowedPropertyAtom(
 	if( n == 8 && SyMemcmpNoCase(z,"callable",8) == 0 ){
 		*pzName = "callable"; *pnName = 8; return 1;
 	}
-	if( n == 5 && SyMemcmpNoCase(z,"mixed",5) == 0 ){
-		*pzName = "mixed"; *pnName = 5; return 1;
-	}
-	if( n == 8 && SyMemcmpNoCase(z,"iterable",8) == 0 ){
-		*pzName = "iterable"; *pnName = 8; return 1;
-	}
+	/* `mixed` (any value) and `iterable` (= array|Traversable) are valid PHP
+	 * property types, enforced by value in VmEnforcePropertyTypeOnStore via
+	 * VmCheckPseudoType. Only `callable` stays disallowed (as in PHP). */
 	return 0;
 }
 

--- a/src/ph7/memobj.c
+++ b/src/ph7/memobj.c
@@ -599,6 +599,13 @@ PH7_PRIVATE ProcMemObjCast PH7_MemObjCastMethod(sxi32 iFlags)
 		return PH7_MemObjToHashmap;
 	}else if( iFlags & MEMOBJ_OBJ ){
 		return PH7_MemObjToObject;
+	}else if( iFlags & MEMOBJ_NULL ){
+		/* `null` is a type, not a weak-coercion target: never silently cast a
+		 * value to null for a standalone `null` type hint. Return/property
+		 * enforcement reject a non-null value before reaching here; this guards
+		 * the parameter default-value path from quietly nulling a non-null
+		 * default. */
+		return 0;
 	}
 	/* NULL cast */
 	return PH7_MemObjToNull;

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -937,6 +937,7 @@ struct ph7_vm
 	ph7_class *pCountableClass;   /* Cached Countable interface pointer */
 	ph7_class *pStringableClass;  /* Cached Stringable interface pointer */
 	ph7_class *pJsonSerializableClass; /* Cached JsonSerializable interface pointer */
+	ph7_class *pTraversableClass; /* Cached Traversable interface pointer (iterable type check) */
 	/* Pending null-coalesce-assign target on an ArrayAccess subscript.
 	 * Set by LOAD_IDX iP2=3 when the key is missing on an ArrayAccess
 	 * object; consumed by NULLC_STORE so it can dispatch to offsetSet

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -1673,6 +1673,7 @@ PH7_PRIVATE sxi32 PH7_VmInit(
 	pVm->pCountableClass   = PH7_VmExtractClass(pVm,"Countable",sizeof("Countable")-1,0,0);
 	pVm->pStringableClass  = PH7_VmExtractClass(pVm,"Stringable",sizeof("Stringable")-1,0,0);
 	pVm->pJsonSerializableClass = PH7_VmExtractClass(pVm,"JsonSerializable",sizeof("JsonSerializable")-1,0,0);
+	pVm->pTraversableClass = PH7_VmExtractClass(pVm,"Traversable",sizeof("Traversable")-1,0,0);
 	/* Initialize null-coalesce-assign scratch slot */
 	pVm->pCoalesceObj = 0;
 	pVm->bCoalesceArmed = 0;
@@ -3275,6 +3276,45 @@ static int VmStringNumericKind(ph7_value *pValue)
 }
 
 /*
+ * Check a value against a "pseudo-type" stored as an SXU32_HIGH class-name atom.
+ * PH7 parses `true`/`false`/`iterable`/`mixed` as class-name atoms (they are not
+ * scalar keywords), so without this every enforcement site — return, parameter,
+ * property, union alternative — would have to string-match the name itself.
+ * Centralising it here keeps the four sites consistent and is the single place
+ * to extend when another literal/pseudo type is added.
+ *   returns  1 : recognised pseudo-type AND the value satisfies it
+ *            0 : recognised pseudo-type AND the value does NOT satisfy it
+ *           -1 : not a pseudo-type (caller should treat sClass as a real class)
+ */
+static int VmCheckPseudoType(ph7_vm *pVm, ph7_value *pValue, const SyString *pClass)
+{
+	const char *z = pClass->zString;
+	sxu32 n = pClass->nByte;
+	if( n == 5 && SyStrnicmp(z,"mixed",5) == 0 ){
+		return 1; /* `mixed` accepts any value, including null */
+	}
+	if( n == 4 && SyStrnicmp(z,"true",4) == 0 ){
+		return ( (pValue->iFlags & MEMOBJ_BOOL) && pValue->x.iVal != 0 ) ? 1 : 0;
+	}
+	if( n == 5 && SyStrnicmp(z,"false",5) == 0 ){
+		return ( (pValue->iFlags & MEMOBJ_BOOL) && pValue->x.iVal == 0 ) ? 1 : 0;
+	}
+	if( n == 8 && SyStrnicmp(z,"iterable",8) == 0 ){
+		/* iterable === array | Traversable */
+		if( pValue->iFlags & MEMOBJ_HASHMAP ){
+			return 1;
+		}
+		if( (pValue->iFlags & MEMOBJ_OBJ) && pVm->pTraversableClass ){
+			ph7_class_instance *pInst = (ph7_class_instance *)pValue->x.pOther;
+			if( PH7_VmInstanceOf(pInst->pClass,pVm->pTraversableClass) ){
+				return 1;
+			}
+		}
+		return 0;
+	}
+	return -1;
+}
+/*
  * Try to coerce *pValue* to fit one of the alternatives in *pAlts*. When
  * *bStrict* is zero this applies PHP 8 weak-mode union semantics (permissive
  * scalar coercion). When bStrict is non-zero, only exact type matches are
@@ -3297,6 +3337,16 @@ static sxi32 VmCoerceToUnion(ph7_vm *pVm, ph7_value *pValue, SySet *pAlts, int b
 		return bNullable ? SXRET_OK : SXERR_INVALID;
 	}
 	aAlts = (ph7_type_alt *)SySetBasePtr(pAlts);
+	/* Pseudo-type alternatives (true/false/iterable; `mixed` never unions) are
+	 * stored as SXU32_HIGH name atoms and need value-checking, not instanceof.
+	 * A match on any one accepts the value (handles e.g. `true|int`, `?true`,
+	 * `iterable|Foo`). */
+	for( i = 0; i < SySetUsed(pAlts); i++ ){
+		if( aAlts[i].nType == SXU32_HIGH
+		 && VmCheckPseudoType(pVm, pValue, &aAlts[i].sClass) == 1 ){
+			return SXRET_OK;
+		}
+	}
 	bHasArray = bHasObjAlt = bHasClassAlt = 0;
 	bHasInt = bHasFloat = bHasString = bHasBool = 0;
 	for( i = 0; i < SySetUsed(pAlts); i++ ){
@@ -3421,6 +3471,14 @@ static sxi32 VmCoerceToUnion(ph7_vm *pVm, ph7_value *pValue, SySet *pAlts, int b
  */
 static sxi32 VmEnforceScalarType(ph7_value *pVal, sxu32 nType, int bStrict)
 {
+	/* A standalone `null` type is not a weak-coercion target: only an actual
+	 * null value satisfies it (and a null value matches via the flag test
+	 * before this is ever called, so pVal is non-null here). Reject rather than
+	 * casting the value to null — otherwise a `null`-typed parameter would
+	 * silently swallow any argument. */
+	if( nType == MEMOBJ_NULL ){
+		return SXERR_INVALID;
+	}
 	if( bStrict ){
 		/* Only int -> float widening is allowed implicitly. */
 		if( nType == MEMOBJ_REAL && (pVal->iFlags & MEMOBJ_INT) ){
@@ -3511,13 +3569,22 @@ static sxi32 VmEnforcePropertyTypeOnStore(ph7_vm *pVm,sxu32 nIdx,ph7_value *pVal
 		}
 		return VmThrowPropertyTypeError(pVm,pVmAttr,ph7_type_name(pValue));
 	}
-	/* NULL handling: allowed only if the type is nullable. */
+	/* NULL handling: allowed if the type is nullable, or is `mixed` (which
+	 * includes null). */
 	if( pValue->iFlags & MEMOBJ_NULL ){
-		if( pAttr->iFlags & PH7_CLASS_ATTR_NULLABLE ){
+		if( (pAttr->iFlags & PH7_CLASS_ATTR_NULLABLE)
+		 || (pAttr->nType == SXU32_HIGH && pAttr->sClass.nByte == 5
+		     && SyStrnicmp(pAttr->sClass.zString,"mixed",5) == 0) ){
 			pVmAttr->iState &= ~VM_CLASS_ATTR_UNINIT;
 			return SXRET_OK;
 		}
 		return VmThrowPropertyTypeError(pVm,pVmAttr,"null");
+	}
+	/* standalone `null` property type (PHP 8.2): a null value was already
+	 * accepted by the nullable check above, so any non-null value here is a
+	 * type error. */
+	if( pAttr->nType == MEMOBJ_NULL ){
+		return VmThrowPropertyTypeError(pVm,pVmAttr,ph7_type_name(pValue));
 	}
 	/* Bare 'object' type hint: accept any class instance, reject non-objects.
 	 * Must be checked before the generic scalar branch since MEMOBJ_OBJ is
@@ -3528,6 +3595,22 @@ static sxi32 VmEnforcePropertyTypeOnStore(ph7_vm *pVm,sxu32 nIdx,ph7_value *pVal
 			return SXRET_OK;
 		}
 		return VmThrowPropertyTypeError(pVm,pVmAttr,ph7_type_name(pValue));
+	}
+	/* Pseudo-types stored as class-name atoms: `iterable` (array|Traversable),
+	 * `true`/`false` (matching bool), `mixed` (any value — its null case is
+	 * handled by the nullable check above). Checked by value before the generic
+	 * class-instanceof branch, which would resolve no such class and then
+	 * wrongly accept any object / reject arrays. */
+	if( pAttr->nType == SXU32_HIGH ){
+		int rcPseudo = VmCheckPseudoType(pVm, pValue, &pAttr->sClass);
+		if( rcPseudo == 1 ){
+			pVmAttr->iState &= ~VM_CLASS_ATTR_UNINIT;
+			return SXRET_OK;
+		}
+		if( rcPseudo == 0 ){
+			return VmThrowPropertyTypeError(pVm,pVmAttr,ph7_type_name(pValue));
+		}
+		/* rcPseudo == -1: real class — fall through to the instanceof branch. */
 	}
 	if( pAttr->nType == SXU32_HIGH ){
 		/* Class / interface type. Resolve self/parent relative to the class
@@ -3836,14 +3919,30 @@ static sxi32 VmEnforceReturnType(ph7_vm *pVm, ph7_vm_func *pFunc, ph7_value *pVa
 		}
 		return VmThrowTypeErrorForReturn(pVm,&pFunc->sName,zExpected,"null");
 	}
-	/* `mixed` accepts any explicitly returned value, including null. It is
-	 * parsed as a class-name atom (SXU32_HIGH, sReturnClass = "mixed") since
-	 * it is not a scalar keyword, so short-circuit it here before the null /
-	 * class-type checks below — which would otherwise demand an object. */
-	if( pFunc->nReturnType == SXU32_HIGH
-	 && pFunc->sReturnClass.nByte == 5
-	 && SyStrnicmp(pFunc->sReturnClass.zString,"mixed",5) == 0 ){
-		return SXRET_OK;
+	/* standalone `null` return type (PHP 8.2): an explicit non-null return is a
+	 * TypeError. (Falling off the end is handled by the generic check above,
+	 * matching how every other typed return reports a missing value.) */
+	if( pFunc->nReturnType == MEMOBJ_NULL ){
+		if( pValue->iFlags & MEMOBJ_NULL ){
+			return SXRET_OK;
+		}
+		return VmThrowTypeErrorForReturn(pVm,&pFunc->sName,"null",
+			VmValueGivenName(pValue,zBuf,sizeof(zBuf)));
+	}
+	/* Pseudo-types parsed as class-name atoms: `mixed` (any value),
+	 * `true`/`false` (the matching bool literal), `iterable` (array|Traversable).
+	 * Check by value before the real-class instanceof branch below. */
+	if( pFunc->nReturnType == SXU32_HIGH ){
+		int rcPseudo = VmCheckPseudoType(pVm, pValue, &pFunc->sReturnClass);
+		if( rcPseudo == 1 ){
+			return SXRET_OK;
+		}
+		if( rcPseudo == 0 ){
+			return VmThrowTypeErrorForReturn(pVm,&pFunc->sName,
+				VmSyStringToCStr(&pFunc->sReturnClass,zTypeBuf,sizeof(zTypeBuf)),
+				VmValueGivenName(pValue,zBuf,sizeof(zBuf)));
+		}
+		/* rcPseudo == -1: a real class — fall through to the instanceof branch. */
 	}
 	/* Union return type — delegate. The function has no flag for nullable
 	 * unions; a null alternative is represented inside aReturnUnion, so pass
@@ -9300,7 +9399,25 @@ case PH7_OP_CALL: {
 						/* Scalar/class type checking */
 						if( aFormalArg[n].nType == SXU32_HIGH ){
 							SyString *pName = &aFormalArg[n].sClass;
-							ph7_class *pClass = PH7_VmExtractClass(&(*pVm),pName->zString,pName->nByte,TRUE,0);
+							ph7_class *pClass;
+							int rcPseudo = VmCheckPseudoType(&(*pVm),pVal,pName);
+							if( rcPseudo == 0 ){
+								/* Recognised pseudo-type (true/false/iterable); value mismatches */
+								char zTypeBuf[128],zGivenBuf[128];
+								rc = VmThrowTypeErrorForArg(&(*pVm),&pVmFunc->sName,n+1,
+									&aFormalArg[n].sName,
+									VmSyStringToCStr(pName,zTypeBuf,sizeof(zTypeBuf)),
+									VmValueGivenName(pVal,zGivenBuf,sizeof(zGivenBuf)));
+								if( rc == PH7_ABORT ) goto Abort;
+								SyMemBackendFree(&pVm->sAllocator, aSlot);
+								PH7_MemObjRelease(pTos);
+								pTos = &pTos[-nCallArgs];
+								pFrameStack = 0;
+								rc = PH7_EXCEPTION;
+								goto SkipFuncBody;
+							}
+							/* rcPseudo==1 -> matched pseudo-type (accept); -1 -> real class */
+							pClass = (rcPseudo == 1) ? 0 : PH7_VmExtractClass(&(*pVm),pName->zString,pName->nByte,TRUE,0);
 							if( pClass ){
 								if( (pVal->iFlags & MEMOBJ_OBJ) == 0 ){
 									if( (pVal->iFlags & MEMOBJ_NULL) == 0 ){
@@ -9608,8 +9725,23 @@ case PH7_OP_CALL: {
 						/* Argument must be a class instance [i.e: object] */
 						SyString *pName = &aFormalArg[n].sClass;
 						ph7_class *pClass;
-						/* Try to extract the desired class */
-						pClass = PH7_VmExtractClass(&(*pVm),pName->zString,pName->nByte,TRUE,0);
+						int rcPseudo = VmCheckPseudoType(&(*pVm),pArg,pName);
+						if( rcPseudo == 0 ){
+							/* Recognised pseudo-type (true/false/iterable); value mismatches */
+							char zTypeBuf[128],zGivenBuf[128];
+							rc = VmThrowTypeErrorForArg(&(*pVm),&pVmFunc->sName,n+1,
+								&aFormalArg[n].sName,
+								VmSyStringToCStr(pName,zTypeBuf,sizeof(zTypeBuf)),
+								VmValueGivenName(pArg,zGivenBuf,sizeof(zGivenBuf)));
+							if( rc == PH7_ABORT ) goto Abort;
+							PH7_MemObjRelease(pTos);
+							pTos = &pTos[-nCallArgs];
+							pFrameStack = 0;
+							rc = PH7_EXCEPTION;
+							goto SkipFuncBody;
+						}
+						/* Try to extract the desired class (rcPseudo==1 accepts; -1 real class) */
+						pClass = (rcPseudo == 1) ? 0 : PH7_VmExtractClass(&(*pVm),pName->zString,pName->nByte,TRUE,0);
 						if( pClass ){
 							if( (pArg->iFlags & MEMOBJ_OBJ) == 0 ){
 								if( (pArg->iFlags & MEMOBJ_NULL) == 0 ){

--- a/tests/ph7/001-smoke/lang/null_param_reject.phpt
+++ b/tests/ph7/001-smoke/lang/null_param_reject.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+null parameter type accepts null and rejects a non-null arg without coercion (PHP 8.2)
+--FILE--
+<?php
+function npTakesNull(null $x) { return $x; }
+echo npTakesNull(null) === null ? "null_ok\n" : "null_fail\n";
+// A non-null arg must be a TypeError, NOT silently coerced to null.
+try { npTakesNull(5); echo "not_rejected\n"; }
+catch (TypeError $e) { echo "int_rejected\n"; }
+?>
+--EXPECT--
+null_ok
+int_rejected
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/param_literal_pseudo_types.phpt
+++ b/tests/ph7/001-smoke/lang/param_literal_pseudo_types.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+true/iterable parameter types are enforced by value (PHP 8.2 / 7.4)
+--FILE--
+<?php
+function plpTrue(true $x) { return $x; }
+function plpIter(iterable $x) { return is_array($x) ? "arr" : "trav"; }
+echo plpTrue(true) === true ? "true_ok\n" : "true_fail\n";
+try { plpTrue(false); } catch (TypeError $e) { echo "false_rejected\n"; }
+echo plpIter([1]), "\n";
+try { plpIter(5); } catch (TypeError $e) { echo "int_rejected\n"; }
+?>
+--EXPECT--
+true_ok
+false_rejected
+arr
+int_rejected
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/return_type_iterable.phpt
+++ b/tests/ph7/001-smoke/lang/return_type_iterable.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+iterable return type accepts array and Traversable, rejects others (PHP 7.4)
+--FILE--
+<?php
+function rtiArr(): iterable { return [1, 2]; }
+function rtiGen(): iterable { return (function () { yield 1; })(); }
+function rtiBad(): iterable { return 5; }
+echo is_array(rtiArr()) ? "arr_ok\n" : "arr_fail\n";
+echo (rtiGen() instanceof Traversable) ? "gen_ok\n" : "gen_fail\n";
+try { rtiBad(); } catch (TypeError $e) { echo "bad_rejected\n"; }
+?>
+--EXPECT--
+arr_ok
+gen_ok
+bad_rejected
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/return_type_literal_reject.phpt
+++ b/tests/ph7/001-smoke/lang/return_type_literal_reject.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+true/null return types reject a wrong value with a catchable TypeError (PHP 8.2)
+--FILE--
+<?php
+function rtRejTrue(): true { return false; }
+function rtRejNull(): null { return 1; }
+try { rtRejTrue(); } catch (TypeError $e) { echo $e->getMessage(), "\n"; }
+try { rtRejNull(); } catch (TypeError $e) { echo $e->getMessage(), "\n"; }
+?>
+--EXPECT--
+rtRejTrue(): Return value must be of type true, false returned
+rtRejNull(): Return value must be of type null, int returned
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/return_type_null.phpt
+++ b/tests/ph7/001-smoke/lang/return_type_null.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+null standalone return type accepts an explicit null return (PHP 8.2)
+--FILE--
+<?php
+function rtLitNullOk(): null { return null; }
+echo rtLitNullOk() === null ? "null_ok\n" : "null_fail\n";
+?>
+--EXPECT--
+null_ok
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/return_type_true_false.phpt
+++ b/tests/ph7/001-smoke/lang/return_type_true_false.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+true/false literal return types accept the matching boolean (PHP 8.2)
+--FILE--
+<?php
+function rtLitTrue(): true { return true; }
+function rtLitFalse(): false { return false; }
+echo rtLitTrue() === true ? "true_ok\n" : "true_fail\n";
+echo rtLitFalse() === false ? "false_ok\n" : "false_fail\n";
+?>
+--EXPECT--
+true_ok
+false_ok
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/union_literal_pseudo_types.phpt
+++ b/tests/ph7/001-smoke/lang/union_literal_pseudo_types.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+true/false in unions and ?true resolve by value, not as a class (PHP 8.2)
+--FILE--
+<?php
+function ulpTI(true|int $x) { return $x; }
+function ulpQT(?true $x) { return $x; }
+echo ulpTI(true) === true ? "ti_true_ok\n" : "ti_true_fail\n";
+echo ulpTI(5) === 5 ? "ti_int_ok\n" : "ti_int_fail\n";
+echo ulpQT(null) === null ? "qt_null_ok\n" : "qt_null_fail\n";
+echo ulpQT(true) === true ? "qt_true_ok\n" : "qt_true_fail\n";
+?>
+--EXPECT--
+ti_true_ok
+ti_int_ok
+qt_null_ok
+qt_true_ok
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/oo/typed_property_iterable.phpt
+++ b/tests/ph7/001-smoke/oo/typed_property_iterable.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+iterable property type accepts array and Traversable, rejects other types (PHP 7.4)
+--FILE--
+<?php
+class IterablePropHolder { public iterable $x = []; }
+$ip = new IterablePropHolder();
+$ip->x = [1, 2];
+echo is_array($ip->x) ? "arr_ok\n" : "arr_fail\n";
+$ip->x = (function () { yield 1; })();   // a Generator is Traversable
+echo ($ip->x instanceof Traversable) ? "trav_ok\n" : "trav_fail\n";
+try { $ip->x = 5; } catch (TypeError $e) { echo "int_rejected\n"; }
+?>
+--EXPECT--
+arr_ok
+trav_ok
+int_rejected
+--CLEAN--
+<?php
+unset($ip);

--- a/tests/ph7/001-smoke/oo/typed_property_mixed.phpt
+++ b/tests/ph7/001-smoke/oo/typed_property_mixed.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+mixed property type accepts any value, including null (PHP 8.0)
+--FILE--
+<?php
+class MixedPropHolder { public mixed $m = 0; }
+$mp = new MixedPropHolder();
+$mp->m = 5;    echo is_int($mp->m) ? "int_ok\n" : "int_fail\n";
+$mp->m = "s";  echo is_string($mp->m) ? "str_ok\n" : "str_fail\n";
+$mp->m = null; echo ($mp->m === null) ? "null_ok\n" : "null_fail\n";
+$mp->m = [1];  echo is_array($mp->m) ? "arr_ok\n" : "arr_fail\n";
+?>
+--EXPECT--
+int_ok
+str_ok
+null_ok
+arr_ok
+--CLEAN--
+<?php
+unset($mp);


### PR DESCRIPTION
Close a cluster of PHP-8.2/7.4 type-system gaps, enforcing each consistently across every site: function return, parameters, typed properties, and unions.

Bugs fixed:
- true/false return enforcement was broken: `function f(): true { return true; }` threw "must be of type true, bool returned". true/false aren't scalar keywords, so the parser stores them (like mixed/iterable) as class-name atoms (SXU32_HIGH) and enforcement routed them through the class-instanceof branch instead of checking the boolean value.
- standalone `null` was rejected at compile time ("Null can not be used as a standalone type"); `?null` is still rejected as PHP does.
- a standalone-null parameter silently coerced a non-null argument to null (data corruption): VmEnforceScalarType's weak branch cast it via PH7_MemObjCastMethod(MEMOBJ_NULL) -> PH7_MemObjToNull.
- iterable was rejected as a property type, and accepted ANY object as a return/parameter type; mixed was rejected as a property type; true/false in a union or `?true` mis-resolved as a class.

Implementation:
- New VmCheckPseudoType(pVm, value, name) helper centralises the check for the pseudo-types stored as SXU32_HIGH name atoms: mixed = any value, true/false = the matching bool literal, iterable = array|Traversable (via a cached pVm->pTraversableClass, added alongside the other built-in interface pointers). Returns match / no-match / not-a-pseudo-type.
- Wired into all four enforcement sites: VmEnforceReturnType, VmEnforcePropertyTypeOnStore, both parameter-binding paths, and VmCoerceToUnion — replacing the scattered inline mixed/true/false branches.
- compile.c: bare `null` now parses as MEMOBJ_NULL (GenStateParseUnionTypeDecl) and is enforced null-only on returns/properties; mixed and iterable removed from GenStateIsDisallowedPropertyAtom (only callable stays disallowed).
- VmEnforceScalarType rejects MEMOBJ_NULL and PH7_MemObjCastMethod returns no cast for it, so a null type never silently swallows a value.

Files: src/ph7/vm.c, src/ph7/compile.c, src/ph7/ph7int.h, src/ph7/memobj.c. Byte-for-byte parity with PHP 8.5.7; make test (2111 smoke + 683 integration), test-compat and test-stress all green. Regression: lang/return_type_{true_false,null,literal_reject,iterable}.phpt, lang/{null_param_reject,param_literal_pseudo_types,union_literal_pseudo_types}.phpt, oo/typed_property_{iterable,mixed}.phpt.

Remaining (cosmetic, tracked under the future error-message-fidelity audit): an iterable TypeError shows "iterable" where PHP renders the expanded "Traversable|array".
