### PR TITLE
Add readonly properties

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -1794,6 +1794,7 @@ PH7_PRIVATE sxi32 PH7_CompileShortList(ph7_gen_state *pGen,sxi32 iCompileFlag)
 /* Forward declarations */
 static sxi32 GenStateCompileFunc(ph7_gen_state *pGen,SyString *pName,sxi32 iFlags,int bHandleClosure,ph7_vm_func **ppFunc);
 static int GenStateIsReservedConstant(SyString *pName);
+static int GenStateIsReadonly(SyToken *pTok);
 static sxi32 GenStateValidateMemberType(ph7_gen_state *pGen,ph7_class *pClass,const SyString *pMemberName,
 	sxu32 nType,const SyString *pTypeClass,const SyString *pTypeText,SySet *pUnionAlts,const char *zErrFmt,sxu32 nLine);
 static void GenStateBuildFQN(ph7_gen_state *pGen,const SyString *pName,SyBlob *pOut);
@@ -5584,10 +5585,33 @@ static sxi32 GenStateCollectFuncArgs(ph7_vm_func *pFunc,ph7_gen_state *pGen,SyTo
 		SySetInit(&sArg.aByteCode,&pGen->pVm->sAllocator,sizeof(VmInstr));
 		SySetInit(&sArg.aUnionAlts,&pGen->pVm->sAllocator,sizeof(ph7_type_alt));
 		SyStringInitFromBuf(&sArg.sTypeName,0,0);
-		/* Parse optional visibility modifier (constructor property promotion, PHP 8.0+) */
-		if( pIn < pEnd && (pIn->nType & PH7_TK_KEYWORD) ){
-			sxu32 nKw = (sxu32)SX_PTR_TO_INT(pIn->pUserData);
-			if( nKw == PH7_TKWRD_PUBLIC || nKw == PH7_TKWRD_PROTECTED || nKw == PH7_TKWRD_PRIVATE ){
+		/* Parse optional visibility + readonly modifiers (constructor property
+		 * promotion, PHP 8.0+/8.1+). A property is promoted when a visibility
+		 * keyword and/or `readonly` is present; `readonly` may appear on either
+		 * side of the visibility keyword (`public readonly T $x`,
+		 * `readonly public T $x`), or alone (`readonly T $x` ⇒ public readonly). */
+		{
+			int bReadonly = 0, bVisSeen = 0;
+			sxi32 iVis = PH7_CLASS_PROT_PUBLIC;
+			if( pIn < pEnd && GenStateIsReadonly(pIn) ){
+				bReadonly = 1;
+				pIn++;
+			}
+			if( pIn < pEnd && (pIn->nType & PH7_TK_KEYWORD) ){
+				sxu32 nKw = (sxu32)SX_PTR_TO_INT(pIn->pUserData);
+				if( nKw == PH7_TKWRD_PUBLIC || nKw == PH7_TKWRD_PROTECTED || nKw == PH7_TKWRD_PRIVATE ){
+					bVisSeen = 1;
+					iVis = (nKw == PH7_TKWRD_PRIVATE) ? PH7_CLASS_PROT_PRIVATE
+						: (nKw == PH7_TKWRD_PROTECTED) ? PH7_CLASS_PROT_PROTECTED
+						: PH7_CLASS_PROT_PUBLIC;
+					pIn++;
+					if( pIn < pEnd && GenStateIsReadonly(pIn) ){
+						bReadonly = 1;
+						pIn++;
+					}
+				}
+			}
+			if( bVisSeen || bReadonly ){
 				if( !bCtorCtx ){
 					if( bAbstractCtx ){
 						rc = PH7_GenCompileError(pGen,E_ERROR,pIn->nLine,
@@ -5602,14 +5626,10 @@ static sxi32 GenStateCollectFuncArgs(ph7_vm_func *pFunc,ph7_gen_state *pGen,SyTo
 					return SXERR_SYNTAX;
 				}
 				sArg.iFlags |= VM_FUNC_ARG_PROMOTED;
-				if( nKw == PH7_TKWRD_PRIVATE ){
-					sArg.iPromoteVis = PH7_CLASS_PROT_PRIVATE;
-				}else if( nKw == PH7_TKWRD_PROTECTED ){
-					sArg.iPromoteVis = PH7_CLASS_PROT_PROTECTED;
-				}else{
-					sArg.iPromoteVis = PH7_CLASS_PROT_PUBLIC;
+				sArg.iPromoteVis = iVis;
+				if( bReadonly ){
+					sArg.iFlags |= VM_FUNC_ARG_READONLY;
 				}
-				pIn++;
 			}
 		}
 		/* Parse optional type hint (single, nullable shorthand, or union) */
@@ -7111,7 +7131,18 @@ static sxi32 GenStateValidateMemberType(
 	}
 	return SXERR_SYNTAX;
 }
-
+/*
+ * Return TRUE if pTok is the context-sensitive `readonly` modifier. PHP does not
+ * reserve `readonly` (it remains valid as a method/function name), so it is
+ * matched as a plain identifier in the class-member modifier position rather
+ * than promoted to a lexer keyword.
+ */
+static int GenStateIsReadonly(SyToken *pTok)
+{
+	return (pTok->nType & PH7_TK_ID)
+		&& pTok->sData.nByte == sizeof("readonly")-1
+		&& SyStrnicmp(pTok->sData.zString,"readonly",sizeof("readonly")-1) == 0;
+}
 static sxi32 GenStateCompileClassAttr(ph7_gen_state *pGen,sxi32 iProtection,sxi32 iFlags,ph7_class *pClass)
 {
 	sxu32 nLine = pGen->pIn->nLine;
@@ -7176,6 +7207,25 @@ loop:
 			return SXERR_ABORT;
 		}
 		goto Synchronize;
+	}
+	/* readonly property rules (PHP 8.1): cannot be static, must be typed, and
+	 * cannot carry a default value. PHP-exact diagnostics. */
+	if( iFlags & PH7_CLASS_ATTR_READONLY ){
+		const char *zRoErr = 0;
+		if( iFlags & PH7_CLASS_ATTR_STATIC ){
+			zRoErr = "Static property %z::$%z cannot be readonly";
+		}else if( (iTypeFlags & PH7_CLASS_ATTR_TYPED) == 0 ){
+			zRoErr = "Readonly property %z::$%z must have type";
+		}else if( pGen->pIn->nType & PH7_TK_EQUAL ){
+			zRoErr = "Readonly property %z::$%z cannot have default value";
+		}
+		if( zRoErr ){
+			rc = PH7_GenCompileError(pGen,E_ERROR,nLine,zRoErr,&pClass->sName,pName);
+			if( rc == SXERR_ABORT ){
+				return SXERR_ABORT;
+			}
+			goto Synchronize;
+		}
 	}
 	/* Reject disallowed pseudo-types (callable/mixed/iterable) on the main
 	 * type atom or any union alternative. void/never are already rejected
@@ -7443,6 +7493,18 @@ static sxi32 GenStateCompileClassMethod(
 			}
 			if( pArg->iFlags & VM_FUNC_ARG_UNION ){
 				iAttrFlags |= PH7_CLASS_ATTR_UNION;
+			}
+			if( pArg->iFlags & VM_FUNC_ARG_READONLY ){
+				/* A readonly promoted property must be typed (PHP 8.1). */
+				if( (iAttrFlags & PH7_CLASS_ATTR_TYPED) == 0 ){
+					rc = PH7_GenCompileError(pGen,E_ERROR,nLine,
+						"Readonly property %z::$%z must have type",&pClass->sName,&pArg->sName);
+					if( rc == SXERR_ABORT ){
+						return SXERR_ABORT;
+					}
+					goto Synchronize;
+				}
+				iAttrFlags |= PH7_CLASS_ATTR_READONLY;
 			}
 			pAttr = PH7_NewClassAttr(pGen->pVm,&pArg->sName,nLine,pArg->iPromoteVis,iAttrFlags);
 			if( pAttr == 0 ){
@@ -8319,7 +8381,8 @@ static sxi32 GenStateCompileClass(ph7_gen_state *pGen,sxi32 iFlags)
 			/* End of class body */
 			break;
 		}
-		if( (pGen->pIn->nType & (PH7_TK_KEYWORD|PH7_TK_DOLLAR)) == 0 ){
+		if( (pGen->pIn->nType & (PH7_TK_KEYWORD|PH7_TK_DOLLAR)) == 0
+			&& !GenStateIsReadonly(pGen->pIn) /* allow a leading `readonly` modifier */ ){
 			rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,
 				"Unexpected token '%z'. Expecting attribute declaration inside class '%z'",
 				&pGen->pIn->sData,pName);
@@ -8332,7 +8395,35 @@ static sxi32 GenStateCompileClass(ph7_gen_state *pGen,sxi32 iFlags)
 		/* Assume public visibility */
 		iProtection = PH7_TKWRD_PUBLIC;
 		iAttrflags = 0;
-		if( pGen->pIn->nType & PH7_TK_KEYWORD ){
+		/* Optional leading `readonly` modifier (PHP 8.1) — context-sensitive, so
+		 * it may precede the visibility keyword: `readonly public int $x`,
+		 * `readonly int $x`. The visibility branch below also accepts it after
+		 * the visibility keyword (`public readonly int $x`). */
+		if( pGen->pIn < pGen->pEnd && GenStateIsReadonly(pGen->pIn) ){
+			int bMod = 0;
+			iAttrflags |= PH7_CLASS_ATTR_READONLY;
+			pGen->pIn++; /* Jump the 'readonly' modifier */
+			/* If a visibility/static modifier follows, let the dispatch below
+			 * handle it; otherwise this is `readonly Type $x` (implicit public)
+			 * and we compile it directly — the type may be a keyword (int/array)
+			 * that the generic keyword dispatch would misread as a method. */
+			if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_KEYWORD) ){
+				sxi32 k = SX_PTR_TO_INT(pGen->pIn->pUserData);
+				bMod = ( k == PH7_TKWRD_PUBLIC || k == PH7_TKWRD_PRIVATE
+					|| k == PH7_TKWRD_PROTECTED || k == PH7_TKWRD_STATIC );
+			}
+			if( !bMod ){
+				rc = GenStateCompileClassAttr(&(*pGen),iProtection,iAttrflags,pClass);
+				if( rc != SXRET_OK ){
+					if( rc == SXERR_ABORT ){
+						return SXERR_ABORT;
+					}
+					goto done;
+				}
+				continue;
+			}
+		}
+		if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_KEYWORD) ){
 			/* Extract the current keyword */
 			nKwrd = SX_PTR_TO_INT(pGen->pIn->pUserData);
 			if( nKwrd == PH7_TKWRD_USE ){
@@ -8400,6 +8491,11 @@ static sxi32 GenStateCompileClass(ph7_gen_state *pGen,sxi32 iFlags)
 			if( nKwrd == PH7_TKWRD_PUBLIC || nKwrd == PH7_TKWRD_PRIVATE || nKwrd == PH7_TKWRD_PROTECTED ){
 				iProtection = nKwrd;
 				pGen->pIn++; /* Jump the visibility token */
+				/* Optional `readonly` after the visibility: `public readonly int $x`. */
+				if( pGen->pIn < pGen->pEnd && GenStateIsReadonly(pGen->pIn) ){
+					iAttrflags |= PH7_CLASS_ATTR_READONLY;
+					pGen->pIn++; /* Jump the 'readonly' modifier */
+				}
 				if( pGen->pIn >= pGen->pEnd
 					|| (pGen->pIn->nType & (PH7_TK_KEYWORD|PH7_TK_DOLLAR|PH7_TK_ID|PH7_TK_OP|PH7_TK_NSSEP)) == 0 ){
 					rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,
@@ -8457,6 +8553,13 @@ static sxi32 GenStateCompileClass(ph7_gen_state *pGen,sxi32 iFlags)
 							iProtection = nKwrd;
 							pGen->pIn++; /* Jump the visibility token */
 						}
+					}
+					/* `readonly` after `static` (an invalid combination): detect it so the
+					 * static+readonly diagnostic fires from GenStateCompileClassAttr rather
+					 * than a generic "expecting method" parse error. */
+					if( pGen->pIn < pGen->pEnd && GenStateIsReadonly(pGen->pIn) ){
+						iAttrflags |= PH7_CLASS_ATTR_READONLY;
+						pGen->pIn++; /* Jump the 'readonly' modifier */
 					}
 					if( pGen->pIn >= pGen->pEnd
 						|| (pGen->pIn->nType & (PH7_TK_KEYWORD|PH7_TK_DOLLAR|PH7_TK_ID|PH7_TK_OP|PH7_TK_NSSEP)) == 0 ){

--- a/src/ph7/oo.c
+++ b/src/ph7/oo.c
@@ -780,6 +780,12 @@ PH7_PRIVATE ph7_class_instance * PH7_CloneClassInstance(ph7_class_instance *pSrc
 			if( pvSrc && pvDest ){
 				PH7_MemObjStore(pvSrc,pvDest);
 			}
+			/* Carry over the per-instance state so the clone matches the source:
+			 * VM_CLASS_ATTR_UNINIT marks a typed property as not-yet-initialized
+			 * and doubles as the readonly write-once latch — without this a clone
+			 * would reset to uninitialized (losing the value's readiness) and a
+			 * readonly property would become writable again. */
+			pDestAttr->iState = pSrcAttr->iState;
 		}
 	}
 	/* call the __clone method on the cloned object if available */

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -568,7 +568,8 @@ struct ph7_vm_func_closure_env
 #define VM_FUNC_ARG_NULLABLE 0x100 /* Argument type is nullable (?type or T|null) */
 #define VM_FUNC_ARG_UNION    0x200 /* Argument has a union type (use aUnionAlts) */
 #define VM_FUNC_ARG_PROMOTED 0x400 /* Constructor promoted property (iPromoteVis holds visibility) */
-/* next free bit: 0x800 */
+#define VM_FUNC_ARG_READONLY 0x800 /* Promoted property is readonly (PHP 8.1) */
+/* next free bit: 0x1000 */
 /*
  * Each user defined function is parsed out and stored in an instance
  * of the following structure.
@@ -680,7 +681,8 @@ struct ph7_class_attr
 #define PH7_CLASS_ATTR_TYPED        0x010  /* Property has an explicit declared type */
 #define PH7_CLASS_ATTR_NULLABLE     0x020  /* Type allows null (?type prefix or T|null union) */
 #define PH7_CLASS_ATTR_UNION        0x040  /* Property has a union type (use aUnionAlts) */
-/* next free bit: 0x080 */
+#define PH7_CLASS_ATTR_READONLY     0x080  /* readonly property (PHP 8.1) */
+/* next free bit: 0x100 */
 /*
  * Each class method is parsed out and stored in an instance of the following
  * structure.
@@ -750,7 +752,9 @@ struct VmClassAttr
 	sxi32 iState;          /* Per-instance state: VM_CLASS_ATTR_UNINIT */
 	ph7_class *pOwner;     /* Class that declares this attribute (for error msgs) */
 };
-#define VM_CLASS_ATTR_UNINIT  0x01 /* Typed property never written (PHP 7.4+) */
+#define VM_CLASS_ATTR_UNINIT  0x01 /* Typed property never written (PHP 7.4+); also the
+                                    * write-once latch for readonly properties (cleared on
+                                    * the first successful write — see VmEnforcePropertyTypeOnStore) */
  /* Forward reference */
 typedef struct VmRefObj VmRefObj;
 /*

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -3165,116 +3165,126 @@ static sxi32 VmThrowErrorAp(
 	return rc;
 }
 /*
+ * Return the class currently active on the self-stack (the innermost `self`
+ * scope), or NULL when executing outside any class context.
+ */
+static ph7_class * VmCurrentSelf(ph7_vm *pVm)
+{
+	if( SySetUsed(&pVm->aSelf) > 0 ){
+		ph7_class **apSelf = (ph7_class **)SySetBasePtr(&pVm->aSelf);
+		return apSelf[SySetUsed(&pVm->aSelf)-1];
+	}
+	return 0;
+}
+/*
+ * Instantiate a built-in error class (e.g. "Error"/"TypeError"), construct it
+ * with the message held in *pMsg, and throw it from the current frame. Consumes
+ * and releases *pMsg. Returns PH7_EXCEPTION on success, or PH7_ABORT when the
+ * class is unavailable or the engine is aborting. Shared scaffolding for the
+ * typed-property / uninitialized-property / readonly error throwers.
+ */
+static sxi32 VmThrowBuiltinError(ph7_vm *pVm,const char *zClass,sxu32 nClass,SyBlob *pMsg)
+{
+	ph7_class *pErrClass;
+	ph7_class_instance *pThis;
+	ph7_class_method *pCons;
+	VmFrame *pFrame;
+	sxi32 rc;
+	pErrClass = PH7_VmExtractClass(&(*pVm),zClass,nClass,TRUE,0);
+	if( pErrClass == 0 ){
+		SyBlobRelease(pMsg);
+		return PH7_ABORT;
+	}
+	pThis = PH7_NewClassInstance(&(*pVm),pErrClass);
+	if( pThis == 0 ){
+		SyBlobRelease(pMsg);
+		return PH7_ABORT;
+	}
+	pCons = PH7_ClassExtractMethod(pErrClass,"__construct",sizeof("__construct")-1);
+	if( pCons ){
+		ph7_value sArg;
+		ph7_value *apArg[1];
+		SyString sMsgStr;
+		SyStringInitFromBuf(&sMsgStr,(const char *)SyBlobData(pMsg),SyBlobLength(pMsg));
+		PH7_MemObjInitFromString(&(*pVm),&sArg,&sMsgStr);
+		apArg[0] = &sArg;
+		PH7_VmCallClassMethod(&(*pVm),pThis,pCons,0,1,apArg);
+		PH7_MemObjRelease(&sArg);
+	}
+	SyBlobRelease(pMsg);
+	pFrame = pVm->pFrame;
+	if( pFrame ){
+		pFrame = VmSkipExceptionFrames(pFrame);
+		pFrame->iFlags |= VM_FRAME_THROW;
+	}
+	rc = VmThrowException(&(*pVm),pThis);
+	PH7_ClassInstanceUnref(pThis);
+	if( rc == SXERR_ABORT ){
+		return PH7_ABORT;
+	}
+	return PH7_EXCEPTION;
+}
+/*
  * Throw a PHP-compatible TypeError whose message describes a failed typed
  * property assignment. Called from the STORE path when coercion is not
  * possible.
  */
 static sxi32 VmThrowPropertyTypeError(ph7_vm *pVm,VmClassAttr *pVmAttr,const char *zGiven)
 {
-	ph7_class *pClass;
 	ph7_class_attr *pAttr = pVmAttr->pAttr;
-	ph7_class_instance *pThis;
-	ph7_class_method *pCons;
-	ph7_value sArg;
-	ph7_value *apArg[1];
+	ph7_class *pOwner = pAttr->pDeclClass ? pAttr->pDeclClass : pVmAttr->pOwner;
 	SyBlob sMsg;
-	SyString sMsgStr;
-	VmFrame *pFrame;
-	sxi32 rc;
-	pClass = PH7_VmExtractClass(&(*pVm),"TypeError",sizeof("TypeError")-1,TRUE,0);
-	if( pClass == 0 ){
-		return PH7_ABORT;
-	}
-	pThis = PH7_NewClassInstance(&(*pVm),pClass);
-	if( pThis == 0 ){
-		return PH7_ABORT;
-	}
 	SyBlobInit(&sMsg,&pVm->sAllocator);
 	/* Prefer the declaring class over the runtime instance class so that an
 	 * inherited typed property reports its original owner, matching PHP. */
-	{
-		ph7_class *pOwner = pAttr->pDeclClass ? pAttr->pDeclClass : pVmAttr->pOwner;
-		if( pOwner ){
-			SyBlobFormat(&sMsg,"Cannot assign %s to property %z::$%z of type %z",
-				zGiven,&pOwner->sName,&pAttr->sName,&pAttr->sTypeName);
-		}else{
-			SyBlobFormat(&sMsg,"Cannot assign %s to property $%z of type %z",
-				zGiven,&pAttr->sName,&pAttr->sTypeName);
-		}
+	if( pOwner ){
+		SyBlobFormat(&sMsg,"Cannot assign %s to property %z::$%z of type %z",
+			zGiven,&pOwner->sName,&pAttr->sName,&pAttr->sTypeName);
+	}else{
+		SyBlobFormat(&sMsg,"Cannot assign %s to property $%z of type %z",
+			zGiven,&pAttr->sName,&pAttr->sTypeName);
 	}
-	pCons = PH7_ClassExtractMethod(pClass,"__construct",sizeof("__construct")-1);
-	if( pCons ){
-		SyStringInitFromBuf(&sMsgStr,(const char *)SyBlobData(&sMsg),SyBlobLength(&sMsg));
-		PH7_MemObjInitFromString(&(*pVm),&sArg,&sMsgStr);
-		apArg[0] = &sArg;
-		PH7_VmCallClassMethod(&(*pVm),pThis,pCons,0,1,apArg);
-		PH7_MemObjRelease(&sArg);
-	}
-	SyBlobRelease(&sMsg);
-	pFrame = pVm->pFrame;
-	if( pFrame ){
-		pFrame = VmSkipExceptionFrames(pFrame);
-		pFrame->iFlags |= VM_FRAME_THROW;
-	}
-	rc = VmThrowException(&(*pVm),pThis);
-	PH7_ClassInstanceUnref(pThis);
-	if( rc == SXERR_ABORT ){
-		return PH7_ABORT;
-	}
-	return PH7_EXCEPTION;
+	return VmThrowBuiltinError(pVm,"TypeError",sizeof("TypeError")-1,&sMsg);
 }
-
 /*
  * Throw a PHP-compatible Error for reading an uninitialized typed property.
  */
 static sxi32 VmThrowUninitializedPropertyError(ph7_vm *pVm,ph7_class *pClass,ph7_class_attr *pAttr)
 {
-	ph7_class *pErrClass;
-	ph7_class_instance *pThis;
-	ph7_class_method *pCons;
-	ph7_value sArg;
-	ph7_value *apArg[1];
+	ph7_class *pOwner = pAttr->pDeclClass ? pAttr->pDeclClass : pClass;
+	const char *zKind = (pAttr->iFlags & PH7_CLASS_ATTR_STATIC) ? "static property" : "property";
 	SyBlob sMsg;
-	SyString sMsgStr;
-	VmFrame *pFrame;
-	sxi32 rc;
-	pErrClass = PH7_VmExtractClass(&(*pVm),"Error",sizeof("Error")-1,TRUE,0);
-	if( pErrClass == 0 ){
-		return PH7_ABORT;
-	}
-	pThis = PH7_NewClassInstance(&(*pVm),pErrClass);
-	if( pThis == 0 ){
-		return PH7_ABORT;
-	}
 	SyBlobInit(&sMsg,&pVm->sAllocator);
-	{
-		ph7_class *pOwner = pAttr->pDeclClass ? pAttr->pDeclClass : pClass;
-		const char *zKind = (pAttr->iFlags & PH7_CLASS_ATTR_STATIC) ? "static property" : "property";
-		SyBlobFormat(&sMsg,"Typed %s %z::$%z must not be accessed before initialization",
-			zKind,&pOwner->sName,&pAttr->sName);
-	}
-	pCons = PH7_ClassExtractMethod(pErrClass,"__construct",sizeof("__construct")-1);
-	if( pCons ){
-		SyStringInitFromBuf(&sMsgStr,(const char *)SyBlobData(&sMsg),SyBlobLength(&sMsg));
-		PH7_MemObjInitFromString(&(*pVm),&sArg,&sMsgStr);
-		apArg[0] = &sArg;
-		PH7_VmCallClassMethod(&(*pVm),pThis,pCons,0,1,apArg);
-		PH7_MemObjRelease(&sArg);
-	}
-	SyBlobRelease(&sMsg);
-	pFrame = pVm->pFrame;
-	if( pFrame ){
-		pFrame = VmSkipExceptionFrames(pFrame);
-		pFrame->iFlags |= VM_FRAME_THROW;
-	}
-	rc = VmThrowException(&(*pVm),pThis);
-	PH7_ClassInstanceUnref(pThis);
-	if( rc == SXERR_ABORT ){
-		return PH7_ABORT;
-	}
-	return PH7_EXCEPTION;
+	SyBlobFormat(&sMsg,"Typed %s %z::$%z must not be accessed before initialization",
+		zKind,&pOwner->sName,&pAttr->sName);
+	return VmThrowBuiltinError(pVm,"Error",sizeof("Error")-1,&sMsg);
 }
-
+/*
+ * Throw the PHP-compatible Error raised on an illegal write to a readonly
+ * property (PHP 8.1). bModify TRUE → a write to an already-initialized property
+ * ("Cannot modify readonly property C::$x"); bModify FALSE → a first write from
+ * a scope that cannot satisfy the readonly set-scope ("Cannot modify
+ * protected(set) readonly property C::$x from {global scope|scope X}").
+ */
+static sxi32 VmThrowReadonlyError(ph7_vm *pVm,ph7_class *pClass,ph7_class_attr *pAttr,int bModify)
+{
+	ph7_class *pOwner = pAttr->pDeclClass ? pAttr->pDeclClass : pClass;
+	SyBlob sMsg;
+	SyBlobInit(&sMsg,&pVm->sAllocator);
+	if( bModify ){
+		SyBlobFormat(&sMsg,"Cannot modify readonly property %z::$%z",&pOwner->sName,&pAttr->sName);
+	}else{
+		ph7_class *pActive = VmCurrentSelf(pVm);
+		if( pActive ){
+			SyBlobFormat(&sMsg,"Cannot modify protected(set) readonly property %z::$%z from scope %z",
+				&pOwner->sName,&pAttr->sName,&pActive->sName);
+		}else{
+			SyBlobFormat(&sMsg,"Cannot modify protected(set) readonly property %z::$%z from global scope",
+				&pOwner->sName,&pAttr->sName);
+		}
+	}
+	return VmThrowBuiltinError(pVm,"Error",sizeof("Error")-1,&sMsg);
+}
 /*
  * Enforce a typed-property assignment. On entry pValue holds the incoming
  * value. For scalar types it may be coerced in place (PHP 7.4 weak mode).
@@ -3432,11 +3442,7 @@ static sxi32 VmCoerceToUnion(ph7_vm *pVm, ph7_value *pValue, SySet *pAlts, int b
 		if( bHasObjAlt ) return SXRET_OK;
 		if( bHasClassAlt ){
 			ph7_class_instance *pInst = (ph7_class_instance *)pValue->x.pOther;
-			ph7_class *pSelfNow = 0;
-			if( SySetUsed(&pVm->aSelf) > 0 ){
-				ph7_class **apSelf = (ph7_class **)SySetBasePtr(&pVm->aSelf);
-				pSelfNow = apSelf[SySetUsed(&pVm->aSelf)-1];
-			}
+			ph7_class *pSelfNow = VmCurrentSelf(pVm);
 			for( i = 0; i < SySetUsed(pAlts); i++ ){
 				ph7_class *pExpected;
 				SyString *pCN;
@@ -3620,6 +3626,28 @@ static sxi32 VmEnforcePropertyTypeOnStore(ph7_vm *pVm,sxu32 nIdx,ph7_value *pVal
 	if( pAttr == 0 || (pAttr->iFlags & PH7_CLASS_ATTR_TYPED) == 0 ){
 		return SXRET_OK;
 	}
+	/* readonly enforcement (PHP 8.1), checked before type coercion. A readonly
+	 * property may be written exactly once and only from within the declaring
+	 * class scope (its set-scope is protected). */
+	if( pAttr->iFlags & PH7_CLASS_ATTR_READONLY ){
+		/* A readonly property is always typed and default-less, so it starts
+		 * VM_CLASS_ATTR_UNINIT and that flag is cleared only by a *successful*
+		 * write below — making it the write-once latch (a type-rejected write
+		 * leaves it set, so a later valid initialization still works). */
+		if( (pVmAttr->iState & VM_CLASS_ATTR_UNINIT) == 0 ){
+			/* Already initialized: any further write is forbidden, any scope. */
+			return VmThrowReadonlyError(pVm,pVmAttr->pOwner,pAttr,1);
+		}
+		{
+			/* First write must come from within the declaring class scope
+			 * (readonly's set-scope is protected — a subclass may initialize). */
+			ph7_class *pDecl = pAttr->pDeclClass ? pAttr->pDeclClass : pVmAttr->pOwner;
+			ph7_class *pActive = VmCurrentSelf(pVm);
+			if( pActive == 0 || pDecl == 0 || !PH7_VmInstanceOf(pActive,pDecl) ){
+				return VmThrowReadonlyError(pVm,pVmAttr->pOwner,pAttr,0);
+			}
+		}
+	}
 	/* Union type: dispatch to the shared coercion helper. Typed properties
 	 * are always evaluated in weak mode regardless of declare(strict_types),
 	 * matching PHP's documented behavior. */
@@ -3686,11 +3714,7 @@ static sxi32 VmEnforcePropertyTypeOnStore(ph7_vm *pVm,sxu32 nIdx,ph7_value *pVal
 		 * currently active on the self-stack. */
 		ph7_class *pExpected = 0;
 		SyString *pClassName = &pAttr->sClass;
-		ph7_class *pSelfNow = 0;
-		if( SySetUsed(&pVm->aSelf) > 0 ){
-			ph7_class **apSelf = (ph7_class **)SySetBasePtr(&pVm->aSelf);
-			pSelfNow = apSelf[SySetUsed(&pVm->aSelf)-1];
-		}
+		ph7_class *pSelfNow = VmCurrentSelf(pVm);
 		if( pClassName->nByte == 4 && SyMemcmp(pClassName->zString,"self",4) == 0 ){
 			pExpected = pSelfNow;
 		}else if( pClassName->nByte == 6 && SyMemcmp(pClassName->zString,"parent",6) == 0 ){
@@ -4181,11 +4205,7 @@ static sxi32 VmEnforceReturnType(ph7_vm *pVm, ph7_vm_func *pFunc, ph7_value *pVa
 		SyString *pClassName = &pFunc->sReturnClass;
 		const char *zExpected;
 		ph7_class *pExpected;
-		ph7_class *pSelfNow = 0;
-		if( SySetUsed(&pVm->aSelf) > 0 ){
-			ph7_class **apSelf = (ph7_class **)SySetBasePtr(&pVm->aSelf);
-			pSelfNow = apSelf[SySetUsed(&pVm->aSelf)-1];
-		}
+		ph7_class *pSelfNow = VmCurrentSelf(pVm);
 		if( pClassName->nByte == 4 && SyMemcmp(pClassName->zString,"self",4) == 0 ){
 			pExpected = pSelfNow;
 		}else if( pClassName->nByte == 6 && SyMemcmp(pClassName->zString,"parent",6) == 0 ){

--- a/tests/ph7/001-smoke/oo/readonly_basic.phpt
+++ b/tests/ph7/001-smoke/oo/readonly_basic.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+readonly property (PHP 8.1): initialized once in the constructor, read back
+--FILE--
+<?php
+class ReadonlyBasic {
+    public readonly int $x;
+    public readonly string $name;
+    public function __construct(int $v, string $n) {
+        $this->x = $v;
+        $this->name = $n;
+    }
+}
+$o = new ReadonlyBasic(42, "Ada");
+echo $o->x, "\n";
+echo $o->name, "\n";
+?>
+--EXPECT--
+42
+Ada
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/oo/readonly_promoted.phpt
+++ b/tests/ph7/001-smoke/oo/readonly_promoted.phpt
@@ -1,0 +1,26 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+readonly promoted constructor properties (incl. implicit-public `readonly T $x`)
+--FILE--
+<?php
+class ReadonlyPromoted {
+    public function __construct(
+        public readonly string $name,
+        private readonly int $age,
+        readonly float $score
+    ) {}
+    public function age(): int { return $this->age; }
+}
+$o = new ReadonlyPromoted("Ada", 36, 9.5);
+echo $o->name, "\n";
+echo $o->age(), "\n";
+echo $o->score, "\n";
+?>
+--EXPECT--
+Ada
+36
+9.5
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/readonly_clone.phpt
+++ b/tests/ph7/002-integration/oo/readonly_clone.phpt
@@ -1,0 +1,41 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+clone preserves readonly/typed init state; a type-rejected readonly init can retry
+--FILE--
+<?php
+class ReadonlyClone {
+    public function __construct(public readonly int $x) {}
+}
+$a = new ReadonlyClone(7);
+$b = clone $a;
+echo $b->x, "\n";              // clone keeps the value and stays readable
+
+// a typed property survives clone without losing its initialized state
+class TypedClone {
+    public int $n;
+    public function __construct() { $this->n = 3; }
+}
+$t = new TypedClone;
+$tc = clone $t;
+echo $tc->n, "\n";
+
+// a type-rejected readonly initialization does not burn the one allowed write
+class ReadonlyRetry {
+    public readonly int $y;
+    public function __construct() {
+        try { $this->y = "bad"; } catch (\TypeError $e) { echo "caught\n"; }
+        $this->y = 9;
+    }
+}
+$r = new ReadonlyRetry;
+echo $r->y, "\n";
+?>
+--EXPECT--
+7
+3
+caught
+9
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/readonly_clone_modify.phpt
+++ b/tests/ph7/002-integration/oo/readonly_clone_modify.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A cloned object's readonly property stays immutable (clone preserves the latch)
+--FILE--
+<?php
+class ReadonlyCloneModify {
+    public function __construct(public readonly int $x) {}
+    public function set(int $v) { $this->x = $v; }
+}
+$a = new ReadonlyCloneModify(1);
+$b = clone $a;
+echo $b->x, "\n";
+$b->set(2);
+?>
+--EXPECTF--
+1
+%s Fatal error:  Uncaught Error: Cannot modify readonly property ReadonlyCloneModify::$x%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/readonly_default.phpt
+++ b/tests/ph7/002-integration/oo/readonly_default.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A readonly property cannot carry a default value
+--FILE--
+<?php
+class ReadonlyDefault {
+    public readonly int $x = 1;
+}
+echo "unreached";
+?>
+--EXPECTF--
+%s Fatal error:  Readonly property ReadonlyDefault::$x cannot have default value%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/readonly_init_outside.phpt
+++ b/tests/ph7/002-integration/oo/readonly_init_outside.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Initializing a readonly property from outside the class scope is a fatal Error
+--FILE--
+<?php
+class ReadonlyInitOutside {
+    public readonly int $x;
+}
+$o = new ReadonlyInitOutside();
+$o->x = 5;
+?>
+--EXPECTF--
+%s Fatal error:  Uncaught Error: %Areadonly property ReadonlyInitOutside::$x from global scope%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/readonly_modify.phpt
+++ b/tests/ph7/002-integration/oo/readonly_modify.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Modifying a readonly property after initialization is a fatal Error
+--FILE--
+<?php
+class ReadonlyModify {
+    public function __construct(public readonly int $x) {}
+}
+$o = new ReadonlyModify(1);
+echo $o->x, "\n";
+$o->x = 2;
+?>
+--EXPECTF--
+1
+%s Fatal error:  Uncaught Error: Cannot modify readonly property ReadonlyModify::$x%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/readonly_untyped.phpt
+++ b/tests/ph7/002-integration/oo/readonly_untyped.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A readonly property must have a declared type
+--FILE--
+<?php
+class ReadonlyUntyped {
+    public readonly $x;
+}
+echo "unreached";
+?>
+--EXPECTF--
+%s Fatal error:  Readonly property ReadonlyUntyped::$x must have type%A
+--CLEAN--
+<?php


### PR DESCRIPTION
Declared (public readonly int $x) and promoted (__construct(public readonly int $x), including the implicit-public `readonly T $x`) readonly properties, PHP 8.1, reusing the typed-property machinery.

readonly is recognized as a context-sensitive identifier in the class-member modifier position (not a reserved lexer keyword, matching PHP) and accepted in any order with visibility — a new GenStateIsReadonly helper plus detection at the member-loop and promoted-param sites. Parse rules emit PHP-exact fatals: a readonly property must be typed, cannot have a default, and cannot be static.

Runtime enforcement lives in VmEnforcePropertyTypeOnStore (every readonly write is typed, so it already flows there): a write to an already-initialized property throws "Cannot modify readonly property C::$x"; a first write from outside the declaring class scope (readonly's set-scope is protected — a subclass may initialize) throws "Cannot modify protected(set) readonly property C::$x from {global scope|scope X}". The write-once latch is the existing VM_CLASS_ATTR_UNINIT flag itself: a readonly property is always typed and default-less, so it starts uninitialized and that flag is cleared only by a successful write (a type-rejected init leaves it set, so a later valid init still works) — no separate flag needed.

Also fixes a pre-existing clone bug the feature surfaced: PH7_CloneClassInstance copied property values but not the per-instance iState, so a clone reset every typed property to uninitialized and made readonly properties writable again; it now carries iState across, matching PHP for readonly and ordinary typed properties.

As part of this work the three property-error throwers (TypeError/uninitialized/ readonly) were consolidated onto a shared VmThrowBuiltinError helper, and the repeated "top of the self-stack" lookup onto a VmCurrentSelf helper.

Byte-for-byte parity with PHP 8.5.7. make test (2143 smoke + 697 integration), test-compat and test-stress green.

Deferred: readonly class (8.2) needs statement-level interception of the readonly identifier before `class`; $x++/$x-- on a readonly property isn't caught (it uses OP_INCR, bypassing the store path — =/.=/+= are enforced).
