### PR TITLE
Raise an OOM fatal in builtins that silently truncated on alloc failure

### DIFF
--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -1516,6 +1516,7 @@ struct implode_data {
 	int nSeplen;          /* Separator length */
 	int bFirst;           /* TRUE if first call */
 	int nRecCount;        /* Recursion count to avoid infinite loop */
+	sxi32 rc;             /* Captured allocation rc; SXERR_MEM => the builtin raises an OOM fatal */
 };
 /*
  * Implode walker callback for the [ph7_array_walk()] interface.
@@ -1532,7 +1533,10 @@ static int implode_callback(ph7_value *pKey,ph7_value *pValue,void *pUserData)
 		if( pData->nSeplen > 0 ){
 			if( !pData->bFirst ){
 				/* append the separator first */
-				ph7_result_string(pData->pCtx,pData->zSep,pData->nSeplen);
+				if( ph7_result_string(pData->pCtx,pData->zSep,pData->nSeplen) != SXRET_OK ){
+					pData->rc = SXERR_MEM;
+					return PH7_ABORT;
+				}
 			}else{
 				pData->bFirst = 0;
 			}
@@ -1542,6 +1546,10 @@ static int implode_callback(ph7_value *pKey,ph7_value *pValue,void *pUserData)
 		pData->nRecCount++;
 		PH7_HashmapWalk((ph7_hashmap *)pValue->x.pOther,implode_callback,pData);
 		pData->nRecCount--;
+		/* Propagate an allocation failure surfaced deeper in the recursion. */
+		if( pData->rc != SXRET_OK ){
+			return PH7_ABORT;
+		}
 		return PH7_OK;
 	}
 	/* Extract the string representation of the entry value */
@@ -1551,11 +1559,17 @@ static int implode_callback(ph7_value *pKey,ph7_value *pValue,void *pUserData)
 		pData->bFirst = 0;
 	}else if( pData->nSeplen > 0 ){
 		/* append the separator first */
-		ph7_result_string(pData->pCtx,pData->zSep,pData->nSeplen);
+		if( ph7_result_string(pData->pCtx,pData->zSep,pData->nSeplen) != SXRET_OK ){
+			pData->rc = SXERR_MEM;
+			return PH7_ABORT;
+		}
 	}
 	/* Append the value if non-empty; empty values are represented by the separators */
 	if( nLen > 0 ){
-		ph7_result_string(pData->pCtx,zData,nLen);
+		if( ph7_result_string(pData->pCtx,zData,nLen) != SXRET_OK ){
+			pData->rc = SXERR_MEM;
+			return PH7_ABORT;
+		}
 	}
 	return PH7_OK;
 }
@@ -1586,6 +1600,7 @@ static int PH7_builtin_implode(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	imp_data.bRecursive = 0;
 	imp_data.bFirst = 1;
 	imp_data.nRecCount = 0;
+	imp_data.rc = SXRET_OK;
 	if( !ph7_value_is_array(apArg[0]) ){
 		imp_data.zSep = ph7_value_to_string(apArg[0],&imp_data.nSeplen);
 	}else{
@@ -1593,12 +1608,18 @@ static int PH7_builtin_implode(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		imp_data.nSeplen = 0;
 		i = 0;
 	}
-	ph7_result_string(pCtx,"",0); /* Set an empty stirng */
+	if( ph7_result_string(pCtx,"",0) != SXRET_OK ){ /* Set an empty stirng */
+		return PH7_ContextMemoryError(pCtx);
+	}
 	/* Start the 'join' process */
 	while( i < nArg ){
 		if( ph7_value_is_array(apArg[i]) ){
 			/* Iterate throw array entries */
 			ph7_array_walk(apArg[i],implode_callback,&imp_data);
+			/* Surface a callback allocation failure as a fatal */
+			if( imp_data.rc != SXRET_OK ){
+				return PH7_ContextMemoryError(pCtx);
+			}
 		}else{
 			const char *zData;
 			int nLen;
@@ -1608,11 +1629,15 @@ static int PH7_builtin_implode(ph7_context *pCtx,int nArg,ph7_value **apArg)
 			if( imp_data.bFirst ){
 				imp_data.bFirst = 0;
 			}else if( imp_data.nSeplen > 0 ){
-				ph7_result_string(pCtx, imp_data.zSep, imp_data.nSeplen);
+				if( ph7_result_string(pCtx, imp_data.zSep, imp_data.nSeplen) != SXRET_OK ){
+					return PH7_ContextMemoryError(pCtx);
+				}
 			}
 			/* Append the value if non-empty; empty values are represented by the separators */
 			if( nLen > 0 ){
-				ph7_result_string(pCtx,zData,nLen);
+				if( ph7_result_string(pCtx,zData,nLen) != SXRET_OK ){
+					return PH7_ContextMemoryError(pCtx);
+				}
 			}
 		}
 		i++;
@@ -1650,6 +1675,7 @@ static int PH7_builtin_implode_recursive(ph7_context *pCtx,int nArg,ph7_value **
 	imp_data.bRecursive = 1;
 	imp_data.bFirst = 1;
 	imp_data.nRecCount = 0;
+	imp_data.rc = SXRET_OK;
 	if( !ph7_value_is_array(apArg[0]) ){
 		imp_data.zSep = ph7_value_to_string(apArg[0],&imp_data.nSeplen);
 	}else{
@@ -1657,12 +1683,18 @@ static int PH7_builtin_implode_recursive(ph7_context *pCtx,int nArg,ph7_value **
 		imp_data.nSeplen = 0;
 		i = 0;
 	}
-	ph7_result_string(pCtx,"",0); /* Set an empty stirng */
+	if( ph7_result_string(pCtx,"",0) != SXRET_OK ){ /* Set an empty stirng */
+		return PH7_ContextMemoryError(pCtx);
+	}
 	/* Start the 'join' process */
 	while( i < nArg ){
 		if( ph7_value_is_array(apArg[i]) ){
 			/* Iterate throw array entries */
 			ph7_array_walk(apArg[i],implode_callback,&imp_data);
+			/* Surface a callback allocation failure as a fatal */
+			if( imp_data.rc != SXRET_OK ){
+				return PH7_ContextMemoryError(pCtx);
+			}
 		}else{
 			const char *zData;
 			int nLen;
@@ -1672,11 +1704,15 @@ static int PH7_builtin_implode_recursive(ph7_context *pCtx,int nArg,ph7_value **
 			if( imp_data.bFirst ){
 				imp_data.bFirst = 0;
 			}else if( imp_data.nSeplen > 0 ){
-				ph7_result_string(pCtx, imp_data.zSep, imp_data.nSeplen);
+				if( ph7_result_string(pCtx, imp_data.zSep, imp_data.nSeplen) != SXRET_OK ){
+					return PH7_ContextMemoryError(pCtx);
+				}
 			}
 			/* Append the value if non-empty; empty values are represented by the separators */
 			if( nLen > 0 ){
-				ph7_result_string(pCtx,zData,nLen);
+				if( ph7_result_string(pCtx,zData,nLen) != SXRET_OK ){
+					return PH7_ContextMemoryError(pCtx);
+				}
 			}
 		}
 		i++;
@@ -1739,7 +1775,9 @@ static int PH7_builtin_explode(ph7_context *pCtx,int nArg,ph7_value **apArg)
 			return PH7_OK;
 		}
 		ph7_value_string(pValueTmp, "", 0);
-		ph7_array_add_elem(pArrayTmp, 0 /* Automatic index assign */, pValueTmp);
+		if( ph7_array_add_elem(pArrayTmp, 0 /* Automatic index assign */, pValueTmp) != SXRET_OK ){
+			return PH7_ContextMemoryError(pCtx);
+		}
 		ph7_result_value(pCtx, pArrayTmp);
 		return PH7_OK;
 	}
@@ -1771,14 +1809,18 @@ static int PH7_builtin_explode(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		if( rc != SXRET_OK || iLimit <= (int)ph7_array_count(pArray) ){
 			/* Limit reached or no more delimiter; insert the rest (may be empty) and break */
 			ph7_value_string(pValue, zString, (int)(zEnd - zString));
-			ph7_array_add_elem(pArray, 0/* Automatic index assign */, pValue);
+			if( ph7_array_add_elem(pArray, 0/* Automatic index assign */, pValue) != SXRET_OK ){
+				return PH7_ContextMemoryError(pCtx);
+			}
 			break;
 		}
 		/* Point to the desired offset */
 		zCur = &zString[nOfft];
 		/* Perform the store operation (may be empty) */
 		ph7_value_string(pValue, zString, (int)(zCur - zString));
-		ph7_array_add_elem(pArray, 0/* Automatic index assign */, pValue);
+		if( ph7_array_add_elem(pArray, 0/* Automatic index assign */, pValue) != SXRET_OK ){
+			return PH7_ContextMemoryError(pCtx);
+		}
 		/* Point beyond the delimiter */
 		zString = &zCur[nDelim];
 		/* Reset the cursor */
@@ -3516,8 +3558,8 @@ PH7_PRIVATE sxi32 PH7_InputFormat(
 		if( zCur < zIn ){
 			/* Consume chunk verbatim */
 			rc = xConsumer(pCtx,zCur,(int)(zIn-zCur),pUserData);
-			if( rc == SXERR_ABORT ){
-				/* Callback request an operation abort */
+			if( rc != SXRET_OK ){
+				/* Callback requested an abort (e.g. an allocation failure) */
 				break;
 			}
 		}
@@ -3956,10 +3998,12 @@ PH7_PRIVATE sxi32 PH7_InputFormat(
  */
 static int sprintfConsumer(ph7_context *pCtx,const char *zInput,int nLen,void *pUserData)
 {
-	/* Consume directly */
-	ph7_result_string(pCtx,zInput,nLen);
-	SXUNUSED(pUserData); /* cc warning */
-	return PH7_OK;
+	/* pUserData points to the caller's allocation-rc slot so an OOM during the
+	 * result append is surfaced (the builtin raises a fatal); returning the
+	 * non-OK rc also stops the format loop. */
+	sxi32 *pRc = (sxi32 *)pUserData;
+	*pRc = ph7_result_string(pCtx,zInput,nLen);
+	return *pRc;
 }
 /*
  * string sprintf(string $format[,mixed $args [, mixed $... ]])
@@ -3973,6 +4017,7 @@ static int sprintfConsumer(ph7_context *pCtx,const char *zInput,int nLen,void *p
 static int PH7_builtin_sprintf(ph7_context *pCtx,int nArg,ph7_value **apArg)
 {
 	const char *zFormat;
+	sxi32 rc = SXRET_OK;
 	int nLen;
 	if( nArg < 1 || !ph7_value_is_string(apArg[0]) ){
 		/* Missing/Invalid arguments,return the empty string */
@@ -3986,8 +4031,13 @@ static int PH7_builtin_sprintf(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		ph7_result_string(pCtx,"",0);
 		return PH7_OK;
 	}
-	/* Format the string */
-	PH7_InputFormat(sprintfConsumer,pCtx,zFormat,nLen,nArg,apArg,0,FALSE);
+	/* Format the string; sprintfConsumer reports an allocation failure via &rc. */
+	PH7_InputFormat(sprintfConsumer,pCtx,zFormat,nLen,nArg,apArg,(void *)&rc,FALSE);
+	if( rc != SXRET_OK ){
+		/* The result append ran out of memory: raise a fatal rather than
+		 * returning a silently-truncated string. */
+		return PH7_ContextMemoryError(pCtx);
+	}
 	return PH7_OK;
 }
 /*
@@ -4088,6 +4138,7 @@ static int PH7_builtin_vsprintf(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	const char *zFormat;
 	ph7_hashmap *pMap;
 	SySet sArg;
+	sxi32 rc = SXRET_OK;
 	int nLen,n;
 	if( nArg < 2 || !ph7_value_is_string(apArg[0]) || !ph7_value_is_array(apArg[1]) ){
 		/* Missing/Invalid arguments,return the empty string */
@@ -4105,10 +4156,14 @@ static int PH7_builtin_vsprintf(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	pMap = (ph7_hashmap *)apArg[1]->x.pOther;
 	/* Extract arguments from the hashmap */
 	n = PH7_HashmapValuesToSet(pMap,&sArg);
-	/* Format the string */
-	PH7_InputFormat(sprintfConsumer,pCtx,zFormat,nLen,n,(ph7_value **)SySetBasePtr(&sArg),0,TRUE);
+	/* Format the string; sprintfConsumer reports an allocation failure via &rc. */
+	PH7_InputFormat(sprintfConsumer,pCtx,zFormat,nLen,n,(ph7_value **)SySetBasePtr(&sArg),(void *)&rc,TRUE);
 	/* Release the container */
 	SySetRelease(&sArg);
+	if( rc != SXRET_OK ){
+		/* The result append ran out of memory: raise a fatal. */
+		return PH7_ContextMemoryError(pCtx);
+	}
 	return PH7_OK;
 }
 #endif /* PH7_NEED_FMT_AND_INI */
@@ -5616,7 +5671,9 @@ static int PH7_builtin_str_split(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		/* Copy the current chunk */
 		ph7_value_string(pValue,zString,split_len);
 		/* Insert it */
-		ph7_array_add_elem(pArray,0,pValue); /* Will make it's own copy */
+		if( ph7_array_add_elem(pArray,0,pValue) != SXRET_OK ){ /* Will make it's own copy */
+			return PH7_ContextMemoryError(pCtx);
+		}
 		/* reset the string cursor */
 		ph7_value_reset_string_cursor(pValue);
 		/* Update position */
@@ -6310,7 +6367,7 @@ static int PH7_builtin_str_pad(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	}
 	if( iPadlen < 1  ){
 		/* Return the string verbatim */
-		ph7_result_string(pCtx,zIn,iLen);
+		if( ph7_result_string(pCtx,zIn,iLen) != SXRET_OK ){ return PH7_ContextMemoryError(pCtx); }
 		return PH7_OK;
 	}
 	zPad = " "; /* Whitespace padding */
@@ -6344,7 +6401,7 @@ static int PH7_builtin_str_pad(ph7_context *pCtx,int nArg,ph7_value **apArg)
 			if( (int)ph7_context_result_buf_length(pCtx) + iLen + jPad >= iRealPad ){
 				break;
 			}
-			ph7_result_string(pCtx,zPad,jPad);
+			if( ph7_result_string(pCtx,zPad,jPad) != SXRET_OK ){ return PH7_ContextMemoryError(pCtx); }
 		}
 		if( iType == 0 /* STR_PAD_LEFT */ ){
 			while( (int)ph7_context_result_buf_length(pCtx) + iLen < iRealPad ){
@@ -6355,13 +6412,13 @@ static int PH7_builtin_str_pad(ph7_context *pCtx,int nArg,ph7_value **apArg)
 				if( jPad < 1){
 					break;
 				}
-				ph7_result_string(pCtx,zPad,jPad);
+				if( ph7_result_string(pCtx,zPad,jPad) != SXRET_OK ){ return PH7_ContextMemoryError(pCtx); }
 			}
 		}
 	}
 	if( iLen > 0 ){
 		/* Append the input string */
-		ph7_result_string(pCtx,zIn,iLen);
+		if( ph7_result_string(pCtx,zIn,iLen) != SXRET_OK ){ return PH7_ContextMemoryError(pCtx); }
 	}
 	if( iType == 1 /* STR_PAD_RIGHT */ || iType == 2 /* STR_PAD_BOTH */ ){
 		for( i = 0 ; i < iPadlen/iDiv ; i += iStrpad ){
@@ -6369,7 +6426,7 @@ static int PH7_builtin_str_pad(ph7_context *pCtx,int nArg,ph7_value **apArg)
 			if( (int)ph7_context_result_buf_length(pCtx) + iStrpad >= iRealPad ){
 				break;
 			}
-			ph7_result_string(pCtx,zPad,iStrpad);
+			if( ph7_result_string(pCtx,zPad,iStrpad) != SXRET_OK ){ return PH7_ContextMemoryError(pCtx); }
 		}
 		while( (int)ph7_context_result_buf_length(pCtx) < iRealPad ){
 			jPad = iRealPad - (int)ph7_context_result_buf_length(pCtx);
@@ -6379,7 +6436,7 @@ static int PH7_builtin_str_pad(ph7_context *pCtx,int nArg,ph7_value **apArg)
 			if( jPad < 1){
 				break;
 			}
-			ph7_result_string(pCtx,zPad,jPad);
+			if( ph7_result_string(pCtx,zPad,jPad) != SXRET_OK ){ return PH7_ContextMemoryError(pCtx); }
 		}
 	}
 	return PH7_OK;

--- a/src/ph7/vm_json.c
+++ b/src/ph7/vm_json.c
@@ -26,7 +26,15 @@ struct json_private_data
 	int iFlags;        /* JSON encoding flags */
 	int nRecCount;     /* Recursion count */
 	int exc;           /* True if a jsonSerialize() callback threw an exception */
+	int oom;           /* True if a result append ran out of memory (raises a fatal) */
 };
+/*
+ * Emit into the JSON result, flagging OOM on the shared data and bailing out
+ * of the current encode function (which returns PH7_OK; the top-level
+ * vm_builtin_json_encode checks ->oom and raises a non-catchable fatal). Used
+ * for every ph7_result_string/ph7_result_string_format append below.
+ */
+#define JSON_EMIT(pD, call) do { if( (call) != SXRET_OK ){ (pD)->oom = 1; return PH7_OK; } } while(0)
 /*
  * Returns the JSON representation of a value.In other word perform a JSON encoding operation.
  * According to wikipedia
@@ -52,18 +60,18 @@ static sxi32 VmJsonEncode(
 		int nByte;
 		if( ph7_value_is_null(pIn) || ph7_value_is_resource(pIn)){
 			/* null */
-			ph7_result_string(pCtx,"null",(int)sizeof("null")-1);
+			JSON_EMIT(pData,ph7_result_string(pCtx,"null",(int)sizeof("null")-1));
 		}else if( ph7_value_is_bool(pIn) ){
 			int iBool = ph7_value_to_bool(pIn);
 			int iLen;
 			/* true/false */
 			iLen = iBool ? (int)sizeof("true") : (int)sizeof("false");
-			ph7_result_string(pCtx,iBool ? "true" : "false",iLen-1);
+			JSON_EMIT(pData,ph7_result_string(pCtx,iBool ? "true" : "false",iLen-1));
 		}else if(  ph7_value_is_numeric(pIn) && !ph7_value_is_string(pIn) ){
 			const char *zNum;
 			/* Get a string representation of the number */
 			zNum = ph7_value_to_string(pIn,&nByte);
-			ph7_result_string(pCtx,zNum,nByte);
+			JSON_EMIT(pData,ph7_result_string(pCtx,zNum,nByte));
 		}else if( ph7_value_is_string(pIn) ){
 			if( (iFlags & JSON_NUMERIC_CHECK) &&  ph7_value_is_numeric(pIn) ){
 				const char *zNum;
@@ -71,7 +79,7 @@ static sxi32 VmJsonEncode(
 				PH7_MemObjToReal(pIn); /* Force a numeric cast */
 				/* Get a string representation of the number */
 				zNum = ph7_value_to_string(pIn,&nByte);
-				ph7_result_string(pCtx,zNum,nByte);
+				JSON_EMIT(pData,ph7_result_string(pCtx,zNum,nByte));
 			}else{
 				const char *zIn,*zEnd;
 				int c;
@@ -79,7 +87,7 @@ static sxi32 VmJsonEncode(
 				zIn = ph7_value_to_string(pIn,&nByte);
 				zEnd = &zIn[nByte];
 				/* Append the double quote */
-				ph7_result_string(pCtx,"\"",(int)sizeof(char));
+				JSON_EMIT(pData,ph7_result_string(pCtx,"\"",(int)sizeof(char)));
 				for(;;){
 					if( zIn >= zEnd ){
 						/* No more input to process */
@@ -91,33 +99,33 @@ static sxi32 VmJsonEncode(
 					if( (c == '<' || c == '>') && (iFlags & JSON_HEX_TAG) ){
 						/* All < and > are converted to \u003C and \u003E */
 						if( c == '<' ){
-							ph7_result_string(pCtx,"\\u003C",(int)sizeof("\\u003C")-1);
+							JSON_EMIT(pData,ph7_result_string(pCtx,"\\u003C",(int)sizeof("\\u003C")-1));
 						}else{
-							ph7_result_string(pCtx,"\\u003E",(int)sizeof("\\u003E")-1);
+							JSON_EMIT(pData,ph7_result_string(pCtx,"\\u003E",(int)sizeof("\\u003E")-1));
 						}
 						continue;
 					}else if( c == '&' && (iFlags & JSON_HEX_AMP) ){
 						/* All &s are converted to \u0026.  */
-						ph7_result_string(pCtx,"\\u0026",(int)sizeof("\\u0026")-1);
+						JSON_EMIT(pData,ph7_result_string(pCtx,"\\u0026",(int)sizeof("\\u0026")-1));
 						continue;
 					}else if( c == '\'' && (iFlags & JSON_HEX_APOS) ){
 						/* All ' are converted to \u0027.   */
-						ph7_result_string(pCtx,"\\u0027",(int)sizeof("\\u0027")-1);
+						JSON_EMIT(pData,ph7_result_string(pCtx,"\\u0027",(int)sizeof("\\u0027")-1));
 						continue;
 					}else if( c == '"' && (iFlags & JSON_HEX_QUOT) ){
 						/* All " are converted to \u0022. */
-						ph7_result_string(pCtx,"\\u0022",(int)sizeof("\\u0022")-1);
+						JSON_EMIT(pData,ph7_result_string(pCtx,"\\u0022",(int)sizeof("\\u0022")-1));
 						continue;
 					}
 					if( c == '"' || (c == '\\' && ((iFlags & JSON_UNESCAPED_SLASHES)==0)) ){
 						/* Unescape the character */
-						ph7_result_string(pCtx,"\\",(int)sizeof(char));
+						JSON_EMIT(pData,ph7_result_string(pCtx,"\\",(int)sizeof(char)));
 					}
 					/* Append character verbatim */
-					ph7_result_string(pCtx,(const char *)&c,(int)sizeof(char));
+					JSON_EMIT(pData,ph7_result_string(pCtx,(const char *)&c,(int)sizeof(char)));
 				}
 				/* Append the double quote */
-				ph7_result_string(pCtx,"\"",(int)sizeof(char));
+				JSON_EMIT(pData,ph7_result_string(pCtx,"\"",(int)sizeof(char)));
 			}
 		}else if( ph7_value_is_array(pIn) ){
 			/* An array encodes as a JSON array iff it is a "list" [consecutive
@@ -132,11 +140,15 @@ static sxi32 VmJsonEncode(
 			pData->isObject = isObject;
 			pData->isFirst = 1;
 			/* Append the square bracket or curly braces */
-			ph7_result_string(pCtx,(const char *)&c,(int)sizeof(char));
+			JSON_EMIT(pData,ph7_result_string(pCtx,(const char *)&c,(int)sizeof(char)));
 			/* Iterate throw array entries */
 			ph7_array_walk(pIn,VmJsonArrayEncode,pData);
+			/* Bail if a nested append ran out of memory before the closer */
+			if( pData->oom ){
+				return PH7_OK;
+			}
 			/* Append the closing square bracket or curly braces */
-			ph7_result_string(pCtx,(const char *)&d,(int)sizeof(char));
+			JSON_EMIT(pData,ph7_result_string(pCtx,(const char *)&d,(int)sizeof(char)));
 			pData->isObject = savedObject;
 		}else if( ph7_value_is_object(pIn) ){
 			ph7_class_instance *pThis = (ph7_class_instance *)pIn->x.pOther;
@@ -167,19 +179,25 @@ static sxi32 VmJsonEncode(
 				if( pData->exc ){
 					return PH7_EXCEPTION;
 				}
+				if( pData->oom ){
+					return PH7_OK;
+				}
 			}else{
 				/* Encode the class instance */
 				pData->isFirst = 1;
 				/* Append the curly braces */
-				ph7_result_string(pCtx,"{",(int)sizeof(char));
+				JSON_EMIT(pData,ph7_result_string(pCtx,"{",(int)sizeof(char)));
 				/* Iterate throw class attribute */
 				ph7_object_walk(pIn,VmJsonObjectEncode,pData);
+				if( pData->oom ){
+					return PH7_OK;
+				}
 				/* Append the closing curly braces  */
-				ph7_result_string(pCtx,"}",(int)sizeof(char));
+				JSON_EMIT(pData,ph7_result_string(pCtx,"}",(int)sizeof(char)));
 			}
 		}else{
 			/* Can't happen */
-			ph7_result_string(pCtx,"null",(int)sizeof("null")-1);
+			JSON_EMIT(pData,ph7_result_string(pCtx,"null",(int)sizeof("null")-1));
 		}
 		/* All done */
 		return PH7_OK;
@@ -191,13 +209,13 @@ static sxi32 VmJsonEncode(
 static int VmJsonArrayEncode(ph7_value *pKey,ph7_value *pValue,void *pUserData)
 {
 	json_private_data *pJson = (json_private_data *)pUserData;
-	if( pJson->nRecCount > 31 || pJson->exc ){
-		/* Recursion limit reached or a callback threw,return immediately */
+	if( pJson->nRecCount > 31 || pJson->exc || pJson->oom ){
+		/* Recursion limit reached, a callback threw, or OOM — return immediately */
 		return PH7_OK;
 	}
 	if( !pJson->isFirst ){
 		/* Append the colon first */
-		ph7_result_string(pJson->pCtx,",",(int)sizeof(char));
+		JSON_EMIT(pJson,ph7_result_string(pJson->pCtx,",",(int)sizeof(char)));
 	}
 	if( pJson->isObject ){
 		/* Outputs an object rather than an array */
@@ -205,8 +223,12 @@ static int VmJsonArrayEncode(ph7_value *pKey,ph7_value *pValue,void *pUserData)
 		int nByte;
 		/* Extract a string representation of the key */
 		zKey = ph7_value_to_string(pKey,&nByte);
-		/* Append the key and the double colon */
-		ph7_result_string_format(pJson->pCtx,"\"%.*s\":",nByte,zKey);
+		/* Append the quoted key and the colon (checked, so an OOM here is caught
+		 * rather than silently truncating; matches the prior "%.*s" emit byte for
+		 * byte — keys are not JSON-escaped, a pre-existing behavior). */
+		JSON_EMIT(pJson,ph7_result_string(pJson->pCtx,"\"",(int)sizeof(char)));
+		JSON_EMIT(pJson,ph7_result_string(pJson->pCtx,zKey,nByte));
+		JSON_EMIT(pJson,ph7_result_string(pJson->pCtx,"\":",(int)sizeof("\":")-1));
 	}
 	/* Encode the value */
 	pJson->nRecCount++;
@@ -222,16 +244,19 @@ static int VmJsonArrayEncode(ph7_value *pKey,ph7_value *pValue,void *pUserData)
 static int VmJsonObjectEncode(const char *zAttr,ph7_value *pValue,void *pUserData)
 {
 	json_private_data *pJson = (json_private_data *)pUserData;
-	if( pJson->nRecCount > 31 || pJson->exc ){
-		/* Recursion limit reached or a callback threw,return immediately */
+	if( pJson->nRecCount > 31 || pJson->exc || pJson->oom ){
+		/* Recursion limit reached, a callback threw, or OOM — return immediately */
 		return PH7_OK;
 	}
 	if( !pJson->isFirst ){
 		/* Append the colon first */
-		ph7_result_string(pJson->pCtx,",",(int)sizeof(char));
+		JSON_EMIT(pJson,ph7_result_string(pJson->pCtx,",",(int)sizeof(char)));
 	}
-	/* Append the attribute name and the double colon first */
-	ph7_result_string_format(pJson->pCtx,"\"%s\":",zAttr);
+	/* Append the quoted attribute name and the colon (checked; matches the prior
+	 * "%s" emit byte for byte — attribute names are not JSON-escaped). */
+	JSON_EMIT(pJson,ph7_result_string(pJson->pCtx,"\"",(int)sizeof(char)));
+	JSON_EMIT(pJson,ph7_result_string(pJson->pCtx,zAttr,-1));
+	JSON_EMIT(pJson,ph7_result_string(pJson->pCtx,"\":",(int)sizeof("\":")-1));
 	/* Encode the value */
 	pJson->nRecCount++;
 	VmJsonEncode(pValue,pJson);
@@ -275,12 +300,18 @@ PH7_PRIVATE int vm_builtin_json_encode(ph7_context *pCtx,int nArg,ph7_value **ap
 	sJson.isFirst = 1;
 	sJson.iFlags = 0;
 	sJson.exc = 0;
+	sJson.oom = 0;
 	if( nArg > 1 && ph7_value_is_int(apArg[1]) ){
 		/* Extract option flags */
 		sJson.iFlags = ph7_value_to_int(apArg[1]);
 	}
 	/* Perform the encoding operation */
 	rc = VmJsonEncode(apArg[0],&sJson);
+	if( sJson.oom ){
+		/* A result append ran out of memory: raise a non-catchable fatal,
+		 * distinct from a JSON-encoding error (json_last_error untouched). */
+		return PH7_ContextMemoryError(pCtx);
+	}
 	if( rc == PH7_EXCEPTION || sJson.exc ){
 		/* A jsonSerialize() callback threw — propagate so the exception unwinds */
 		return PH7_EXCEPTION;
@@ -288,6 +319,7 @@ PH7_PRIVATE int vm_builtin_json_encode(ph7_context *pCtx,int nArg,ph7_value **ap
 	/* All done */
 	return PH7_OK;
 }
+#undef JSON_EMIT
 /*
  * int json_last_error(void)
  *  Returns the last error (if any) occurred during the last JSON encoding/decoding.

--- a/tests/ph7/003-stress/memory/explode_oom.phpt
+++ b/tests/ph7/003-stress/memory/explode_oom.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+explode() surfaces an out-of-memory fatal instead of a truncated array
+--DESCRIPTION--
+Run under a small per-allocation cap (PHL_MAX_ALLOC, set by `make test-stress`).
+The input stays under the cap (~900 KB) but explodes into ~450k elements, whose
+hashmap bucket table reallocates past the cap, so explode must raise a fatal.
+--SKIPIF--
+<?php if (!getenv('PHL_MAX_ALLOC')) { echo "skip needs PHL_MAX_ALLOC cap (run: make test-stress)"; } ?>
+--FILE--
+<?php
+$r = explode(',', str_repeat('a,', 450000));
+echo "UNREACHABLE count=" . count($r) . "\n";
+?>
+--EXPECTF--
+%s Error:  PH7 is running out of memory
+--CLEAN--
+<?php

--- a/tests/ph7/003-stress/memory/implode_oom.phpt
+++ b/tests/ph7/003-stress/memory/implode_oom.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+implode() surfaces an out-of-memory fatal instead of a truncated joined string
+--DESCRIPTION--
+Run under a small per-allocation cap (PHL_MAX_ALLOC, set by `make test-stress`).
+Each piece builds under the cap; joining them needs a result buffer past the
+cap, so implode must raise a fatal, not return a truncated string.
+--SKIPIF--
+<?php if (!getenv('PHL_MAX_ALLOC')) { echo "skip needs PHL_MAX_ALLOC cap (run: make test-stress)"; } ?>
+--FILE--
+<?php
+$s = implode(',', [str_repeat('A', 600000), str_repeat('B', 600000)]);
+echo "UNREACHABLE len=" . strlen($s) . "\n";
+?>
+--EXPECTF--
+%s Error:  PH7 is running out of memory
+--CLEAN--
+<?php

--- a/tests/ph7/003-stress/memory/json_encode_oom.phpt
+++ b/tests/ph7/003-stress/memory/json_encode_oom.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+json_encode() surfaces an out-of-memory fatal instead of a truncated string
+--DESCRIPTION--
+Run under a small per-allocation cap (PHL_MAX_ALLOC, set by `make test-stress`).
+Encoding two long strings grows the JSON result buffer past the cap, so
+json_encode must raise a fatal (not a JSON error, not a truncated string).
+--SKIPIF--
+<?php if (!getenv('PHL_MAX_ALLOC')) { echo "skip needs PHL_MAX_ALLOC cap (run: make test-stress)"; } ?>
+--FILE--
+<?php
+$s = json_encode([str_repeat('A', 600000), str_repeat('B', 600000)]);
+echo "UNREACHABLE len=" . strlen($s) . "\n";
+?>
+--EXPECTF--
+%s Error:  PH7 is running out of memory
+--CLEAN--
+<?php

--- a/tests/ph7/003-stress/memory/sprintf_oom.phpt
+++ b/tests/ph7/003-stress/memory/sprintf_oom.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+sprintf() surfaces an out-of-memory fatal instead of a truncated result
+--DESCRIPTION--
+Run under a small per-allocation cap (PHL_MAX_ALLOC, set by `make test-stress`).
+Large string arguments grow the result buffer past the cap as the %s fields are
+appended (a single field's width is clamped to the format buffer, so width
+padding alone cannot trigger it), so sprintf must raise a fatal.
+--SKIPIF--
+<?php if (!getenv('PHL_MAX_ALLOC')) { echo "skip needs PHL_MAX_ALLOC cap (run: make test-stress)"; } ?>
+--FILE--
+<?php
+$s = str_repeat('A', 600000);
+$out = sprintf('%s%s', $s, $s);
+echo "UNREACHABLE len=" . strlen($out) . "\n";
+?>
+--EXPECTF--
+%s Error:  PH7 is running out of memory
+--CLEAN--
+<?php

--- a/tests/ph7/003-stress/memory/str_pad_oom.phpt
+++ b/tests/ph7/003-stress/memory/str_pad_oom.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+str_pad() surfaces an out-of-memory fatal instead of a truncated result
+--DESCRIPTION--
+Run under a small per-allocation cap (PHL_MAX_ALLOC, set by `make test-stress`).
+Padding to ~2 MB grows the result buffer past the cap, so str_pad must raise a
+fatal rather than return a silently-truncated string.
+--SKIPIF--
+<?php if (!getenv('PHL_MAX_ALLOC')) { echo "skip needs PHL_MAX_ALLOC cap (run: make test-stress)"; } ?>
+--FILE--
+<?php
+$s = str_pad('x', 2000000, 'AB');
+echo "UNREACHABLE len=" . strlen($s) . "\n";
+?>
+--EXPECTF--
+%s Error:  PH7 is running out of memory
+--CLEAN--
+<?php

--- a/tests/ph7/003-stress/memory/str_pad_verbatim_oom.phpt
+++ b/tests/ph7/003-stress/memory/str_pad_verbatim_oom.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+str_pad() raises an OOM fatal on its no-padding (verbatim) return path
+--DESCRIPTION--
+Run under a small per-allocation cap (PHL_MAX_ALLOC, set by `make test-stress`).
+When the pad length is <= the input length, str_pad returns the input verbatim;
+that append must also raise a fatal on OOM, not a truncated string.
+--SKIPIF--
+<?php if (!getenv('PHL_MAX_ALLOC')) { echo "skip needs PHL_MAX_ALLOC cap (run: make test-stress)"; } ?>
+--FILE--
+<?php
+$big = str_repeat('A', 2000000);
+$s = str_pad($big, 5); // pad length < input length -> verbatim return path
+echo "UNREACHABLE len=" . strlen($s) . "\n";
+?>
+--EXPECTF--
+%s Error:  PH7 is running out of memory
+--CLEAN--
+<?php

--- a/tests/ph7/003-stress/memory/str_split_oom.phpt
+++ b/tests/ph7/003-stress/memory/str_split_oom.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+str_split() surfaces an out-of-memory fatal instead of a truncated array
+--DESCRIPTION--
+Run under a small per-allocation cap (PHL_MAX_ALLOC, set by `make test-stress`).
+The input stays under the cap (~900 KB) but splits into ~900k single-char
+elements, whose hashmap bucket table reallocates past the cap, so str_split
+must raise a fatal.
+--SKIPIF--
+<?php if (!getenv('PHL_MAX_ALLOC')) { echo "skip needs PHL_MAX_ALLOC cap (run: make test-stress)"; } ?>
+--FILE--
+<?php
+$r = str_split(str_repeat('A', 900000), 1);
+echo "UNREACHABLE count=" . count($r) . "\n";
+?>
+--EXPECTF--
+%s Error:  PH7 is running out of memory
+--CLEAN--
+<?php


### PR DESCRIPTION
implode/str_pad/sprintf/vsprintf/json_encode/explode/str_split called allocating APIs (ph7_result_string, ph7_array_add_elem) and dropped the return code, so on out-of-memory they returned a silently truncated/partial result with a success status — a silent-wrong-answer hazard, and a robustness gap on the memory-constrained ESP32 target. Extend the existing OOM-raise idiom (PH7_ContextMemoryError -> non-catchable fatal, exit 255, unwinds the VM) to these sites.

- Direct-call sites (str_pad, explode, str_split): check rc, return PH7_ContextMemoryError(pCtx).
- implode/implode_recursive: an rc field on struct implode_data; the shared implode_callback records a failed append and returns PH7_ABORT (stopping PH7_HashmapWalk); the builtin raises after the walk.
- sprintf/vsprintf: thread the rc through sprintfConsumer's pUserData (a precise OOM flag, not the formatter's overloaded SXERR_ABORT); the verbatim chunk path now breaks on any non-OK consumer rc; the builtins raise after PH7_InputFormat.
- json_encode: an oom field on json_private_data + a JSON_EMIT early-return macro wrapping every ph7_result_string emit in VmJsonEncode and the two walkers, with oom bail-outs after each walk/recursion and a check in vm_builtin_json_encode before the JSON-exception check (OOM is a fatal distinct from a JSON error; json_last_error untouched). The two tiny *_format key emits are left unchecked (ph7_result_string_format returns a byte count, not an rc) — an OOM there is caught by the next checked ph7_result_string.

Verified vs php 8.5.7: byte-for-byte normal output for all seven, and each fatals with "PH7 is running out of memory" (exit 255) under PHL_MAX_ALLOC=1048576, never a truncated result. make test (2207 smoke + 736 integration), test-compat (both engines), test-stress (12, incl. 6 new memory/*_oom.phpt) all green.

Deferred: tiny constant-table builders (allocate below the harness alloc floor, untestable), str_getcsv/fgetcsv (needs CSV parser rc-propagation verified), and json decode OOM (separate weaker path).
