### PR TITLE
Add readonly classes and ++/-- enforcement

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -7157,6 +7157,12 @@ static sxi32 GenStateCompileClassAttr(ph7_gen_state *pGen,sxi32 iProtection,sxi3
 	SyStringInitFromBuf(&sTypeClass,0,0);
 	SyStringInitFromBuf(&sTypeText,0,0);
 	SySetInit(&aUnionAlts,&pGen->pVm->sAllocator,sizeof(ph7_type_alt));
+	/* In a readonly class (PHP 8.2) every declared instance property is readonly;
+	 * the per-property readonly rules below then apply uniformly (a static or
+	 * untyped property, or one with a default, raises the same PHP-exact fatal). */
+	if( pClass->iFlags & PH7_CLASS_READONLY ){
+		iFlags |= PH7_CLASS_ATTR_READONLY;
+	}
 	/* Extract visibility level */
 	iProtection = GetProtectionLevel(iProtection);
 	/* Parse optional type hint (typed properties, PHP 7.4+) */
@@ -7494,8 +7500,9 @@ static sxi32 GenStateCompileClassMethod(
 			if( pArg->iFlags & VM_FUNC_ARG_UNION ){
 				iAttrFlags |= PH7_CLASS_ATTR_UNION;
 			}
-			if( pArg->iFlags & VM_FUNC_ARG_READONLY ){
-				/* A readonly promoted property must be typed (PHP 8.1). */
+			if( (pArg->iFlags & VM_FUNC_ARG_READONLY) || (pClass->iFlags & PH7_CLASS_READONLY) ){
+				/* A readonly promoted property must be typed (PHP 8.1); in a
+				 * readonly class (8.2) every promoted property is readonly too. */
 				if( (iAttrFlags & PH7_CLASS_ATTR_TYPED) == 0 ){
 					rc = PH7_GenCompileError(pGen,E_ERROR,nLine,
 						"Readonly property %z::$%z must have type",&pClass->sName,&pArg->sName);
@@ -9019,26 +9026,83 @@ done:
  *   This also applies to constructors as of PHP 5.4. Before 5.4 constructor signatures
  *   could differ.
  */
-static sxi32 PH7_CompileAbstractClass(ph7_gen_state *pGen)
+/*
+ * Recognize a class-declaration modifier token: the `final`/`abstract` keywords
+ * or the context-sensitive `readonly` identifier (PHP 8.2). On a match, *piFlag
+ * receives the corresponding PH7_CLASS_* bit.
+ */
+static int GenStateTokenIsClassModifier(SyToken *pTok,sxi32 *piFlag)
 {
-	sxi32 rc;
-	pGen->pIn++; /* Jump the 'abstract' keyword */
-	rc = GenStateCompileClass(&(*pGen),PH7_CLASS_ABSTRACT);
-	return rc;
+	if( pTok->nType & PH7_TK_KEYWORD ){
+		sxu32 nKw = (sxu32)SX_PTR_TO_INT(pTok->pUserData);
+		if( nKw == PH7_TKWRD_FINAL ){ *piFlag = PH7_CLASS_FINAL; return TRUE; }
+		if( nKw == PH7_TKWRD_ABSTRACT ){ *piFlag = PH7_CLASS_ABSTRACT; return TRUE; }
+	}
+	if( GenStateIsReadonly(pTok) ){ *piFlag = PH7_CLASS_READONLY; return TRUE; }
+	return FALSE;
 }
 /*
- * Compile a user-defined final class.
- *  According to the PHP language reference manual
- *    PHP 5 introduces the final keyword, which prevents child classes from overriding
- *    a method by prefixing the definition with final. If the class itself is being defined
- *    final then it cannot be extended.
+ * Advance *ppIn over a leading run of class modifiers, returning the combined
+ * PH7_CLASS_* flags (0 if none). If a modifier is repeated, the first repeated
+ * token is reported via *ppDup (NULL when none); pass 0 for ppDup to ignore it.
+ * This stays side-effect-free so it can be used for speculative look-ahead.
  */
-static sxi32 PH7_CompileFinalClass(ph7_gen_state *pGen)
+static sxi32 GenStateScanClassModifiers(SyToken **ppIn,SyToken *pEnd,SyToken **ppDup)
 {
+	SyToken *pIn = *ppIn,*pDup = 0;
+	sxi32 iFlags = 0,iFlag;
+	while( pIn < pEnd && GenStateTokenIsClassModifier(pIn,&iFlag) ){
+		if( (iFlags & iFlag) && pDup == 0 ){
+			pDup = pIn;
+		}
+		iFlags |= iFlag;
+		pIn++;
+	}
+	*ppIn = pIn;
+	if( ppDup ){ *ppDup = pDup; }
+	return iFlags;
+}
+/*
+ * Test whether the token stream starts a *modified* class declaration: a run of
+ * one or more `final`/`abstract`/`readonly` modifiers (in any order) terminated
+ * by the `class` keyword. Requiring at least one modifier leaves a bare
+ * `class`/`interface`/`trait` (and any expression that merely starts with
+ * `readonly`) to their existing handlers.
+ */
+static int GenStateStartsModifiedClass(SyToken *pIn,SyToken *pEnd)
+{
+	sxi32 iFlags = GenStateScanClassModifiers(&pIn,pEnd,0);
+	return iFlags != 0 && pIn < pEnd && (pIn->nType & PH7_TK_KEYWORD)
+		&& (sxu32)SX_PTR_TO_INT(pIn->pUserData) == PH7_TKWRD_CLASS;
+}
+/*
+ * Compile a class declaration carrying one or more leading modifiers
+ * (`final`/`abstract`/`readonly`, any order). Consumes the modifier run, leaving
+ * the cursor on the `class` keyword for GenStateCompileClass, and rejects a
+ * repeated modifier (`final final class`) or the mutually-exclusive
+ * `abstract`+`final` pair, like PHP.
+ */
+static sxi32 PH7_CompileClassModifiers(ph7_gen_state *pGen)
+{
+	SyToken *pDup;
+	sxi32 iFlags = GenStateScanClassModifiers(&pGen->pIn,pGen->pEnd,&pDup);
 	sxi32 rc;
-	pGen->pIn++; /* Jump the 'final' keyword */
-	rc = GenStateCompileClass(&(*pGen),PH7_CLASS_FINAL);
-	return rc;
+	if( pDup ){
+		rc = PH7_GenCompileError(pGen,E_ERROR,pDup->nLine,
+			"Multiple %z modifiers are not allowed",&pDup->sData);
+		if( rc == SXERR_ABORT ){
+			return SXERR_ABORT;
+		}
+	}
+	if( (iFlags & (PH7_CLASS_FINAL|PH7_CLASS_ABSTRACT))
+		== (PH7_CLASS_FINAL|PH7_CLASS_ABSTRACT) ){
+		rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,
+			"Cannot use the final modifier on an abstract class");
+		if( rc == SXERR_ABORT ){
+			return SXERR_ABORT;
+		}
+	}
+	return GenStateCompileClass(&(*pGen),iFlags);
 }
 /*
  * Compile a user-defined trait.
@@ -11045,13 +11109,11 @@ static ProcLangConstruct GenStateGetStatementHandler(
 			return PH7_CompileClass;
 		}else if(nKeywordID == PH7_TKWRD_TRAIT && (pLookahed->nType & PH7_TK_ID) ){
 			return PH7_CompileTrait;
-		}else if( nKeywordID == PH7_TKWRD_ABSTRACT && (pLookahed->nType & PH7_TK_KEYWORD)
-			&& SX_PTR_TO_INT(pLookahed->pUserData) == PH7_TKWRD_CLASS ){
-				return PH7_CompileAbstractClass;
-		}else if( nKeywordID == PH7_TKWRD_FINAL && (pLookahed->nType & PH7_TK_KEYWORD)
-			&& SX_PTR_TO_INT(pLookahed->pUserData) == PH7_TKWRD_CLASS ){
-				return PH7_CompileFinalClass;
 		}
+		/* `final`/`abstract` (and `readonly`, an ID) class modifiers — possibly
+		 * combined — are routed via GenStateStartsModifiedClass in the chunk
+		 * compiler, which can scan the whole modifier run (the lookahead here is
+		 * a single token and cannot see past `final readonly …`). */
 	}
 	/* Not a language construct */
 	return 0;
@@ -11118,7 +11180,12 @@ static sxi32 GenStateCompileChunk(
 			}
 		}else{
 			xCons = 0;
-			if( pGen->pIn->nType & PH7_TK_KEYWORD ){
+			if( GenStateStartsModifiedClass(pGen->pIn,pGen->pEnd) ){
+				/* `final`/`abstract`/`readonly` (any order) before `class`. Handled
+				 * here rather than the keyword-only dispatcher because `readonly`
+				 * is a context-sensitive ID and combos need a full-run scan. */
+				xCons = PH7_CompileClassModifiers;
+			}else if( pGen->pIn->nType & PH7_TK_KEYWORD ){
 				sxu32 nKeyword = (sxu32)SX_PTR_TO_INT(pGen->pIn->pUserData);
 				/* Try to extract a language construct handler */
 				xCons = GenStateGetStatementHandler(nKeyword,(&pGen->pIn[1] < pGen->pEnd) ? &pGen->pIn[1] : 0);

--- a/src/ph7/oo.c
+++ b/src/ph7/oo.c
@@ -243,6 +243,22 @@ PH7_PRIVATE sxi32 PH7_ClassInherit(ph7_gen_state *pGen,ph7_class *pSub,ph7_class
 	if( rc != SXRET_OK ){
 		return rc;
 	}
+	/* readonly class inheritance (PHP 8.2): a readonly class may only extend a
+	 * readonly class, and a non-readonly class may not extend a readonly one. */
+	if( (pBase->iFlags & PH7_CLASS_READONLY) != (pSub->iFlags & PH7_CLASS_READONLY) ){
+		if( pBase->iFlags & PH7_CLASS_READONLY ){
+			rc = PH7_GenCompileError(&(*pGen),E_ERROR,pSub->nLine,
+				"Non-readonly class %z cannot extend readonly class %z",
+				&pSub->sName,&pBase->sName);
+		}else{
+			rc = PH7_GenCompileError(&(*pGen),E_ERROR,pSub->nLine,
+				"Readonly class %z cannot extend non-readonly class %z",
+				&pSub->sName,&pBase->sName);
+		}
+		if( rc == SXERR_ABORT ){
+			return SXERR_ABORT;
+		}
+	}
 	/* Copy public/protected attributes from the base class */
 	SyHashResetLoopCursor(&pBase->hAttr);
 	while((pEntry = SyHashGetNextEntry(&pBase->hAttr)) != 0 ){

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -651,6 +651,7 @@ struct ph7_class
 #define PH7_CLASS_ABSTRACT    0x004 /* Class is abstract */
 #define PH7_CLASS_TRAIT       0x008 /* Class is a trait */
 #define PH7_CLASS_TRAIT_VISITING 0x010 /* Trait is currently being applied (cycle detection) */
+#define PH7_CLASS_READONLY    0x020 /* Class is readonly (PHP 8.2): every declared property is readonly */
 /* Class attribute/methods/constants protection levels */
 #define PH7_CLASS_PROT_PUBLIC     1 /* public */
 #define PH7_CLASS_PROT_PROTECTED  2 /* protected */

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -3286,6 +3286,32 @@ static sxi32 VmThrowReadonlyError(ph7_vm *pVm,ph7_class *pClass,ph7_class_attr *
 	return VmThrowBuiltinError(pVm,"Error",sizeof("Error")-1,&sMsg);
 }
 /*
+ * Reject an in-place mutation (`++`/`--`) of a readonly property. The increment
+ * and decrement opcodes mutate the per-instance slot directly, bypassing
+ * VmEnforcePropertyTypeOnStore, so they consult the typed-slot table here. A
+ * readonly property reached by `++`/`--` is necessarily already initialized (an
+ * uninitialized read is rejected earlier at OP_MEMBER), so the mutation is always
+ * the "Cannot modify readonly property" case. Returns SXRET_OK to proceed, or the
+ * PH7_EXCEPTION/PH7_ABORT produced by the throw.
+ */
+static sxi32 VmCheckReadonlyMutate(ph7_vm *pVm,sxu32 nIdx)
+{
+	SyHashEntry *pSlot;
+	VmClassAttr *pVmAttr;
+	if( nIdx == SXU32_HIGH || SyHashTotalEntry(&pVm->hTypedSlot) == 0 ){
+		return SXRET_OK; /* Non-lvalue operand, or no typed/readonly properties — skip */
+	}
+	pSlot = SyHashGet(&pVm->hTypedSlot,(const void *)&nIdx,sizeof(sxu32));
+	if( pSlot == 0 ){
+		return SXRET_OK; /* Not a typed slot */
+	}
+	pVmAttr = (VmClassAttr *)pSlot->pUserData;
+	if( pVmAttr->pAttr && (pVmAttr->pAttr->iFlags & PH7_CLASS_ATTR_READONLY) ){
+		return VmThrowReadonlyError(pVm,pVmAttr->pOwner,pVmAttr->pAttr,1);
+	}
+	return SXRET_OK;
+}
+/*
  * Enforce a typed-property assignment. On entry pValue holds the incoming
  * value. For scalar types it may be coerced in place (PHP 7.4 weak mode).
  * For class types, instanceof is verified.
@@ -4739,6 +4765,21 @@ static sxi32 VmByteCodeExec(
 	pEntryFrame = pVm->pFrame;
 	pc = nPc;
 /*
+ * Route an enforcement helper's return code from inside the main switch:
+ * proceed on SXRET_OK, abort on PH7_ABORT, and on PH7_EXCEPTION jump to the
+ * enclosing catch block (if any) or unwind out of the VM loop.
+ */
+#define PH7_DISPATCH_ENFORCE_RC(rcVar) \
+	if( (rcVar) == PH7_ABORT ){ goto Abort; } \
+	if( (rcVar) == PH7_EXCEPTION ){ \
+		VmFrame *_pFrmE = pVm->pFrame; \
+		if( _pFrmE && (_pFrmE->iFlags & VM_FRAME_EXCEPTION) && _pFrmE->iExceptionJump > 0 ){ \
+			pc = _pFrmE->iExceptionJump - 1; \
+			break; \
+		} \
+		goto Exception; \
+	}
+/*
  * Typed-property enforcement helper for compound stores. Called before
  * PH7_MemObjStore writes into a member memobj slot. On failure throws a
  * PHP TypeError and either jumps to the nearest catch block or propagates
@@ -4747,15 +4788,18 @@ static sxi32 VmByteCodeExec(
 #define PH7_ENFORCE_TYPED_STORE(nIdxArg, pSrcArg) \
 	{ \
 		sxi32 _rcT = VmEnforcePropertyTypeOnStore(&(*pVm),(nIdxArg),(pSrcArg)); \
-		if( _rcT == PH7_ABORT ){ goto Abort; } \
-		if( _rcT == PH7_EXCEPTION ){ \
-			VmFrame *_pFrmT = pVm->pFrame; \
-			if( _pFrmT && (_pFrmT->iFlags & VM_FRAME_EXCEPTION) && _pFrmT->iExceptionJump > 0 ){ \
-				pc = _pFrmT->iExceptionJump - 1; \
-				break; \
-			} \
-			goto Exception; \
-		} \
+		PH7_DISPATCH_ENFORCE_RC(_rcT) \
+	}
+/*
+ * Readonly enforcement helper for the in-place mutation opcodes (`++`/`--`),
+ * which bypass the typed-store path. Throws "Cannot modify readonly property"
+ * when the lvalue slot is a readonly property, otherwise proceeds. Must be used
+ * inside a case of the main switch.
+ */
+#define PH7_ENFORCE_READONLY_MUTATE(nIdxArg) \
+	{ \
+		sxi32 _rcR = VmCheckReadonlyMutate(&(*pVm),(nIdxArg)); \
+		PH7_DISPATCH_ENFORCE_RC(_rcR) \
 	}
 	/* Execute as much as we can */
 	for(;;){
@@ -6206,6 +6250,10 @@ case PH7_OP_INCR:
 		goto Abort;
 	}
 #endif
+	/* `++` on a readonly property is forbidden regardless of the current value's
+	 * type (it bypasses the store path), so enforce before the type guard below
+	 * — which otherwise skips object/array/resource operands. */
+	PH7_ENFORCE_READONLY_MUTATE(pTos->nIdx);
 	if( (pTos->iFlags & (MEMOBJ_HASHMAP|MEMOBJ_OBJ|MEMOBJ_RES)) == 0 ){
 		if( pTos->nIdx != SXU32_HIGH ){
 			ph7_value *pObj;
@@ -6287,6 +6335,11 @@ case PH7_OP_DECR:
 		goto Abort;
 	}
 #endif
+	/* `--` on a readonly property is forbidden regardless of the current value's
+	 * type (it bypasses the store path), so enforce before the type guard below
+	 * — which otherwise skips null/object/array/resource operands (e.g. a readonly
+	 * property currently holding null). */
+	PH7_ENFORCE_READONLY_MUTATE(pTos->nIdx);
 	/* NULL stays excluded: PHP leaves `--` on null untouched (no-op). */
 	if( (pTos->iFlags & (MEMOBJ_HASHMAP|MEMOBJ_OBJ|MEMOBJ_RES|MEMOBJ_NULL)) == 0 ){
 		if( pTos->nIdx != SXU32_HIGH ){

--- a/tests/ph7/001-smoke/oo/readonly_class_basic.phpt
+++ b/tests/ph7/001-smoke/oo/readonly_class_basic.phpt
@@ -1,0 +1,38 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+readonly class (PHP 8.2): all declared properties become readonly; modifier combos
+--FILE--
+<?php
+readonly class RoClassPoint {
+    public int $x;
+    public string $label;
+    public function __construct(int $x, string $label) {
+        $this->x = $x;
+        $this->label = $label;
+    }
+}
+$p = new RoClassPoint(3, "origin");
+echo $p->x, "\n";
+echo $p->label, "\n";
+
+// final/abstract combine with readonly, in either order
+final readonly class RoClassFr { public int $n; public function __construct() { $this->n = 1; } }
+echo (new RoClassFr)->n, "\n";
+
+readonly final class RoClassRf { public int $n; public function __construct() { $this->n = 2; } }
+echo (new RoClassRf)->n, "\n";
+
+// readonly stays usable as an ordinary identifier
+function readonly() { return 42; }
+echo readonly(), "\n";
+?>
+--EXPECT--
+3
+origin
+1
+2
+42
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/oo/readonly_class_promoted.phpt
+++ b/tests/ph7/001-smoke/oo/readonly_class_promoted.phpt
@@ -1,0 +1,33 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+readonly class (PHP 8.2): promoted constructor properties become readonly and read back
+--FILE--
+<?php
+readonly class Money {
+    public function __construct(
+        public int $amount,
+        public string $currency,
+    ) {}
+}
+$m = new Money(100, "EUR");
+echo $m->amount, "\n";
+echo $m->currency, "\n";
+
+// a non-readonly typed property of a non-readonly class still increments normally
+class RoClassPromotedCounter {
+    public int $n = 0;
+    public function bump(): void { $this->n++; }
+}
+$c = new RoClassPromotedCounter;
+$c->bump();
+$c->bump();
+echo $c->n, "\n";
+?>
+--EXPECT--
+100
+EUR
+2
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/readonly_class_abstract_final.phpt
+++ b/tests/ph7/002-integration/oo/readonly_class_abstract_final.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+the mutually-exclusive abstract+final class modifiers are rejected
+--FILE--
+<?php
+abstract final class RoAbsFin {}
+echo "unreached\n";
+?>
+--EXPECTF--
+%s Fatal error:  Cannot use the final modifier on an abstract class%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/readonly_class_default.phpt
+++ b/tests/ph7/002-integration/oo/readonly_class_default.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+readonly class: a declared property with a default value is a fatal
+--FILE--
+<?php
+readonly class RoClassDefault {
+    public int $x = 5;
+}
+echo "unreached\n";
+?>
+--EXPECTF--
+%s Fatal error:  Readonly property RoClassDefault::$x cannot have default value%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/readonly_class_dup_modifier.phpt
+++ b/tests/ph7/002-integration/oo/readonly_class_dup_modifier.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+a repeated class modifier (readonly readonly) is rejected
+--FILE--
+<?php
+readonly readonly class RoDup {}
+echo "unreached\n";
+?>
+--EXPECTF--
+%s Fatal error:  Multiple readonly modifiers are not allowed%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/readonly_class_extend_nonreadonly.phpt
+++ b/tests/ph7/002-integration/oo/readonly_class_extend_nonreadonly.phpt
@@ -1,0 +1,15 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+readonly class inheritance: a non-readonly class cannot extend a readonly class
+--FILE--
+<?php
+readonly class RoBase {}
+class PlainChild extends RoBase {}
+echo "unreached\n";
+?>
+--EXPECTF--
+%s Fatal error:  Non-readonly class PlainChild cannot extend readonly class RoBase%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/readonly_class_inherited_prop.phpt
+++ b/tests/ph7/002-integration/oo/readonly_class_inherited_prop.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+readonly class: an inherited readonly property is immutable; the error names its declaring class
+--FILE--
+<?php
+readonly class RoInhBase {
+    public int $x;
+    public function __construct() { $this->x = 1; }
+}
+readonly class RoInhChild extends RoInhBase {}
+$o = new RoInhChild();
+echo $o->x, "\n";
+$o->x = 9;
+?>
+--EXPECTF--
+1
+%s Fatal error:  Uncaught Error: Cannot modify readonly property RoInhBase::$x%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/readonly_class_modify.phpt
+++ b/tests/ph7/002-integration/oo/readonly_class_modify.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+readonly class: modifying a declared property after init is a fatal Error
+--FILE--
+<?php
+readonly class RoClassModify {
+    public int $x;
+    public function __construct() { $this->x = 1; }
+}
+$o = new RoClassModify();
+echo $o->x, "\n";
+$o->x = 2;
+?>
+--EXPECTF--
+1
+%s Fatal error:  Uncaught Error: Cannot modify readonly property RoClassModify::$x%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/readonly_class_promoted_untyped.phpt
+++ b/tests/ph7/002-integration/oo/readonly_class_promoted_untyped.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+readonly class: an untyped promoted constructor property is a fatal (must have type)
+--FILE--
+<?php
+readonly class RoClassPromotedUntyped {
+    public function __construct(public $x) {}
+}
+echo "unreached\n";
+?>
+--EXPECTF--
+%s Fatal error:  Readonly property RoClassPromotedUntyped::$x must have type%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/readonly_class_readonly_extend_plain.phpt
+++ b/tests/ph7/002-integration/oo/readonly_class_readonly_extend_plain.phpt
@@ -1,0 +1,15 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+readonly class inheritance: a readonly class cannot extend a non-readonly class
+--FILE--
+<?php
+class PlainBase {}
+readonly class RoChild extends PlainBase {}
+echo "unreached\n";
+?>
+--EXPECTF--
+%s Fatal error:  Readonly class RoChild cannot extend non-readonly class PlainBase%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/readonly_class_static.phpt
+++ b/tests/ph7/002-integration/oo/readonly_class_static.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+readonly class: a static declared property is a fatal (static cannot be readonly)
+--FILE--
+<?php
+readonly class RoClassStatic {
+    public static int $x;
+}
+echo "unreached\n";
+?>
+--EXPECTF--
+%s Fatal error:  Static property RoClassStatic::$x cannot be readonly%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/readonly_class_untyped.phpt
+++ b/tests/ph7/002-integration/oo/readonly_class_untyped.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+readonly class: an untyped declared property is a fatal (must have type)
+--FILE--
+<?php
+readonly class RoClassUntyped {
+    public $x;
+}
+echo "unreached\n";
+?>
+--EXPECTF--
+%s Fatal error:  Readonly property RoClassUntyped::$x must have type%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/readonly_incr.phpt
+++ b/tests/ph7/002-integration/oo/readonly_incr.phpt
@@ -1,0 +1,25 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+++/-- on an initialized readonly property is a (catchable) Error; the value is unchanged
+--FILE--
+<?php
+class RoIncr {
+    public function __construct(public readonly int $x) {}
+}
+$o = new RoIncr(5);
+try { $o->x++; } catch (\Error $e) { echo $e->getMessage(), "\n"; }
+try { $o->x--; } catch (\Error $e) { echo $e->getMessage(), "\n"; }
+try { ++$o->x; } catch (\Error $e) { echo $e->getMessage(), "\n"; }
+try { --$o->x; } catch (\Error $e) { echo $e->getMessage(), "\n"; }
+echo $o->x, "\n";
+?>
+--EXPECT--
+Cannot modify readonly property RoIncr::$x
+Cannot modify readonly property RoIncr::$x
+Cannot modify readonly property RoIncr::$x
+Cannot modify readonly property RoIncr::$x
+5
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/readonly_incr_null.phpt
+++ b/tests/ph7/002-integration/oo/readonly_incr_null.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+-- on a readonly property currently holding null still throws (not a silent no-op)
+--FILE--
+<?php
+class RoIncrNull {
+    public readonly ?int $x;
+    public function __construct() { $this->x = null; }
+    public function dec(): void { $this->x--; }
+}
+(new RoIncrNull)->dec();
+?>
+--EXPECTF--
+%AFatal error:  Uncaught Error: Cannot modify readonly property RoIncrNull::$x%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/readonly_incr_uninit.phpt
+++ b/tests/ph7/002-integration/oo/readonly_incr_uninit.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+++ on an uninitialized readonly property reports the read error first (ordering parity)
+--FILE--
+<?php
+class RoIncrUninit {
+    public readonly int $x;
+    public function bump(): void { $this->x++; }
+}
+(new RoIncrUninit)->bump();
+?>
+--EXPECTF--
+%s Fatal error:  Uncaught Error: Typed property RoIncrUninit::$x must not be accessed before initialization%A
+--CLEAN--
+<?php


### PR DESCRIPTION
Complete the readonly feature (PHP 8.2 `readonly class` + the deferred `++`/`--` gap), reusing the readonly-property machinery shipped earlier.

A `readonly class C {}` makes every declared instance property — including promoted constructor params — readonly. The leverage: a new PH7_CLASS_READONLY (0x020) class flag is OR'd into each property's flags at the GenStateCompileClassAttr choke point (and the promoted-param path in GenStateCompileClassMethod), so every existing per-property rule fires for free with PHP-exact messages — untyped, default value, static, write-once and modify-after-init.

Parsing: `readonly` is a context-sensitive PH7_TK_ID, invisible to the keyword-gated statement dispatcher, so the two single-modifier handlers (final/abstract class) are replaced by one PH7_CompileClassModifiers plus a GenStateStartsModifiedClass run-scanner in the chunk compiler. It accepts any order/combination of {final, abstract, readonly} terminated by `class` (final readonly / readonly final / abstract readonly all work) and rejects a repeated modifier ("Multiple T modifiers are not allowed") or the mutually-exclusive abstract+final pair ("Cannot use the final modifier on an abstract class"). The scanner stays side-effect-free so the speculative look-ahead can share it.

Inheritance is bidirectional (PH7_ClassInherit): a non-readonly class cannot extend a readonly one and vice-versa, with PHP-exact fatals.

`++`/`--` on a readonly property previously bypassed enforcement (OP_INCR/ OP_DECR mutate the slot directly). A VmCheckReadonlyMutate helper, dispatched via PH7_ENFORCE_READONLY_MUTATE (mirroring PH7_ENFORCE_TYPED_STORE; both now share a PH7_DISPATCH_ENFORCE_RC routing macro), throws "Cannot modify readonly property" before the mutation. It runs above the opcodes' value-type guard so a readonly property currently holding null/object/array is still caught; an uninitialized readonly still reports the read error first (OP_MEMBER's peek), matching PHP's ordering.

Byte-for-byte parity with PHP 8.5.7. make test (2144 smoke + 711 integration), test-compat and test-stress green.
