### PR TITLE
Make catch blocks share the enclosing variable scope

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -14426,13 +14426,29 @@ static sxi32 VmThrowException(
 				SySetReset(&pVm->aException);
 			}
 		}
-		/* Create a private frame first */
+		/* Create the catch frame (made transparent below) */
 		rc = VmEnterFrame(&(*pVm),0,0,&pFrame);
 		if( rc == SXRET_OK ){
-			ph7_value *pObj = VmExtractMemObj(&(*pVm),&pCatch->sThis,FALSE,TRUE);
-			pFrame->iFlags |= VM_FRAME_CATCH;
+			ph7_value *pObj;
+			/* Transparent wrapper: the catch body shares the enclosing variable
+			 * scope (PHP semantics). VM_FRAME_EXCEPTION makes VmSkipExceptionFrames
+			 * resolve variables — and bind $e — against the real enclosing frame, so
+			 * outer locals, $this and a closure held in a variable are all visible
+			 * inside the catch (and $e/any var written there persists afterwards).
+			 * VM_FRAME_CATCH is kept for the deferred-exception walk. iExceptionJump
+			 * stays 0, so the try-frame-only paths (all guarded by iExceptionJump>0)
+			 * are unaffected. Must be set BEFORE binding $e below. */
+			pFrame->iFlags |= VM_FRAME_CATCH | VM_FRAME_EXCEPTION;
+			pObj = VmExtractMemObj(&(*pVm),&pCatch->sThis,FALSE,TRUE);
 			if( pObj ){
+				/* The catch variable now resolves in the (shared) enclosing frame,
+				 * so it may already hold a value from a prior catch or assignment.
+				 * Pin the new instance, then release the slot's prior contents
+				 * (runs its __destruct / frees the old value) before rebinding —
+				 * iRef++ first keeps a re-thrown same exception alive across the
+				 * release. Mirrors PH7_MemObjStore's overwrite-then-release. */
 				pThis->iRef++;
+				PH7_MemObjRelease(pObj);
 				pObj->x.pOther = pThis;
 				MemObjSetType(pObj,MEMOBJ_OBJ);
 			}

--- a/tests/ph7/001-smoke/lang/catch_scope_closure_call.phpt
+++ b/tests/ph7/001-smoke/lang/catch_scope_closure_call.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+a closure held in an enclosing variable is callable inside a catch block
+--FILE--
+<?php
+$echoArg = function ($a) { return $a; };
+$noArg = function () { return "z"; };
+try {
+    throw new Exception("e");
+} catch (Exception $e) {
+    echo $echoArg("hi") . "\n";
+    echo $noArg() . "\n";
+}
+?>
+--EXPECT--
+hi
+z
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/catch_scope_enclosing_var.phpt
+++ b/tests/ph7/001-smoke/lang/catch_scope_enclosing_var.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+catch block shares the enclosing variable scope (reads outer locals)
+--FILE--
+<?php
+$x = "VAL";
+$n = 41;
+try {
+    throw new Exception("e");
+} catch (Exception $e) {
+    echo $x . "\n";
+    echo ($n + 1) . "\n";
+}
+?>
+--EXPECT--
+VAL
+42
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/catch_scope_this.phpt
+++ b/tests/ph7/001-smoke/lang/catch_scope_this.phpt
@@ -1,0 +1,29 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+$this is accessible inside a method's catch block
+--FILE--
+<?php
+class CatchScopeThisBox {
+    public $v = 7;
+    public function run() {
+        try {
+            throw new Exception("e");
+        } catch (Exception $e) {
+            echo $this->v . "\n";
+            $this->v = 9;
+            echo $this->v . "\n";
+        }
+    }
+}
+$b = new CatchScopeThisBox();
+$b->run();
+echo $b->v . "\n";
+?>
+--EXPECT--
+7
+9
+9
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/catch_scope_write_persists.phpt
+++ b/tests/ph7/001-smoke/lang/catch_scope_write_persists.phpt
@@ -1,0 +1,30 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+a variable assigned inside a catch block is visible after the try/catch
+--FILE--
+<?php
+function inFunc() {
+    try {
+        throw new Exception("e");
+    } catch (Exception $e) {
+        $w = "W";
+    }
+    return isset($w) ? $w : "UNSET";
+}
+echo inFunc() . "\n";
+
+// global scope
+try {
+    throw new Exception("e");
+} catch (Exception $e) {
+    $y = "SET";
+}
+echo (isset($y) ? $y : "UNSET") . "\n";
+?>
+--EXPECT--
+W
+SET
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/catch_var_persists.phpt
+++ b/tests/ph7/001-smoke/lang/catch_var_persists.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+the caught exception variable is still set after the catch block
+--FILE--
+<?php
+try {
+    throw new Exception("boom");
+} catch (Exception $e) {
+    echo "in: " . $e->getMessage() . "\n";
+}
+echo "after: " . $e->getMessage() . "\n";
+?>
+--EXPECT--
+in: boom
+after: boom
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/catch_var_rebind_releases.phpt
+++ b/tests/ph7/001-smoke/lang/catch_var_rebind_releases.phpt
@@ -1,0 +1,39 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+rebinding the catch variable releases its prior value (runs the destructor)
+--FILE--
+<?php
+class CatchRebindDtor {
+    public $n;
+    public function __construct($n) { $this->n = $n; }
+    public function __destruct() { echo "dtor{$this->n}\n"; }
+}
+function catchRebindRun() {
+    try {
+        throw new Exception("a");
+    } catch (Exception $e) {
+        $e = new CatchRebindDtor(1);
+        echo "c1\n";
+    }
+    // second catch rebinds $e in the same scope: the prior CatchRebindDtor(1)
+    // must be released here (its destructor runs), not leaked.
+    try {
+        throw new Exception("b");
+    } catch (Exception $e) {
+        echo "c2\n";
+    }
+    echo "endfn\n";
+}
+catchRebindRun();
+echo "done\n";
+?>
+--EXPECT--
+c1
+dtor1
+c2
+endfn
+done
+--CLEAN--
+<?php


### PR DESCRIPTION
A catch block ran in an isolated frame flagged only VM_FRAME_CATCH, so its (separately compiled) body resolved variables against an empty scope: no enclosing local was visible, $this was unset inside a method's catch, and $e/any variable written in the catch was discarded on frame exit. The closure-call symptom (filed as "operand stack misaligned") was just $fn resolving to null inside the catch.

The try body never had this bug because OP_LOAD_EXCEPTION wraps it in a transparent VM_FRAME_EXCEPTION frame, which VmSkipExceptionFrames walks through during variable resolution. Flag the catch frame the same way (VM_FRAME_CATCH | VM_FRAME_EXCEPTION) before binding $e, so $e, enclosing locals, $this and var writes all resolve against the real enclosing frame (and $e persists after the catch, matching PHP). Safe because every other VM_FRAME_EXCEPTION path is additionally guarded by iExceptionJump > 0, which is 0 for the catch frame; only the three intended transparency behaviours change.

Because $e now resolves to a possibly-preexisting slot in the enclosing frame, release the slot's prior value before rebinding (iRef++ first so a re-thrown same exception survives the release) — otherwise reusing a catch variable across two try/catch leaked the earlier object and skipped its destructor.

Byte-for-byte parity with PHP 8.5.7; make test (2122 smoke + 683 integration) and test-compat green. Regression:
lang/catch_scope_{enclosing_var,closure_call,this,write_persists}.phpt, lang/catch_var_{persists,rebind_releases}.phpt.
