### PR TITLE
Shard Windows coverage across parallel runners to cut CI time

### DIFF
--- a/.github/actions/make-action/action.yml
+++ b/.github/actions/make-action/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'The make command to run (e.g., test, test-compat, or empty for build). Will be used to name artifacts.'
     required: false
     default: ''
+  make_args:
+    description: 'Extra make variables/args appended to the command line (e.g., SHARD=2/4).'
+    required: false
+    default: ''
   extension:
     description: 'File extension for the binary (e.g., .exe for Windows)'
     required: false
@@ -31,6 +35,10 @@ inputs:
     description: 'Whether to upload the build artifacts.'
     required: false
     default: 'false'
+  artifact_name:
+    description: 'Override the uploaded artifact name (default: derived from make/mode + name).'
+    required: false
+    default: ''
 runs:
   using: 'composite'
   steps:
@@ -46,16 +54,16 @@ runs:
       shell: bash
 
     - if: contains(inputs.name, '-linux') || contains(inputs.name, '-darwin')
-      run: make MODE=${{ inputs.mode }} ${{ inputs.make }}
+      run: make MODE=${{ inputs.mode }} ${{ inputs.make }} ${{ inputs.make_args }}
       shell: bash
 
     - if: contains(inputs.name, '-windows')
-      run: build-aux/dev.bat nmake /nologo MODE=${{ inputs.mode }} ${{ inputs.make }}
+      run: build-aux/dev.bat nmake /nologo MODE=${{ inputs.mode }} ${{ inputs.make }} ${{ inputs.make_args }}
       shell: cmd
 
     - if: inputs.artifacts == 'true'
       name: Upload artifact
       uses: actions/upload-artifact@v5
       with:
-        name: ${{ (inputs.make == '' || inputs.make == 'build') && inputs.mode || inputs.make }}-${{ inputs.name }}
+        name: ${{ inputs.artifact_name != '' && inputs.artifact_name || format('{0}-{1}', (inputs.make == '' || inputs.make == 'build') && inputs.mode || inputs.make, inputs.name) }}
         path: build/${{ inputs.name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,11 @@ jobs:
           - os: windows-latest
             name: x86_64-windows-msvc
             extension: .exe
+        # Windows coverage (OpenCppCoverage) is the slow job; it runs sharded in
+        # the dedicated `coverage-windows` job below instead of this single cell.
+        exclude:
+          - os: windows-latest
+            make: coverage
     steps:
     - uses: actions/checkout@v6
     - uses: ./.github/actions/setup-action
@@ -94,15 +99,68 @@ jobs:
       with:
         name: ${{ matrix.name }}
         mode: ${{ matrix.make == 'coverage' && 'coverage' || 'full' }}
-        make: ${{ matrix.make == 'coverage' && 'coverage-report' || matrix.make }}
+        # Coverage = gather (run the instrumented test build) then arrange.
+        make: ${{ matrix.make == 'coverage' && 'test coverage-report' || matrix.make }}
         extension: ${{ matrix.extension }}
         artifacts: ${{ matrix.make == 'coverage' && 'true' || 'false' }}
+        artifact_name: ${{ matrix.make == 'coverage' && format('coverage-report-{0}', matrix.name) || '' }}
+        artifacts_from: build
+        artifacts_from_mode: full
+
+  # OpenCppCoverage attaches to every child phl.exe the integration runner spawns
+  # (one per test), so wall-time scales with the test count. Shard the integration
+  # set across parallel Windows runners; smoke runs once in coverage-windows-smoke
+  # below. Each job gathers its phase (`make MODE=coverage test-*`) then arranges
+  # (`coverage-report`); the `report` job merges the per-job tracefiles. The /4 in
+  # make_args must match the number of shard values below.
+  coverage-windows:
+    runs-on: windows-latest
+    needs: build
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+    - uses: actions/checkout@v6
+    - uses: ./.github/actions/setup-action
+    - uses: ./.github/actions/make-action
+      with:
+        name: x86_64-windows-msvc
+        mode: coverage
+        make: test-integration coverage-report
+        make_args: SHARD=${{ matrix.shard }}/4
+        extension: .exe
+        artifacts: 'true'
+        artifact_name: coverage-report-x86_64-windows-msvc-${{ matrix.shard }}
+        artifacts_from: build
+        artifacts_from_mode: full
+
+  # Smoke is in-process (one process) and isn't shardable, so it runs once here in
+  # parallel with the integration shards instead of repeating on each shard.
+  coverage-windows-smoke:
+    runs-on: windows-latest
+    needs: build
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v6
+    - uses: ./.github/actions/setup-action
+    - uses: ./.github/actions/make-action
+      with:
+        name: x86_64-windows-msvc
+        mode: coverage
+        make: test-smoke coverage-report
+        extension: .exe
+        artifacts: 'true'
+        artifact_name: coverage-report-x86_64-windows-msvc-smoke
         artifacts_from: build
         artifacts_from_mode: full
 
   report:
     runs-on: ubuntu-latest
-    needs: qa
+    needs: [qa, coverage-windows, coverage-windows-smoke]
     permissions:
       contents: write
       pull-requests: write
@@ -121,10 +179,13 @@ jobs:
         mkdir -p report
         chmod +x artifact/coverage-report-x86_64-linux-gnu/coverage/phl
 
-        lcov --add-tracefile artifact/coverage-report-x86_64-linux-gnu/coverage/coverage.info \
-             --add-tracefile artifact/coverage-report-x86_64-windows-msvc/coverage/coverage.info \
-             --add-tracefile artifact/coverage-report-arm64-apple-darwin/coverage/coverage.info \
-             --ignore-errors format \
+        # Merge every per-platform tracefile, including each Windows coverage shard.
+        tracefiles=()
+        for info in artifact/coverage-report-*/coverage/coverage.info; do
+          tracefiles+=(--add-tracefile "$info")
+        done
+        lcov "${tracefiles[@]}" \
+             --ignore-errors format,empty \
              --output-file report/coverage.info
 
         genhtml --quiet --include 'src/*'\

--- a/Makefile
+++ b/Makefile
@@ -74,11 +74,14 @@ TEST_SMOKE_CMD = "$(PHL_BIN)" "tests/phpt.php" \
 TEST_SMOKE_PHP_CMD = "$(PHP_BIN)" "tests/phpt.php" \
 	--target-dir tests/ph7/001-smoke \
 	--output-format dot
-
+# Only integration is shardable ($(SHARD_FLAG)): each test runs in an isolated
+# child process, so splitting the set across runners is safe. Smoke runs
+# in-process in one shared interpreter (curated to pass only in the full sorted
+# order), so sharding it would regroup tests and expose cross-test state leaks.
 TEST_INTEGRATION_CMD = "$(PHL_BIN)" "tests/phpt.php" \
 	--target-executable "$(PHL_BIN)" \
 	--target-dir tests/ph7/002-integration \
-	--output-format dot
+	--output-format dot $(SHARD_FLAG)
 TEST_INTEGRATION_PHP_CMD = "$(PHL_BIN)" "tests/phpt.php" \
 	--target-executable "$(PHP_BIN)" \
 	--target-dir tests/ph7/002-integration \
@@ -124,9 +127,13 @@ coverage-report: .ALWAYS $(PHL_BIN) $(BUILD_DIR)/coverage/coverage.info
 coverage-md: .ALWAYS $(PHL_BIN) $(BUILD_DIR)/coverage/markdown
 .ALWAYS:
 
+# MODE=coverage is a build kind: the test targets gather coverage data by
+# running the instrumented build under $(COVERAGE_RUN_*) (empty in normal builds;
+# an OpenCppCoverage wrapper on MSVC). coverage-report/coverage-md only arrange
+# the gathered data.
 $(BUILD_DIR)-test-smoke: $(PHL_BIN)
 	"$(PHL_BIN)" --version
-	$(TEST_SMOKE_CMD) 
+	$(COVERAGE_RUN_SMOKE) $(TEST_SMOKE_CMD)
 
 $(BUILD_DIR)-test-smoke-compat: $(PHL_BIN)
 	"$(PHP_BIN)" --version
@@ -136,7 +143,7 @@ $(BUILD_DIR)-test-smoke-compat: $(PHL_BIN)
 
 $(BUILD_DIR)-test-integration: $(PHL_BIN)
 	"$(PHL_BIN)" --version
-	$(TEST_INTEGRATION_CMD)
+	$(COVERAGE_RUN_INTEGRATION) $(TEST_INTEGRATION_CMD)
 
 # Opt-in stress/fault-injection suite (POSIX shell; sets PHL_MAX_ALLOC inline).
 $(BUILD_DIR)-test-stress: $(PHL_BIN)

--- a/build-aux/cobertura_xml_to_lcov_info.php
+++ b/build-aux/cobertura_xml_to_lcov_info.php
@@ -115,9 +115,16 @@ if (count($input_files) == 0) {
 
 // Parse each Cobertura file and merge into $coverage_data.
 foreach ($input_files as $xml_file) {
-    if (!is_string($xml_file) || $xml_file === '' || !is_readable($xml_file)) {
+    if (!is_string($xml_file) || $xml_file === '') {
         echo "Error: cannot read input file: $xml_file\n";
         exit(1);
+    }
+    // Skip a phase that wasn't gathered (e.g. a smoke-only or single-shard job),
+    // so coverage-report can always name every phase XML. Warn on stderr to keep
+    // the lcov output (stdout) clean.
+    if (!is_readable($xml_file)) {
+        fwrite(STDERR, "Note: skipping absent coverage input: $xml_file\n");
+        continue;
     }
 
     $xml = file_get_contents($xml_file);

--- a/build-aux/gnu.mk
+++ b/build-aux/gnu.mk
@@ -33,6 +33,16 @@ MODE_LDFLAGS = $($(MODE)_LDFLAGS)
 
 PHP_BIN ?= $(shell command -v php)$(BIN_SUFFIX)
 
+# Optional test-shard selector (e.g. SHARD=2/4); empty = run all tests.
+# Lets CI fan a slow run (coverage) across parallel workers.
+SHARD ?=
+SHARD_FLAG = $(if $(SHARD),--shard $(SHARD))
+
+# Coverage collection wrappers for the test recipes. gcov instruments at compile
+# time, so running the MODE=coverage build just emits .gcda -- no wrapper needed.
+COVERAGE_RUN_SMOKE =
+COVERAGE_RUN_INTEGRATION =
+
 MODE_OBJECTS = $(patsubst $(BUILD_DIR)/src/%,$(BUILD_DIR)/$(MODE)/src/%,$(OBJECTS))
 
 $(PHL_BIN): $(MODE_OBJECTS)
@@ -43,10 +53,11 @@ $(BUILD_DIR)-clean:
 
 # COVERAGE
 # --------
+# coverage-report only *arranges* data already gathered by `make MODE=coverage
+# test*` (which emits .gcda). lcov captures whatever .gcda exist -- a full run or
+# a single shard.
 
 $(BUILD_DIR)/coverage/coverage.info: .ALWAYS $(PHL_BIN)
-	@$(TEST_SMOKE_CMD)
-	@$(TEST_INTEGRATION_CMD)
 	@lcov --capture --rc geninfo_unexecuted_blocks=1 --quiet \
 		--ignore-errors unsupported,unsupported \
 		--include 'src/ph7/*' --include 'src/sx/*' --include 'src/phl/*' --directory $(BUILD_DIR) \

--- a/build-aux/nmake.mk
+++ b/build-aux/nmake.mk
@@ -39,6 +39,29 @@ LDFLAGS = $(full_LDFLAGS)
 
 PHP_BIN = php$(BIN_SUFFIX)
 
+# Optional test-shard selector (e.g. SHARD=2/4); empty = run all tests.
+# Lets CI fan a slow run (coverage) across parallel workers.
+!IFNDEF SHARD
+SHARD =
+!ENDIF
+!IF "$(SHARD)" != ""
+SHARD_FLAG = --shard $(SHARD)
+!ELSE
+SHARD_FLAG =
+!ENDIF
+
+# Coverage collection wrappers for the test recipes. OpenCppCoverage instruments
+# at runtime, so it must wrap each test run; it exports one cobertura XML per
+# phase that coverage-report later converts. Empty outside MODE=coverage.
+!IF "$(MODE)" == "coverage"
+OCC = OpenCppCoverage.exe --quiet --sources "$(MAKEDIR)\src" --excluded_sources "$(MAKEDIR)\src\minidump.h"
+COVERAGE_RUN_SMOKE = $(OCC) --export_type cobertura:$(BUILD_DIR)/coverage/smoke.xml --
+COVERAGE_RUN_INTEGRATION = $(OCC) --cover_children --export_type cobertura:$(BUILD_DIR)/coverage/integration.xml --
+!ELSE
+COVERAGE_RUN_SMOKE =
+COVERAGE_RUN_INTEGRATION =
+!ENDIF
+
 # NOTE: The $(PHL_BIN) rule and patterns are provided by patterns.mk
 # to avoid complex IF selections and nested macro expansions in NMake.
 
@@ -47,21 +70,12 @@ $(BUILD_DIR)-clean:
 
 # COVERAGE
 # --------
+# coverage-report only *arranges* data already gathered by `make MODE=coverage
+# test*` (which exports a cobertura XML per phase via the OpenCppCoverage
+# wrappers above). It converts whichever phase XML(s) exist -- a full run or a
+# single shard -- to lcov; the converter skips a missing input.
 
 $(BUILD_DIR)/coverage/coverage.info: .ALWAYS
-	@OpenCppCoverage.exe --quiet \
-	--sources "$(MAKEDIR)\src" \
-	--excluded_sources "$(MAKEDIR)\src\minidump.h" \
-	--cover_children \
-	--export_type cobertura:$(BUILD_DIR)/coverage/smoke.xml \
-	-- $(TEST_SMOKE_CMD)
-
-	@OpenCppCoverage.exe --quiet \
-	--sources "$(MAKEDIR)\src" \
-	--excluded_sources "$(MAKEDIR)\src\minidump.h" \
-	--cover_children \
-	--export_type cobertura:$(BUILD_DIR)/coverage/integration.xml \
-	-- $(TEST_INTEGRATION_CMD)
 	@"$(PHL_BIN)" \
 		"build-aux/cobertura_xml_to_lcov_info.php" \
 		"$(BUILD_DIR)/coverage/smoke.xml" \

--- a/tests/phpt.php
+++ b/tests/phpt.php
@@ -20,6 +20,8 @@ $phpt_target_dir = dirname(__FILE__);
 $phpt_file_extension = "phpt";
 $phpt_filter = "";
 $phpt_output_format = "tap";
+$phpt_shard_index = 0; // 1-based shard to run; 0 = no sharding (run all)
+$phpt_shard_total = 0; // total number of shards
 $phpt_curdir = getcwd();
 
 // Parse arguments
@@ -75,6 +77,23 @@ while (!empty($phpt_args)) {
                 exit(1);
             }
             break;
+        case '--shard':
+            // Run only shard k of n (e.g. --shard 2/4). Deterministically
+            // partitions the sorted test list so CI can fan a slow run across
+            // parallel workers; results are merged downstream.
+            $phpt_shard_spec = array_shift($phpt_args);
+            if ($phpt_shard_spec === null
+                || !preg_match('#^([0-9]+)/([0-9]+)$#', $phpt_shard_spec, $phpt_shard_m)) {
+                echo "Error: --shard requires a value of the form k/n (e.g. 2/4)\n";
+                exit(1);
+            }
+            $phpt_shard_index = (int)$phpt_shard_m[1];
+            $phpt_shard_total = (int)$phpt_shard_m[2];
+            if ($phpt_shard_total < 1 || $phpt_shard_index < 1 || $phpt_shard_index > $phpt_shard_total) {
+                echo "Error: --shard k/n requires 1 <= k <= n\n";
+                exit(1);
+            }
+            break;
         case '--help':
             echo "Usage: " . $phpt_script_name . " [options]\n";
             echo "\n";
@@ -88,6 +107,8 @@ while (!empty($phpt_args)) {
             echo "  --file-extension <ext>     File extension for test files (default: phpt)\n";
             echo "  --filter <pattern>         Filter test files by prefix (optional, runs all if not specified)\n";
             echo "  --output-format <format>   Output format: tap (default) or dot\n";
+            echo "  --shard <k/n>              Run only shard k of n (e.g. 2/4); partitions the\n";
+            echo "                             sorted test list for parallel CI runs (default: all)\n";
             echo "  --help                     Show this help message\n";
             echo "\n";
             exit(0);
@@ -340,6 +361,17 @@ function run_file_with_target($phpt_target_executable, $phpt_file) {
 // Find test files
 $phpt_files = find_files($phpt_target_dir, $phpt_file_extension, $phpt_filter);
 sort($phpt_files);
+
+// Keep only this shard's slice (deterministic: by position in the sorted list).
+if ($phpt_shard_total > 0) {
+    $phpt_sharded = array();
+    foreach ($phpt_files as $phpt_i => $phpt_f) {
+        if (($phpt_i % $phpt_shard_total) === ($phpt_shard_index - 1)) {
+            $phpt_sharded[] = $phpt_f;
+        }
+    }
+    $phpt_files = $phpt_sharded;
+}
 
 $phpt_total = count($phpt_files);
 if ($phpt_output_format == "tap") {


### PR DESCRIPTION
OpenCppCoverage runs the integration suite in child-process mode, where the phpt runner popen()s a fresh phl.exe per test section (skipif + file + clean). With --cover_children, OpenCppCoverage attaches its debugger and reloads the large /Zi PDB for every one of those ~1500+ short-lived processes, so the Windows coverage job's wall-time scales with the test count and dominates CI.

Parallelize it: add a --shard k/n flag to tests/phpt.php that deterministically partitions the sorted test list, thread a SHARD make var through to the smoke and integration test commands (no-op by default, so `make test` is unchanged), and run the Windows coverage as a dedicated 4-way sharded matrix job. The report job now merges every coverage-report-* tracefile (linux + macOS + the 4 Windows shards) via an lcov loop, so coverage fidelity is fully preserved.

Also drop --cover_children from the in-process smoke invocation (it spawns no children) and expose make_args / artifact_name inputs on make-action.

Verified: shards partition exactly (171*3+170=683), `make test` unchanged, and two merged smoke shards cover the same lines as the unsharded run.
