### PR TITLE
Add the hash family (hash/hash_hmac/hash_equals/hash_algos) + SHA-2

### DIFF
--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -4193,13 +4193,9 @@ static int PH7_builtin_md5(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		ph7_result_string(pCtx,"",0);
 		return PH7_OK;
 	}
-	/* Extract the input string */
+	/* Extract the input string (the empty string hashes to a well-defined
+	 * digest in PHP — d41d8cd9… — so it must NOT short-circuit). */
 	pIn = (const void *)ph7_value_to_string(apArg[0],&nLen);
-	if( nLen < 1 ){
-		/* Empty string */
-		ph7_result_string(pCtx,"",0);
-		return PH7_OK;
-	}
 	if( nArg > 1 && ph7_value_is_bool(apArg[1])){
 		raw_output = ph7_value_to_bool(apArg[1]);
 	}
@@ -4237,13 +4233,9 @@ static int PH7_builtin_sha1(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		ph7_result_string(pCtx,"",0);
 		return PH7_OK;
 	}
-	/* Extract the input string */
+	/* Extract the input string (the empty string hashes to a well-defined
+	 * digest in PHP — da39a3ee… — so it must NOT short-circuit). */
 	pIn = (const void *)ph7_value_to_string(apArg[0],&nLen);
-	if( nLen < 1 ){
-		/* Empty string */
-		ph7_result_string(pCtx,"",0);
-		return PH7_OK;
-	}
 	if( nArg > 1 && ph7_value_is_bool(apArg[1])){
 		raw_output = ph7_value_to_bool(apArg[1]);
 	}
@@ -4280,7 +4272,8 @@ static int PH7_builtin_crc32(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	/* Extract the input string */
 	pIn = (const void *)ph7_value_to_string(apArg[0],&nLen);
 	if( nLen < 1 ){
-		/* Empty string */
+		/* crc32("") is 0 in PHP, so this short-circuit is correct here — unlike
+		 * md5()/sha1(), whose empty-string digests are non-zero. */
 		ph7_result_int(pCtx,0);
 		return PH7_OK;
 	}
@@ -4288,6 +4281,209 @@ static int PH7_builtin_crc32(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	nCRC = SyCrc32(pIn,(sxu32)nLen);
 	/* Return the CRC32 as 64-bit integer */
 	ph7_result_int64(pCtx,(ph7_int64)nCRC^ 0xFFFFFFFF);
+	return PH7_OK;
+}
+/*
+ * The hash() family (hash/hash_hmac/hash_equals/hash_algos). Each algorithm is
+ * described by a small record so one dispatch (and one generic HMAC) serves them
+ * all. Thin adapters normalize the differing context types and the reversed
+ * MD5Final argument order behind a uniform Init/Update/Final over a HashCtx union.
+ */
+static void HashMd5Init(HashCtx *c){ MD5Init(&c->md5); }
+static void HashMd5Update(HashCtx *c,const unsigned char *d,unsigned int n){ MD5Update(&c->md5,d,n); }
+static void HashMd5Final(HashCtx *c,unsigned char *o){ MD5Final(o,&c->md5); }
+static void HashSha1Init(HashCtx *c){ SHA1Init(&c->sha1); }
+static void HashSha1Update(HashCtx *c,const unsigned char *d,unsigned int n){ SHA1Update(&c->sha1,d,n); }
+static void HashSha1Final(HashCtx *c,unsigned char *o){ SHA1Final(&c->sha1,o); }
+static void HashSha224Init(HashCtx *c){ SHA224Init(&c->sha256); }
+static void HashSha256Init(HashCtx *c){ SHA256Init(&c->sha256); }
+static void HashSha256Update(HashCtx *c,const unsigned char *d,unsigned int n){ SHA256Update(&c->sha256,d,n); }
+static void HashSha256Final(HashCtx *c,unsigned char *o){ SHA256Final(&c->sha256,o); }
+static void HashSha384Init(HashCtx *c){ SHA384Init(&c->sha512); }
+static void HashSha512Init(HashCtx *c){ SHA512Init(&c->sha512); }
+static void HashSha512Update(HashCtx *c,const unsigned char *d,unsigned int n){ SHA512Update(&c->sha512,d,n); }
+static void HashSha512Final(HashCtx *c,unsigned char *o){ SHA512Final(&c->sha512,o); }
+typedef struct HashAlgo HashAlgo;
+struct HashAlgo {
+	const char *zName;   /* lowercase canonical name */
+	int nDigestLen;      /* output bytes: 16/20/28/32/48/64 */
+	int nBlockLen;       /* internal block bytes (for HMAC): 64 or 128 */
+	void (*xInit)(HashCtx *);
+	void (*xUpdate)(HashCtx *,const unsigned char *,unsigned int);
+	void (*xFinal)(HashCtx *,unsigned char *);
+};
+static const HashAlgo aHashAlgo[] = {
+	{ "md5",    16, 64,  HashMd5Init,    HashMd5Update,    HashMd5Final    },
+	{ "sha1",   20, 64,  HashSha1Init,   HashSha1Update,   HashSha1Final   },
+	{ "sha224", 28, 64,  HashSha224Init, HashSha256Update, HashSha256Final },
+	{ "sha256", 32, 64,  HashSha256Init, HashSha256Update, HashSha256Final },
+	{ "sha384", 48, 128, HashSha384Init, HashSha512Update, HashSha512Final },
+	{ "sha512", 64, 128, HashSha512Init, HashSha512Update, HashSha512Final },
+};
+/* Case-insensitive algorithm lookup (PHP accepts 'SHA256' etc.). */
+static const HashAlgo * HashFindAlgo(const char *zName,int nLen){
+	sxu32 i;
+	for( i = 0; i < SX_ARRAYSIZE(aHashAlgo); i++ ){
+		if( (int)SyStrlen(aHashAlgo[i].zName) == nLen
+			&& SyStrnicmp(aHashAlgo[i].zName,zName,(sxu32)nLen) == 0 ){
+			return &aHashAlgo[i];
+		}
+	}
+	return 0;
+}
+/*
+ * string hash(string $algo,string $data[,bool $binary = false])
+ *   Generate a hash value (message digest).
+ */
+static int PH7_builtin_hash(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	const HashAlgo *pAlgo;
+	const char *zAlgo,*zData;
+	int nAlgoLen,nDataLen,raw_output = FALSE;
+	HashCtx sCtx;
+	unsigned char zDigest[64];
+	if( nArg < 2 ){
+		return PH7_VmThrowException(pCtx,"ArgumentCountError",
+			"hash() expects at least 2 arguments, %d given",nArg);
+	}
+	zAlgo = ph7_value_to_string(apArg[0],&nAlgoLen);
+	pAlgo = HashFindAlgo(zAlgo,nAlgoLen);
+	if( pAlgo == 0 ){
+		return PH7_VmThrowException(pCtx,"ValueError",
+			"hash(): Argument #1 ($algo) must be a valid hashing algorithm");
+	}
+	zData = ph7_value_to_string(apArg[1],&nDataLen);
+	if( nArg > 2 ){
+		raw_output = ph7_value_to_bool(apArg[2]);
+	}
+	pAlgo->xInit(&sCtx);
+	pAlgo->xUpdate(&sCtx,(const unsigned char *)zData,(unsigned int)nDataLen);
+	pAlgo->xFinal(&sCtx,zDigest);
+	if( raw_output ){
+		ph7_result_string(pCtx,(const char *)zDigest,pAlgo->nDigestLen);
+	}else{
+		SyBinToHexConsumer((const void *)zDigest,(sxu32)pAlgo->nDigestLen,HashConsumer,pCtx);
+	}
+	return PH7_OK;
+}
+/*
+ * string hash_hmac(string $algo,string $data,string $key[,bool $binary = false])
+ *   Generate a keyed hash value using the HMAC method (RFC 2104).
+ */
+static int PH7_builtin_hash_hmac(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	const HashAlgo *pAlgo;
+	const char *zAlgo,*zData,*zKey;
+	int nAlgoLen,nDataLen,nKeyLen,raw_output = FALSE;
+	HashCtx sCtx;
+	unsigned char zKeyBlock[128],zIpad[128],zOpad[128],zInner[64],zDigest[64];
+	int i,nBlock,nDigest;
+	if( nArg < 3 ){
+		return PH7_VmThrowException(pCtx,"ArgumentCountError",
+			"hash_hmac() expects at least 3 arguments, %d given",nArg);
+	}
+	zAlgo = ph7_value_to_string(apArg[0],&nAlgoLen);
+	pAlgo = HashFindAlgo(zAlgo,nAlgoLen);
+	if( pAlgo == 0 ){
+		return PH7_VmThrowException(pCtx,"ValueError",
+			"hash_hmac(): Argument #1 ($algo) must be a valid cryptographic hashing algorithm");
+	}
+	zData = ph7_value_to_string(apArg[1],&nDataLen);
+	zKey = ph7_value_to_string(apArg[2],&nKeyLen);
+	if( nArg > 3 ){
+		raw_output = ph7_value_to_bool(apArg[3]);
+	}
+	nBlock = pAlgo->nBlockLen;
+	nDigest = pAlgo->nDigestLen;
+	/* Reduce the key to a single block: hash it if longer than the block, then
+	 * zero-pad (a short or empty key is just zero-padded). */
+	SyZero(zKeyBlock,sizeof(zKeyBlock));
+	if( nKeyLen > nBlock ){
+		pAlgo->xInit(&sCtx);
+		pAlgo->xUpdate(&sCtx,(const unsigned char *)zKey,(unsigned int)nKeyLen);
+		pAlgo->xFinal(&sCtx,zKeyBlock);
+	}else if( nKeyLen > 0 ){
+		SyMemcpy(zKey,zKeyBlock,(sxu32)nKeyLen);
+	}
+	for( i = 0; i < nBlock; i++ ){
+		zIpad[i] = (unsigned char)(zKeyBlock[i] ^ 0x36);
+		zOpad[i] = (unsigned char)(zKeyBlock[i] ^ 0x5c);
+	}
+	/* inner = H((key ^ ipad) || data) */
+	pAlgo->xInit(&sCtx);
+	pAlgo->xUpdate(&sCtx,zIpad,(unsigned int)nBlock);
+	pAlgo->xUpdate(&sCtx,(const unsigned char *)zData,(unsigned int)nDataLen);
+	pAlgo->xFinal(&sCtx,zInner);
+	/* out = H((key ^ opad) || inner) */
+	pAlgo->xInit(&sCtx);
+	pAlgo->xUpdate(&sCtx,zOpad,(unsigned int)nBlock);
+	pAlgo->xUpdate(&sCtx,zInner,(unsigned int)nDigest);
+	pAlgo->xFinal(&sCtx,zDigest);
+	if( raw_output ){
+		ph7_result_string(pCtx,(const char *)zDigest,nDigest);
+	}else{
+		SyBinToHexConsumer((const void *)zDigest,(sxu32)nDigest,HashConsumer,pCtx);
+	}
+	return PH7_OK;
+}
+/*
+ * bool hash_equals(string $known_string,string $user_string)
+ *   Timing-attack-safe string comparison.
+ */
+static int PH7_builtin_hash_equals(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	const char *zKnown,*zUser;
+	int nKnown,nUser,i;
+	volatile unsigned char vDiff = 0;
+	if( nArg < 2 ){
+		return PH7_VmThrowException(pCtx,"ArgumentCountError",
+			"hash_equals() expects exactly 2 arguments, %d given",nArg);
+	}
+	if( !ph7_value_is_string(apArg[0]) ){
+		return PH7_VmThrowException(pCtx,"TypeError",
+			"hash_equals(): Argument #1 ($known_string) must be of type string, %s given",
+			ph7_type_name(apArg[0]));
+	}
+	if( !ph7_value_is_string(apArg[1]) ){
+		return PH7_VmThrowException(pCtx,"TypeError",
+			"hash_equals(): Argument #2 ($user_string) must be of type string, %s given",
+			ph7_type_name(apArg[1]));
+	}
+	zKnown = ph7_value_to_string(apArg[0],&nKnown);
+	zUser = ph7_value_to_string(apArg[1],&nUser);
+	if( nKnown != nUser ){
+		ph7_result_bool(pCtx,0);
+		return PH7_OK;
+	}
+	/* Constant-time: read every byte, never short-circuit. */
+	for( i = 0; i < nKnown; i++ ){
+		vDiff |= (unsigned char)(zKnown[i] ^ zUser[i]);
+	}
+	ph7_result_bool(pCtx,vDiff == 0);
+	return PH7_OK;
+}
+/*
+ * array hash_algos(void)
+ *   Return a list of the registered hashing algorithms.
+ */
+static int PH7_builtin_hash_algos(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	ph7_value *pArray,*pValue;
+	sxu32 i;
+	SXUNUSED(nArg);
+	SXUNUSED(apArg);
+	pArray = ph7_context_new_array(pCtx);
+	pValue = ph7_context_new_scalar(pCtx);
+	if( pArray == 0 || pValue == 0 ){
+		ph7_result_null(pCtx);
+		return PH7_OK;
+	}
+	for( i = 0; i < SX_ARRAYSIZE(aHashAlgo); i++ ){
+		ph7_value_string(pValue,aHashAlgo[i].zName,-1);
+		ph7_array_add_elem(pArray,0 /* Automatic 0-based index */,pValue);
+		ph7_value_reset_string_cursor(pValue);
+	}
+	ph7_result_value(pCtx,pArray);
 	return PH7_OK;
 }
 #endif /* PH7_DISABLE_HASH_FUNC */
@@ -6958,6 +7154,10 @@ static const ph7_builtin_func aBuiltInFunc[] = {
 	{ "md5",          PH7_builtin_md5       },
 	{ "sha1",         PH7_builtin_sha1      },
 	{ "crc32",        PH7_builtin_crc32     },
+	{ "hash",         PH7_builtin_hash      },
+	{ "hash_hmac",    PH7_builtin_hash_hmac },
+	{ "hash_equals",  PH7_builtin_hash_equals },
+	{ "hash_algos",   PH7_builtin_hash_algos },
 #endif /* PH7_DISABLE_HASH_FUNC */
 #endif /* PH7_NEED_BUILTIN_REG */
 #ifdef PH7_NEED_FMT_AND_INI

--- a/src/sx/sxdigest.h
+++ b/src/sx/sxdigest.h
@@ -25,6 +25,38 @@ struct SHA1Context {
 	unsigned char buffer[64];
 };
 
+/* SHA-224 / SHA-256 context. The variants differ in the initial hash value
+ * (chosen by Init) and the output length: Final emits exactly nDigestLen bytes
+ * (28 or 32), which also lets HMAC key-reduction rely on the zero-padding past
+ * the digest. */
+typedef struct SHA256Context SHA256Context;
+struct SHA256Context {
+	sxu32 state[8];
+	sxu64 nLen;              /* total bytes hashed */
+	unsigned char buffer[64];
+	sxu32 nIndex;            /* bytes currently buffered (0..63) */
+	int nDigestLen;          /* 32 (sha256) or 28 (sha224) — set by Init */
+};
+
+/* SHA-384 / SHA-512 context (same factoring; Final emits nDigestLen = 64 or 48). */
+typedef struct SHA512Context SHA512Context;
+struct SHA512Context {
+	sxu64 state[8];
+	sxu64 nLen;              /* total bytes hashed (high 64 bits unused for realistic input) */
+	unsigned char buffer[128];
+	sxu32 nIndex;            /* bytes currently buffered (0..127) */
+	int nDigestLen;          /* 64 (sha512) or 48 (sha384) — set by Init */
+};
+
+/* A union over every digest context so a single fixed-size, correctly-aligned
+ * buffer can back any algorithm (used by the hash() descriptor dispatch). */
+typedef union HashCtx {
+	MD5Context md5;
+	SHA1Context sha1;
+	SHA256Context sha256;
+	SHA512Context sha512;
+} HashCtx;
+
 /* Digest function prototypes */
 PH7_PRIVATE sxi32 MD5Init(MD5Context *pCtx);
 PH7_PRIVATE void MD5Update(MD5Context *ctx, const unsigned char *buf, unsigned int len);
@@ -35,6 +67,18 @@ PH7_PRIVATE void SHA1Init(SHA1Context *context);
 PH7_PRIVATE void SHA1Update(SHA1Context *context,const unsigned char *data,unsigned int len);
 PH7_PRIVATE void SHA1Final(SHA1Context *context, unsigned char digest[20]);
 PH7_PRIVATE sxi32 SySha1Compute(const void *pIn,sxu32 nLen,unsigned char zDigest[20]);
+
+PH7_PRIVATE void SHA256Init(SHA256Context *pCtx);   /* SHA-256 (32-byte digest) */
+PH7_PRIVATE void SHA224Init(SHA256Context *pCtx);   /* SHA-224 (28-byte digest) */
+PH7_PRIVATE void SHA256Update(SHA256Context *pCtx,const unsigned char *data,unsigned int len);
+PH7_PRIVATE void SHA256Final(SHA256Context *pCtx,unsigned char *digest);
+PH7_PRIVATE sxi32 SySha256Compute(const void *pIn,sxu32 nLen,unsigned char zDigest[32]);
+
+PH7_PRIVATE void SHA512Init(SHA512Context *pCtx);   /* SHA-512 (64-byte digest) */
+PH7_PRIVATE void SHA384Init(SHA512Context *pCtx);   /* SHA-384 (48-byte digest) */
+PH7_PRIVATE void SHA512Update(SHA512Context *pCtx,const unsigned char *data,unsigned int len);
+PH7_PRIVATE void SHA512Final(SHA512Context *pCtx,unsigned char *digest);
+PH7_PRIVATE sxi32 SySha512Compute(const void *pIn,sxu32 nLen,unsigned char zDigest[64]);
 
 PH7_PRIVATE sxu32 SyCrc32(const void *pSrc,sxu32 nLen);
 #endif /* PH7_DISABLE_HASH_FUNC */

--- a/src/sx/sxhash.c
+++ b/src/sx/sxhash.c
@@ -450,6 +450,211 @@ PH7_PRIVATE sxi32 SySha1Compute(const void *pIn,sxu32 nLen,unsigned char zDigest
 	SHA1Final(&sCtx,zDigest);
 	return SXRET_OK;
 }
+/*
+ * SHA-224 / SHA-256 (FIPS 180-4). One core transform; SHA-224 differs only in
+ * the initial hash value (set by Init) and the truncated output length. All
+ * byte<->word conversions are done explicitly so the code is endian-independent.
+ */
+#define SHA2_ROTR32(x,n) (((x) >> (n)) | ((x) << (32 - (n))))
+static const sxu32 SHA256_K[64] = {
+	0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,
+	0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174,
+	0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc,0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da,
+	0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7,0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967,
+	0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13,0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85,
+	0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3,0xd192e819,0xd6990624,0xf40e3585,0x106aa070,
+	0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5,0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3,
+	0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
+};
+static void SHA256Transform(sxu32 state[8],const unsigned char block[64]){
+	sxu32 w[64],a,b,c,d,e,f,g,h,t1,t2;
+	int i;
+	for( i = 0; i < 16; i++ ){
+		w[i] = ((sxu32)block[i*4] << 24) | ((sxu32)block[i*4+1] << 16)
+			 | ((sxu32)block[i*4+2] << 8) | ((sxu32)block[i*4+3]);
+	}
+	for( i = 16; i < 64; i++ ){
+		sxu32 s0 = SHA2_ROTR32(w[i-15],7) ^ SHA2_ROTR32(w[i-15],18) ^ (w[i-15] >> 3);
+		sxu32 s1 = SHA2_ROTR32(w[i-2],17) ^ SHA2_ROTR32(w[i-2],19) ^ (w[i-2] >> 10);
+		w[i] = w[i-16] + s0 + w[i-7] + s1;
+	}
+	a = state[0]; b = state[1]; c = state[2]; d = state[3];
+	e = state[4]; f = state[5]; g = state[6]; h = state[7];
+	for( i = 0; i < 64; i++ ){
+		sxu32 S1 = SHA2_ROTR32(e,6) ^ SHA2_ROTR32(e,11) ^ SHA2_ROTR32(e,25);
+		sxu32 ch = (e & f) ^ ((~e) & g);
+		sxu32 S0 = SHA2_ROTR32(a,2) ^ SHA2_ROTR32(a,13) ^ SHA2_ROTR32(a,22);
+		sxu32 maj = (a & b) ^ (a & c) ^ (b & c);
+		t1 = h + S1 + ch + SHA256_K[i] + w[i];
+		t2 = S0 + maj;
+		h = g; g = f; f = e; e = d + t1; d = c; c = b; b = a; a = t1 + t2;
+	}
+	state[0] += a; state[1] += b; state[2] += c; state[3] += d;
+	state[4] += e; state[5] += f; state[6] += g; state[7] += h;
+}
+PH7_PRIVATE void SHA256Init(SHA256Context *pCtx){
+	pCtx->state[0] = 0x6a09e667; pCtx->state[1] = 0xbb67ae85;
+	pCtx->state[2] = 0x3c6ef372; pCtx->state[3] = 0xa54ff53a;
+	pCtx->state[4] = 0x510e527f; pCtx->state[5] = 0x9b05688c;
+	pCtx->state[6] = 0x1f83d9ab; pCtx->state[7] = 0x5be0cd19;
+	pCtx->nLen = 0; pCtx->nIndex = 0; pCtx->nDigestLen = 32;
+}
+PH7_PRIVATE void SHA224Init(SHA256Context *pCtx){
+	pCtx->state[0] = 0xc1059ed8; pCtx->state[1] = 0x367cd507;
+	pCtx->state[2] = 0x3070dd17; pCtx->state[3] = 0xf70e5939;
+	pCtx->state[4] = 0xffc00b31; pCtx->state[5] = 0x68581511;
+	pCtx->state[6] = 0x64f98fa7; pCtx->state[7] = 0xbefa4fa4;
+	pCtx->nLen = 0; pCtx->nIndex = 0; pCtx->nDigestLen = 28;
+}
+PH7_PRIVATE void SHA256Update(SHA256Context *pCtx,const unsigned char *data,unsigned int len){
+	pCtx->nLen += len;
+	while( len > 0 ){
+		unsigned int n = 64 - pCtx->nIndex;
+		if( n > len ){ n = len; }
+		SyMemcpy(data,&pCtx->buffer[pCtx->nIndex],n);
+		pCtx->nIndex += n; data += n; len -= n;
+		if( pCtx->nIndex == 64 ){
+			SHA256Transform(pCtx->state,pCtx->buffer);
+			pCtx->nIndex = 0;
+		}
+	}
+}
+PH7_PRIVATE void SHA256Final(SHA256Context *pCtx,unsigned char *digest){
+	sxu64 nBits = pCtx->nLen << 3;
+	unsigned char c = 0x80;
+	int i;
+	SHA256Update(pCtx,&c,1);
+	c = 0x00;
+	while( pCtx->nIndex != 56 ){
+		SHA256Update(pCtx,&c,1);
+	}
+	for( i = 7; i >= 0; i-- ){
+		unsigned char b = (unsigned char)((nBits >> (i*8)) & 0xff);
+		SHA256Update(pCtx,&b,1);
+	}
+	/* nIndex is now 0 (a final block was processed). Emit nDigestLen bytes. */
+	for( i = 0; i < pCtx->nDigestLen; i++ ){
+		digest[i] = (unsigned char)((pCtx->state[i>>2] >> ((3-(i&3))*8)) & 0xff);
+	}
+}
+PH7_PRIVATE sxi32 SySha256Compute(const void *pIn,sxu32 nLen,unsigned char zDigest[32]){
+	SHA256Context sCtx;
+	SHA256Init(&sCtx);
+	SHA256Update(&sCtx,(const unsigned char *)pIn,nLen);
+	SHA256Final(&sCtx,zDigest);
+	return SXRET_OK;
+}
+/*
+ * SHA-384 / SHA-512 (FIPS 180-4). Same structure as SHA-256 but with 64-bit
+ * words, 80 rounds, a 128-byte block, and a 128-bit length field (the high 64
+ * bits are always zero for realistic inputs).
+ */
+#define SHA2_ROTR64(x,n) (((x) >> (n)) | ((x) << (64 - (n))))
+static const sxu64 SHA512_K[80] = {
+	0x428a2f98d728ae22ULL,0x7137449123ef65cdULL,0xb5c0fbcfec4d3b2fULL,0xe9b5dba58189dbbcULL,
+	0x3956c25bf348b538ULL,0x59f111f1b605d019ULL,0x923f82a4af194f9bULL,0xab1c5ed5da6d8118ULL,
+	0xd807aa98a3030242ULL,0x12835b0145706fbeULL,0x243185be4ee4b28cULL,0x550c7dc3d5ffb4e2ULL,
+	0x72be5d74f27b896fULL,0x80deb1fe3b1696b1ULL,0x9bdc06a725c71235ULL,0xc19bf174cf692694ULL,
+	0xe49b69c19ef14ad2ULL,0xefbe4786384f25e3ULL,0x0fc19dc68b8cd5b5ULL,0x240ca1cc77ac9c65ULL,
+	0x2de92c6f592b0275ULL,0x4a7484aa6ea6e483ULL,0x5cb0a9dcbd41fbd4ULL,0x76f988da831153b5ULL,
+	0x983e5152ee66dfabULL,0xa831c66d2db43210ULL,0xb00327c898fb213fULL,0xbf597fc7beef0ee4ULL,
+	0xc6e00bf33da88fc2ULL,0xd5a79147930aa725ULL,0x06ca6351e003826fULL,0x142929670a0e6e70ULL,
+	0x27b70a8546d22ffcULL,0x2e1b21385c26c926ULL,0x4d2c6dfc5ac42aedULL,0x53380d139d95b3dfULL,
+	0x650a73548baf63deULL,0x766a0abb3c77b2a8ULL,0x81c2c92e47edaee6ULL,0x92722c851482353bULL,
+	0xa2bfe8a14cf10364ULL,0xa81a664bbc423001ULL,0xc24b8b70d0f89791ULL,0xc76c51a30654be30ULL,
+	0xd192e819d6ef5218ULL,0xd69906245565a910ULL,0xf40e35855771202aULL,0x106aa07032bbd1b8ULL,
+	0x19a4c116b8d2d0c8ULL,0x1e376c085141ab53ULL,0x2748774cdf8eeb99ULL,0x34b0bcb5e19b48a8ULL,
+	0x391c0cb3c5c95a63ULL,0x4ed8aa4ae3418acbULL,0x5b9cca4f7763e373ULL,0x682e6ff3d6b2b8a3ULL,
+	0x748f82ee5defb2fcULL,0x78a5636f43172f60ULL,0x84c87814a1f0ab72ULL,0x8cc702081a6439ecULL,
+	0x90befffa23631e28ULL,0xa4506cebde82bde9ULL,0xbef9a3f7b2c67915ULL,0xc67178f2e372532bULL,
+	0xca273eceea26619cULL,0xd186b8c721c0c207ULL,0xeada7dd6cde0eb1eULL,0xf57d4f7fee6ed178ULL,
+	0x06f067aa72176fbaULL,0x0a637dc5a2c898a6ULL,0x113f9804bef90daeULL,0x1b710b35131c471bULL,
+	0x28db77f523047d84ULL,0x32caab7b40c72493ULL,0x3c9ebe0a15c9bebcULL,0x431d67c49c100d4cULL,
+	0x4cc5d4becb3e42b6ULL,0x597f299cfc657e2aULL,0x5fcb6fab3ad6faecULL,0x6c44198c4a475817ULL
+};
+static void SHA512Transform(sxu64 state[8],const unsigned char block[128]){
+	sxu64 w[80],a,b,c,d,e,f,g,h,t1,t2;
+	int i;
+	for( i = 0; i < 16; i++ ){
+		w[i] = ((sxu64)block[i*8] << 56) | ((sxu64)block[i*8+1] << 48)
+			 | ((sxu64)block[i*8+2] << 40) | ((sxu64)block[i*8+3] << 32)
+			 | ((sxu64)block[i*8+4] << 24) | ((sxu64)block[i*8+5] << 16)
+			 | ((sxu64)block[i*8+6] << 8) | ((sxu64)block[i*8+7]);
+	}
+	for( i = 16; i < 80; i++ ){
+		sxu64 s0 = SHA2_ROTR64(w[i-15],1) ^ SHA2_ROTR64(w[i-15],8) ^ (w[i-15] >> 7);
+		sxu64 s1 = SHA2_ROTR64(w[i-2],19) ^ SHA2_ROTR64(w[i-2],61) ^ (w[i-2] >> 6);
+		w[i] = w[i-16] + s0 + w[i-7] + s1;
+	}
+	a = state[0]; b = state[1]; c = state[2]; d = state[3];
+	e = state[4]; f = state[5]; g = state[6]; h = state[7];
+	for( i = 0; i < 80; i++ ){
+		sxu64 S1 = SHA2_ROTR64(e,14) ^ SHA2_ROTR64(e,18) ^ SHA2_ROTR64(e,41);
+		sxu64 ch = (e & f) ^ ((~e) & g);
+		sxu64 S0 = SHA2_ROTR64(a,28) ^ SHA2_ROTR64(a,34) ^ SHA2_ROTR64(a,39);
+		sxu64 maj = (a & b) ^ (a & c) ^ (b & c);
+		t1 = h + S1 + ch + SHA512_K[i] + w[i];
+		t2 = S0 + maj;
+		h = g; g = f; f = e; e = d + t1; d = c; c = b; b = a; a = t1 + t2;
+	}
+	state[0] += a; state[1] += b; state[2] += c; state[3] += d;
+	state[4] += e; state[5] += f; state[6] += g; state[7] += h;
+}
+PH7_PRIVATE void SHA512Init(SHA512Context *pCtx){
+	pCtx->state[0] = 0x6a09e667f3bcc908ULL; pCtx->state[1] = 0xbb67ae8584caa73bULL;
+	pCtx->state[2] = 0x3c6ef372fe94f82bULL; pCtx->state[3] = 0xa54ff53a5f1d36f1ULL;
+	pCtx->state[4] = 0x510e527fade682d1ULL; pCtx->state[5] = 0x9b05688c2b3e6c1fULL;
+	pCtx->state[6] = 0x1f83d9abfb41bd6bULL; pCtx->state[7] = 0x5be0cd19137e2179ULL;
+	pCtx->nLen = 0; pCtx->nIndex = 0; pCtx->nDigestLen = 64;
+}
+PH7_PRIVATE void SHA384Init(SHA512Context *pCtx){
+	pCtx->state[0] = 0xcbbb9d5dc1059ed8ULL; pCtx->state[1] = 0x629a292a367cd507ULL;
+	pCtx->state[2] = 0x9159015a3070dd17ULL; pCtx->state[3] = 0x152fecd8f70e5939ULL;
+	pCtx->state[4] = 0x67332667ffc00b31ULL; pCtx->state[5] = 0x8eb44a8768581511ULL;
+	pCtx->state[6] = 0xdb0c2e0d64f98fa7ULL; pCtx->state[7] = 0x47b5481dbefa4fa4ULL;
+	pCtx->nLen = 0; pCtx->nIndex = 0; pCtx->nDigestLen = 48;
+}
+PH7_PRIVATE void SHA512Update(SHA512Context *pCtx,const unsigned char *data,unsigned int len){
+	pCtx->nLen += len;
+	while( len > 0 ){
+		unsigned int n = 128 - pCtx->nIndex;
+		if( n > len ){ n = len; }
+		SyMemcpy(data,&pCtx->buffer[pCtx->nIndex],n);
+		pCtx->nIndex += n; data += n; len -= n;
+		if( pCtx->nIndex == 128 ){
+			SHA512Transform(pCtx->state,pCtx->buffer);
+			pCtx->nIndex = 0;
+		}
+	}
+}
+PH7_PRIVATE void SHA512Final(SHA512Context *pCtx,unsigned char *digest){
+	sxu64 nBits = pCtx->nLen << 3;
+	unsigned char c = 0x80;
+	int i;
+	SHA512Update(pCtx,&c,1);
+	c = 0x00;
+	while( pCtx->nIndex != 112 ){
+		SHA512Update(pCtx,&c,1);
+	}
+	/* 128-bit length: the high 64 bits are zero for realistic input. */
+	for( i = 0; i < 8; i++ ){
+		SHA512Update(pCtx,&c,1);
+	}
+	for( i = 7; i >= 0; i-- ){
+		unsigned char b = (unsigned char)((nBits >> (i*8)) & 0xff);
+		SHA512Update(pCtx,&b,1);
+	}
+	for( i = 0; i < pCtx->nDigestLen; i++ ){
+		digest[i] = (unsigned char)((pCtx->state[i>>3] >> ((7-(i&7))*8)) & 0xff);
+	}
+}
+PH7_PRIVATE sxi32 SySha512Compute(const void *pIn,sxu32 nLen,unsigned char zDigest[64]){
+	SHA512Context sCtx;
+	SHA512Init(&sCtx);
+	SHA512Update(&sCtx,(const unsigned char *)pIn,nLen);
+	SHA512Final(&sCtx,zDigest);
+	return SXRET_OK;
+}
 #endif /* PH7_DISABLE_HASH_FUNC */
 static const sxu32 crc32_table[] = {
 	0x00000000, 0x77073096, 0xee0e612c, 0x990951ba,

--- a/tests/ph7/001-smoke/function/hash/hash.phpt
+++ b/tests/ph7/001-smoke/function/hash/hash.phpt
@@ -1,0 +1,27 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+hash() computes md5/sha1/sha2-family digests (NIST 'abc' + empty string)
+--FILE--
+<?php
+foreach (['md5','sha1','sha224','sha256','sha384','sha512'] as $a) {
+    echo $a, " abc=", hash($a, "abc"), "\n";
+    echo $a, " ''=", hash($a, ""), "\n";
+}
+?>
+--EXPECT--
+md5 abc=900150983cd24fb0d6963f7d28e17f72
+md5 ''=d41d8cd98f00b204e9800998ecf8427e
+sha1 abc=a9993e364706816aba3e25717850c26c9cd0d89d
+sha1 ''=da39a3ee5e6b4b0d3255bfef95601890afd80709
+sha224 abc=23097d223405d8228642a477bda255b32aadbce4bda0b3f7e36c9da7
+sha224 ''=d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f
+sha256 abc=ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+sha256 ''=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+sha384 abc=cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7
+sha384 ''=38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b
+sha512 abc=ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f
+sha512 ''=cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/hash/hash_multiblock.phpt
+++ b/tests/ph7/001-smoke/function/hash/hash_multiblock.phpt
@@ -1,0 +1,25 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+hash() across block boundaries (>64 and >128 bytes), case-insensitive algos, raw output
+--FILE--
+<?php
+$big = str_repeat("a", 200); // spans multiple 64- and 128-byte blocks
+echo hash("sha256", $big), "\n";
+echo hash("sha512", $big), "\n";
+// PHP accepts the algorithm name case-insensitively
+echo hash("SHA256", "abc") === hash("sha256", "abc") ? "case-insensitive\n" : "FAIL\n";
+// raw binary output lengths
+echo strlen(hash("sha256", "x", true)),
+     strlen(hash("sha512", "x", true)),
+     strlen(hash("sha224", "x", true)),
+     strlen(hash("sha384", "x", true)), "\n";
+?>
+--EXPECT--
+c2a908d98f5df987ade41b5fce213067efbcc21ef2240212a41e54b5e7c28ae5
+4b11459c33f52a22ee8236782714c150a3b2c60994e9acee17fe68947a3e6789f31e7668394592da7bef827cddca88c4e6f86e4df7ed1ae6cba71f3e98faee9f
+case-insensitive
+32642848
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/hash_algos/hash_algos.phpt
+++ b/tests/ph7/001-smoke/function/hash_algos/hash_algos.phpt
@@ -1,0 +1,31 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+hash_algos() returns a 0-indexed list whose every entry is a usable algorithm
+--FILE--
+<?php
+$algos = hash_algos();
+// 0-indexed list (PHL supports a curated subset; assert membership, not the full set)
+echo array_key_exists(0, $algos) ? "list\n" : "notlist\n";
+foreach (['md5','sha1','sha224','sha256','sha384','sha512'] as $a) {
+    echo $a, in_array($a, $algos, true) ? " present\n" : " MISSING\n";
+}
+// every advertised algorithm must actually work
+$ok = true;
+foreach ($algos as $a) {
+    if (strlen(hash($a, "x")) < 1) { $ok = false; }
+}
+echo $ok ? "all-usable\n" : "BROKEN\n";
+?>
+--EXPECT--
+list
+md5 present
+sha1 present
+sha224 present
+sha256 present
+sha384 present
+sha512 present
+all-usable
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/hash_equals/hash_equals.phpt
+++ b/tests/ph7/001-smoke/function/hash_equals/hash_equals.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+hash_equals() constant-time comparison: equal, differing, and different-length
+--FILE--
+<?php
+echo hash_equals("abc", "abc")  ? "eq\n"   : "ne\n";
+echo hash_equals("abc", "abd")  ? "eq\n"   : "ne\n";
+echo hash_equals("abc", "abcd") ? "eq\n"   : "ne\n";
+echo hash_equals("", "")        ? "eq\n"   : "ne\n";
+echo hash_equals("x", "")       ? "eq\n"   : "ne\n";
+?>
+--EXPECT--
+eq
+ne
+ne
+eq
+ne
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/hash_hmac/hash_hmac.phpt
+++ b/tests/ph7/001-smoke/function/hash_hmac/hash_hmac.phpt
@@ -1,0 +1,28 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+hash_hmac() RFC 2104 keyed digests, incl. key longer than the block and empty key
+--FILE--
+<?php
+echo hash_hmac("md5",  "data", "key"), "\n";
+echo hash_hmac("sha1", "data", "key"), "\n";
+echo hash_hmac("sha256", "The quick brown fox jumps over the lazy dog", "key"), "\n";
+echo hash_hmac("sha512", "data", "key"), "\n";
+// key longer than the 64-byte block is hashed down first
+echo hash_hmac("sha256", "data", str_repeat("k", 200)), "\n";
+// empty key
+echo hash_hmac("sha256", "data", ""), "\n";
+// raw output length
+echo strlen(hash_hmac("sha256", "d", "k", true)), "\n";
+?>
+--EXPECT--
+9d5c73ef85594d34ec4438b7c97e51d8
+104152c5bfdca07bc633eebd46199f0255c9f49d
+f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8
+3c5953a18f7303ec653ba170ae334fafa08e3846f2efe317b87efce82376253cb52a8c31ddcde5a3a2eee183c2b34cb91f85e64ddbc325f7692b199473579c58
+0163658d479ec73f2b801df07141db1426aaae2c6b5e8e6d9e6789f92f5e2b4f
+e528c4d99e6177f5841f712a143b90843299a4aa181a06501422d9ca862bd2a5
+32
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/md5/md5_empty.phpt
+++ b/tests/ph7/001-smoke/function/md5/md5_empty.phpt
@@ -1,0 +1,15 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+md5 of the empty string is the well-defined empty digest (not "")
+--FILE--
+<?php
+echo md5(""), "\n";
+echo bin2hex(md5("", true)), "\n";
+?>
+--EXPECT--
+d41d8cd98f00b204e9800998ecf8427e
+d41d8cd98f00b204e9800998ecf8427e
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/sha1/sha1_empty.phpt
+++ b/tests/ph7/001-smoke/function/sha1/sha1_empty.phpt
@@ -1,0 +1,15 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+sha1 of the empty string is the well-defined empty digest (not "")
+--FILE--
+<?php
+echo sha1(""), "\n";
+echo bin2hex(sha1("", true)), "\n";
+?>
+--EXPECT--
+da39a3ee5e6b4b0d3255bfef95601890afd80709
+da39a3ee5e6b4b0d3255bfef95601890afd80709
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/function/hash/hash_unknown_algo.phpt
+++ b/tests/ph7/002-integration/function/hash/hash_unknown_algo.phpt
@@ -1,0 +1,13 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+hash() with an unknown algorithm throws a ValueError (PHP 8)
+--FILE--
+<?php
+hash("nope", "x");
+?>
+--EXPECTF--
+%s Fatal error:  Uncaught ValueError: hash(): Argument #1 ($algo) must be a valid hashing algorithm%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/function/hash_equals/hash_equals_type_error.phpt
+++ b/tests/ph7/002-integration/function/hash_equals/hash_equals_type_error.phpt
@@ -1,0 +1,13 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+hash_equals() with a non-string known_string throws a TypeError
+--FILE--
+<?php
+hash_equals(123, "x");
+?>
+--EXPECTF--
+%s Fatal error:  Uncaught TypeError: hash_equals(): Argument #1 ($known_string) must be of type string, int given%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/function/hash_equals/hash_equals_type_error_arg2.phpt
+++ b/tests/ph7/002-integration/function/hash_equals/hash_equals_type_error_arg2.phpt
@@ -1,0 +1,13 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+hash_equals() with a non-string user_string throws a TypeError naming argument #2
+--FILE--
+<?php
+hash_equals("x", [1]);
+?>
+--EXPECTF--
+%s Fatal error:  Uncaught TypeError: hash_equals(): Argument #2 ($user_string) must be of type string, array given%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/function/hash_hmac/hash_hmac_unknown_algo.phpt
+++ b/tests/ph7/002-integration/function/hash_hmac/hash_hmac_unknown_algo.phpt
@@ -1,0 +1,13 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+hash_hmac() with an unknown algorithm throws a ValueError (PHP 8)
+--FILE--
+<?php
+hash_hmac("nope", "data", "key");
+?>
+--EXPECTF--
+%s Fatal error:  Uncaught ValueError: hash_hmac(): Argument #1 ($algo) must be a valid cryptographic hashing algorithm%A
+--CLEAN--
+<?php


### PR DESCRIPTION
PHL exposed only md5/sha1/crc32 and function_exists("hash") was false — a hard blocker for framework and auth code (signatures, CSRF tokens, HMAC). Adds the PHP hash family over md5/sha1/sha224/sha256/sha384/sha512.

SHA-256 and SHA-512 are added as standard FIPS 180-4 Init/Update/Final primitives in src/sx/sxhash.c (contexts + a HashCtx union in sxdigest.h), endian-independent (explicit byte<->word packing). SHA-224/384 reuse the 256/512 transforms with a different initial IV and a truncated output length carried in the context.

A small algorithm-descriptor table in builtin.c ({name, digestLen, blockLen, init/update/final}) drives hash/hash_hmac/hash_algos through one dispatch; thin adapters normalize the per-algo context types and the reversed MD5Final argument order behind a uniform HashCtx signature. hash() supports raw/hex output and case-insensitive algorithm names; one generic HMAC over the descriptor handles all algorithms (block sizes 64/128, key-longer-than-block reduction, empty key); hash_equals() is a constant-time compare (length check then volatile XOR-accumulate over every byte); hash_algos() returns a 0-indexed list of the supported names. Errors match PHP 8.5 exactly — unknown algorithm ValueError (hash_hmac's says "cryptographic"), hash_equals non-string TypeError naming $known_string/$user_string, and ArgumentCountError.

Also fixes a pre-existing bug: md5("")/sha1("") returned "" (an nLen<1 early-return) where PHP returns the empty-string digest. Removed only that short-circuit (kept the nArg<1 path the *_invalid tests rely on; crc32("")==0 keeps its short-circuit, now commented).

Byte-for-byte parity with PHP 8.5.7 across NIST/php reference vectors including multi-block (>64/>128-byte) inputs and HMAC long/empty keys. make test (2151 smoke + 715 integration), test-compat and test-stress green. function_exists ("hash") is now true. Unblocks password_*.

Documented gaps: streaming hash_init/update/final and the full ~60-algorithm set (PHL supports the md5/sha1/sha2-family subset; hash_algos returns those 6).

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
