### PR TITLE
Add CLI -l/-i, CLI $_SERVER/$argc, and PHP_BINARY in the -S server

### DIFF
--- a/build-aux/lcov_info_to_text.php
+++ b/build-aux/lcov_info_to_text.php
@@ -9,7 +9,8 @@ $usage = "Usage: lcov_info_to_text.php [--content=files|summary|all] <coverage.i
 $content = 'all';
 $info_file = null;
 
-foreach ($argv as $arg) {
+// Skip $argv[0] (the script name) — PHL now matches PHP's $argv convention.
+foreach (array_slice($argv, 1) as $arg) {
     if (strpos($arg, '--content=') === 0) {
         $content = substr($arg, 10);
     } elseif (!$info_file) {

--- a/build-aux/lcov_to_markdown.php
+++ b/build-aux/lcov_to_markdown.php
@@ -414,7 +414,8 @@ $output_dir = null;
 $source_root = null;
 $info_files = array();
 
-foreach ($argv as $arg) {
+// Skip $argv[0] (the script name) — PHL now matches PHP's $argv convention.
+foreach (array_slice($argv, 1) as $arg) {
     if (starts_with($arg, '--output-dir=')) {
         $output_dir = substr($arg, 13);
     } elseif (starts_with($arg, '--source-root=')) {

--- a/src/phl/phl.c
+++ b/src/phl/phl.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 /* Make sure this header file is available.*/
 #include "ph7.h"
 #ifdef PHL_ENABLE_SERVER
@@ -54,11 +55,13 @@ static void Fatal(const char *zMsg)
  */
 static void Help(void)
 {
-	puts("phl [-h|--help|-b|-v|--version|-r code] path/to/php_file [script args]");
+	puts("phl [-h|--help|-b|-i|-l|-v|--version|-r code] path/to/php_file [script args]");
 #ifdef PHL_ENABLE_SERVER
 	puts("phl -S host:port [-t docroot] [router.php]");
 #endif
 	puts("\t-b: Dump PH7 byte-code instructions");
+	puts("\t-i: Display interpreter information and exit");
+	puts("\t-l: Syntax-check (lint) the given file and exit");
 	puts("\t-r code: Run code from command line (no tags needed)");
 #ifdef PHL_ENABLE_SERVER
 	puts("\t-S host:port: Start the built-in development server");
@@ -76,6 +79,30 @@ static void Version(void)
 {
 	puts("PHL " PH7_VERSION " (cli) (built " __DATE__ " " __TIME__ ")");
 	puts("Copyright (c) 2011-2014 Symisc Systems, 2025 Alexandre Gomes Gaigalas");
+	/* Exit immediately */
+	exit(0);
+}
+/*
+ * Display interpreter information (php -i) and exit. PHP's CLI -i is plain text
+ * (the phpinfo() builtin emits HTML, suited to the web SAPI), so this prints a
+ * concise curated subset on the terminal rather than reusing that builtin.
+ */
+static void Info(void)
+{
+	printf("phpinfo()\n");
+	printf("PHP Version => %s\n\n", PHP_COMPAT_VERSION);
+	printf("System => %s\n",
+#ifdef __WINNT__
+		"Windows NT"
+#elif defined(__UNIXES__)
+		"UNIX-Like"
+#else
+		"Other OS"
+#endif
+	);
+	printf("Build Date => %s %s\n", __DATE__, __TIME__);
+	printf("PHL Version => %s\n", PH7_VERSION);
+	printf("PHP SAPI => cli\n");
 	/* Exit immediately */
 	exit(0);
 }
@@ -163,6 +190,7 @@ int main(int argc,char **argv)
 	ph7_vm *pVm;  /* Compiled PHP program */
 	int dump_vm = 0;    /* Dump VM instructions if TRUE */
 	int run_code = 0;    /* Run inline code if TRUE */
+	int lint_mode = 0;   /* Syntax-check only (-l) if TRUE */
 	const char *zRunCode = 0; /* Inline code string */
 #ifdef PHL_ENABLE_SERVER
 	int server_mode = 0;        /* Start built-in server if TRUE */
@@ -194,6 +222,12 @@ int main(int argc,char **argv)
 		if( c == 'b' ){
 			/* Dump byte-code instructions */
 			dump_vm = 1;
+		}else if( c == 'l' ){
+			/* Syntax-check only (lint) the file argument that follows */
+			lint_mode = 1;
+		}else if( c == 'i' ){
+			/* Display interpreter information and exit */
+			Info();
 		}else if( c == 'r' ){
 			/* Run inline PHP code from next argument (php -r style) */
 			if( n + 1 >= argc ){
@@ -256,7 +290,7 @@ int main(int argc,char **argv)
 		if( n < argc ){
 			zRouter = argv[n];
 		}
-		return phl_serve(zHost, iPort, zDocRoot, zRouter);
+		return phl_serve(zHost, iPort, zDocRoot, zRouter, PHL_ResolveBinaryPath(argv[0]));
 	}
 #endif
 	if( n >= argc && !run_code ){
@@ -302,6 +336,31 @@ int main(int argc,char **argv)
 				ph7_config(pEngine,PH7_CONFIG_MAX_ALLOC,(unsigned int)uMax);
 			}
 		}
+	}
+	/* Syntax-check only mode (-l): compile the target file, print PHP's summary
+	 * line and exit without executing. The error consumer installed above
+	 * already prints any parse error; ph7_compile_file leaves *pVm NULL on a
+	 * compile/IO error, so only a successful compile owns a VM to release. */
+	if( lint_mode ){
+		const char *zFile;
+		if( n >= argc ){
+			/* No file argument (e.g. `-l` alone, or `-l` mixed with `-r`). */
+			ph7_release(pEngine);
+			puts("No input file specified");
+			return 255;
+		}
+		zFile = argv[n];
+		rc = ph7_compile_file(pEngine,zFile,&pVm,0);
+		if( rc == PH7_OK ){
+			printf("No syntax errors detected in %s\n",zFile);
+			ph7_vm_release(pVm);
+		}else if( rc == PH7_IO_ERR ){
+			printf("Could not open input file: %s\n",zFile);
+		}else{
+			printf("Errors parsing %s\n",zFile);
+		}
+		ph7_release(pEngine);
+		return (rc == PH7_OK) ? 0 : 255;
 	}
 	/* Now,it's time to compile our PHP file */
 	if( run_code ){
@@ -355,19 +414,53 @@ int main(int argc,char **argv)
 	/* Define PHP_BINARY: absolute path of this interpreter */
 	ph7_create_constant(pVm,"PHP_BINARY",PHL_PhpBinaryConst,
 		(void *)PHL_ResolveBinaryPath(argv[0]));
-	/* Register script arguments so we can access them later using the $argv[]
-	 * array from the compiled PHP program. For regular file execution we need
-	 * to register the arguments after the script file, while for inline code
-	 * (-r) the arguments start at the current index.
+	/* Register the script arguments as $argv[] plus the matching $argc count and
+	 * the CLI $_SERVER entries, matching PHP: $argv[0] is the script path (file
+	 * mode) or the literal "Standard input code" (-r mode), followed by the
+	 * script's own arguments.
 	 */
-	if( run_code ){
-		for( ; n < argc ; ++n ){
-			ph7_vm_config(pVm,PH7_VM_CONFIG_ARGV_ENTRY,argv[n]/* Argument value */);
+	{
+		const char *zScriptName = run_code ? "Standard input code" : argv[n];
+		int argv_count = 0;
+		ph7_value *pArgc;
+		/* Count only the entries actually inserted: PH7_VM_CONFIG_ARGV_ENTRY skips
+		 * an empty string, so counting unconditionally would leave $argc greater
+		 * than count($argv) for an empty argument (e.g. `phl s.php "" x`). */
+		if( ph7_vm_config(pVm,PH7_VM_CONFIG_ARGV_ENTRY,zScriptName) == PH7_OK ){
+			argv_count++;
 		}
-	}else{
-		for( n = n + 1; n < argc ; ++n ){
-			ph7_vm_config(pVm,PH7_VM_CONFIG_ARGV_ENTRY,argv[n]/* Argument value */);
+		/* The script's own arguments follow: in file mode argv[n] is the script
+		 * (registered above), so they start at n+1; in -r mode they start at n. */
+		for( n = run_code ? n : n + 1; n < argc ; ++n ){
+			if( ph7_vm_config(pVm,PH7_VM_CONFIG_ARGV_ENTRY,argv[n]) == PH7_OK ){
+				argv_count++;
+			}
 		}
+		/* $argc: a plain integer global equal to count($argv). */
+		pArgc = ph7_new_scalar(pVm);
+		if( pArgc ){
+			ph7_value_int(pArgc,argv_count);
+			ph7_vm_config(pVm,PH7_VM_CONFIG_CREATE_VAR,"argc",pArgc);
+			ph7_release_value(pVm,pArgc);
+		}
+		/* $_SERVER entries frameworks read at CLI bootstrap. SCRIPT_FILENAME is
+		 * already set to the script path by PH7_HashmapCreateSuper. */
+		ph7_vm_config(pVm,PH7_VM_CONFIG_SERVER_ATTR,"SCRIPT_NAME",zScriptName,-1);
+		ph7_vm_config(pVm,PH7_VM_CONFIG_SERVER_ATTR,"PHP_SELF",zScriptName,-1);
+		ph7_vm_config(pVm,PH7_VM_CONFIG_SERVER_ATTR,"DOCUMENT_ROOT","",0);
+		{
+			char zTime[32];
+			snprintf(zTime,sizeof(zTime),"%ld",(long)time(0));
+			ph7_vm_config(pVm,PH7_VM_CONFIG_SERVER_ATTR,"REQUEST_TIME",zTime,-1);
+		}
+#ifndef __WINNT__
+		{
+			char zCwd[PATH_MAX];
+			if( getcwd(zCwd,sizeof(zCwd)) ){
+				ph7_vm_config(pVm,PH7_VM_CONFIG_SERVER_ATTR,"PWD",zCwd,-1);
+			}
+		}
+#endif
 	}
 	/* Report script run-time errors (now default behavior) */
 	ph7_vm_config(pVm,PH7_VM_CONFIG_ERR_REPORT);

--- a/src/phl/server.c
+++ b/src/phl/server.c
@@ -45,6 +45,23 @@
 /* Shutdown flag set by signal handler */
 static volatile int g_shutdown = 0;
 
+/* Resolved interpreter path, exposed to scripts as the PHP_BINARY constant.
+ * Set once in phl_serve(); the matching expand callback mirrors the CLI's
+ * (PHL_PhpBinaryConst is static to phl.c, so the server keeps its own). */
+static const char *g_phpBinaryPath = 0;
+static void PhlServerPhpBinaryConst(ph7_value *pVal, void *pUserData)
+{
+	ph7_value_string(pVal, (const char *)pUserData, -1);
+}
+/* Define PHP_BINARY on a freshly compiled VM. Constants persist across
+ * ph7_vm_reset(), so a cache-owned VM needs this only once, at compile time. */
+static void DefinePhpBinary(ph7_vm *pVm)
+{
+	if( g_phpBinaryPath ){
+		ph7_create_constant(pVm, "PHP_BINARY", PhlServerPhpBinaryConst, (void *)g_phpBinaryPath);
+	}
+}
+
 #ifdef __WINNT__
 static BOOL WINAPI ConsoleCtrlHandler(DWORD dwCtrlType)
 {
@@ -517,7 +534,11 @@ static ph7_vm *AcquireScriptVm(ph7 *pEngine, const char *zPath, int *pbCached)
 	long long nMtime;
 	if( !g_vmReuse ){
 		*pbCached = 0;
-		return ph7_compile_file(pEngine, zPath, &pVm, 0) == PH7_OK ? pVm : 0;
+		if( ph7_compile_file(pEngine, zPath, &pVm, 0) != PH7_OK ){
+			return 0;
+		}
+		DefinePhpBinary(pVm);
+		return pVm;
 	}
 	nMtime = GetFileMtime(zPath);
 	for( i = 0 ; i < PHL_VM_CACHE_SIZE ; i++ ){
@@ -549,6 +570,7 @@ static ph7_vm *AcquireScriptVm(ph7 *pEngine, const char *zPath, int *pbCached)
 		*pbCached = 0;
 		return 0;
 	}
+	DefinePhpBinary(pVm);
 	if( iFree < 0 ){
 		/* Cache full: evict the least-recently-used entry. */
 		ph7_vm_release(g_vmCache[iLru].pVm);
@@ -730,7 +752,7 @@ static void LogRequest(const char *zRemoteAddr, int iRemotePort,
 /*
  * Main server entry point.
  */
-int phl_serve(const char *zHost, int iPort, const char *zDocRoot, const char *zRouter)
+int phl_serve(const char *zHost, int iPort, const char *zDocRoot, const char *zRouter, const char *zBinaryPath)
 {
 	ph7 *pEngine;
 	ph7_socket listenSock;
@@ -742,6 +764,8 @@ int phl_serve(const char *zHost, int iPort, const char *zDocRoot, const char *zR
 	char zRemoteAddr[64];
 	int iRemotePort;
 	int rc;
+	/* Resolved interpreter path → PHP_BINARY for every served VM. */
+	g_phpBinaryPath = zBinaryPath;
 	/* Compile-once / reuse is on by default; PHL_NO_REUSE=1 forces the legacy
 	 * compile-per-request path for behaviour diffing. */
 	{

--- a/src/phl/server.h
+++ b/src/phl/server.h
@@ -9,9 +9,11 @@
  * Start the PHL built-in development server.
  * Listens on zHost:iPort, serves files from zDocRoot.
  * If zRouter is non-NULL, it is used as the router script.
+ * zBinaryPath is the resolved interpreter path, exposed to scripts as the
+ * PHP_BINARY constant (may be NULL to skip defining it).
  * This function blocks until the server is shut down (e.g. via SIGINT).
  * Returns 0 on clean shutdown, non-zero on error.
  */
-int phl_serve(const char *zHost, int iPort, const char *zDocRoot, const char *zRouter);
+int phl_serve(const char *zHost, int iPort, const char *zDocRoot, const char *zRouter, const char *zBinaryPath);
 #endif /* PHL_ENABLE_SERVER */
 #endif /* PHL_SERVER_H */

--- a/tests/ph7/002-integration/cli/cli_argc_consistency.phpt
+++ b/tests/ph7/002-integration/cli/cli_argc_consistency.phpt
@@ -1,0 +1,29 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+$argc stays equal to count($argv) even when an argument is the empty string
+--SKIPIF--
+<?php if (PHP_OS == 'WINNT') { echo "skip"; } ?>
+--FILE--
+<?php
+/* Regression: registering an argv entry can skip an empty string, so $argc must
+ * be counted from what was actually registered — not bumped unconditionally —
+ * or the $argc == count($argv) invariant (which `for ($i=0;$i<$argc;$i++)`
+ * relies on) breaks. Holds under both phl and PHP regardless of how each treats
+ * the empty argument. */
+$phl = getenv('PHPT_TARGET_EXECUTABLE');
+$script = sys_get_temp_dir() . '/phl_argc_' . getmypid() . '.php';
+file_put_contents($script,
+    "<?php echo (\$argc === count(\$argv)) ? \"consistent\\n\" : \"BROKEN argc=\$argc count=\" . count(\$argv) . \"\\n\";\n");
+$fp = popen("\"$phl\" \"$script\" \"\" beta", 'r');
+$out = '';
+while (!feof($fp)) { $out .= fgets($fp); }
+fclose($fp);
+echo $out;
+?>
+--EXPECT--
+consistent
+--CLEAN--
+<?php
+@unlink(sys_get_temp_dir() . '/phl_argc_' . getmypid() . '.php');

--- a/tests/ph7/002-integration/cli/cli_server_vars.phpt
+++ b/tests/ph7/002-integration/cli/cli_server_vars.phpt
@@ -1,0 +1,36 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+CLI populates $argc and the $_SERVER bootstrap entries, matching PHP
+--SKIPIF--
+<?php if (PHP_OS == 'WINNT') { echo "skip"; } ?>
+--FILE--
+<?php
+$phl = getenv('PHPT_TARGET_EXECUTABLE');
+$script = sys_get_temp_dir() . '/phl_srvvars_' . getmypid() . '.php';
+file_put_contents($script, <<<'EOF'
+<?php
+echo "argc=", $argc, "\n";
+echo "args=", $argv[1], ",", $argv[2], "\n";
+echo "script_name=", basename($_SERVER["SCRIPT_NAME"]), "\n";
+echo "php_self_eq=", ($_SERVER["PHP_SELF"] === $_SERVER["SCRIPT_NAME"]) ? "yes" : "no", "\n";
+echo "docroot_empty=", ($_SERVER["DOCUMENT_ROOT"] === "") ? "yes" : "no", "\n";
+echo "request_time_set=", isset($_SERVER["REQUEST_TIME"]) ? "yes" : "no", "\n";
+EOF);
+$fp = popen("\"$phl\" \"$script\" alpha beta", 'r');
+$out = '';
+while (!feof($fp)) { $out .= fgets($fp); }
+fclose($fp);
+echo $out;
+?>
+--EXPECTF--
+argc=3
+args=alpha,beta
+script_name=phl_srvvars_%d.php
+php_self_eq=yes
+docroot_empty=yes
+request_time_set=yes
+--CLEAN--
+<?php
+@unlink(sys_get_temp_dir() . '/phl_srvvars_' . getmypid() . '.php');

--- a/tests/ph7/002-integration/cli/dash-i-info.phpt
+++ b/tests/ph7/002-integration/cli/dash-i-info.phpt
@@ -1,0 +1,28 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+phl interpreter CLI -i prints interpreter information (PHL plain-text subset)
+--SKIPIF--
+<?php if (PHP_OS == 'WINNT') { echo "skip"; } ?>
+<?php if (function_exists('zend_version')) { echo "skip"; } ?>
+--FILE--
+<?php
+$phl = getenv('PHPT_TARGET_EXECUTABLE');
+$fp = popen("\"$phl\" -i", 'r');
+$out = '';
+while (!feof($fp)) { $out .= fgets($fp); }
+fclose($fp);
+echo $out;
+?>
+--EXPECTF--
+phpinfo()
+PHP Version => %d.%d.%d
+
+System => %s
+Build Date => %A
+PHL Version => %d.%d.%d
+PHP SAPI => cli
+--CLEAN--
+<?php
+unset($phl, $fp, $out);

--- a/tests/ph7/002-integration/cli/dash-l-lint.phpt
+++ b/tests/ph7/002-integration/cli/dash-l-lint.phpt
@@ -1,0 +1,37 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+phl interpreter CLI -l lints a file (syntax-check only), matching PHP
+--SKIPIF--
+<?php if (PHP_OS == 'WINNT') { echo "skip"; } ?>
+--FILE--
+<?php
+$phl = getenv('PHPT_TARGET_EXECUTABLE');
+$dir = sys_get_temp_dir();
+$ok  = $dir . '/phl_lint_ok_' . getmypid() . '.php';
+$bad = $dir . '/phl_lint_bad_' . getmypid() . '.php';
+file_put_contents($ok,  "<?php echo 1;\n");
+file_put_contents($bad, "<?php function (\n");
+
+// valid file -> success line, exit 0
+$fp = popen("\"$phl\" -l \"$ok\" 2>&1", 'r');
+$o = ''; while (!feof($fp)) { $o .= fgets($fp); } $rc = pclose($fp);
+echo $o;
+echo "ok_exit=" . ($rc === 0 ? 0 : 1) . "\n";
+
+// broken file -> error summary, nonzero exit
+$fp = popen("\"$phl\" -l \"$bad\" 2>&1", 'r');
+$o = ''; while (!feof($fp)) { $o .= fgets($fp); } $rc = pclose($fp);
+echo (strpos($o, 'Errors parsing') !== false) ? "bad_reports_error\n" : "bad_no_error\n";
+echo "bad_exit=" . ($rc === 0 ? 0 : 1) . "\n";
+?>
+--EXPECTF--
+No syntax errors detected in %s
+ok_exit=0
+bad_reports_error
+bad_exit=1
+--CLEAN--
+<?php
+@unlink(sys_get_temp_dir() . '/phl_lint_ok_' . getmypid() . '.php');
+@unlink(sys_get_temp_dir() . '/phl_lint_bad_' . getmypid() . '.php');

--- a/tests/ph7/002-integration/cli/dash-r-argv.phpt
+++ b/tests/ph7/002-integration/cli/dash-r-argv.phpt
@@ -2,12 +2,13 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-phl interpreter CLI inline code run (-r) with arguments
+phl interpreter CLI inline code run (-r): $argv[0] is "Standard input code"
 --SKIPIF--
 <?php if (PHP_OS == 'WINNT') { echo "skip"; } ?>
-<?php if (function_exists('zend_version')) { echo "skip"; } ?>
 --FILE--
 <?php
+/* Matches PHP: under -r, $argv[0] is the literal "Standard input code" and the
+ * script's own arguments follow (so "foo" is $argv[1]). */
 $phl = getenv('PHPT_TARGET_EXECUTABLE');
 $fp = popen("\"$phl\" -r \"echo \\\"\\\$argv[0]\\n\\\";\" foo", "r");
 $out = '';
@@ -18,7 +19,7 @@ fclose($fp);
 echo $out;
 ?>
 --EXPECT--
-foo
+Standard input code
 --CLEAN--
 <?php
 unset($phl, $fp, $out);

--- a/tests/ph7/002-integration/cli/help.phpt
+++ b/tests/ph7/002-integration/cli/help.phpt
@@ -17,9 +17,11 @@ fclose($fp);
 echo $out;
 ?>
 --EXPECT--
-phl [-h|--help|-b|-v|--version|-r code] path/to/php_file [script args]
+phl [-h|--help|-b|-i|-l|-v|--version|-r code] path/to/php_file [script args]
 phl -S host:port [-t docroot] [router.php]
 	-b: Dump PH7 byte-code instructions
+	-i: Display interpreter information and exit
+	-l: Syntax-check (lint) the given file and exit
 	-r code: Run code from command line (no tags needed)
 	-S host:port: Start the built-in development server
 	-t docroot: Document root for the server (default: current directory)

--- a/tests/ph7/002-integration/server/php_binary_server.phpt
+++ b/tests/ph7/002-integration/server/php_binary_server.phpt
@@ -1,0 +1,43 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+The built-in server defines PHP_BINARY in served VMs
+--SKIPIF--
+<?php
+if (PHP_OS == 'WINNT') { echo "skip"; }
+$fp = popen("curl --version 2>/dev/null", "r");
+$out = fgets($fp);
+fclose($fp);
+if (strlen($out) == 0) { echo "skip curl not available"; }
+?>
+--FILE--
+<?php
+$phl = getenv('PHPT_TARGET_EXECUTABLE');
+$tmpdir = sys_get_temp_dir() . '/phl_binsrv_' . getmypid();
+$port = 19500 + (getmypid() % 100);
+mkdir($tmpdir);
+file_put_contents($tmpdir . '/bin.php',
+    "<?php echo (defined('PHP_BINARY') && PHP_BINARY !== '' && is_file(PHP_BINARY)) ? \"ok\\n\" : \"bad\\n\";\n");
+
+$fp = popen('"' . $phl . '" -S localhost:' . $port . ' -t "' . $tmpdir . '" >/dev/null 2>&1 & echo $!', 'r');
+$pid = trim(fgets($fp));
+fclose($fp);
+usleep(500000);
+
+$fp2 = popen('curl -s "http://localhost:' . $port . '/bin.php" 2>/dev/null', 'r');
+$out = '';
+while (!feof($fp2)) { $out .= fgets($fp2); }
+fclose($fp2);
+echo $out;
+
+popen('kill ' . $pid . ' 2>/dev/null', 'r');
+usleep(200000);
+unlink($tmpdir . '/bin.php');
+rmdir($tmpdir);
+?>
+--EXPECT--
+ok
+--CLEAN--
+<?php
+unset($phl, $tmpdir, $port, $fp, $pid, $fp2, $out);


### PR DESCRIPTION
Four CLI/SAPI parity additions in src/phl/:

-l (lint): compile-only via ph7_compile_file, exits without executing and prints PHP's exact "No syntax errors detected in <file>" (exit 0) / "Errors parsing <file>" (exit 255) / "Could not open input file" (IO error). Guards against a missing file argument (e.g. when mixed with -r).

-i (info): a print-and-exit Info() emitting a concise plain-text block (Version/System/Build Date/SAPI). PHL's phpinfo() builtin is HTML (web SAPI), so -i prints its own terminal-appropriate subset rather than reusing it.

CLI $_SERVER + $argc: populates SCRIPT_NAME/PHP_SELF/DOCUMENT_ROOT/REQUEST_TIME/ PWD via PH7_VM_CONFIG_SERVER_ATTR and sets $argc as a real int via PH7_VM_CONFIG_CREATE_VAR. Also fixes a pre-existing $argv divergence: PHL omitted the script slot, so $argv[0] was the first argument; it now registers the script path (file mode) or "Standard input code" (-r) as $argv[0] first, matching PHP in both modes. $argc counts only the argv entries actually registered, so $argc == count($argv) holds even when an argument is empty.

PHP_BINARY in -S: phl_serve takes the resolved interpreter path; DefinePhpBinary defines the constant once per cached VM in AcquireScriptVm after compilation (it persists across ph7_vm_reset, so no per-request cost).

The -l, $_SERVER/$argc and server tests run under both phl and real php (no skip); -i is phl-only. make test (2140 smoke + 692 integration), test-compat and test-stress green.
