### PR TITLE
Implement PHP-exact var_export() + __set_state

### DIFF
--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -253,6 +253,7 @@ struct ph7_hashmap
  * Hashmap control flags.
  */
 #define HASHMAP_COUNTING 0x01 /* Set during recursive count to detect cycles */
+#define HASHMAP_DUMPING  0x02 /* Set during var_export recursion to detect cycles */
 /* An instance of the following structure is the context
  * for the FOREACH_STEP/FOREACH_INIT VM instructions.
  * Those instructions are used to implement the 'foreach'
@@ -1557,6 +1558,7 @@ PH7_PRIVATE int vm_builtin_json_validate(ph7_context *pCtx,int nArg,ph7_value **
 /* vm_serialize.c function prototypes */
 PH7_PRIVATE int vm_builtin_serialize(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE int vm_builtin_unserialize(ph7_context *pCtx,int nArg,ph7_value **apArg);
+PH7_PRIVATE void PH7_AppendShortestReal(SyBlob *pOut,double d);
 /* vm_xml.c function prototypes */
 #ifndef PH7_DISABLE_BUILTIN_FUNC
 PH7_PRIVATE int vm_builtin_xml_parser_create(ph7_context *pCtx,int nArg,ph7_value **apArg);

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -13794,8 +13794,166 @@ static int vm_builtin_print_r(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	return SXRET_OK;
 }
 /*
+ * var_export() — PHP-exact evaluable representation of a value.
+ *
+ * Distinct from print_r/var_dump (which share PH7_MemObjDump): var_export emits
+ * parseable PHP — 'single-quoted' strings, true/false/NULL, array (\n  k => v,\n),
+ * and \Class::__set_state(array(...)) for objects. PHP's indentation is quirky
+ * (2-space array entries; 3-space object property lines; a composite value always
+ * opens at containerIndent+2) but deterministic; this matches it byte-for-byte.
+ */
+/* Instance flag (distinct from oo.c's CLASS_INSTANCE_DESTROYED 0x001) marking an
+ * object currently on the var_export recursion stack, for cycle detection. */
+#define VM_INSTANCE_DUMPING 0x002
+typedef struct VmExportCtx VmExportCtx;
+struct VmExportCtx
+{
+	SyBlob *pOut;
+	int nIndent;  /* indentation of the container emitting this entry */
+	int depth;    /* recursion guard */
+};
+static void VmExportValue(SyBlob *pOut, ph7_value *pVal, int nIndent, int depth);
+/* Append nIndent spaces. */
+static void VmExportIndent(SyBlob *pOut, int nIndent)
+{
+	int i;
+	for( i = 0; i < nIndent; i++ ){ SyBlobAppend(pOut," ",1); }
+}
+/* Append a single-quoted PHP string literal (escapes ' and \, batching safe runs
+ * in one append). A NUL byte can't live in a single-quoted literal, so PHP splits
+ * it out as ' . "\0" . ' — match that. */
+static void VmExportQuoted(SyBlob *pOut, const char *z, int n)
+{
+	int i, run = 0;
+	SyBlobAppend(pOut,"'",1);
+	for( i = 0; i < n; i++ ){
+		char c = z[i];
+		if( c != '\0' && c != '\'' && c != '\\' ){ continue; } /* extend the safe run */
+		if( i > run ){ SyBlobAppend(pOut,&z[run],(sxu32)(i-run)); }
+		if( c == '\0' ){ SyBlobAppend(pOut,"' . \"\\0\" . '",12); }
+		else { SyBlobAppend(pOut,"\\",1); SyBlobAppend(pOut,&z[i],1); }
+		run = i+1;
+	}
+	if( n > run ){ SyBlobAppend(pOut,&z[run],(sxu32)(n-run)); }
+	SyBlobAppend(pOut,"'",1);
+}
+/* True if the array/object is already on the var_export recursion stack. */
+static int VmExportIsCycle(ph7_value *pVal)
+{
+	if( ph7_value_is_array(pVal) ){
+		return (((ph7_hashmap *)pVal->x.pOther)->iFlags & HASHMAP_DUMPING) != 0;
+	}
+	if( ph7_value_is_object(pVal) ){
+		return (((ph7_class_instance *)pVal->x.pOther)->iFlags & VM_INSTANCE_DUMPING) != 0;
+	}
+	return 0;
+}
+/* Emit " => " then the value: a scalar inline, a composite on its own line at
+ * containerIndent+2. A circular reference renders inline as NULL (like PHP). */
+static void VmExportEntryValue(SyBlob *pOut, ph7_value *pVal, int nContainerIndent, int depth)
+{
+	SyBlobAppend(pOut," => ",4);
+	if( VmExportIsCycle(pVal) ){
+		SyBlobAppend(pOut,"NULL",4);
+	}else if( ph7_value_is_array(pVal) || ph7_value_is_object(pVal) ){
+		SyBlobAppend(pOut,"\n",1);
+		VmExportIndent(pOut,nContainerIndent+2);
+		VmExportValue(pOut,pVal,nContainerIndent+2,depth+1);
+	}else{
+		VmExportValue(pOut,pVal,nContainerIndent+2,depth+1);
+	}
+	SyBlobAppend(pOut,",\n",2);
+}
+/* Array walker: "<indent+2>key => value,\n" for each entry. */
+static int VmExportArrayWalk(ph7_value *pKey, ph7_value *pValue, void *pUserData)
+{
+	VmExportCtx *pC = (VmExportCtx *)pUserData;
+	VmExportIndent(pC->pOut,pC->nIndent+2);
+	if( ph7_value_is_string(pKey) ){
+		int n;
+		const char *z = ph7_value_to_string(pKey,&n);
+		VmExportQuoted(pC->pOut,z,n);
+	}else{
+		SyBlobFormat(pC->pOut,"%qd",ph7_value_to_int64(pKey));
+	}
+	VmExportEntryValue(pC->pOut,pValue,pC->nIndent,pC->depth);
+	return PH7_OK;
+}
+static void VmExportValue(SyBlob *pOut, ph7_value *pVal, int nIndent, int depth)
+{
+	if( depth > 4096 ){ return; } /* backstop for pathological finite nesting */
+	if( ph7_value_is_null(pVal) ){
+		SyBlobAppend(pOut,"NULL",4);
+	}else if( ph7_value_is_bool(pVal) ){
+		if( ph7_value_to_bool(pVal) ){ SyBlobAppend(pOut,"true",4); }
+		else { SyBlobAppend(pOut,"false",5); }
+	}else if( ph7_value_is_float(pVal) ){
+		/* float before int: ph7_value_is_int is lenient (true for integer reals). */
+		sxu32 before = SyBlobLength(pOut), i, after;
+		const char *z;
+		int plain = 1;
+		PH7_AppendShortestReal(pOut,ph7_value_to_double(pVal));
+		z = (const char *)SyBlobData(pOut);
+		after = SyBlobLength(pOut);
+		for( i = before; i < after; i++ ){
+			if( !((z[i]>='0'&&z[i]<='9')||z[i]=='-') ){ plain = 0; break; }
+		}
+		if( plain ){ SyBlobAppend(pOut,".0",2); } /* integer-form floats render 1.0/100.0 */
+	}else if( ph7_value_is_int(pVal) ){
+		SyBlobFormat(pOut,"%qd",ph7_value_to_int64(pVal));
+	}else if( ph7_value_is_string(pVal) ){
+		int n;
+		const char *z = ph7_value_to_string(pVal,&n);
+		VmExportQuoted(pOut,z,n);
+	}else if( ph7_value_is_array(pVal) ){
+		ph7_hashmap *pMap = (ph7_hashmap *)pVal->x.pOther;
+		if( pMap->iFlags & HASHMAP_DUMPING ){
+			SyBlobAppend(pOut,"NULL",4); /* circular reference -> NULL, like PHP */
+		}else{
+			VmExportCtx ctx;
+			pMap->iFlags |= HASHMAP_DUMPING;
+			SyBlobAppend(pOut,"array (\n",8);
+			ctx.pOut = pOut; ctx.nIndent = nIndent; ctx.depth = depth;
+			ph7_array_walk(pVal,VmExportArrayWalk,&ctx);
+			VmExportIndent(pOut,nIndent);
+			SyBlobAppend(pOut,")",1);
+			pMap->iFlags &= ~HASHMAP_DUMPING;
+		}
+	}else if( ph7_value_is_object(pVal) ){
+		ph7_class_instance *pThis = (ph7_class_instance *)pVal->x.pOther;
+		if( pThis->iFlags & VM_INSTANCE_DUMPING ){
+			SyBlobAppend(pOut,"NULL",4); /* circular reference -> NULL, like PHP */
+		}else{
+			SyString *pClassName = &pThis->pClass->sName;
+			SyHashEntry *pEntry;
+			pThis->iFlags |= VM_INSTANCE_DUMPING;
+			SyBlobAppend(pOut,"\\",1);
+			SyBlobAppend(pOut,pClassName->zString,pClassName->nByte);
+			SyBlobAppend(pOut,"::__set_state(array(\n",21);
+			SyHashResetLoopCursor(&pThis->hAttr);
+			while( (pEntry = SyHashGetNextEntry(&pThis->hAttr)) != 0 ){
+				VmClassAttr *pVmAttr = (VmClassAttr *)pEntry->pUserData;
+				SyString *pAName = &pVmAttr->pAttr->sName;
+				ph7_value *pAttrVal;
+				if( pVmAttr->pAttr->iFlags & (PH7_CLASS_ATTR_STATIC|PH7_CLASS_ATTR_CONSTANT) ){ continue; }
+				VmExportIndent(pOut,nIndent+3); /* object property lines sit one deeper than arrays */
+				VmExportQuoted(pOut,pAName->zString,(int)pAName->nByte);
+				pAttrVal = PH7_ClassInstanceExtractAttrValue(pThis,pVmAttr);
+				if( pAttrVal ){ VmExportEntryValue(pOut,pAttrVal,nIndent,depth); }
+				else { SyBlobAppend(pOut," => NULL,\n",10); }
+			}
+			VmExportIndent(pOut,nIndent);
+			SyBlobAppend(pOut,"))",2);
+			pThis->iFlags &= ~VM_INSTANCE_DUMPING;
+		}
+	}else{
+		/* resource / other -> PHP emits NULL (with a warning we omit) */
+		SyBlobAppend(pOut,"NULL",4);
+	}
+}
+/*
  * string/null var_export(expression,[bool $return = FALSE])
- * Same job as print_r. (see coment above)
+ *  PHP-exact evaluable representation (see VmExportValue).
  */
 static int vm_builtin_var_export(ph7_context *pCtx,int nArg,ph7_value **apArg)
 {
@@ -13811,8 +13969,8 @@ static int vm_builtin_var_export(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		/* Where to redirect output */
 		ret_string = ph7_value_to_bool(apArg[1]);
 	}
-	/* Generate dump */
-	PH7_MemObjDump(&sDump,apArg[0],FALSE,0,0,0);
+	/* Generate the PHP-exact evaluable representation */
+	VmExportValue(&sDump,apArg[0],0,0);
 	if( !ret_string ){
 		/* Output dump */
 		ph7_context_output(pCtx,(const char *)SyBlobData(&sDump),(int)SyBlobLength(&sDump));

--- a/src/ph7/vm_serialize.c
+++ b/src/ph7/vm_serialize.c
@@ -40,20 +40,22 @@ struct serialize_data
 };
 static sxi32 VmSerialize(ph7_value *pIn, serialize_data *pData);
 /*
- * Emit the shortest decimal string that round-trips to the given double, in
- * PHP's serialize style: uppercase 'E' exponent with no leading zeros and a
+ * Append the shortest decimal string that round-trips to the given double, in
+ * PHP's gcvt/serialize style: uppercase 'E' exponent with no leading zeros and a
  * "1.0E+20"-style mantissa; INF/-INF/NAN spelled out. PHP switches to the
  * exponential form when the leading-digit exponent e satisfies e >= 17 or
- * e <= -5 (php_gcvt with ndigit == 17), and to decimal otherwise.
+ * e <= -5 (php_gcvt with ndigit == 17), and to decimal otherwise. Emits just the
+ * number (no "d:"/";") so var_export can reuse it (see PH7_AppendShortestReal
+ * decl in ph7int.h).
  */
-static void VmSerializeReal(SyBlob *pOut, double d)
+PH7_PRIVATE void PH7_AppendShortestReal(SyBlob *pOut, double d)
 {
 	char zExp[64];
 	char zDig[24];   /* significant digits, no sign/point */
 	const char *p;
 	int sig, nDig, e, decpt, neg;
-	if( PH7_IS_NAN(d) ){ SyBlobAppend(pOut,"d:NAN;",6); return; }
-	if( PH7_IS_INF(d) ){ SyBlobAppend(pOut, d<0.0?"d:-INF;":"d:INF;", d<0.0?7:6); return; }
+	if( PH7_IS_NAN(d) ){ SyBlobAppend(pOut,"NAN",3); return; }
+	if( PH7_IS_INF(d) ){ SyBlobAppend(pOut, d<0.0?"-INF":"INF", d<0.0?4:3); return; }
 	/* Find the fewest significant digits that re-parse bit-exactly. */
 	for( sig = 1; sig <= 17; sig++ ){
 		snprintf(zExp,sizeof(zExp),"%.*e",sig-1,d);
@@ -72,7 +74,6 @@ static void VmSerializeReal(SyBlob *pOut, double d)
 	e = (*p) ? atoi(p+1) : 0;
 	while( nDig > 1 && zDig[nDig-1] == '0' ){ nDig--; } /* trim trailing zeros */
 	decpt = e + 1; /* digits to the left of the decimal point */
-	SyBlobAppend(pOut,"d:",2);
 	if( neg ){ SyBlobAppend(pOut,"-",1); }
 	if( decpt > 17 || decpt < -3 ){
 		/* Exponential: <lead>.<rest>E<sign><exp> (mantissa always has a dot). */
@@ -98,6 +99,12 @@ static void VmSerializeReal(SyBlob *pOut, double d)
 		SyBlobAppend(pOut,".",1);
 		SyBlobAppend(pOut,&zDig[decpt],nDig-decpt);
 	}
+}
+/* Serialize a double as d:<shortest>; */
+static void VmSerializeReal(SyBlob *pOut, double d)
+{
+	SyBlobAppend(pOut,"d:",2);
+	PH7_AppendShortestReal(pOut,d);
 	SyBlobAppend(pOut,";",1);
 }
 /* Emit s:<bytelen>:"<raw>"; for an arbitrary byte string. */

--- a/tests/ph7/001-smoke/function/var_export/arrays.phpt
+++ b/tests/ph7/001-smoke/function/var_export/arrays.phpt
@@ -1,0 +1,52 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+var_export() arrays: lists, mixed keys, nesting, indentation
+--FILE--
+<?php
+
+var_export([1,2,3]); echo "\n";
+var_export([5=>"a","k"=>"b"]); echo "\n";
+var_export([1,"k"=>[true,null,"x"]]); echo "\n";
+var_export([]); echo "\n";
+var_export(["n"=>null,"b"=>false,"f"=>1.5,"deep"=>[[1],[2,3]]]); echo "\n";
+?>
+--EXPECT--
+array (
+  0 => 1,
+  1 => 2,
+  2 => 3,
+)
+array (
+  5 => 'a',
+  'k' => 'b',
+)
+array (
+  0 => 1,
+  'k' => 
+  array (
+    0 => true,
+    1 => NULL,
+    2 => 'x',
+  ),
+)
+array (
+)
+array (
+  'n' => NULL,
+  'b' => false,
+  'f' => 1.5,
+  'deep' => 
+  array (
+    0 => 
+    array (
+      0 => 1,
+    ),
+    1 => 
+    array (
+      0 => 2,
+      1 => 3,
+    ),
+  ),
+)

--- a/tests/ph7/001-smoke/function/var_export/cycles.phpt
+++ b/tests/ph7/001-smoke/function/var_export/cycles.phpt
@@ -1,0 +1,40 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+var_export() circular references render as NULL (no infinite recursion)
+--FILE--
+<?php
+
+set_error_handler(function($n, $s){ return true; }); // swallow the circular-ref warning
+$a = [1, 2]; $a[2] = &$a;
+var_export($a); echo "\n";
+class VeCycle { public $child; public $v = 7; }
+$o = new VeCycle; $o->child = $o;
+var_export($o); echo "\n";
+$x = [1, 2];                 // shared but NOT circular -> fully expanded twice
+var_export([$x, $x]); echo "\n";
+restore_error_handler();
+?>
+--EXPECT--
+array (
+  0 => 1,
+  1 => 2,
+  2 => NULL,
+)
+\VeCycle::__set_state(array(
+   'child' => NULL,
+   'v' => 7,
+))
+array (
+  0 => 
+  array (
+    0 => 1,
+    1 => 2,
+  ),
+  1 => 
+  array (
+    0 => 1,
+    1 => 2,
+  ),
+)

--- a/tests/ph7/001-smoke/function/var_export/objects.phpt
+++ b/tests/ph7/001-smoke/function/var_export/objects.phpt
@@ -1,0 +1,45 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+var_export() objects: __set_state, visibility (bare names), nesting
+--FILE--
+<?php
+
+class VeVis { public $a=1; protected $b=2; private $c=3; }
+var_export(new VeVis); echo "\n";
+class VeNest { public $arr=[1,[2,3]]; public $s="hi"; }
+var_export(new VeNest); echo "\n";
+class VeEmpty {}
+var_export(new VeEmpty); echo "\n";
+class VeInner { public $x=1; }
+class VeOuter { public $o; }
+$o = new VeOuter; $o->o = new VeInner;
+var_export($o); echo "\n";
+?>
+--EXPECT--
+\VeVis::__set_state(array(
+   'a' => 1,
+   'b' => 2,
+   'c' => 3,
+))
+\VeNest::__set_state(array(
+   'arr' => 
+  array (
+    0 => 1,
+    1 => 
+    array (
+      0 => 2,
+      1 => 3,
+    ),
+  ),
+   's' => 'hi',
+))
+\VeEmpty::__set_state(array(
+))
+\VeOuter::__set_state(array(
+   'o' => 
+  \VeInner::__set_state(array(
+     'x' => 1,
+  )),
+))

--- a/tests/ph7/001-smoke/function/var_export/scalars.phpt
+++ b/tests/ph7/001-smoke/function/var_export/scalars.phpt
@@ -1,0 +1,38 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+var_export() scalars: null/bool/int/float/string (evaluable)
+--FILE--
+<?php
+
+foreach ([null,true,false,0,1,-7,PHP_INT_MAX] as $v){ var_export($v); echo "\n"; }
+foreach ([0.0,-0.0,0.1,1.5,1.0,100.0,1e20,1/3,1e-7,INF,-INF,NAN] as $v){ var_export($v); echo "\n"; }
+foreach (["", "x", "a'b\\c", "two\nlines", "nul\0byte"] as $v){ var_export($v); echo "\n"; }
+?>
+--EXPECT--
+NULL
+true
+false
+0
+1
+-7
+9223372036854775807
+0.0
+-0.0
+0.1
+1.5
+1.0
+100.0
+1.0E+20
+0.3333333333333333
+1.0E-7
+INF
+-INF
+NAN
+''
+'x'
+'a\'b\\c'
+'two
+lines'
+'nul' . "\0" . 'byte'

--- a/tests/ph7/001-smoke/function/var_export/set_state.phpt
+++ b/tests/ph7/001-smoke/function/var_export/set_state.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+var_export() + __set_state round-trip via eval()
+--FILE--
+<?php
+
+class VeRound {
+    public $a; public $b;
+    static function __set_state($d){ $o = new VeRound; $o->a = $d["a"]; $o->b = $d["b"]; return $o; }
+}
+$o = new VeRound; $o->a = 42; $o->b = ["x", true];
+$code = var_export($o, true);
+$r = eval("return $code;");
+echo $r->a, "|", $r->b[0], "|", ($r->b[1] ? "T" : "F"), "\n";
+echo (var_export($r, true) === $code) ? "stable\n" : "DRIFT\n";
+?>
+--EXPECT--
+42|x|T
+stable


### PR DESCRIPTION
var_export() was aliased to the shared PH7_MemObjDump path with ShowType=FALSE ("Same job as print_r"), so it emitted print_r-style, non-evaluable output: arrays as Array(N) {...}, unquoted strings, TRUE/FALSE, null, and objects as Object(C) {...} instead of PHP's \C::__set_state(array(...)). The output was not valid PHP — a correctness bug — and __set_state was the remaining Tier-2 item.

vm.c gains a dedicated recursive VmExportValue matching PHP 8.5 byte-for-byte: NULL/true/false/int; single-quoted strings escaping '/\ and splitting NUL as 'a' . "\0" . 'b'; floats via the shared shortest formatter with ".0" appended to integer-form values (1.0/100.0); array (\n  k => v,\n); and \Class::__set_state(array(...)) over bare (non-mangled) property names. PHP's quirky indentation is reproduced exactly (2-space array entries, 3-space object property lines, composite values opening at containerIndent+2). __set_state needs no engine work — the emitted text is a normal static call eval() runs.

The shortest-real core is factored out of serialize into PH7_AppendShortestReal (vm_serialize.c, declared in ph7int.h) and reused by both; serialize stays byte-for-byte.

Circular references are detected via a HASHMAP_DUMPING flag (mirroring the existing HASHMAP_COUNTING precedent) for arrays and a VM_INSTANCE_DUMPING instance flag for objects, set on entry and cleared on exit; the back-reference renders inline as NULL like PHP. This prevents the infinite recursion / O(n^2) output a naive depth guard would allow (a self-referential array previously blew up to ~67MB); shared-but-not-circular values still expand fully.

Verified byte-for-byte vs php 8.5.7 across scalars/floats (incl. INF/NAN/.0)/ strings (NUL/newline/high bytes)/mixed-key+nested arrays/visibility objects/ deep nesting, the eval(var_export($o,true)) round-trip, and circular refs; 6 smoke .phpt. make test (2179 smoke + 718 integration), test-compat (both engines), test-stress all green.

Deferred / documented divergences: var_dump/print_r fidelity, object-ids (#N), __debugInfo, spl_object_id/hash (need a per-instance id field); the circular-reference warning text (error-format audit); and stdClass rendering as (object) array(...) (PHL's stdClass is itself broken — phantom $value prop / no dynamic properties).
