### PR TITLE
Support yield from (generator delegation)

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -4781,6 +4781,28 @@ PH7_PRIVATE sxi32 PH7_CompileYield(ph7_gen_state *pGen, sxi32 iCompileFlag)
 	pGen->pIn++;
 	/* Now pGen->pIn points to the first token after 'yield'
 	 * pGen->pEnd points to the delimiter (;, ), ], etc.) */
+	/* `yield from <iterable>` — generator delegation (PHP 7.0). 'from' is a
+	 * contextual identifier, not a keyword; a variable named $from lexes as
+	 * PH7_TK_DOLLAR, never PH7_TK_ID, so `yield $from` cannot match here. */
+	if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_ID)
+		&& pGen->pIn->sData.nByte == 4
+		&& SyStrnicmp(pGen->pIn->sData.zString, "from", 4) == 0 ){
+		pGen->pIn++; /* Skip 'from' */
+		rc = PH7_CompileExpr(pGen, 0, 0);
+		if( rc == SXERR_ABORT ){
+			return SXERR_ABORT;
+		}
+		if( rc == SXERR_EMPTY ){
+			rc = PH7_GenCompileError(pGen, E_ERROR,
+				(pGen->pIn < pGen->pEnd) ? pGen->pIn->nLine : 0,
+				"Missing expression after 'yield from'");
+			if( rc == SXERR_ABORT ){
+				return SXERR_ABORT;
+			}
+		}
+		PH7_VmEmitInstr(pGen->pVm, PH7_OP_YIELD_FROM, 0, 0, 0, 0);
+		return SXRET_OK;
+	}
 	if( pGen->pIn >= pGen->pEnd ){
 		/* Bare yield — no value */
 		PH7_VmEmitInstr(pGen->pVm, PH7_OP_YIELD, 0, 0, 0, 0);
@@ -6028,7 +6050,7 @@ static sxi32 GenStateCompileFuncBody(
 		VmInstr *aInstr = (VmInstr *)SySetBasePtr(&pFunc->aByteCode);
 		sxu32 i;
 		for( i = 0; i < SySetUsed(&pFunc->aByteCode); i++ ){
-			if( aInstr[i].iOp == PH7_OP_YIELD ){
+			if( aInstr[i].iOp == PH7_OP_YIELD || aInstr[i].iOp == PH7_OP_YIELD_FROM ){
 				pFunc->iFlags |= VM_FUNC_GENERATOR;
 				break;
 			}

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -454,6 +454,11 @@ struct ph7_exec_ctx
 	ph7_value sRetValue;      /* Final return value */
 	sxu32 nExceptionBase;     /* Exception stack depth at entry */
 	void *pPrivate;           /* Generator wrapper (ph7_generator*) or NULL for fibers */
+	/* `yield from` delegation state — per generator instance, so independent
+	 * instances never clash (unlike the shared foreach aStep). */
+	ph7_value sDelegate;             /* The iterable being delegated (kept alive) */
+	ph7_hashmap_node *pDelegateNode; /* Array cursor: next node to read, else 0 */
+	sxi32 iDelegateState;            /* 0=inactive, 1=array, 2=iterator, 3=generator */
 };
 /* Special return code from VmByteCodeExec signaling fiber suspension */
 #define PH7_SUSPEND  0x100
@@ -1071,6 +1076,7 @@ enum ph7_vm_op {
   PH7_OP_PULL,         /* Stack pull */
   PH7_OP_SWAP,         /* Stack swap */
   PH7_OP_YIELD,        /* Stack yield */
+  PH7_OP_YIELD_FROM,   /* Generator delegation (yield from <iterable>) */
   PH7_OP_CVT_BOOL,     /* Boolean cast */
   PH7_OP_CVT_NUMC,     /* Numeric (integer,real or both) type cast */
   PH7_OP_INCR,         /* Increment ++ */

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -1123,6 +1123,8 @@ static int vm_builtin_Fiber_destruct(ph7_context *pCtx, int nArg, ph7_value **ap
 /* Forward declarations for Fiber/Generator infrastructure */
 static ph7_exec_ctx * VmNewExecCtx(ph7_vm *pVm, ph7_vm_func *pFunc);
 static void VmReleaseExecCtx(ph7_vm *pVm, ph7_exec_ctx *pCtx);
+static ph7_generator * VmGeneratorExtractCtx(ph7_vm *pVm, ph7_value *pGenObj);
+static sxi32 VmIterCallMethod(ph7_vm *pVm,ph7_class_instance *pThis,const char *zName,sxu32 nLen,ph7_value *pResult);
 static sxi32 VmFiberSetupFrame(ph7_vm *pVm, ph7_exec_ctx *pExecCtx,
 	ph7_class_instance *pClosureThis, int nArg, ph7_value **apArg);
 static sxi32 VmCallClassMethodWithMap(ph7_vm *pVm, ph7_class_instance *pThis,
@@ -4870,12 +4872,7 @@ case PH7_OP_DONE:
 		 * defensively we clear the pointer after a successful check). */
 		pEnforceRetFunc = 0;
 	}
-	if( pInstr->iP1 ){
-#ifdef UNTRUST
-		if( pTos < pStack ){
-			goto Abort;
-		}
-#endif
+	if( pInstr->iP1 && pTos >= pStack ){
 		if( pLastRef ){
 			*pLastRef = pTos->nIdx;
 		}
@@ -4885,7 +4882,11 @@ case PH7_OP_DONE:
 		}
 		VmPopOperand(&pTos,1);
 	}else if( pLastRef ){
-		/* Nothing referenced */
+		/* Nothing referenced — also the throw-unwind path: the compiler routes
+		 * an uncaught exception to this terminal OP_DONE with iP1 set but an
+		 * empty operand stack (pTos == pStack-1), so there is no return value to
+		 * store. Guarding on pTos >= pStack (matching the two sibling branches
+		 * above) avoids the below-base read that crashed under glibc/ASan. */
 		*pLastRef = SXU32_HIGH;
 	}
 	/* Execute pending finally blocks for any try/catch contexts pushed during
@@ -9249,6 +9250,186 @@ case PH7_OP_YIELD: {
 	goto Suspend;
 }
 /*
+ * OP_YIELD_FROM * * *
+ *
+ * Generator delegation: `yield from <iterable>`. Re-yield every (key,value) of an
+ * array/Traversable/Generator from the OUTER generator, preserving the inner
+ * keys; the expression evaluates to the inner Generator's return value (or NULL).
+ *
+ * This opcode is RE-ENTRANT: it suspends back to its own pc and, on each resume,
+ * advances the per-instance delegate cursor stored on the exec context (never the
+ * shared foreach aStep, so independent generator instances cannot clash). The
+ * iterable operand is consumed on first entry; the expression result is pushed at
+ * exhaustion — net stack effect +1, identical to OP_YIELD.
+ */
+case PH7_OP_YIELD_FROM: {
+	ph7_generator *pGenFrom;
+	ph7_exec_ctx *pCtxFrom;
+	ph7_value sKey,sVal;
+	sxi32 rcm = SXRET_OK;   /* delegate iterator-method status */
+	int bExhausted = 0;
+	if( pVm->pActiveCtx == 0 || pVm->pActiveCtx->pPrivate == 0 ){
+		VmErrorFormat(&(*pVm),PH7_CTX_ERR,"Cannot use \"yield from\" outside of a generator");
+		goto Abort;
+	}
+	pCtxFrom = pVm->pActiveCtx;
+	pGenFrom = (ph7_generator *)pCtxFrom->pPrivate;
+	PH7_MemObjInit(pVm,&sKey);
+	PH7_MemObjInit(pVm,&sVal);
+	if( pCtxFrom->iDelegateState == 0 ){
+		/* First entry: classify the iterable on the stack top. */
+		int bIterable = 1;
+#ifdef UNTRUST
+		if( pTos < pStack ){ goto Abort; }
+#endif
+		if( pTos->iFlags & MEMOBJ_HASHMAP ){
+			PH7_MemObjStore(pTos,&pCtxFrom->sDelegate);
+			pCtxFrom->pDelegateNode = ((ph7_hashmap *)pCtxFrom->sDelegate.x.pOther)->pFirst;
+			pCtxFrom->iDelegateState = 1;
+		}else if( pTos->iFlags & MEMOBJ_OBJ ){
+			ph7_class_instance *pThis = (ph7_class_instance *)pTos->x.pOther;
+			ph7_class *pIterCls = PH7_VmExtractClass(&(*pVm),"Iterator",sizeof("Iterator")-1,FALSE,0);
+			if( pVm->pGeneratorClass && PH7_VmInstanceOf(pThis->pClass,pVm->pGeneratorClass) ){
+				PH7_MemObjStore(pTos,&pCtxFrom->sDelegate);
+				pCtxFrom->iDelegateState = 3;
+			}else if( pIterCls && PH7_VmInstanceOf(pThis->pClass,pIterCls) ){
+				PH7_MemObjStore(pTos,&pCtxFrom->sDelegate);
+				pCtxFrom->iDelegateState = 2;
+			}else{
+				ph7_class *pAggCls = PH7_VmExtractClass(&(*pVm),"IteratorAggregate",
+					sizeof("IteratorAggregate")-1,FALSE,0);
+				if( pAggCls && PH7_VmInstanceOf(pThis->pClass,pAggCls) ){
+					/* Delegate to the Iterator returned by getIterator() */
+					ph7_value sIt;
+					PH7_MemObjInit(pVm,&sIt);
+					rcm = VmIterCallMethod(pVm,pThis,"getIterator",sizeof("getIterator")-1,&sIt);
+					if( rcm == PH7_ABORT || rcm == PH7_EXCEPTION ){
+						/* getIterator() threw/aborted: drop it, consume the
+						 * operand, and propagate. */
+						PH7_MemObjRelease(&sIt);
+						VmPopOperand(&pTos,1);
+						goto yf_propagate;
+					}
+					if( (sIt.iFlags & MEMOBJ_OBJ) && sIt.x.pOther && pIterCls
+						&& PH7_VmInstanceOf(((ph7_class_instance *)sIt.x.pOther)->pClass,pIterCls) ){
+						PH7_MemObjStore(&sIt,&pCtxFrom->sDelegate);
+						pCtxFrom->iDelegateState = 2;
+					}else{
+						bIterable = 0;
+					}
+					PH7_MemObjRelease(&sIt);
+				}else{
+					bIterable = 0;
+				}
+			}
+		}else{
+			bIterable = 0;
+		}
+		VmPopOperand(&pTos,1); /* Consume the iterable operand */
+		if( !bIterable ){
+			/* Non-iterable source: throw a catchable Error (PHP 8.5), then
+			 * funnel through the shared teardown/route path. */
+			rc = VmThrowFromVm(&(*pVm),"Error",
+				"Can use \"yield from\" only with arrays and Traversables",
+				sizeof("Can use \"yield from\" only with arrays and Traversables")-1);
+			rcm = (rc == SXERR_ABORT) ? PH7_ABORT : PH7_EXCEPTION;
+			goto yf_propagate;
+		}
+		if( pCtxFrom->iDelegateState >= 2 ){
+			/* rewind() the delegate (also starts a fresh generator) */
+			rcm = VmIterCallMethod(pVm,(ph7_class_instance *)pCtxFrom->sDelegate.x.pOther,
+				"rewind",sizeof("rewind")-1,0);
+			if( rcm == PH7_ABORT || rcm == PH7_EXCEPTION ){ goto yf_propagate; }
+		}
+	}else{
+		/* Resume entry: discard the value VmResumeCtx pushed. Forwarding send()
+		 * into the delegated generator is deferred (see the Generator::throw TODO);
+		 * arrays/Traversables ignore send() anyway. */
+#ifdef UNTRUST
+		if( pTos < pStack ){ goto Abort; }
+#endif
+		PH7_MemObjRelease(pTos);
+		pTos--;
+		if( pCtxFrom->iDelegateState >= 2 ){
+			rcm = VmIterCallMethod(pVm,(ph7_class_instance *)pCtxFrom->sDelegate.x.pOther,
+				"next",sizeof("next")-1,0);
+			if( rcm == PH7_ABORT || rcm == PH7_EXCEPTION ){ goto yf_propagate; }
+		}
+	}
+	/* Fetch the current (key,value) of the delegate, or mark exhausted. */
+	if( pCtxFrom->iDelegateState == 1 ){
+		if( pCtxFrom->pDelegateNode == 0 ){
+			bExhausted = 1;
+		}else{
+			PH7_HashmapExtractNodeKey(pCtxFrom->pDelegateNode,&sKey);
+			PH7_HashmapExtractNodeValue(pCtxFrom->pDelegateNode,&sVal,TRUE);
+			/* Forward traversal follows pPrev (the hashmap's "reverse link",
+			 * matching PH7_HashmapGetNextEntry). */
+			pCtxFrom->pDelegateNode = pCtxFrom->pDelegateNode->pPrev;
+		}
+	}else{
+		ph7_class_instance *pThis = (ph7_class_instance *)pCtxFrom->sDelegate.x.pOther;
+		ph7_value sValid;
+		int isValid;
+		PH7_MemObjInit(pVm,&sValid);
+		rcm = VmIterCallMethod(pVm,pThis,"valid",sizeof("valid")-1,&sValid);
+		PH7_MemObjToBool(&sValid);
+		isValid = (sValid.x.iVal != 0);
+		PH7_MemObjRelease(&sValid);
+		if( rcm == PH7_ABORT || rcm == PH7_EXCEPTION ){ goto yf_propagate; }
+		if( !isValid ){
+			bExhausted = 1;
+		}else{
+			rcm = VmIterCallMethod(pVm,pThis,"current",sizeof("current")-1,&sVal);
+			if( rcm == PH7_ABORT || rcm == PH7_EXCEPTION ){ goto yf_propagate; }
+			rcm = VmIterCallMethod(pVm,pThis,"key",sizeof("key")-1,&sKey);
+			if( rcm == PH7_ABORT || rcm == PH7_EXCEPTION ){ goto yf_propagate; }
+		}
+	}
+	if( bExhausted ){
+		/* Expression value: inner Generator's return value (state 3) or NULL. */
+		ph7_value sResult;
+		PH7_MemObjInit(pVm,&sResult);
+		if( pCtxFrom->iDelegateState == 3 ){
+			ph7_generator *pInner = VmGeneratorExtractCtx(&(*pVm),&pCtxFrom->sDelegate);
+			if( pInner && pInner->pCtx ){
+				PH7_MemObjStore(&pInner->pCtx->sRetValue,&sResult);
+			}
+		}
+		PH7_MemObjRelease(&pCtxFrom->sDelegate);
+		pCtxFrom->pDelegateNode = 0;
+		pCtxFrom->iDelegateState = 0;
+		pTos++;
+		PH7_MemObjStore(&sResult,pTos);
+		PH7_MemObjRelease(&sResult);
+		PH7_MemObjRelease(&sKey);
+		PH7_MemObjRelease(&sVal);
+		break; /* fall through to pc+1 with the result on the stack top */
+	}
+	/* Re-yield (key,value) from the OUTER generator, preserving the inner key.
+	 * The outer generator's implicit auto-key counter is NOT advanced by the
+	 * delegated keys — PHP keeps it independent across `yield from`, so a later
+	 * plain `yield` continues from the outer's own counter. */
+	PH7_MemObjStore(&sVal,&pGenFrom->sYieldValue);
+	PH7_MemObjStore(&sKey,&pGenFrom->sYieldKey);
+	PH7_MemObjRelease(&sKey);
+	PH7_MemObjRelease(&sVal);
+	/* Suspend, re-entering this SAME opcode on resume (pc, not pc+1). */
+	VmSuspendCtx(pVm,pCtxFrom,pc,(sxi32)(pTos - pStack));
+	goto Suspend;
+yf_propagate:
+	/* A delegate iterator method threw/aborted (or the source was non-iterable):
+	 * tear down the delegation, then route via the shared dispatch macro. rcm is
+	 * always PH7_EXCEPTION or PH7_ABORT here. */
+	PH7_MemObjRelease(&sKey);
+	PH7_MemObjRelease(&sVal);
+	PH7_MemObjRelease(&pCtxFrom->sDelegate);
+	pCtxFrom->pDelegateNode = 0;
+	pCtxFrom->iDelegateState = 0;
+	PH7_DISPATCH_ENFORCE_RC(rcm)
+	goto Exception; /* defensive default — unreachable for ABORT/EXCEPTION */
+}
+/*
  * OP_CALL P1 * *
  *  Call a PHP or a foreign function and push the return value of the called
  *  function on the stack.
@@ -10678,6 +10859,7 @@ static ph7_exec_ctx * VmNewExecCtx(ph7_vm *pVm, ph7_vm_func *pFunc)
 	pCtx->pc = 0;
 	PH7_MemObjInit(pVm, &pCtx->sSuspendValue);
 	PH7_MemObjInit(pVm, &pCtx->sRetValue);
+	PH7_MemObjInit(pVm, &pCtx->sDelegate);
 	/* Allocate a private operand stack */
 	pStack = VmNewOperandStack(pVm, SySetUsed(&pFunc->aByteCode));
 	if( pStack == 0 ){
@@ -10839,6 +11021,7 @@ static void VmReleaseExecCtx(ph7_vm *pVm, ph7_exec_ctx *pCtx)
 	/* Release values */
 	PH7_MemObjRelease(&pCtx->sSuspendValue);
 	PH7_MemObjRelease(&pCtx->sRetValue);
+	PH7_MemObjRelease(&pCtx->sDelegate);
 	/* Release the frame if it's detached (not in the VM chain) */
 	if( pCtx->pFrame ){
 		VmSlot *aSlot;
@@ -11829,6 +12012,7 @@ static const char * VmInstrToString(sxi32 nOp)
 	case PH7_OP_USECONST:   zOp = "USECONST   "; break;
 	case PH7_OP_SWAP:       zOp = "SWAP       "; break;
 	case PH7_OP_YIELD:      zOp = "YIELD      "; break;
+	case PH7_OP_YIELD_FROM: zOp = "YIELD_FROM "; break;
 	case PH7_OP_NULLC:      zOp = "NULLC      "; break;
 	case PH7_OP_NULLC_JMP:  zOp = "NULLC_JMP  "; break;
 	case PH7_OP_NULLC_STORE:zOp = "NULLC_STORE"; break;

--- a/tests/ph7/002-integration/lang/yield_from_aggregate.phpt
+++ b/tests/ph7/002-integration/lang/yield_from_aggregate.phpt
@@ -1,0 +1,31 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+yield from: delegate over a user IteratorAggregate
+--SKIPIF--
+<?php if (function_exists('zend_version') && version_compare(PHP_VERSION, '7.0.0', '<')) echo 'skip Requires PHP 7.0+'; ?>
+--FILE--
+<?php
+class Seq implements Iterator {
+    private $i = 0; private $d;
+    function __construct(array $d) { $this->d = $d; }
+    function rewind(): void { $this->i = 0; }
+    function valid(): bool { return $this->i < count($this->d); }
+    function current(): mixed { return array_values($this->d)[$this->i]; }
+    function key(): mixed { return array_keys($this->d)[$this->i]; }
+    function next(): void { $this->i++; }
+}
+class Bag implements IteratorAggregate {
+    private $d;
+    function __construct(array $d) { $this->d = $d; }
+    function getIterator(): Iterator { return new Seq($this->d); }
+}
+function g() { yield from new Bag(["p" => 1, "q" => 2]); }
+foreach (g() as $k => $v) { echo "$k=$v\n"; }
+?>
+--EXPECT--
+p=1
+q=2
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/yield_from_array.phpt
+++ b/tests/ph7/002-integration/lang/yield_from_array.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+yield from: delegate over an array (values + keys)
+--SKIPIF--
+<?php if (function_exists('zend_version') && version_compare(PHP_VERSION, '7.0.0', '<')) echo 'skip Requires PHP 7.0+'; ?>
+--FILE--
+<?php
+function g() { yield from [1, 2, 3]; }
+echo implode(",", iterator_to_array(g(), false)), "\n";
+function h() { yield from ["a" => 10, "b" => 20]; }
+foreach (h() as $k => $v) { echo "$k=$v\n"; }
+?>
+--EXPECT--
+1,2,3
+a=10
+b=20
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/yield_from_array_null.phpt
+++ b/tests/ph7/002-integration/lang/yield_from_array_null.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+yield from: array delegation expression value is null
+--SKIPIF--
+<?php if (function_exists('zend_version') && version_compare(PHP_VERSION, '7.0.0', '<')) echo 'skip Requires PHP 7.0+'; ?>
+--FILE--
+<?php
+function g() {
+    $r = yield from [1, 2];
+    var_export($r);
+    echo "\n";
+}
+foreach (g() as $v) {}
+?>
+--EXPECT--
+NULL
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/yield_from_caught_continues.phpt
+++ b/tests/ph7/002-integration/lang/yield_from_caught_continues.phpt
@@ -1,0 +1,48 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+yield from: a generator-internal exception caught by the caller resumes after the catch
+--SKIPIF--
+<?php if (function_exists('zend_version') && version_compare(PHP_VERSION, '7.0.0', '<')) echo 'skip Requires PHP 7.0+'; ?>
+--FILE--
+<?php
+// Regression: the throw-unwind routes to the generator's terminal OP_DONE with
+// an empty operand stack; the result-store branch used to read below the stack
+// base, corrupting VM state (segfault under glibc/ASan, dropped continuation
+// elsewhere). The statement after a caller-side catch must run.
+
+// non-iterable yield from -> Error, caught by the caller, then continue
+function g() { yield from 5; }
+try {
+    foreach (g() as $v) {}
+} catch (\Error $e) {
+    echo "caught ", get_class($e), "\n";
+}
+echo "after-typeerror\n";
+
+// a delegated Iterator method throws, caught by the caller, then continue
+class Boom implements Iterator {
+    private $i = 0;
+    function rewind(): void {}
+    function valid(): bool { return $this->i < 3; }
+    function current(): mixed { return $this->i; }
+    function key(): mixed { return $this->i; }
+    function next(): void { throw new Exception("stop at " . $this->i); }
+}
+function gi() { yield from new Boom(); }
+try {
+    foreach (gi() as $v) { echo "got $v\n"; }
+} catch (\Throwable $e) {
+    echo "caught ", $e->getMessage(), "\n";
+}
+echo "after-iterator\n";
+?>
+--EXPECT--
+caught Error
+after-typeerror
+got 0
+caught stop at 0
+after-iterator
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/yield_from_empty.phpt
+++ b/tests/ph7/002-integration/lang/yield_from_empty.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+yield from: empty source yields nothing, numbering continues
+--SKIPIF--
+<?php if (function_exists('zend_version') && version_compare(PHP_VERSION, '7.0.0', '<')) echo 'skip Requires PHP 7.0+'; ?>
+--FILE--
+<?php
+function g() {
+    yield from [];
+    yield "a";
+    yield "b";
+}
+var_export(iterator_to_array(g()));
+echo "\n";
+?>
+--EXPECT--
+array (
+  0 => 'a',
+  1 => 'b',
+)
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/yield_from_getreturn.phpt
+++ b/tests/ph7/002-integration/lang/yield_from_getreturn.phpt
@@ -1,0 +1,26 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+yield from: expression value is the inner generator return
+--SKIPIF--
+<?php if (function_exists('zend_version') && version_compare(PHP_VERSION, '7.0.0', '<')) echo 'skip Requires PHP 7.0+'; ?>
+--FILE--
+<?php
+function inner() {
+    yield 1;
+    yield 2;
+    return "DONE";
+}
+function g() {
+    $r = yield from inner();
+    echo "ret=$r\n";
+    yield $r;
+}
+echo implode(",", iterator_to_array(g(), false)), "\n";
+?>
+--EXPECT--
+ret=DONE
+1,2,DONE
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/yield_from_independent.phpt
+++ b/tests/ph7/002-integration/lang/yield_from_independent.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+yield from: independent generator instances do not clash
+--SKIPIF--
+<?php if (function_exists('zend_version') && version_compare(PHP_VERSION, '7.0.0', '<')) echo 'skip Requires PHP 7.0+'; ?>
+--FILE--
+<?php
+function g() { yield from [1, 2, 3]; }
+$a = g(); $b = g();
+$a->current(); $b->current();
+$a->next();
+echo $a->current(), " ", $b->current(), "\n";
+?>
+--EXPECT--
+2 1
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/yield_from_int_keys.phpt
+++ b/tests/ph7/002-integration/lang/yield_from_int_keys.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+yield from: inner int keys preserved, outer auto-key continues
+--SKIPIF--
+<?php if (function_exists('zend_version') && version_compare(PHP_VERSION, '7.0.0', '<')) echo 'skip Requires PHP 7.0+'; ?>
+--FILE--
+<?php
+function g() {
+    yield "first";
+    yield from [0 => "inner"];
+    yield "after";
+}
+foreach (g() as $k => $v) { echo "$k => $v\n"; }
+?>
+--EXPECT--
+0 => first
+0 => inner
+1 => after
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/yield_from_iterator.phpt
+++ b/tests/ph7/002-integration/lang/yield_from_iterator.phpt
@@ -1,0 +1,25 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+yield from: delegate over a user Iterator
+--SKIPIF--
+<?php if (function_exists('zend_version') && version_compare(PHP_VERSION, '7.0.0', '<')) echo 'skip Requires PHP 7.0+'; ?>
+--FILE--
+<?php
+class Seq implements Iterator {
+    private $i = 0; private $d;
+    function __construct(array $d) { $this->d = $d; }
+    function rewind(): void { $this->i = 0; }
+    function valid(): bool { return $this->i < count($this->d); }
+    function current(): mixed { return $this->d[$this->i]; }
+    function key(): mixed { return $this->i; }
+    function next(): void { $this->i++; }
+}
+function g() { yield from new Seq(["x", "y", "z"]); }
+echo implode(",", iterator_to_array(g(), false)), "\n";
+?>
+--EXPECT--
+x,y,z
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/yield_from_iterator_throws.phpt
+++ b/tests/ph7/002-integration/lang/yield_from_iterator_throws.phpt
@@ -1,0 +1,29 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+yield from: an exception from a delegated Iterator method propagates
+--SKIPIF--
+<?php if (function_exists('zend_version') && version_compare(PHP_VERSION, '7.0.0', '<')) echo 'skip Requires PHP 7.0+'; ?>
+--FILE--
+<?php
+class Boom implements Iterator {
+    private $i = 0;
+    function rewind(): void {}
+    function valid(): bool { return $this->i < 3; }
+    function current(): mixed { return $this->i; }
+    function key(): mixed { return $this->i; }
+    function next(): void { throw new Exception("stop at " . $this->i); }
+}
+function g() { yield from new Boom(); }
+try {
+    foreach (g() as $v) { echo "got $v\n"; }
+} catch (\Throwable $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+got 0
+caught: stop at 0
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/yield_from_nested.phpt
+++ b/tests/ph7/002-integration/lang/yield_from_nested.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+yield from: nested delegation
+--SKIPIF--
+<?php if (function_exists('zend_version') && version_compare(PHP_VERSION, '7.0.0', '<')) echo 'skip Requires PHP 7.0+'; ?>
+--FILE--
+<?php
+function a() { yield 1; yield 2; }
+function b() { yield 0; yield from a(); yield 3; }
+function c() { yield from b(); yield 4; }
+echo implode(",", iterator_to_array(c(), false)), "\n";
+?>
+--EXPECT--
+0,1,2,3,4
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/yield_from_trait.phpt
+++ b/tests/ph7/002-integration/lang/yield_from_trait.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+yield from: a trait method whose only generator marker is yield from
+--SKIPIF--
+<?php if (function_exists('zend_version') && version_compare(PHP_VERSION, '7.0.0', '<')) echo 'skip Requires PHP 7.0+'; ?>
+--FILE--
+<?php
+trait Source { function items() { yield from [1, 2, 3]; } }
+class Repo { use Source; }
+$r = new Repo;
+echo implode(",", iterator_to_array($r->items(), false)), "\n";
+?>
+--EXPECT--
+1,2,3
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/yield_from_trait_alias.phpt
+++ b/tests/ph7/002-integration/lang/yield_from_trait_alias.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+yield from: aliased trait generator method
+--SKIPIF--
+<?php if (function_exists('zend_version') && version_compare(PHP_VERSION, '7.0.0', '<')) echo 'skip Requires PHP 7.0+'; ?>
+--FILE--
+<?php
+trait Source2 { function raw() { yield from ["a", "b"]; } }
+class Repo2 { use Source2 { raw as fetch; } }
+$r = new Repo2;
+echo implode(",", iterator_to_array($r->fetch(), false)), "\n";
+?>
+--EXPECT--
+a,b
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/yield_from_typeerror.phpt
+++ b/tests/ph7/002-integration/lang/yield_from_typeerror.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+yield from: non-iterable source throws a catchable Error
+--SKIPIF--
+<?php if (function_exists('zend_version') && version_compare(PHP_VERSION, '7.0.0', '<')) echo 'skip Requires PHP 7.0+'; ?>
+--FILE--
+<?php
+function g() { yield from 5; }
+try {
+    foreach (g() as $v) {}
+} catch (\Error $e) {
+    echo get_class($e), "\n";
+}
+?>
+--EXPECT--
+Error
+--CLEAN--
+<?php


### PR DESCRIPTION
Generators worked fully (yield/current/next/send/throw/getReturn) but `yield from <iterable>` failed at parse. `yield from` is the standard way to compose generators — re-yield an inner array/Traversable/Generator from an outer generator, preserving keys, with the construct evaluating to the inner's return value.

It is implemented with a new re-entrant PH7_OP_YIELD_FROM opcode rather than a `foreach($x as $k=>$v){yield $k=>$v;}` desugar: the foreach aStep is a shared LIFO that independent/interleaved generator instances would corrupt, so the delegation state (the iterable, an array node cursor, and a kind tag) lives per ph7_exec_ctx instead — correct for independent instances by construction.

parse.c: in PH7_CompileYield, a contextual `from` after `yield` (an identifier, never a $variable) branches to emit the operand expression plus OP_YIELD_FROM. The single VM_FUNC_GENERATOR detection scan (compile.c) now also flags OP_YIELD_FROM — the generators-x-traits point: it runs in the shared method/function compiler, so a trait method using `yield from` becomes a generator with no trait-specific code (verified for trait, aliased-trait, and trait-delegating-to-trait generators).

The opcode classifies the source (array / Generator / Iterator / IteratorAggregate->getIterator() / else->catchable Error), drives it step-wise — arrays via the hashmap's pPrev reverse-link cursor, objects via rewind/valid/current/key/next — and re-yields each (key,value) from the outer generator preserving the inner keys. The outer generator's implicit auto-key counter is NOT advanced by delegated keys (PHP keeps it independent across yield from). It suspends back to its own pc and, on resume, advances; at exhaustion the expression evaluates to the inner Generator's getReturn() (or NULL), pushed with the same net +1 stack effect as OP_YIELD. Every delegate iterator-method call's exec status is checked, so a throwing/aborting method propagates (via the shared PH7_DISPATCH_ENFORCE_RC dispatch) instead of looping.

Verified byte-for-byte vs php 8.5.7: arrays, key preservation, int-key collision with the outer auto-key, nested delegation, getReturn capture, user Iterator and IteratorAggregate, independent interleaved instances, the non-iterable Error, and an exception from a delegated Iterator method propagating; 13 .phpt. make test (2197 smoke + 731 integration), test-compat (both engines), test-stress green; existing generator suite unregressed.

Documented deferrals / limitations: send()/throw() forwarding into the delegated generator; an exception thrown by a delegated Generator's body during next() not propagating out of the driving generator (pre-existing, shared with foreach-over-a-generator); a partially-consumed Generator delegate restarts via rewind(); by-reference iteration of a yield-from generator is not rejected; and a generator-internal exception (yield-from Error, typed-store TypeError, ...) caught by a caller-side try/catch skips the post-catch statement (pre-existing and VM-wide, in the resumed-generator exception machinery; only OP_THROW resumes the caller's continuation).

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
