### PR TITLE
Support anonymous classes (new class(args) extends B implements I {...})

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -8312,7 +8312,18 @@ static int GenStateClassIsExceptionOrError(ph7_class *pBase)
 	}
 	return FALSE;
 }
-static sxi32 GenStateCompileClass(ph7_gen_state *pGen,sxi32 iFlags)
+/*
+ * Compile a class declaration, named or anonymous.
+ *
+ * For a named class pAnonName is 0 and the class name is read from the token
+ * stream. For an anonymous class (`new class(args) extends B implements I {…}`)
+ * pAnonName carries the synthesized class name, the optional constructor
+ * '(args)' token range is returned through ppArgStart/ppArgEnd for the caller to
+ * compile, and no name token is expected. Everything after the header (extends/
+ * implements, body, install) is shared by both paths.
+ */
+static sxi32 GenStateCompileClassEx(ph7_gen_state *pGen,sxi32 iFlags,
+	SyString *pAnonName,SyToken **ppArgStart,SyToken **ppArgEnd)
 {
 	sxu32 nLine = pGen->pIn->nLine;
 	ph7_class *pClass,*pBase;
@@ -8326,31 +8337,48 @@ static sxi32 GenStateCompileClass(ph7_gen_state *pGen,sxi32 iFlags)
 	sxi32 rc;
 	/* Jump the 'class' keyword */
 	pGen->pIn++;
-	if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_ID) == 0 ){
-		/* Syntax error */
-		rc = PH7_GenCompileError(pGen,E_ERROR,nLine,"Invalid class name");
-		if( rc == SXERR_ABORT ){
-			/* Error count limit reached,abort immediately */
-			return SXERR_ABORT;
+	if( pAnonName ){
+		/* Anonymous class: no name token. Capture the optional constructor
+		 * '(args)' range for the caller (which always supplies the out-params),
+		 * then use the synthesized name. */
+		*ppArgStart = *ppArgEnd = 0;
+		if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_LPAREN) ){
+			pGen->pIn++; /* Jump '(' */
+			*ppArgStart = pGen->pIn;
+			PH7_DelimitNestedTokens(pGen->pIn,pGen->pEnd,
+				PH7_TK_LPAREN/*'('*/,PH7_TK_RPAREN/*')'*/,ppArgEnd);
+			pGen->pIn = *ppArgEnd;
+			if( pGen->pIn < pGen->pEnd ){ pGen->pIn++; } /* Jump ')' */
 		}
-		/* Synchronize with the first semi-colon or curly braces */
-		while( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & (PH7_TK_OCB/*'{'*/|PH7_TK_SEMI/*';'*/)) == 0 ){
-			pGen->pIn++;
+		pName = pAnonName;
+		pClass = PH7_NewRawClass(pGen->pVm,pAnonName,nLine);
+	}else{
+		if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_ID) == 0 ){
+			/* Syntax error */
+			rc = PH7_GenCompileError(pGen,E_ERROR,nLine,"Invalid class name");
+			if( rc == SXERR_ABORT ){
+				/* Error count limit reached,abort immediately */
+				return SXERR_ABORT;
+			}
+			/* Synchronize with the first semi-colon or curly braces */
+			while( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & (PH7_TK_OCB/*'{'*/|PH7_TK_SEMI/*';'*/)) == 0 ){
+				pGen->pIn++;
+			}
+			return SXRET_OK;
 		}
-		return SXRET_OK;
-	}
-	/* Extract class name */
-	pName = &pGen->pIn->sData;
-	/* Advance the stream cursor */
-	pGen->pIn++;
-	/* Build FQN and obtain a raw class */ {
-		SyBlob sFQN;
-		SyString sFQNStr;
-		SyBlobInit(&sFQN,&pGen->pVm->sAllocator);
-		GenStateBuildFQN(pGen,pName,&sFQN);
-		SyStringInitFromBuf(&sFQNStr,(const char *)SyBlobData(&sFQN),SyBlobLength(&sFQN));
-		pClass = PH7_NewRawClass(pGen->pVm,&sFQNStr,nLine);
-		SyBlobRelease(&sFQN);
+		/* Extract class name */
+		pName = &pGen->pIn->sData;
+		/* Advance the stream cursor */
+		pGen->pIn++;
+		/* Build FQN and obtain a raw class */ {
+			SyBlob sFQN;
+			SyString sFQNStr;
+			SyBlobInit(&sFQN,&pGen->pVm->sAllocator);
+			GenStateBuildFQN(pGen,pName,&sFQN);
+			SyStringInitFromBuf(&sFQNStr,(const char *)SyBlobData(&sFQN),SyBlobLength(&sFQN));
+			pClass = PH7_NewRawClass(pGen->pVm,&sFQNStr,nLine);
+			SyBlobRelease(&sFQN);
+		}
 	}
 	if( pClass == 0 ){
 		PH7_GenCompileError(pGen,E_ERROR,nLine,"Fatal, PH7 is running out of memory");
@@ -9140,6 +9168,80 @@ done:
 	pGen->pIn = &pEnd[1];
 	pGen->pEnd = pTmp;
 	return PH7_OK;
+}
+/* Compile a named class declaration (the common case). */
+static sxi32 GenStateCompileClass(ph7_gen_state *pGen,sxi32 iFlags)
+{
+	return GenStateCompileClassEx(pGen,iFlags,0,0,0);
+}
+/*
+ * Compile an anonymous class expression: `new class(args) extends B implements I
+ * { ... }` (PHP 7.0). Mirrors PH7_CompileAnnonFunc: synthesize a unique name,
+ * compile + install the class body once (at compile time, like every other
+ * class), then emit the instantiation — push the constructor arguments, load the
+ * synthesized class name, and OP_NEW. The class is installed once per source
+ * site, matching PHP's one-class-per-anonymous-site semantics.
+ */
+PH7_PRIVATE sxi32 PH7_CompileAnnonClass(ph7_gen_state *pGen,sxi32 iCompileFlag)
+{
+	char zName[128];         /* Synthesized class name */
+	static int iCnt = 1;     /* Single-threaded compile: no locking needed */
+	SyString sName;
+	SyToken *pArgStart,*pArgEnd;
+	ph7_value *pObj;
+	sxu32 nLine = pGen->pIn->nLine;
+	sxu32 nIdx,nLen;
+	sxi32 nArg,rc;
+	SXUNUSED(iCompileFlag);
+	/* Generate a unique anonymous-class name (collision-checked) */
+	nLen = SyBufferFormat(zName,sizeof(zName),"class@anonymous_%d",iCnt++);
+	while( PH7_VmExtractClass(pGen->pVm,zName,nLen,FALSE,0) != 0 && nLen < sizeof(zName) - 2 ){
+		nLen = SyBufferFormat(zName,sizeof(zName),"class@anonymous_%d",iCnt++);
+	}
+	SyStringInitFromBuf(&sName,zName,nLen);
+	/* Compile + install the class body; capture the constructor '(args)' range.
+	 * On entry pGen->pIn sits on the 'class' keyword and pGen->pEnd bounds the
+	 * delimited construct; GenStateCompileClassEx restores both on success. */
+	pArgStart = pArgEnd = 0;
+	rc = GenStateCompileClassEx(pGen,0,&sName,&pArgStart,&pArgEnd);
+	if( rc != SXRET_OK ){
+		return rc;
+	}
+	/* Emit the instantiation. OP_NEW expects the class name on the stack top
+	 * with the constructor arguments beneath it, so push the args first. */
+	nArg = 0;
+	if( pArgStart < pArgEnd ){
+		SyToken *pSavedIn = pGen->pIn;
+		SyToken *pSavedEnd = pGen->pEnd;
+		SyToken *pArgNext;
+		pGen->pIn = pArgStart;
+		pGen->pEnd = pArgEnd;
+		while( SXRET_OK == PH7_GetNextExpr(pGen->pIn,pGen->pEnd,&pArgNext) ){
+			if( pGen->pIn < pArgNext ){
+				rc = GenStateCompileArrayEntry(pGen,pGen->pIn,pArgNext,EXPR_FLAG_RDONLY_LOAD,0);
+				if( rc == SXERR_ABORT ){
+					pGen->pIn = pSavedIn;
+					pGen->pEnd = pSavedEnd;
+					return SXERR_ABORT;
+				}
+				nArg++;
+			}
+			pGen->pIn = &pArgNext[1];
+		}
+		pGen->pIn = pSavedIn;
+		pGen->pEnd = pSavedEnd;
+	}
+	/* Load the synthesized class name */
+	pObj = PH7_ReserveConstObj(pGen->pVm,&nIdx);
+	if( pObj == 0 ){
+		PH7_GenCompileError(&(*pGen),E_ERROR,nLine,"Fatal, PH7 engine is running out of memory");
+		return SXERR_ABORT;
+	}
+	PH7_MemObjInitFromString(pGen->pVm,pObj,&sName);
+	PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOADC,0,nIdx,0,0);
+	/* Instantiate: pops the name + nArg arguments, runs __construct */
+	PH7_VmEmitInstr(pGen->pVm,PH7_OP_NEW,nArg,0,GenStateAttachStrictFlag(pGen,0),0);
+	return SXRET_OK;
 }
 /*
  * Compile a user-defined abstract class.
@@ -10853,6 +10955,12 @@ static sxi32 GenStateEmitExprCode(
 				}
 			}
 		}
+	}
+	if( iVmOp == PH7_OP_NEW && pNode->pLeft && pNode->pLeft->pOp == 0
+		&& pNode->pLeft->xCode == PH7_CompileAnnonClass ){
+		/* `new class {…}`: PH7_CompileAnnonClass already emitted the args, the
+		 * class-name constant, and OP_NEW. Suppress this redundant OP_NEW. */
+		iVmOp = 0;
 	}
 	if( iVmOp > 0 ){
 		if( iVmOp == PH7_OP_INCR || iVmOp == PH7_OP_DECR ){

--- a/src/ph7/parse.c
+++ b/src/ph7/parse.c
@@ -688,6 +688,52 @@ Synchronize:
 	return rc;
 }
 /*
+ * Assemble an anonymous-class token range (PHP 7.0):
+ *   class [ ( args ) ] [ extends Name ] [ implements N1, N2 … ] { body }
+ * On entry *ppCur points at the 'class' keyword. On exit *ppCur points just past
+ * the closing '}', so the whole construct becomes a single 'new' operand and the
+ * expression tree-builder never sees the inner braces/keywords. The header and
+ * body are re-parsed precisely later by GenStateCompileClassEx — here we only
+ * delimit the span (mirroring ExprAssembleAnnon for closures).
+ */
+static sxi32 ExprAssembleAnnonClass(ph7_gen_state *pGen,SyToken **ppCur,SyToken *pEnd)
+{
+	SyToken *pIn = *ppCur;
+	sxu32 nLine = pIn->nLine;
+	sxi32 rc;
+	pIn++; /* Jump the 'class' keyword */
+	/* Optional constructor argument list */
+	if( pIn < pEnd && (pIn->nType & PH7_TK_LPAREN) ){
+		pIn++; /* Jump '(' */
+		PH7_DelimitNestedTokens(pIn,pEnd,PH7_TK_LPAREN/*'('*/,PH7_TK_RPAREN/*')'*/,&pIn);
+		if( pIn < pEnd ){
+			pIn++; /* Jump ')' */
+		}
+	}
+	/* Optional 'extends Base' / 'implements I1, I2 …': skip up to the body '{'
+	 * (no braces appear between ')' and the class body). */
+	while( pIn < pEnd && (pIn->nType & PH7_TK_OCB/*'{'*/) == 0 ){
+		pIn++;
+	}
+	if( pIn >= pEnd || (pIn->nType & PH7_TK_OCB) == 0 ){
+		/* Syntax error: missing class body */
+		rc = PH7_GenCompileError(&(*pGen),E_ERROR,nLine,
+			"Syntax error while declaring anonymous class, missing '{'");
+		if( rc != SXERR_ABORT ){
+			rc = SXERR_SYNTAX;
+		}
+		*ppCur = pIn;
+		return rc;
+	}
+	pIn++; /* Jump the leading '{' */
+	PH7_DelimitNestedTokens(pIn,pEnd,PH7_TK_OCB/*'{'*/,PH7_TK_CCB/*'}'*/,&pIn);
+	if( pIn < pEnd ){
+		pIn++; /* Jump the trailing '}' */
+	}
+	*ppCur = pIn;
+	return SXRET_OK;
+}
+/*
  * Assemble a PHP 7.4 arrow function token range:
  *    [static] fn [&] ( params ) [: [?] type] => expression
  * On entry *ppCur points at 'static' or 'fn'. On exit *ppCur points just
@@ -980,6 +1026,21 @@ static sxi32 ExprExtractNode(ph7_gen_state *pGen,ph7_expr_node **ppNode,int iLas
 				 }
 				 pNode->xCode = PH7_CompileAnnonFunc;
 			  }
+		 }else if( nKeyword == PH7_TKWRD_CLASS && &pCur[1] < pGen->pEnd
+			 && ( (pCur[1].nType & (PH7_TK_OCB/*'{'*/|PH7_TK_LPAREN/*'('*/))
+				|| ( (pCur[1].nType & PH7_TK_KEYWORD)
+					&& ( SX_PTR_TO_INT(pCur[1].pUserData) == PH7_TKWRD_EXTENDS
+						|| SX_PTR_TO_INT(pCur[1].pUserData) == PH7_TKWRD_IMPLEMENTS ) ) ) ){
+			 /* Anonymous class: new class(args) [extends/implements] { body }.
+			  * Only when 'class' is followed by '{', '(', extends or implements —
+			  * this excludes the '::class' constant (e.g. self::class), where
+			  * 'class' is a plain name handled by the literal fallback below. */
+			 rc = ExprAssembleAnnonClass(&(*pGen),&pCur,pGen->pEnd);
+			 if( rc != SXRET_OK ){
+				 SyMemBackendPoolFree(&pGen->pVm->sAllocator,pNode);
+				 return rc;
+			 }
+			 pNode->xCode = PH7_CompileAnnonClass;
 		 }else if( nKeyword == PH7_TKWRD_FN
 			|| ( nKeyword == PH7_TKWRD_STATIC && &pCur[1] < pGen->pEnd
 				 && (pCur[1].nType & PH7_TK_KEYWORD)
@@ -1582,7 +1643,8 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 				 /* New */
 				 if( apNode[iLeft]->pOp == 0 ){
 					 ProcNodeConstruct xCons = apNode[iLeft]->xCode;
-					 if( xCons != PH7_CompileVariable && xCons != PH7_CompileLiteral && xCons != PH7_CompileSimpleString){
+					 if( xCons != PH7_CompileVariable && xCons != PH7_CompileLiteral && xCons != PH7_CompileSimpleString
+						 && xCons != PH7_CompileAnnonClass){
 						 pToken = apNode[iLeft]->pStart;
 						 /* Syntax error */
 						 rc = PH7_GenCompileError(pGen,E_ERROR,pNode->pStart->nLine,

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1716,6 +1716,7 @@ PH7_PRIVATE sxi32 PH7_CompileShortArray(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileList(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileShortList(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileAnnonFunc(ph7_gen_state *pGen,sxi32 iCompileFlag);
+PH7_PRIVATE sxi32 PH7_CompileAnnonClass(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileArrowFunc(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileMatch(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileThrowExpr(ph7_gen_state *pGen,sxi32 iCompileFlag);

--- a/src/ph7/vm_serialize.c
+++ b/src/ph7/vm_serialize.c
@@ -32,11 +32,12 @@
 typedef struct serialize_data serialize_data;
 struct serialize_data
 {
-	ph7_vm *pVm;   /* The underlying VM */
-	SyBlob *pOut;  /* Output accumulator */
-	int depth;     /* Current nesting level (cycle guard) */
-	int exc;       /* A magic method threw -> propagate the exception */
-	int err;       /* Recursion overflow or bad input -> serialize returns false */
+	ph7_vm *pVm;          /* The underlying VM */
+	ph7_context *pCtx;    /* Call context (for throwing exceptions) */
+	SyBlob *pOut;         /* Output accumulator */
+	int depth;            /* Current nesting level (cycle guard) */
+	int exc;              /* A magic method threw -> propagate the exception */
+	int err;              /* Recursion overflow or bad input -> serialize returns false */
 };
 static sxi32 VmSerialize(ph7_value *pIn, serialize_data *pData);
 /*
@@ -206,6 +207,14 @@ static sxi32 VmSerializeObject(ph7_value *pIn, serialize_data *pData)
 	VmClassAttr *pVmAttr;
 	SyBlob sBody, *pSave;
 	sxu32 nCount = 0;
+	/* Anonymous classes cannot be serialized (PHP throws an Exception). Their
+	 * synthesized name contains '@', which no ordinary class name can. */
+	if( SyByteFind(pClassName->zString,pClassName->nByte,'@',0) == SXRET_OK ){
+		PH7_VmThrowException(pData->pCtx,"Exception",
+			"Serialization of 'class@anonymous' is not allowed");
+		pData->exc = 1;
+		return PH7_EXCEPTION;
+	}
 	SyBlobInit(&sBody,&pVm->sAllocator);
 	pSave = pData->pOut;
 	pData->pOut = &sBody;     /* recursion appends to the body blob */
@@ -307,6 +316,7 @@ PH7_PRIVATE int vm_builtin_serialize(ph7_context *pCtx, int nArg, ph7_value **ap
 	}
 	SyBlobInit(&sOut,&pCtx->pVm->sAllocator);
 	sData.pVm = pCtx->pVm;
+	sData.pCtx = pCtx;
 	sData.pOut = &sOut;
 	sData.depth = 0;
 	sData.exc = 0;

--- a/tests/ph7/001-smoke/oo/anon_class_basic.phpt
+++ b/tests/ph7/001-smoke/oo/anon_class_basic.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Anonymous class: constructor args, property, method
+--FILE--
+<?php
+$o = new class(5) {
+    public $x;
+    function __construct($v) { $this->x = $v; }
+    function dbl() { return $this->x * 2; }
+};
+echo $o->dbl(), "\n";
+?>
+--EXPECT--
+10
+--CLEAN--
+<?php
+unset($o);

--- a/tests/ph7/001-smoke/oo/anon_class_empty.phpt
+++ b/tests/ph7/001-smoke/oo/anon_class_empty.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Anonymous class: empty body, no properties
+--FILE--
+<?php
+$o = new class {};
+var_export(get_object_vars($o));
+echo "\n", substr(get_class($o), 0, 15), "\n";
+?>
+--EXPECT--
+array (
+)
+class@anonymous
+--CLEAN--
+<?php
+unset($o);

--- a/tests/ph7/001-smoke/oo/anon_class_extends.phpt
+++ b/tests/ph7/001-smoke/oo/anon_class_extends.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Anonymous class: extends a base class
+--FILE--
+<?php
+class AnonBaseA { protected $b = 3; function g() { return $this->b + 4; } }
+$o = new class extends AnonBaseA {};
+echo $o->g(), " ", var_export($o instanceof AnonBaseA, true), "\n";
+?>
+--EXPECT--
+7 true
+--CLEAN--
+<?php
+unset($o);

--- a/tests/ph7/001-smoke/oo/anon_class_extends_implements.phpt
+++ b/tests/ph7/001-smoke/oo/anon_class_extends_implements.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Anonymous class: extends + implements together
+--FILE--
+<?php
+class AnonBaseB {}
+interface AnonIfaceB {}
+$o = new class(7) extends AnonBaseB implements AnonIfaceB {
+    public $v;
+    function __construct($v) { $this->v = $v; }
+};
+echo $o->v, " ", var_export($o instanceof AnonBaseB && $o instanceof AnonIfaceB, true), "\n";
+?>
+--EXPECT--
+7 true
+--CLEAN--
+<?php
+unset($o);

--- a/tests/ph7/001-smoke/oo/anon_class_implements.phpt
+++ b/tests/ph7/001-smoke/oo/anon_class_implements.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Anonymous class: implements interface + instanceof
+--FILE--
+<?php
+interface AnonIfaceA { function f(); }
+$o = new class implements AnonIfaceA { function f() { return "ok"; } };
+echo $o->f(), " ", var_export($o instanceof AnonIfaceA, true), "\n";
+?>
+--EXPECT--
+ok true
+--CLEAN--
+<?php
+unset($o);

--- a/tests/ph7/001-smoke/oo/anon_class_nested.phpt
+++ b/tests/ph7/001-smoke/oo/anon_class_nested.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Anonymous class: nested anonymous class in a method
+--FILE--
+<?php
+$o = new class {
+    function make() { return new class { function g() { return 42; } }; }
+};
+echo $o->make()->g(), "\n";
+?>
+--EXPECT--
+42
+--CLEAN--
+<?php
+unset($o);

--- a/tests/ph7/001-smoke/oo/anon_class_promotion.phpt
+++ b/tests/ph7/001-smoke/oo/anon_class_promotion.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Anonymous class: constructor property promotion
+--FILE--
+<?php
+$o = new class(9) {
+    function __construct(public int $n) {}
+};
+echo $o->n, "\n";
+?>
+--EXPECT--
+9
+--CLEAN--
+<?php
+unset($o);

--- a/tests/ph7/001-smoke/oo/anon_class_serialize.phpt
+++ b/tests/ph7/001-smoke/oo/anon_class_serialize.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Anonymous class cannot be serialized (throws Exception)
+--FILE--
+<?php
+try {
+    serialize(new class { public $a = 1; });
+} catch (\Exception $e) {
+    echo $e->getMessage(), "\n";
+}
+// also when nested inside a container
+try {
+    serialize([1, new class {}, 2]);
+} catch (\Exception $e) {
+    echo "nested: ", $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Serialization of 'class@anonymous' is not allowed
+nested: Serialization of 'class@anonymous' is not allowed
+--CLEAN--
+<?php


### PR DESCRIPTION
`new class {...}` (PHP 7.0) failed at parse. Anonymous classes are common in modern PHP — test doubles, inline single-use implementations of an interface, ad-hoc value objects, DI bindings. They are now implemented as a fourth member of the anonymous-construct family alongside closures, arrow functions, and match, with no new VM opcodes.

parse.c gains ExprAssembleAnnonClass, which delimits the whole `class ... {body}` span (modeled on the closure ExprAssembleAnnon) so the expression tree-builder never sees the inner braces/keywords, and an ExprExtractNode dispatch branch that recognizes `class` only when it is followed by `{`, `(`, extends, or implements — so the `::class` constant (self::class, Foo::class) still routes to the literal path. PH7_CompileAnnonClass is added to the `new`-operand allowlist.

compile.c's GenStateCompileClass is parameterized into GenStateCompileClassEx (an optional synthesized name plus a captured constructor `(args)` token range); the named path is a thin wrapper, so the refactor is behavior-preserving for named classes (the shared extends/implements/body/install tail is unchanged). The new PH7_CompileAnnonClass synthesizes a unique class@anonymous_%d name, compiles and installs the class body once per source site (compile time, like every class), then emits the instantiation — push the constructor arguments, load the class-name constant, OP_NEW — and the parent `new`'s redundant OP_NEW is suppressed. Constructor property promotion, extends, implements + instanceof, traits, constants, static properties, and nested anonymous classes all work through the shared class machinery; runtime is identical to a named `new`.

serialize() of an anonymous-class object (or any container transitively holding one) now throws the same catchable Exception PHP does — "Serialization of 'class@anonymous' is not allowed" — via PH7_VmThrowException in vm_serialize.c, detecting the '@' that only synthesized anon names carry, instead of silently emitting a non-round-trippable O:...:"class@anonymous_N":... blob.

Verified byte-for-byte vs php 8.5.7: basic/promoted/extends/implements/both/ nested/empty bodies, instanceof, traits, consts, static props, ::class unaffected, and the serialize rejection (catchable + nested); 8 smoke .phpt. make test (2197 smoke + 718 integration), test-compat (both engines), test-stress green.

Documented divergences / limitations: the synthesized class-name text (class@anonymous_%d vs PHP's class@anonymous\0<file>:<line>) — tests assert the class@anonymous prefix only; an abstract-method anon body fatals at instantiation rather than at compile (error-format §3.7); and named/spread constructor arguments (new class(x: 1){...}, new class(...$a){...}) are not yet supported (the anon path compiles its captured (args) token range positionally, bypassing the named-arg/OP_SPREAD machinery that operates on parsed call-arg nodes — a follow-up; positional args work, and spread-to-constructor is additionally broken for named `new` too, so it is a pre-existing engine gap).
