### PR TITLE
Add per-instance object id: spl_object_id/hash, var_dump #N, __debugInfo

### DIFF
--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -7645,36 +7645,21 @@ PH7_PRIVATE void PH7_RegisterHashmapFunctions(ph7_vm *pVm)
  * This function SXRET_OK on success. Any other return value including
  * SXERR_LIMIT(infinite recursion) indicates failure.
  */
-PH7_PRIVATE sxi32 PH7_HashmapDump(SyBlob *pOut,ph7_hashmap *pMap,int ShowType,int nTab,int nDepth)
+/*
+ * Dump the entries of a hashmap [i.e: the key/value lines between the opening
+ * '{' and the closing '}'] in the var_dump/print_r style. Factored out of
+ * PH7_HashmapDump so the var_dump object renderer can reuse it for a
+ * __debugInfo() array body (which carries an object header, not "array(N)").
+ * Returns SXERR_LIMIT if a nested value hit the depth cap.
+ */
+PH7_PRIVATE sxi32 PH7_HashmapDumpEntries(SyBlob *pOut,ph7_hashmap *pMap,int ShowType,int nTab,int nDepth)
 {
-	ph7_hashmap_node *pEntry;
+	ph7_hashmap_node *pEntry = pMap->pFirst;
 	ph7_value *pObj;
 	sxu32 n = 0;
 	int isRef;
-	sxi32 rc;
+	sxi32 rc = SXRET_OK;
 	int i;
-	if( nDepth > 31 ){
-		static const char zInfinite[] = "Nesting limit reached: Infinite recursion?";
-		/* Nesting limit reached */
-		SyBlobAppend(&(*pOut),zInfinite,sizeof(zInfinite)-1);
-		if( ShowType ){
-			SyBlobAppend(&(*pOut),")",sizeof(char));
-		}
-		return SXERR_LIMIT;
-	}
-	/* Point to the first inserted entry */
-	pEntry = pMap->pFirst;
-	rc = SXRET_OK;
-	if( !ShowType ){
-		SyBlobAppend(&(*pOut),"Array(",sizeof("Array(")-1);
-	}
-	/* Total entries */
-	SyBlobFormat(&(*pOut),"%u) {",pMap->nEntry);
-#ifdef __WINNT__
-	SyBlobAppend(&(*pOut),"\r\n",sizeof("\r\n")-1);
-#else
-	SyBlobAppend(&(*pOut),"\n",sizeof(char));
-#endif
 	for(;;){
 		if( n >= pMap->nEntry ){
 			break;
@@ -7711,6 +7696,32 @@ PH7_PRIVATE sxi32 PH7_HashmapDump(SyBlob *pOut,ph7_hashmap *pMap,int ShowType,in
 		n++;
 		pEntry = pEntry->pPrev; /* Reverse link */
 	}
+	return rc;
+}
+PH7_PRIVATE sxi32 PH7_HashmapDump(SyBlob *pOut,ph7_hashmap *pMap,int ShowType,int nTab,int nDepth)
+{
+	sxi32 rc;
+	int i;
+	if( nDepth > 31 ){
+		static const char zInfinite[] = "Nesting limit reached: Infinite recursion?";
+		/* Nesting limit reached */
+		SyBlobAppend(&(*pOut),zInfinite,sizeof(zInfinite)-1);
+		if( ShowType ){
+			SyBlobAppend(&(*pOut),")",sizeof(char));
+		}
+		return SXERR_LIMIT;
+	}
+	if( !ShowType ){
+		SyBlobAppend(&(*pOut),"Array(",sizeof("Array(")-1);
+	}
+	/* Total entries */
+	SyBlobFormat(&(*pOut),"%u) {",pMap->nEntry);
+#ifdef __WINNT__
+	SyBlobAppend(&(*pOut),"\r\n",sizeof("\r\n")-1);
+#else
+	SyBlobAppend(&(*pOut),"\n",sizeof(char));
+#endif
+	rc = PH7_HashmapDumpEntries(&(*pOut),pMap,ShowType,nTab,nDepth);
 	for( i = 0 ; i < nTab ; i++ ){
 		SyBlobAppend(&(*pOut)," ",sizeof(char));
 	}

--- a/src/ph7/oo.c
+++ b/src/ph7/oo.c
@@ -644,6 +644,8 @@ static ph7_class_instance * NewClassInstance(ph7_vm *pVm,ph7_class *pClass)
 	pThis->iRef = 1;
 	pThis->pVm = pVm;
 	pThis->pClass = pClass;
+	/* Assign a fresh monotonic object handle id (clones get their own, like PHP). */
+	pThis->nObjId = pVm->nNextObjId++;
 	SyHashInit(&pThis->hAttr,&pVm->sAllocator,0,0);
 	return pThis;
 }
@@ -1033,6 +1035,26 @@ PH7_PRIVATE sxi32 PH7_ClassInstanceCmp(ph7_class_instance *pLeft,ph7_class_insta
  * This function SXRET_OK on success. Any other return value including
  * SXERR_LIMIT(infinite recursion) indicates failure.
  */
+/*
+ * Emit a class-instance dump header plus its trailing newline. For var_dump
+ * (ShowType) it completes the "object(" prefix the caller already emitted as
+ *   ClassName)#<id> (<count>) {
+ * for print_r it emits the legacy PHL  Object(ClassName) {  (count/id unused).
+ */
+static void DumpClassInstanceHeader(SyBlob *pOut,ph7_class *pClass,sxu32 nObjId,int ShowType,sxu32 nCount)
+{
+	if( !ShowType ){
+		SyBlobAppend(&(*pOut),"Object(",sizeof("Object(")-1);
+		SyBlobFormat(&(*pOut),"%z) {",&pClass->sName);
+	}else{
+		SyBlobFormat(&(*pOut),"%z)#%u (%u) {",&pClass->sName,nObjId,nCount);
+	}
+#ifdef __WINNT__
+	SyBlobAppend(&(*pOut),"\r\n",sizeof("\r\n")-1);
+#else
+	SyBlobAppend(&(*pOut),"\n",sizeof(char));
+#endif
+}
 PH7_PRIVATE sxi32 PH7_ClassInstanceDump(SyBlob *pOut,ph7_class_instance *pThis,int ShowType,int nTab,int nDepth)
 {
 	SyHashEntry *pEntry;
@@ -1049,16 +1071,49 @@ PH7_PRIVATE sxi32 PH7_ClassInstanceDump(SyBlob *pOut,ph7_class_instance *pThis,i
 		return SXERR_LIMIT;
 	}
 	rc = SXRET_OK;
-	if( !ShowType ){
-		SyBlobAppend(&(*pOut),"Object(",sizeof("Object(")-1);
+	{
+		/* Both var_dump and print_r consult __debugInfo() (PHP behavior);
+		 * var_export uses a separate renderer and never reaches here. When the
+		 * method is present and returns an array, render that array's entries as
+		 * the object body, with the header showing the debug array's count. The
+		 * nDepth guard above protects against a __debugInfo returning the object
+		 * itself. */
+		ph7_class_method *pDbg = PH7_ClassExtractMethod(pThis->pClass,"__debugInfo",sizeof("__debugInfo")-1);
+		if( pDbg ){
+			ph7_value sResult;
+			PH7_MemObjInit(pThis->pVm,&sResult);
+			PH7_VmCallClassMethod(pThis->pVm,pThis,pDbg,&sResult,0,0);
+			if( sResult.iFlags & MEMOBJ_HASHMAP ){
+				ph7_hashmap *pMap = (ph7_hashmap *)sResult.x.pOther;
+				/* Header count is the debug array's entry count. */
+				DumpClassInstanceHeader(&(*pOut),pThis->pClass,pThis->nObjId,ShowType,pMap->nEntry);
+				rc = PH7_HashmapDumpEntries(&(*pOut),pMap,ShowType,nTab,nDepth);
+				for( i = 0 ; i < nTab ; i++ ){
+					SyBlobAppend(&(*pOut)," ",sizeof(char));
+				}
+				SyBlobAppend(&(*pOut),"}",sizeof(char));
+				PH7_MemObjRelease(&sResult);
+				return rc;
+			}
+			/* Non-array return: behave as if __debugInfo were absent. */
+			PH7_MemObjRelease(&sResult);
+		}
 	}
-	/* Append class name */
-	SyBlobFormat(&(*pOut),"%z) {",&pThis->pClass->sName);
-#ifdef __WINNT__
-	SyBlobAppend(&(*pOut),"\r\n",sizeof("\r\n")-1);
-#else
-	SyBlobAppend(&(*pOut),"\n",sizeof(char));
-#endif
+	{
+		/* var_dump's header needs the property count up front, so pre-count the
+		 * non-static/non-constant attributes (matching the dump loop below). */
+		sxu32 nProp = 0;
+		if( ShowType ){
+			SyHashResetLoopCursor(&pThis->hAttr);
+			while((pEntry = SyHashGetNextEntry(&pThis->hAttr)) != 0){
+				VmClassAttr *pVmAttr = (VmClassAttr *)pEntry->pUserData;
+				if((pVmAttr->pAttr->iFlags & (PH7_CLASS_ATTR_CONSTANT|PH7_CLASS_ATTR_STATIC)) == 0 ){
+					nProp++;
+				}
+			}
+		}
+		DumpClassInstanceHeader(&(*pOut),pThis->pClass,pThis->nObjId,ShowType,nProp);
+	}
 	/* Dump object attributes */
 	SyHashResetLoopCursor(&pThis->hAttr);
 	while((pEntry = SyHashGetNextEntry(&pThis->hAttr)) != 0){

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -728,6 +728,8 @@ struct ph7_class_instance
 	SyHash hAttr;       /* Hashtable of active class members */
 	sxi32 iRef;         /* Reference count */
 	sxi32 iFlags;       /* Control flags */
+	sxu32 nObjId;       /* Per-instance monotonic handle id (from pVm->nNextObjId,
+	                     * never reused). Drives spl_object_id/hash + var_dump #N. */
 };
 /*
  * A single instruction of the virtual machine has an opcode
@@ -913,6 +915,8 @@ struct ph7_vm
 	int closure_cnt;           /* Loaded closures counter */
 	int json_rc;               /* JSON return status [refer to json_encode()/json_decode()]*/
 	sxu32 unique_id;           /* Random number used to generate unique ID [refer to uniqid() for more info]*/
+	sxu32 nNextObjId;          /* Next object handle id to hand out (monotonic; reset to 1 per exec
+	                            * so a reused VM looks like a fresh process). See ph7_class_instance.nObjId */
 	ProcErrLog xErrLog;        /* error_log() consumer [refer to PH7_VM_CONFIG_ERR_LOG_HANDLER] */
 	sxu32 nOutputLen;          /* Total number of generated output */
 	ph7_output_consumer sVmConsumer; /* Registered output consumer callback */
@@ -1611,6 +1615,8 @@ PH7_PRIVATE int vm_builtin_get_class_methods(ph7_context *pCtx,int nArg,ph7_valu
 PH7_PRIVATE int vm_builtin_get_class_vars(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE int vm_builtin_get_object_vars(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE int vm_builtin_is_a(ph7_context *pCtx,int nArg,ph7_value **apArg);
+PH7_PRIVATE int vm_builtin_spl_object_id(ph7_context *pCtx,int nArg,ph7_value **apArg);
+PH7_PRIVATE int vm_builtin_spl_object_hash(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE int vm_builtin_is_subclass_of(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE int vm_builtin_call_user_func(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE int vm_builtin_call_user_func_array(ph7_context *pCtx,int nArg,ph7_value **apArg);
@@ -1754,6 +1760,7 @@ PH7_PRIVATE void PH7_HashmapExtractNodeValue(ph7_hashmap_node *pNode,ph7_value *
 PH7_PRIVATE void PH7_HashmapExtractNodeKey(ph7_hashmap_node *pNode,ph7_value *pKey);
 PH7_PRIVATE void PH7_RegisterHashmapFunctions(ph7_vm *pVm);
 PH7_PRIVATE sxi32 PH7_HashmapDump(SyBlob *pOut,ph7_hashmap *pMap,int ShowType,int nTab,int nDepth);
+PH7_PRIVATE sxi32 PH7_HashmapDumpEntries(SyBlob *pOut,ph7_hashmap *pMap,int ShowType,int nTab,int nDepth);
 PH7_PRIVATE sxi32 PH7_HashmapWalk(ph7_hashmap *pMap,int (*xWalk)(ph7_value *,ph7_value *,void *),void *pUserData);
 PH7_PRIVATE int PH7_HashmapIsList(ph7_hashmap *pMap);
 #ifndef PH7_DISABLE_DISK_IO

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -1968,6 +1968,8 @@ PH7_PRIVATE sxi32 PH7_VmMakeReady(
 	}
 	/* Random number betwwen 0 and 1023 used to generate unique ID */
 	pVm->unique_id = PH7_VmRandomNum(&(*pVm)) & 1023;
+	/* First object handle id handed out is 1 (matches PHP's first userland object #1) */
+	pVm->nNextObjId = 1;
 	/* VM is ready for bytecode execution */
 	return SXRET_OK;
 }
@@ -2243,6 +2245,9 @@ PH7_PRIVATE sxi32 PH7_VmReset(ph7_vm *pVm)
 	VmReinitMemObj(&(*pVm),&pVm->sCoalesceKey);
 	/* Re-roll the uniqid() seed, matching PH7_VmMakeReady(). */
 	pVm->unique_id = PH7_VmRandomNum(&(*pVm)) & 1023;
+	/* Restart object handle ids per exec so a reused VM (e.g. the -S server)
+	 * looks like a fresh process, matching PH7_VmMakeReady(). */
+	pVm->nNextObjId = 1;
 	/* Set the ready flag */
 	pVm->nMagic = PH7_VM_RUN;
 	return SXRET_OK;
@@ -16851,6 +16856,9 @@ static const ph7_builtin_func aVmFunc[] = {
 	{ "get_object_vars",         vm_builtin_get_object_vars   },
 	{ "is_subclass_of",          vm_builtin_is_subclass_of    },
 	{ "is_a", vm_builtin_is_a },
+	   /* SPL object identity */
+	{ "spl_object_id",   vm_builtin_spl_object_id   },
+	{ "spl_object_hash", vm_builtin_spl_object_hash },
 	   /* SPL Autoloading */
 	{ "spl_autoload_register",   vm_builtin_spl_autoload_register   },
 	{ "spl_autoload_unregister", vm_builtin_spl_autoload_unregister },

--- a/src/ph7/vm_builtin_class.c
+++ b/src/ph7/vm_builtin_class.c
@@ -827,6 +827,43 @@ PH7_PRIVATE int vm_builtin_is_a(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	return PH7_OK;
 }
 /*
+ * int spl_object_id(object $object)
+ *  Return the integer object handle (per-instance id) of the given object.
+ * PHL note: PHP 8 throws a TypeError when passed a non-object; PHL returns NULL
+ * to stay consistent with the engine's graceful-degradation convention.
+ */
+PH7_PRIVATE int vm_builtin_spl_object_id(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	ph7_class_instance *pThis;
+	if( nArg < 1 || !ph7_value_is_object(apArg[0]) ){
+		ph7_result_null(pCtx);
+		return PH7_OK;
+	}
+	pThis = (ph7_class_instance *)apArg[0]->x.pOther;
+	ph7_result_int64(pCtx,(ph7_int64)pThis->nObjId);
+	return PH7_OK;
+}
+/*
+ * string spl_object_hash(object $object)
+ *  Return a 32-char hex identifier, unique and stable per live object.
+ * PHL note: PHP derives this from the internal handle plus a per-process key, so
+ * the exact value is NOT reproducible. PHL returns the zero-padded object id,
+ * which preserves the only guaranteed properties: unique per live object, stable
+ * across calls, and distinct objects -> distinct strings. A non-object returns
+ * NULL (PHP 8 throws a TypeError; see spl_object_id above).
+ */
+PH7_PRIVATE int vm_builtin_spl_object_hash(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	ph7_class_instance *pThis;
+	if( nArg < 1 || !ph7_value_is_object(apArg[0]) ){
+		ph7_result_null(pCtx);
+		return PH7_OK;
+	}
+	pThis = (ph7_class_instance *)apArg[0]->x.pOther;
+	ph7_result_string_format(pCtx,"%08x%08x%08x%08x",0,0,0,(unsigned int)pThis->nObjId);
+	return PH7_OK;
+}
+/*
  * bool is_subclass_of(object/string $object,object/string $class_name)
  *   Checks if the object has this class as one of its parents.
  * Parameters

--- a/tests/ph7/001-smoke/oo/object_var_dump.phpt
+++ b/tests/ph7/001-smoke/oo/object_var_dump.phpt
@@ -19,7 +19,7 @@ $output = ob_get_clean();
 echo $output;
 ?>
 --EXPECTF--
-object(TestClass) {
+object(TestClass)#%d (2) {
  ['public_attr'] =>
   string(4) "test"
  ['private_attr'] =>

--- a/tests/ph7/002-integration/oo/spl_object_hash_relational.phpt
+++ b/tests/ph7/002-integration/oo/spl_object_hash_relational.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+spl_object_hash() returns a 32-char string, stable per object and distinct across objects
+--DESCRIPTION--
+The exact hash value is PHP-internal-handle derived and NOT reproducible; PHL
+returns the zero-padded object id. Only the guaranteed properties (length 32,
+stable per object, distinct objects -> distinct) are asserted, so this runs
+under both engines.
+--FILE--
+<?php
+class C {}
+$a = new C; $b = new C;
+echo strlen(spl_object_hash($a)), "\n";
+echo (spl_object_hash($a) === spl_object_hash($a)) ? "stable\n" : "unstable\n";
+echo (spl_object_hash($a) !== spl_object_hash($b)) ? "distinct\n" : "same\n";
+?>
+--EXPECT--
+32
+stable
+distinct
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/spl_object_id_absolute.phpt
+++ b/tests/ph7/002-integration/oo/spl_object_id_absolute.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+spl_object_id() hands out sequential ids starting at 1 (objects held alive)
+--FILE--
+<?php
+class C {}
+$a = new C; $b = new C; $c = new C;
+echo spl_object_id($a), "\n";
+echo spl_object_id($b), "\n";
+echo spl_object_id($c), "\n";
+?>
+--EXPECT--
+1
+2
+3
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/spl_object_id_clone.phpt
+++ b/tests/ph7/002-integration/oo/spl_object_id_clone.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A cloned object receives its own distinct object id
+--FILE--
+<?php
+class C { public $v = 1; }
+$a = new C;
+$b = clone $a;
+echo (spl_object_id($a) !== spl_object_id($b)) ? "distinct\n" : "same\n";
+?>
+--EXPECT--
+distinct
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/spl_object_id_relational.phpt
+++ b/tests/ph7/002-integration/oo/spl_object_id_relational.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+spl_object_id() is stable per object and distinct across objects
+--FILE--
+<?php
+class C {}
+$a = new C; $b = new C;
+echo (spl_object_id($a) === spl_object_id($a)) ? "stable\n" : "unstable\n";
+echo (spl_object_id($a) !== spl_object_id($b)) ? "distinct\n" : "same\n";
+echo function_exists('spl_object_id') ? "exists\n" : "missing\n";
+?>
+--EXPECT--
+stable
+distinct
+exists
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/var_dump_debuginfo.phpt
+++ b/tests/ph7/002-integration/oo/var_dump_debuginfo.phpt
@@ -1,0 +1,45 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+var_dump and print_r consult __debugInfo(); var_export and foreach use real props
+--DESCRIPTION--
+PHL-only on the dump byte format. Semantics match PHP: var_dump/print_r show the
+__debugInfo() array (real "secret" hidden), while var_export and foreach see the
+real properties.
+--SKIPIF--
+<?php if (function_exists('zend_version')) echo 'skip'; ?>
+--FILE--
+<?php
+class D {
+    public $secret = 42;
+    public function __debugInfo() { return ['shown' => 'yes', 'n' => 7]; }
+}
+$o = new D;
+var_dump($o);
+print_r($o);
+echo "\n";
+var_export($o);
+echo "\n";
+foreach ($o as $k => $v) { echo "$k=$v\n"; }
+?>
+--EXPECT--
+object(D)#1 (2) {
+ [shown] =>
+  string(3) "yes"
+ [n] =>
+  int(7)
+ }
+Object(D) {
+ [shown] =>
+  yes
+ [n] =>
+  7
+ }
+
+\D::__set_state(array(
+   'secret' => 42,
+))
+secret=42
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/var_dump_object_header.phpt
+++ b/tests/ph7/002-integration/oo/var_dump_object_header.phpt
@@ -1,0 +1,25 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+var_dump object header is object(Class)#id (propCount); static/const excluded from count
+--DESCRIPTION--
+PHL-only: the var_dump header now carries the object id (#N) and the property
+count, but the body keeps PHL's existing format (single-quoted keys, 1-space
+indent) — full var_dump byte-fidelity is a separate deferred task.
+--SKIPIF--
+<?php if (function_exists('zend_version')) echo 'skip'; ?>
+--FILE--
+<?php
+class C { public $x = 1; public $y = "two"; public static $s = 9; const K = 5; }
+var_dump(new C);
+?>
+--EXPECT--
+object(C)#1 (2) {
+ ['x'] =>
+  int(1)
+ ['y'] =>
+  string(3) "two"
+ }
+--CLEAN--
+<?php


### PR DESCRIPTION
PHL objects had no handle/identity, blocking spl_object_id/spl_object_hash, var_dump's object(C)#N (count) header, and __debugInfo. Add one field and wire the three consumers.

- sxu32 nObjId on ph7_class_instance, assigned from a per-VM monotonic nNextObjId at the single creation choke point (NewClassInstance) — so new and clone both get it, and a clone receives its own id like PHP. Counter inits to 1 in PH7_VmMakeReady and resets to 1 in PH7_VmReset, so a reused VM (-S server) sees ids from 1 per request like a fresh process.
- spl_object_id / spl_object_hash (vm_builtin_class.c, registered in aVmFunc[]): id as int; a 32-char hex (%08x x4 of the id, robust without %032llx). Non- object returns NULL (PHL graceful-degradation; PHP 8 throws TypeError).
- var_dump object header: PH7_ClassInstanceDump completes the "object(" prefix as ClassName)#id (count) {, counting non-static/non-constant props; print_r's Object(C) { is unchanged.
- __debugInfo: var_dump AND print_r render the returned array as the body (real props hidden); var_export and foreach keep real props — matches PHP. Reuses a new PH7_HashmapDumpEntries factored out of PH7_HashmapDump.

Verified vs php 8.5.7: spl_object_id ids 1,2,3 + clone-new-id match byte for byte (objects held alive); __debugInfo/var_export/foreach property visibility matches. make test (2207 smoke + 742 integration), test-compat (both engines), test-stress (13) all green.

Divergences (documented): monotonic ids don't reuse freed handles (PHP does, so reproducible (zero-padded id); var_dump body format still PHL (full byte- fidelity deferred); sxu32 wrap at ~4e9 creations.

## Checklist
