### PR TITLE
Add iterator_to_array/count/apply and Traversable spread

### DIFF
--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -7412,9 +7412,153 @@ static int ph7_hashmap_all(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	return PH7_OK;
 }
 /*
+ * The iterator_*() family — walk a Traversable via the shared PH7_VmIteratorWalk
+ * helper (the reusable form of the foreach Iterator protocol).
+ */
+/* Step shared by iterator_to_array (pArray set) and iterator_count (pArray NULL). */
+struct IterCollect { ph7_value *pArray; int bPreserve; sxi64 nCount; };
+static sxi32 IterCollectStep(ph7_vm *pVm, ph7_value *pKey, ph7_value *pValue, void *pUserData)
+{
+	struct IterCollect *p = (struct IterCollect *)pUserData;
+	(void)pVm;
+	p->nCount++;
+	if( p->pArray ){
+		/* preserve_keys: insert with the iterator key (later wins on collision);
+		 * otherwise append with an auto-assigned int index. */
+		ph7_array_add_elem(p->pArray, p->bPreserve ? pKey : 0, pValue);
+	}
+	return SXRET_OK;
+}
+/*
+ * array iterator_to_array(Traversable|array $iterator, bool $preserve_keys = true)
+ */
+static int ph7_iterator_to_array(ph7_context *pCtx, int nArg, ph7_value **apArg)
+{
+	struct IterCollect sCol;
+	ph7_value *pArray;
+	sxi32 rc;
+	if( nArg < 1 ){ ph7_result_null(pCtx); return PH7_OK; }
+	pArray = ph7_context_new_array(pCtx);
+	if( pArray == 0 ){ ph7_result_null(pCtx); return PH7_OK; }
+	sCol.pArray = pArray;
+	sCol.bPreserve = (nArg > 1) ? ph7_value_to_bool(apArg[1]) : 1;
+	sCol.nCount = 0;
+	if( ph7_value_is_array(apArg[0]) ){
+		/* PHP 8.2 accepts a plain array: copy it (preserving or renumbering keys). */
+		ph7_hashmap *pMap = (ph7_hashmap *)apArg[0]->x.pOther;
+		ph7_hashmap_node *pEntry = pMap->pFirst;
+		sxu32 n;
+		for( n = 0 ; n < pMap->nEntry ; n++ ){
+			ph7_value sKey, *pVal;
+			PH7_MemObjInit(pCtx->pVm,&sKey);
+			PH7_HashmapExtractNodeKey(pEntry,&sKey);
+			pVal = (ph7_value *)SySetAt(&pCtx->pVm->aMemObj,pEntry->nValIdx);
+			if( pVal ){ ph7_array_add_elem(pArray, sCol.bPreserve ? &sKey : 0, pVal); }
+			PH7_MemObjRelease(&sKey);
+			pEntry = pEntry->pPrev;
+		}
+		ph7_result_value(pCtx,pArray);
+		return PH7_OK;
+	}
+	rc = PH7_VmIteratorWalk(pCtx->pVm, apArg[0], IterCollectStep, &sCol);
+	if( rc == PH7_EXCEPTION || rc == PH7_ABORT ){ return rc; }
+	if( rc == SXERR_NOTIMPLEMENTED ){
+		return PH7_VmThrowException(pCtx,"TypeError",
+			"iterator_to_array(): Argument #1 ($iterator) must be of type Traversable|array, %s given",
+			ph7_type_name(apArg[0]));
+	}
+	ph7_result_value(pCtx,pArray);
+	return PH7_OK;
+}
+/*
+ * int iterator_count(Traversable|array $iterator)
+ */
+static int ph7_iterator_count(ph7_context *pCtx, int nArg, ph7_value **apArg)
+{
+	struct IterCollect sCol;
+	sxi32 rc;
+	if( nArg < 1 ){ ph7_result_int(pCtx,0); return PH7_OK; }
+	if( ph7_value_is_array(apArg[0]) ){
+		ph7_result_int64(pCtx, (ph7_int64)((ph7_hashmap *)apArg[0]->x.pOther)->nEntry);
+		return PH7_OK;
+	}
+	sCol.pArray = 0; sCol.bPreserve = 0; sCol.nCount = 0;
+	rc = PH7_VmIteratorWalk(pCtx->pVm, apArg[0], IterCollectStep, &sCol);
+	if( rc == PH7_EXCEPTION || rc == PH7_ABORT ){ return rc; }
+	if( rc == SXERR_NOTIMPLEMENTED ){
+		return PH7_VmThrowException(pCtx,"TypeError",
+			"iterator_count(): Argument #1 ($iterator) must be of type Traversable|array, %s given",
+			ph7_type_name(apArg[0]));
+	}
+	ph7_result_int64(pCtx, sCol.nCount);
+	return PH7_OK;
+}
+/* iterator_apply step: call the fixed callback with $args each iteration. The
+ * arg pointers are resolved fresh per step because the iterator's own methods
+ * run user code between iterations and may reallocate the aMemObj pool. */
+struct IterApply { ph7_value *pCallback; ph7_value *pArgsArray; sxi64 nCount; };
+static sxi32 IterApplyStep(ph7_vm *pVm, ph7_value *pKey, ph7_value *pValue, void *pUserData)
+{
+	struct IterApply *p = (struct IterApply *)pUserData;
+	ph7_value sResult;
+	SySet aArg;
+	sxi32 rc;
+	int bContinue;
+	(void)pKey; (void)pValue; /* iterator_apply does NOT pass the element to the callback */
+	SySetInit(&aArg,&pVm->sAllocator,sizeof(ph7_value *));
+	if( p->pArgsArray && (p->pArgsArray->iFlags & MEMOBJ_HASHMAP) ){
+		ph7_hashmap *pMap = (ph7_hashmap *)p->pArgsArray->x.pOther;
+		ph7_hashmap_node *pEntry = pMap->pFirst;
+		sxu32 n;
+		for( n = 0 ; n < pMap->nEntry ; n++ ){
+			ph7_value *pVal = (ph7_value *)SySetAt(&pVm->aMemObj,pEntry->nValIdx);
+			if( pVal ){ SySetPut(&aArg,(const void *)&pVal); }
+			pEntry = pEntry->pPrev;
+		}
+	}
+	PH7_MemObjInit(pVm,&sResult);
+	rc = PH7_VmCallUserFunction(pVm, p->pCallback, (int)SySetUsed(&aArg),
+		(ph7_value **)SySetBasePtr(&aArg), &sResult);
+	SySetRelease(&aArg);
+	if( rc == PH7_EXCEPTION || rc == PH7_ABORT ){ PH7_MemObjRelease(&sResult); return rc; }
+	p->nCount++;
+	PH7_MemObjToBool(&sResult);
+	bContinue = (sResult.x.iVal != 0);
+	PH7_MemObjRelease(&sResult);
+	return bContinue ? SXRET_OK : SXERR_EOF; /* falsy return stops iteration */
+}
+/*
+ * int iterator_apply(Traversable $iterator, callable $callback, array $args = [])
+ */
+static int ph7_iterator_apply(ph7_context *pCtx, int nArg, ph7_value **apArg)
+{
+	struct IterApply sApp;
+	sxi32 rc;
+	if( nArg < 2 ){ ph7_result_int(pCtx,0); return PH7_OK; }
+	if( !ph7_value_is_callable(apArg[1]) ){
+		return PH7_VmThrowException(pCtx,"TypeError",
+			"iterator_apply(): Argument #2 ($callback) must be a valid callback");
+	}
+	sApp.pCallback = apArg[1];
+	sApp.pArgsArray = (nArg > 2 && ph7_value_is_array(apArg[2])) ? apArg[2] : 0;
+	sApp.nCount = 0;
+	rc = PH7_VmIteratorWalk(pCtx->pVm, apArg[0], IterApplyStep, &sApp);
+	if( rc == PH7_EXCEPTION || rc == PH7_ABORT ){ return rc; }
+	if( rc == SXERR_NOTIMPLEMENTED ){
+		return PH7_VmThrowException(pCtx,"TypeError",
+			"iterator_apply(): Argument #1 ($iterator) must be of type Traversable, %s given",
+			ph7_type_name(apArg[0]));
+	}
+	ph7_result_int64(pCtx, sApp.nCount);
+	return PH7_OK;
+}
+/*
  * Table of hashmap functions.
  */
 static const ph7_builtin_func aHashmapFunc[] = {
+	{"iterator_to_array",  ph7_iterator_to_array },
+	{"iterator_count",     ph7_iterator_count },
+	{"iterator_apply",     ph7_iterator_apply },
 	{"count",             ph7_hashmap_count },
 	{"sizeof",            ph7_hashmap_count },
 	{"array_key_exists",  ph7_hashmap_key_exists },

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1479,6 +1479,10 @@ PH7_PRIVATE sxu32 PH7_VmRandomNum(ph7_vm *pVm);
 PH7_PRIVATE sxi32 PH7_VmCallClassMethod(ph7_vm *pVm,ph7_class_instance *pThis,ph7_class_method *pMethod,
 	ph7_value *pResult,int nArg,ph7_value **apArg);
 PH7_PRIVATE sxi32 PH7_VmCallUserFunction(ph7_vm *pVm,ph7_value *pFunc,int nArg,ph7_value **apArg,ph7_value *pResult);
+/* Per-element callback for PH7_VmIteratorWalk: return SXRET_OK to continue,
+ * SXERR_EOF to stop early (not an error), or PH7_EXCEPTION/PH7_ABORT to propagate. */
+typedef sxi32 (*ProcIterStep)(ph7_vm *pVm,ph7_value *pKey,ph7_value *pValue,void *pUserData);
+PH7_PRIVATE sxi32 PH7_VmIteratorWalk(ph7_vm *pVm,ph7_value *pObj,ProcIterStep xStep,void *pUserData);
 PH7_PRIVATE sxi32 PH7_VmCallUserFunctionAp(ph7_vm *pVm,ph7_value *pFunc,ph7_value *pResult,...);
 PH7_PRIVATE sxi32 PH7_VmUnsetMemObj(ph7_vm *pVm,sxu32 nObjIdx,int bForce);
 PH7_PRIVATE void PH7_VmRandomString(ph7_vm *pVm,char *zBuf,int nLen);

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -4444,6 +4444,39 @@ static sxi32 VmResolveNamedArgs(
 	return SXRET_OK;
 }
 /*
+ * Is this value an object implementing Traversable (Iterator / IteratorAggregate
+ * / Generator)? Used by the spread sites to decide whether to unpack it.
+ */
+static int VmValueIsTraversable(ph7_vm *pVm, ph7_value *pVal)
+{
+	if( (pVal->iFlags & MEMOBJ_OBJ) == 0 || pVal->x.pOther == 0 || pVm->pTraversableClass == 0 ){
+		return 0;
+	}
+	return PH7_VmInstanceOf(((ph7_class_instance *)pVal->x.pOther)->pClass, pVm->pTraversableClass);
+}
+/*
+ * PH7_VmIteratorWalk step for array-literal Traversable spread `[...$it]`:
+ * merge each element with PHP 8.1 array-unpack key rules — string keys are
+ * preserved (later wins), integer keys are renumbered.
+ */
+static sxi32 VmSpreadMergeStep(ph7_vm *pVm, ph7_value *pKey, ph7_value *pValue, void *pUserData)
+{
+	ph7_hashmap *pMap = (ph7_hashmap *)pUserData;
+	(void)pVm;
+	PH7_HashmapInsert(pMap, (pKey->iFlags & MEMOBJ_STRING) ? pKey : 0 /* auto-index */, pValue);
+	return SXRET_OK;
+}
+/*
+ * PH7_VmIteratorWalk step for call-argument Traversable spread `f(...$it)`:
+ * collect values positionally (keys ignored) into a temp array.
+ */
+static sxi32 VmSpreadValuesStep(ph7_vm *pVm, ph7_value *pKey, ph7_value *pValue, void *pUserData)
+{
+	(void)pVm; (void)pKey;
+	PH7_HashmapInsert((ph7_hashmap *)pUserData, 0 /* auto-index */, pValue);
+	return SXRET_OK;
+}
+/*
  * Execute as much of a PH7 bytecode program as we can then return.
  *
  * [PH7_VmMakeReady()] must be called before this routine in order to
@@ -5132,6 +5165,14 @@ case PH7_OP_LOAD_MAP: {
 						VmErrorFormat(&(*pVm),PH7_CTX_ERR,
 							"Fatal, PH7 engine is running out of memory while spreading array at instruction #:%d",pc);
 						rcSpread = PH7_ABORT;
+						break;
+					}
+				}else if( VmValueIsTraversable(pVm,&pEntry[1]) ){
+					/* Traversable unpacking (PHP 8.1): walk it into the map using the
+					 * same key rules as array spread (string keys kept, int renumbered). */
+					sxi32 rcW = PH7_VmIteratorWalk(&(*pVm),&pEntry[1],VmSpreadMergeStep,pMap);
+					if( rcW == PH7_EXCEPTION || rcW == PH7_ABORT ){
+						rcSpread = rcW;
 						break;
 					}
 				}else{
@@ -7159,6 +7200,50 @@ case PH7_OP_SPREAD: {
 		goto Abort;
 	}
 #endif
+	/* Traversable argument unpacking f(...$it): materialize the iterator into a
+	 * temp array (positional values), then expand it onto the operand stack
+	 * like an array. Materialising first leaves the stack untouched until the
+	 * walk succeeds; values are deep-copied (PH7_MemObjStore) so the temp can
+	 * be freed immediately. */
+	if( VmValueIsTraversable(pVm,pTos) ){
+		ph7_hashmap *pTmpMap = PH7_NewHashmap(&(*pVm),0,0);
+		sxi32 rcW;
+		sxu32 nEnt;
+		if( pTmpMap == 0 ){ goto Abort; }
+		rcW = PH7_VmIteratorWalk(&(*pVm),pTos,VmSpreadValuesStep,pTmpMap);
+		if( rcW == PH7_EXCEPTION || rcW == PH7_ABORT ){
+			PH7_HashmapRelease(pTmpMap,TRUE);
+			if( rcW == PH7_ABORT ){ goto Abort; }
+			goto Exception;
+		}
+		nEnt = pTmpMap->nEntry;
+		if( nEnt == 0 ){
+			VmPopOperand(&pTos,1);
+			pVm->iSpreadExtra--;
+		}else if( pVm->iSpreadExtra + (sxi32)(nEnt - 1) >= VM_STACK_GUARD ){
+			VmErrorFormat(&(*pVm), PH7_CTX_ERR,
+				"Argument unpacking: cumulative expansion exceeds stack guard (%d)", VM_STACK_GUARD);
+		}else{
+			ph7_hashmap_node *pNodeT = pTmpMap->pFirst;
+			ph7_value *pElemT;
+			sxu32 iT;
+			pElemT = (ph7_value *)SySetAt(&pVm->aMemObj, pNodeT->nValIdx);
+			if( pElemT ){ PH7_MemObjStore(pElemT, pTos); }else{ PH7_MemObjRelease(pTos); }
+			pTos->nIdx = SXU32_HIGH;
+			pNodeT = pNodeT->pPrev;
+			for( iT = 1; iT < nEnt; iT++ ){
+				pTos++;
+				PH7_MemObjInit(pVm, pTos);
+				pTos->nIdx = SXU32_HIGH;
+				pElemT = (ph7_value *)SySetAt(&pVm->aMemObj, pNodeT->nValIdx);
+				if( pElemT ){ PH7_MemObjStore(pElemT, pTos); }
+				pNodeT = pNodeT->pPrev;
+			}
+			pVm->iSpreadExtra += (sxi32)(nEnt - 1);
+		}
+		PH7_HashmapRelease(pTmpMap,TRUE);
+		break;
+	}
 	if( pTos->iFlags & MEMOBJ_HASHMAP ){
 		ph7_hashmap *pMap = (ph7_hashmap *)pTos->x.pOther;
 		sxu32 nEntry = pMap->nEntry;
@@ -12061,6 +12146,113 @@ PH7_PRIVATE sxi32 PH7_VmCallClassMethod(
 	)
 {
 	return VmCallClassMethodWithMap(pVm,pThis,pMethod,pResult,nArg,apArg,0);
+}
+/*
+ * Helper for PH7_VmIteratorWalk: call a zero-arg Iterator method by name,
+ * returning its result. Returns the exec status so a method that throws
+ * (PH7_EXCEPTION) or aborts (PH7_ABORT) is propagated — unlike the foreach
+ * opcode, which discards it.
+ */
+static sxi32 VmIterCallMethod(ph7_vm *pVm,ph7_class_instance *pThis,const char *zName,sxu32 nLen,ph7_value *pResult)
+{
+	ph7_class_method *pMethod = PH7_ClassExtractMethod(pThis->pClass,zName,nLen);
+	if( pMethod == 0 ){
+		return SXRET_OK; /* missing method: treat as no-op (mirrors foreach leniency) */
+	}
+	return PH7_VmCallClassMethod(&(*pVm),pThis,pMethod,pResult,0,0);
+}
+/*
+ * Walk a Traversable (Iterator / IteratorAggregate / Generator), invoking xStep
+ * for each (key,value) pair. This is the reusable form of the Iterator protocol
+ * that the foreach opcode drives inline; it is consumed by iterator_to_array /
+ * iterator_count / iterator_apply and by Traversable spread.
+ *
+ * Returns:
+ *   SXRET_OK            walk completed (or xStep stopped early via SXERR_EOF)
+ *   SXERR_NOTIMPLEMENTED pObj is not a Traversable (caller raises a TypeError)
+ *   PH7_EXCEPTION       an iterator method or the step threw
+ *   PH7_ABORT           an iterator method or the step requested a VM halt
+ *
+ * pKey/pValue handed to xStep are owned by the walk (released after the step
+ * returns); xStep must copy what it needs.
+ */
+PH7_PRIVATE sxi32 PH7_VmIteratorWalk(ph7_vm *pVm,ph7_value *pObj,ProcIterStep xStep,void *pUserData)
+{
+	ph7_class_instance *pThis;        /* the live Iterator (after aggregate resolution) */
+	ph7_class_instance *pAggregate = 0;
+	ph7_class *pIteratorClass;
+	sxi32 rc = SXRET_OK;
+	if( (pObj->iFlags & MEMOBJ_OBJ) == 0 || pObj->x.pOther == 0 ){
+		return SXERR_NOTIMPLEMENTED;
+	}
+	pThis = (ph7_class_instance *)pObj->x.pOther;
+	pIteratorClass = PH7_VmExtractClass(&(*pVm),"Iterator",sizeof("Iterator")-1,FALSE,0);
+	if( pIteratorClass == 0 ){
+		return SXERR_NOTIMPLEMENTED;
+	}
+	if( PH7_VmInstanceOf(pThis->pClass,pIteratorClass) ){
+		pThis->iRef++; /* keep the iterator alive across the walk */
+	}else{
+		/* Maybe an IteratorAggregate: resolve its inner Iterator via getIterator() */
+		ph7_class *pAggClass = PH7_VmExtractClass(&(*pVm),"IteratorAggregate",sizeof("IteratorAggregate")-1,FALSE,0);
+		ph7_value sInner;
+		int bOk = 0;
+		if( pAggClass == 0 || !PH7_VmInstanceOf(pThis->pClass,pAggClass) ){
+			return SXERR_NOTIMPLEMENTED; /* not Traversable at all */
+		}
+		PH7_MemObjInit(&(*pVm),&sInner);
+		rc = VmIterCallMethod(pVm,pThis,"getIterator",sizeof("getIterator")-1,&sInner);
+		if( rc == PH7_EXCEPTION || rc == PH7_ABORT ){
+			PH7_MemObjRelease(&sInner);
+			return rc;
+		}
+		if( (sInner.iFlags & MEMOBJ_OBJ) && sInner.x.pOther ){
+			ph7_class_instance *pIter = (ph7_class_instance *)sInner.x.pOther;
+			if( PH7_VmInstanceOf(pIter->pClass,pIteratorClass) ){
+				pAggregate = pThis; pAggregate->iRef++; /* keep the aggregate alive */
+				pThis = pIter; pThis->iRef++;           /* survive release of sInner */
+				bOk = 1;
+			}
+		}
+		PH7_MemObjRelease(&sInner);
+		if( !bOk ){
+			/* getIterator() returned a non-Iterator: surface as not-a-Traversable */
+			return SXERR_NOTIMPLEMENTED;
+		}
+	}
+	/* Drive rewind / valid / current / key / step / next */
+	rc = VmIterCallMethod(pVm,pThis,"rewind",sizeof("rewind")-1,0);
+	if( rc == PH7_EXCEPTION || rc == PH7_ABORT ){ goto done; }
+	for(;;){
+		ph7_value sValid,sValue,sKey;
+		int isValid;
+		PH7_MemObjInit(&(*pVm),&sValid);
+		rc = VmIterCallMethod(pVm,pThis,"valid",sizeof("valid")-1,&sValid);
+		if( rc == PH7_EXCEPTION || rc == PH7_ABORT ){ PH7_MemObjRelease(&sValid); goto done; }
+		PH7_MemObjToBool(&sValid);
+		isValid = (sValid.x.iVal != 0);
+		PH7_MemObjRelease(&sValid);
+		if( !isValid ){ rc = SXRET_OK; break; }
+		PH7_MemObjInit(&(*pVm),&sValue);
+		rc = VmIterCallMethod(pVm,pThis,"current",sizeof("current")-1,&sValue);
+		if( rc == PH7_EXCEPTION || rc == PH7_ABORT ){ PH7_MemObjRelease(&sValue); goto done; }
+		PH7_MemObjInit(&(*pVm),&sKey);
+		rc = VmIterCallMethod(pVm,pThis,"key",sizeof("key")-1,&sKey);
+		if( rc == PH7_EXCEPTION || rc == PH7_ABORT ){ PH7_MemObjRelease(&sValue); PH7_MemObjRelease(&sKey); goto done; }
+		rc = xStep(&(*pVm),&sKey,&sValue,pUserData);
+		PH7_MemObjRelease(&sValue);
+		PH7_MemObjRelease(&sKey);
+		if( rc != SXRET_OK ){
+			if( rc == SXERR_EOF ){ rc = SXRET_OK; } /* early stop is success */
+			goto done;
+		}
+		rc = VmIterCallMethod(pVm,pThis,"next",sizeof("next")-1,0);
+		if( rc == PH7_EXCEPTION || rc == PH7_ABORT ){ goto done; }
+	}
+done:
+	PH7_ClassInstanceUnref(pThis);
+	if( pAggregate ){ PH7_ClassInstanceUnref(pAggregate); }
+	return rc;
 }
 /*
  * Dispatch a call to an object's __invoke magic method, forwarding arguments

--- a/tests/ph7/001-smoke/function/iterator_apply/iterator_apply.phpt
+++ b/tests/ph7/001-smoke/function/iterator_apply/iterator_apply.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+iterator_apply invokes the callback per element, stops on false, returns the count
+--FILE--
+<?php
+function iaGen() { yield 1; yield 2; yield 3; yield 4; }
+// Runs for every element (callback returns true) -> full count.
+echo iterator_apply(iaGen(), function () { return true; }), "\n";
+// Stops once the callback returns false (after the 3rd call).
+echo iterator_apply(iaGen(), function () { static $n = 0; $n++; return $n < 3; }), "\n";
+// The fixed $args are passed to the callback each iteration.
+echo iterator_apply(iaGen(), function ($step) { return $step === 10; }, [10]), "\n";
+?>
+--EXPECT--
+4
+3
+4
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/iterator_count/iterator_count.phpt
+++ b/tests/ph7/001-smoke/function/iterator_count/iterator_count.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+iterator_count over a Generator and an array
+--FILE--
+<?php
+function icGen() { yield 1; yield 2; yield 3; yield 4; }
+echo iterator_count(icGen()), "\n";
+echo iterator_count([10, 20, 30]), "\n";
+function icEmpty() { if (false) { yield 1; } }
+echo iterator_count(icEmpty()), "\n";
+?>
+--EXPECT--
+4
+3
+0
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/iterator_to_array/iterator_to_array.phpt
+++ b/tests/ph7/001-smoke/function/iterator_to_array/iterator_to_array.phpt
@@ -1,0 +1,38 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+iterator_to_array over Generator / Iterator / IteratorAggregate / array
+--FILE--
+<?php
+function itaGen() { yield "a" => 1; yield "b" => 2; }
+$r = iterator_to_array(itaGen());
+echo $r["a"], $r["b"], "\n";                       // preserve keys (default)
+echo implode(",", iterator_to_array(itaGen(), false)), "\n"; // renumber
+
+class ItaRange implements Iterator {
+    private $i = 0;
+    public function rewind(): void { $this->i = 0; }
+    public function valid(): bool { return $this->i < 3; }
+    public function current(): mixed { return $this->i * 10; }
+    public function key(): mixed { return $this->i; }
+    public function next(): void { $this->i++; }
+}
+echo implode(",", iterator_to_array(new ItaRange())), "\n";
+
+class ItaBag implements IteratorAggregate {
+    public function getIterator(): Iterator { return new ItaRange(); }
+}
+echo implode(",", iterator_to_array(new ItaBag())), "\n";
+
+echo implode(",", iterator_to_array([5, 6, 7])), "\n"; // array passthrough
+?>
+--EXPECT--
+12
+1,2
+0,10,20
+0,10,20
+5,6,7
+--CLEAN--
+<?php
+unset($r);

--- a/tests/ph7/001-smoke/function/iterator_to_array/iterator_to_array_throws.phpt
+++ b/tests/ph7/001-smoke/function/iterator_to_array/iterator_to_array_throws.phpt
@@ -1,0 +1,26 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+An exception thrown by an iterator method (or apply callback) propagates and is catchable
+--FILE--
+<?php
+class ItaThrower implements Iterator {
+    public function rewind(): void {}
+    public function valid(): bool { return true; }
+    public function current(): mixed { throw new RuntimeException("from current"); }
+    public function key(): mixed { return 0; }
+    public function next(): void {}
+}
+try { iterator_to_array(new ItaThrower()); }
+catch (RuntimeException $e) { echo "caught: ", $e->getMessage(), "\n"; }
+
+function itaOne() { yield 1; }
+try { iterator_apply(itaOne(), function () { throw new RuntimeException("from callback"); }); }
+catch (RuntimeException $e) { echo "caught: ", $e->getMessage(), "\n"; }
+?>
+--EXPECT--
+caught: from current
+caught: from callback
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/spread_traversable.phpt
+++ b/tests/ph7/001-smoke/lang/spread_traversable.phpt
@@ -1,0 +1,31 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Traversable spread: array-literal [...$it] and call-argument f(...$it)
+--FILE--
+<?php
+function spGen() { yield 1; yield 2; yield 3; }
+// Array-literal spread of a Traversable (int keys renumbered).
+echo implode(",", [0, ...spGen(), 9]), "\n";
+// String keys are preserved (PHP 8.1).
+function spKv() { yield "a" => 1; yield "b" => 2; }
+$kv = [...spKv()];
+echo $kv["a"], $kv["b"], "\n";
+// Call-argument spread of a Traversable held in a variable.
+function spSum(...$a) { return array_sum($a); }
+$g = spGen();
+echo spSum(...$g), "\n";
+// A non-Traversable object still raises the spread error.
+class SpPlain {}
+try { $x = [...new SpPlain()]; }
+catch (\Throwable $e) { echo get_class($e), "\n"; }
+?>
+--EXPECT--
+0,1,2,3,9
+12
+6
+TypeError
+--CLEAN--
+<?php
+unset($kv, $g);


### PR DESCRIPTION
Two related Tier-1 gaps shared one missing core: a reusable "walk a Traversable into values" routine. foreach drove the Iterator protocol inline but the logic was welded to the bytecode foreach-step state machine, so it couldn't be called from a builtin or the spread opcodes.

Added PH7_VmIteratorWalk(pVm, pObj, xStep, pUserData) (vm.c, decl in ph7int.h): resolves Iterator / IteratorAggregate(getIterator()) / Generator, drives rewind/valid/current/key/next, invokes a per-element step callback, and — unlike foreach — propagates PH7_EXCEPTION/PH7_ABORT thrown by an iterator method or the step (it checks the PH7_VmCallClassMethod return that foreach discards). It holds a ref on the iterator (and aggregate) across the walk so user code can't free it mid-iteration.

Consumers route through it:
- iterator_to_array(Traversable|array, bool $preserve_keys=true), iterator_count(...), iterator_apply(Traversable, callable, array $args=[]) — new builtins in hashmap.c (aHashmapFunc[]). iterator_apply re-resolves its $args each iteration (iterator methods run user code between calls and may realloc the aMemObj pool), stops on a falsy return, and propagates a throwing callback.
- Array-literal spread [...$it] (LOAD_MAP) and call-arg spread f(...$it) (OP_SPREAD): walk a Traversable into the merge / a materialized temp array (deep-copied via PH7_MemObjStore so the temp frees immediately). A new VmValueIsTraversable() helper centralises the "is this an unpackable object" check used by both spread sites. Non-Traversable objects still raise the catchable "Only arrays and Traversables can be unpacked" error.
