### PR TITLE
Populate by-ref builtin out-params into subscript/property targets

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -10716,9 +10716,14 @@ static sxi32 GenStateEmitExprCode(
 				sxu32 nArgNsBase = SySetUsed(&pGen->aNullsafeJmp);
 				sxi32 iArgFlags = iFlags & ~EXPR_FLAG_LOAD_IDX_STORE;
 				/* For a by-ref argument position, drop the read-only flag so the
-				 * variable is created if absent (PH7_OP_LOAD iP1=0 => bCreate). */
+				 * variable is created if absent (PH7_OP_LOAD iP1=0 => bCreate), and
+				 * set write-context so a subscript target (preg_match($p,$s,$a['k']))
+				 * auto-vivifies its element and exposes a writable memobj slot for the
+				 * builtin to write back through. A plain $var target is unaffected
+				 * (iP1=0 either way). See PLAN.md §2 for the full rationale. */
 				if( n < 31 && (byRefMask & (1u<<n)) ){
 					iArgFlags &= ~EXPR_FLAG_RDONLY_LOAD;
+					iArgFlags |= EXPR_FLAG_LOAD_IDX_STORE;
 				}
 				rc = GenStateEmitExprCode(&(*pGen),apNode[n],iArgFlags);
 				if( rc != SXRET_OK ){

--- a/src/ph7/vm_pcre.c
+++ b/src/ph7/vm_pcre.c
@@ -250,18 +250,20 @@ static pcre2_code *PcreCompile(
 /*
  * Write a value back to the caller's variable through the stack slot's nIdx.
  *
- * For a plain positional variable argument the call compiler auto-vivifies
- * known by-reference out-params (see GenStateByRefBuiltinMask in compile.c),
- * so even a bare undefined variable (e.g. preg_match($p,$s,$m) with $m never
- * assigned) arrives with a real nIdx and is written back here, matching PHP's
- * reference semantics.
+ * For a positional out-param argument the call compiler auto-vivifies known
+ * by-reference out-params (see GenStateByRefBuiltinMask in compile.c), so a
+ * bare undefined variable (e.g. preg_match($p,$s,$m) with $m never assigned),
+ * an array subscript (preg_match($p,$s,$a['k'])), and a declared/untyped
+ * property (preg_match($p,$s,$o->prop)) all arrive with a real nIdx and are
+ * written back here, matching PHP's reference semantics.
  *
  * nIdx stays SXU32_HIGH and the write-back to the caller is skipped (the value
- * still lands in the local stack slot) when the argument is not a plain lvalue
- * variable: a literal, a function-call result, an array/property subscript
- * (element vivification is not wired), or any variable in a call that also uses
- * named or spread arguments (compile-time positions no longer map to the
- * runtime arg slots, so the compiler conservatively does not vivify).
+ * still lands in the local stack slot) when the argument cannot expose a stable
+ * memobj slot: a literal, a function-call result, a subscript of a non-lvalue
+ * parent (foo()['k']), or any variable in a call that also uses named or spread
+ * arguments (compile-time positions no longer map to the runtime arg slots, so
+ * the compiler conservatively does not vivify). An uninitialized typed property
+ * is also not wired (it throws before the write) -- see PLAN.md deferrals.
  */
 static void PcreStoreByRef(ph7_vm *pVm, ph7_value *pArg, ph7_value *pNewVal)
 {

--- a/tests/ph7/001-smoke/function/preg_match/preg_match_nonlvalue_parent.phpt
+++ b/tests/ph7/001-smoke/function/preg_match/preg_match_nonlvalue_parent.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+preg_match with a by-ref subscript of a non-lvalue parent is a safe no-op (no crash)
+--FILE--
+<?php
+function preg_match_nonlvalue_src() { return ['k' => 0]; }
+// the call result is a temporary; the write-back has nowhere to land and is
+// dropped. The important property is that this does not crash the interpreter.
+preg_match('/(\w+)/', 'Hi', preg_match_nonlvalue_src()['k']);
+echo "ok\n";
+?>
+--EXPECT--
+ok
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/preg_match/preg_match_property_declared.phpt
+++ b/tests/ph7/001-smoke/function/preg_match/preg_match_property_declared.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+preg_match populates a declared untyped property passed as a by-ref target
+--FILE--
+<?php
+class PregMatchPropDeclared { public $p; }
+$o = new PregMatchPropDeclared();
+$r = preg_match('/(\w+) (\w+)/', 'Hello World', $o->p);
+echo $r . "\n";
+echo $o->p[0] . "\n";
+echo $o->p[1] . "\n";
+echo $o->p[2] . "\n";
+?>
+--EXPECT--
+1
+Hello World
+Hello
+World
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/preg_match/preg_match_property_typed_default.phpt
+++ b/tests/ph7/001-smoke/function/preg_match/preg_match_property_typed_default.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+preg_match populates a typed property that has a default (already initialized)
+--FILE--
+<?php
+class PregMatchPropTypedDefault { public array $q = []; }
+$o = new PregMatchPropTypedDefault();
+$r = preg_match('/(\w+)/', 'Hi', $o->q);
+echo $r . "\n";
+echo $o->q[0] . "\n";
+echo $o->q[1] . "\n";
+?>
+--EXPECT--
+1
+Hi
+Hi
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/preg_match/preg_match_subscript_autovivify.phpt
+++ b/tests/ph7/001-smoke/function/preg_match/preg_match_subscript_autovivify.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+preg_match auto-vivifies both the array and the element of a subscript by-ref target
+--FILE--
+<?php
+// $a is never declared; the by-ref subscript creates both $a and $a['k'].
+$r = preg_match('/(\w+)/', 'Hi', $a['k']);
+echo $r . "\n";
+echo (is_array($a) ? 'array' : 'not-array') . "\n";
+echo $a['k'][0] . "\n";
+echo $a['k'][1] . "\n";
+?>
+--EXPECT--
+1
+array
+Hi
+Hi
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/preg_match/preg_match_subscript_cow.phpt
+++ b/tests/ph7/001-smoke/function/preg_match/preg_match_subscript_cow.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+preg_match into a subscript COW-separates: a shared copy is left untouched
+--FILE--
+<?php
+$a = ['k' => 0];
+$b = $a; // share the array
+$r = preg_match('/(\w+)/', 'Hi', $a['k']);
+echo $r . "\n";
+echo $a['k'][0] . "\n";   // $a was written
+var_export($b['k']); echo "\n"; // $b must remain the original 0, not the matches array
+?>
+--EXPECT--
+1
+Hi
+0
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/preg_match/preg_match_subscript_existing_array.phpt
+++ b/tests/ph7/001-smoke/function/preg_match/preg_match_subscript_existing_array.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+preg_match populates an array-subscript by-ref target without touching siblings
+--FILE--
+<?php
+$a = ['x' => 1];
+$r = preg_match('/(\w+) (\w+)/', 'Hello World', $a['m']);
+echo $r . "\n";
+echo $a['m'][0] . "\n";
+echo $a['m'][1] . "\n";
+echo $a['m'][2] . "\n";
+echo $a['x'] . "\n"; // sibling untouched
+?>
+--EXPECT--
+1
+Hello World
+Hello
+World
+1
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/preg_match/preg_match_subscript_nested.phpt
+++ b/tests/ph7/001-smoke/function/preg_match/preg_match_subscript_nested.phpt
@@ -1,0 +1,26 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+preg_match populates a nested array-subscript by-ref target, COW-correct
+--FILE--
+<?php
+$a = ['x' => ['y' => 0]];
+$b = $a; // share
+$r = preg_match('/(\w+) (\w+)/', 'Hello World', $a['x']['y']);
+echo $r . "\n";
+echo $a['x']['y'][0] . "\n";
+echo $a['x']['y'][1] . "\n";
+var_export($b['x']['y']); echo "\n"; // shared copy untouched (still 0, not an array)
+// deeper, fully auto-vivified
+preg_match('/(\w+)/', 'Hi', $c['p']['q']['r']);
+echo $c['p']['q']['r'][0] . "\n";
+?>
+--EXPECT--
+1
+Hello World
+Hello
+0
+Hi
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/preg_match_all/preg_match_all_subscript.phpt
+++ b/tests/ph7/001-smoke/function/preg_match_all/preg_match_all_subscript.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+preg_match_all populates an array-subscript by-ref target ($matches)
+--FILE--
+<?php
+$a = [];
+$r = preg_match_all('/\d/', '1 2 3', $a['m']);
+echo $r . "\n";
+echo implode(',', $a['m'][0]) . "\n";
+?>
+--EXPECT--
+3
+1,2,3
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/preg_replace/preg_replace_subscript_count.phpt
+++ b/tests/ph7/001-smoke/function/preg_replace/preg_replace_subscript_count.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+preg_replace populates the &$count out-param through an array subscript
+--FILE--
+<?php
+$a = [];
+$s = preg_replace('/\d/', '#', '1a2b3', -1, $a['c']);
+echo $s . "\n";
+echo $a['c'] . "\n";
+?>
+--EXPECT--
+#a#b#
+3
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/preg_replace_callback/preg_replace_callback_subscript_count.phpt
+++ b/tests/ph7/001-smoke/function/preg_replace_callback/preg_replace_callback_subscript_count.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+preg_replace_callback populates the &$count out-param through an array subscript
+--FILE--
+<?php
+$a = [];
+$s = preg_replace_callback('/\d/', fn($m) => '#', '1a2', -1, $a['c']);
+echo $s . "\n";
+echo $a['c'] . "\n";
+?>
+--EXPECT--
+#a#
+2
+--CLEAN--
+<?php


### PR DESCRIPTION
preg_match($p,$s,$a['k']) and ->prop by-ref targets silently failed to populate the element/property — the matches/count landed only in a discarded stack copy, while the plain $var case worked. The call-arg compiler cleared EXPR_FLAG_LOAD_IDX_STORE for every argument, so a by-ref subscript target's LOAD_IDX compiled read-only (iP2=0) and never auto-vivified the element or exposed its memobj slot for write-back.

Fix: in GenStateEmitExprCode's call-arg loop, also set EXPR_FLAG_LOAD_IDX_STORE on by-ref out-param positions (per GenStateByRefBuiltinMask: preg_match/preg_match_all $matches, preg_replace/preg_replace_callback &$count). No VM change — the LOAD_IDX iP2=1 write-context path already COW-separates, auto-vivifies, and exposes the element's nValIdx, and PcreStoreByRef writes back through it. Nested subscripts and shared-array COW are handled correctly; the declared/untyped property path was already correct and is locked with a test.

Verified byte-for-byte vs php 8.5.7 across subscript (existing/vivified), COW isolation, nested, declared+typed-default property, preg_match_all, preg_replace/preg_replace_callback &$count, and non-lvalue no-crash. make test (2207 smoke + 732 integration), test-compat (both engines), test-stress all green. 10 new smoke .phpt.
