### PR TITLE
Scope the catch/finally pending-return signal per nested exec

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -727,6 +727,40 @@ static void VmMaterializeCatchReturn(ph7_vm *pVm, ph7_value *pResult, VmFrame *p
 	}
 }
 /*
+ * Per-exec scoping of the catch/finally pending-return signal
+ * (pVm->bReturnRequested / sCatchReturn), which is a VM-global. A *real* nested
+ * body (a called function, a match/default eval) that runs while an outer
+ * catch/finally return is pending would clobber the signal via its own
+ * exception handling, so VmByteCodeExec saves it on entry, runs on a clean
+ * slate, and at exit either restores it (normal completion) or discards it (an
+ * escaping exception, which per PHP discards the pending return). See PLAN.md.
+ * VmSaveOuterReturn moves the live signal into *pSaved and clears it.
+ */
+static void VmSaveOuterReturn(ph7_vm *pVm, ph7_value *pSaved)
+{
+	PH7_MemObjInit(&(*pVm),pSaved);
+	PH7_MemObjStore(&pVm->sCatchReturn,pSaved);
+	pVm->bReturnRequested = 0;
+	PH7_MemObjRelease(&pVm->sCatchReturn);
+}
+/* Restore the saved outer signal (NORMAL exit: Done/Suspend). */
+static void VmRestoreOuterReturn(ph7_vm *pVm, int bSaved, ph7_value *pSaved)
+{
+	if( bSaved ){
+		pVm->bReturnRequested = 1;
+		PH7_MemObjStore(pSaved,&pVm->sCatchReturn);
+		PH7_MemObjRelease(pSaved);
+	}
+}
+/* Discard the saved outer signal (ABNORMAL exit: Abort/Exception). The live
+ * signal stays cleared; just release the saved value. */
+static void VmDiscardOuterReturn(int bSaved, ph7_value *pSaved)
+{
+	if( bSaved ){
+		PH7_MemObjRelease(pSaved);
+	}
+}
+/*
  * Compare two functions signature and return the comparison result.
  */
 static int VmOverloadCompare(SyString *pFirst,SyString *pSecond)
@@ -4756,6 +4790,11 @@ static sxi32 VmByteCodeExec(
 	VmFrame *pEntryFrame;  /* Active frame at entry (for return-unwind frame teardown) */
 	sxi32 pc;
 	sxi32 rc;
+	/* Saved outer catch/finally pending-return signal (see VmSaveOuterReturn).
+	 * Only a real nested body (bReturnPropagates==FALSE) isolates it, and only
+	 * when a return is actually pending — so the common path is untouched. */
+	int bSavedReturn = 0;
+	ph7_value sSavedReturn;
 	/* Argument container */
 	SySetInit(&aArg,&pVm->sAllocator,sizeof(ph7_value *));
 	if( nTos < 0 ){
@@ -4766,6 +4805,10 @@ static sxi32 VmByteCodeExec(
 	nExceptionBase = SySetUsed(&pVm->aException);
 	pEntryFrame = pVm->pFrame;
 	pc = nPc;
+	if( !bReturnPropagates && pVm->bReturnRequested ){
+		bSavedReturn = 1;
+		VmSaveOuterReturn(&(*pVm),&sSavedReturn);
+	}
 /*
  * Route an enforcement helper's return code from inside the main switch:
  * proceed on SXRET_OK, abort on PH7_ABORT, and on PH7_EXCEPTION jump to the
@@ -10716,12 +10759,15 @@ case PH7_OP_CONSUME: {
 		pc++; /* Next instruction in the stream */
 	} /* For(;;) */
 Done:
+	VmRestoreOuterReturn(&(*pVm),bSavedReturn,&sSavedReturn);
 	SySetRelease(&aArg);
 	return SXRET_OK;
 Suspend:
+	VmRestoreOuterReturn(&(*pVm),bSavedReturn,&sSavedReturn);
 	SySetRelease(&aArg);
 	return PH7_SUSPEND;
 Abort:
+	VmDiscardOuterReturn(bSavedReturn,&sSavedReturn);
 	SySetRelease(&aArg);
 	while( pTos >= pStack ){
 		PH7_MemObjRelease(pTos);
@@ -10729,6 +10775,7 @@ Abort:
 	}
 	return PH7_ABORT;
 Exception:
+	VmDiscardOuterReturn(bSavedReturn,&sSavedReturn);
 	SySetRelease(&aArg);
 	while( pTos >= pStack ){
 		PH7_MemObjRelease(pTos);

--- a/tests/ph7/002-integration/lang/catch_return_finally_calls_function.phpt
+++ b/tests/ph7/002-integration/lang/catch_return_finally_calls_function.phpt
@@ -1,0 +1,29 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A catch-return survives a finally that calls a function with its own try/catch
+--FILE--
+<?php
+function crf_helper() {
+    // An inner throw+catch here used to clobber the VM-global pending-return
+    // signal, dropping the caller's catch-return.
+    try { throw new Exception("inner"); } catch (Exception $e) { /* swallow */ }
+    return 1;
+}
+function crf_target() {
+    try {
+        throw new RuntimeException("boom");
+    } catch (RuntimeException $e) {
+        return "CAUGHT-RETURN";
+    } finally {
+        crf_helper();
+    }
+    return "FELL-THROUGH";
+}
+echo crf_target() . "\n";
+?>
+--EXPECT--
+CAUGHT-RETURN
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/catch_return_finally_helper_returns.phpt
+++ b/tests/ph7/002-integration/lang/catch_return_finally_helper_returns.phpt
@@ -1,0 +1,29 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A catch-return survives a finally whose helper uses its own catch-return
+--FILE--
+<?php
+function crhr_helper() {
+    // The helper materializes its OWN catch-return (into its own result),
+    // which consumes the shared signal — the caller's return must still survive.
+    try { throw new Exception("inner"); } catch (Exception $e) { return 99; }
+}
+function crhr_target() {
+    try {
+        throw new Exception("a");
+    } catch (Exception $e) {
+        return "OUTER";
+    } finally {
+        $x = crhr_helper();
+        echo "helper=$x\n";
+    }
+}
+echo crhr_target() . "\n";
+?>
+--EXPECT--
+helper=99
+OUTER
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/catch_return_finally_override.phpt
+++ b/tests/ph7/002-integration/lang/catch_return_finally_override.phpt
@@ -1,0 +1,27 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A finally can still override a catch-return after calling a helper
+--FILE--
+<?php
+function crfo_helper() {
+    try { throw new Exception("inner"); } catch (Exception $e) {}
+    return 5;
+}
+function crfo_target() {
+    try {
+        throw new Exception("a");
+    } catch (Exception $e) {
+        return "X";
+    } finally {
+        crfo_helper();
+        return "FINALLY";   // overrides the catch-return
+    }
+}
+echo crfo_target() . "\n";
+?>
+--EXPECT--
+FINALLY
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/return_in_try_finally_calls_function.phpt
+++ b/tests/ph7/002-integration/lang/return_in_try_finally_calls_function.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A try-return survives a finally that calls a function with its own try/catch
+--FILE--
+<?php
+function rtf_helper() {
+    try { throw new Exception("inner"); } catch (Exception $e) { return 1; }
+}
+function rtf_target() {
+    try {
+        return "TRY-RETURN";
+    } finally {
+        rtf_helper();
+    }
+}
+echo rtf_target() . "\n";
+?>
+--EXPECT--
+TRY-RETURN
+--CLEAN--
+<?php


### PR DESCRIPTION
A `catch{ return X; }` followed by a `finally{ helper(); }` silently dropped X when helper() ran its own try/catch (or its own catch-return): the pending-return signal (bReturnRequested/sCatchReturn) is a single VM-global, and helper()'s exception handling clobbered it — VmThrowException clears it at its top, and a helper catch-return materializes (and clears) it — so the enclosing function fell through to the code after the try/catch/finally.

Fix: per-exec scoping in VmByteCodeExec. A real nested body (bReturnPropagates==FALSE: a called function, match/default eval, …) that starts while a return is pending saves the (bReturnRequested, sCatchReturn) pair, resets to a clean slate, and restores it on normal exit (Done/Suspend) so the caller's pending return survives whatever the nested body does. On abnormal exit (Abort/Exception) the saved return is discarded: an exception escaping the nested body escapes the enclosing finally too, which per PHP discards the pending return. Mini-programs (bReturnPropagates==TRUE) do not isolate — they must propagate the signal outward. Gated on a return actually being pending at entry, so the common path is untouched.

Verified byte-for-byte vs php 8.5.7: finally calls a function with an internal try/catch; helper uses its own catch-return; finally overrides the return after a helper call; return-in-try with the same finally; multi-level nesting; and the escape/discard cases. make test (2207 smoke + 736 integration), test-compat (both engines), test-stress all green.

Deferred (both pre-existing, reproduce on the unmodified engine): an inline try/catch written directly inside a finally still clobbers (no nested exec to bracket; VmThrowException's top-level clear can't yet distinguish caught- within-finally from escapes-finally), and an uncaught exception escaping a finally corrupts/hangs.
