### PR TITLE
Isolate a generator/fiber's exception handlers across suspend/resume

### DIFF
--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -452,7 +452,12 @@ struct ph7_exec_ctx
 	sxi32 iState;             /* One of PH7_CTX_STATE_* */
 	ph7_value sSuspendValue;  /* Value passed out via Fiber::suspend() / yield */
 	ph7_value sRetValue;      /* Final return value */
-	sxu32 nExceptionBase;     /* Exception stack depth at entry */
+	sxu32 nExceptionBase;     /* Exception-stack depth below this body's own handlers
+	                           * (caller depth); refreshed at each resume */
+	SySet aSavedException;    /* This body's own exception handlers (ph7_exception*),
+	                           * parked here while suspended so a generator/fiber that
+	                           * suspends inside a try does not corrupt the caller's
+	                           * exception stack */
 	void *pPrivate;           /* Generator wrapper (ph7_generator*) or NULL for fibers */
 	/* `yield from` delegation state — per generator instance, so independent
 	 * instances never clash (unlike the shared foreach aStep). */

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -4807,7 +4807,18 @@ static sxi32 VmByteCodeExec(
 	}else{
 		pTos = &pStack[nTos];
 	}
-	nExceptionBase = SySetUsed(&pVm->aException);
+	/* Finally-drain base. For a resumed generator/fiber TOP-LEVEL body, its own
+	 * exception handlers were just re-published above the caller depth
+	 * (VmRestoreCtxExceptionHandlers), so the live SySetUsed over-counts; take the
+	 * caller-depth base recorded on the ctx instead. The pFrame==active-ctx-frame
+	 * guard restricts this to the resumed body only — a nested call or a
+	 * catch/finally mini-program run within it has a different pVm->pFrame and
+	 * falls through to the live depth (the common, unchanged path). */
+	if( pVm->pActiveCtx && pVm->pActiveCtx->pFrame == pVm->pFrame ){
+		nExceptionBase = pVm->pActiveCtx->nExceptionBase;
+	}else{
+		nExceptionBase = SySetUsed(&pVm->aException);
+	}
 	pEntryFrame = pVm->pFrame;
 	pc = nPc;
 	if( !bReturnPropagates && pVm->bReturnRequested ){
@@ -10912,6 +10923,9 @@ static ph7_exec_ctx * VmNewExecCtx(ph7_vm *pVm, ph7_vm_func *pFunc)
 	PH7_MemObjInit(pVm, &pCtx->sSuspendValue);
 	PH7_MemObjInit(pVm, &pCtx->sRetValue);
 	PH7_MemObjInit(pVm, &pCtx->sDelegate);
+	/* Container for this body's own exception handlers while suspended (borrowed
+	 * ph7_exception* pointers — never freed here, owned by the compiled func). */
+	SySetInit(&pCtx->aSavedException, &pVm->sAllocator, sizeof(ph7_exception *));
 	/* Allocate a private operand stack */
 	pStack = VmNewOperandStack(pVm, SySetUsed(&pFunc->aByteCode));
 	if( pStack == 0 ){
@@ -10928,6 +10942,41 @@ static ph7_exec_ctx * VmNewExecCtx(ph7_vm *pVm, ph7_vm_func *pFunc)
 	}
 	pCtx->pFrame = pFrame;
 	return pCtx;
+}
+/*
+ * On suspend, move this exec-context's own exception handlers (the entries on
+ * pVm->aException above pCtx->nExceptionBase) into pCtx->aSavedException and
+ * truncate the global stack back to the caller's depth. Without this, a
+ * generator/fiber that suspends inside a try leaves handlers referencing its
+ * now-detached frame on the global stack, corrupting the caller's try/catch.
+ */
+static void VmParkCtxExceptionHandlers(ph7_vm *pVm, ph7_exec_ctx *pCtx)
+{
+	sxu32 nUsed = SySetUsed(&pVm->aException);
+	if( nUsed > pCtx->nExceptionBase ){
+		ph7_exception **apBase = (ph7_exception **)SySetBasePtr(&pVm->aException);
+		sxu32 i;
+		for( i = pCtx->nExceptionBase; i < nUsed; i++ ){
+			SySetPut(&pCtx->aSavedException, (const void *)&apBase[i]);
+		}
+		SySetTruncate(&pVm->aException, pCtx->nExceptionBase);
+	}
+}
+/*
+ * On resume, re-publish the parked handlers on top of pVm->aException (at the
+ * current caller depth, already recorded in pCtx->nExceptionBase) and clear the
+ * park. Inverse of VmParkCtxExceptionHandlers.
+ */
+static void VmRestoreCtxExceptionHandlers(ph7_vm *pVm, ph7_exec_ctx *pCtx)
+{
+	sxu32 i, n = SySetUsed(&pCtx->aSavedException);
+	if( n > 0 ){
+		ph7_exception **apSaved = (ph7_exception **)SySetBasePtr(&pCtx->aSavedException);
+		for( i = 0; i < n; i++ ){
+			SySetPut(&pVm->aException, (const void *)&apSaved[i]);
+		}
+		SySetReset(&pCtx->aSavedException);
+	}
 }
 /*
  * Start executing a fiber context for the first time.
@@ -10964,6 +11013,7 @@ static sxi32 VmStartCtx(ph7_vm *pVm, ph7_exec_ctx *pCtx, ph7_value *pResult)
 		/* Fiber suspended. Detach the fiber's frame from the VM chain. */
 		pVm->pFrame = pCtx->pFrame->pParent;
 		pCtx->pFrame->pParent = 0;
+		VmParkCtxExceptionHandlers(pVm, pCtx);
 		if( pResult ){
 			PH7_MemObjStore(&pCtx->sSuspendValue, pResult);
 		}
@@ -11013,6 +11063,12 @@ static sxi32 VmResumeCtx(ph7_vm *pVm, ph7_exec_ctx *pCtx, ph7_value *pResumeValu
 		PH7_MemObjRelease(&pCtx->pStack[pCtx->nTos + 1]);
 	}
 	pCtx->nTos++;
+	/* Refresh the caller-depth base and re-publish this body's own exception
+	 * handlers on top of pVm->aException at that depth, so the resumed body's
+	 * try/catch and finally-drain bound line up (see VmByteCodeExec's base
+	 * override). Must run before VmByteCodeExec recaptures its local base. */
+	pCtx->nExceptionBase = SySetUsed(&pVm->aException);
+	VmRestoreCtxExceptionHandlers(pVm, pCtx);
 	/* Re-attach the fiber's frame to the VM frame chain */
 	pCtx->pFrame->pParent = pVm->pFrame;
 	pVm->pFrame = pCtx->pFrame;
@@ -11032,6 +11088,7 @@ static sxi32 VmResumeCtx(ph7_vm *pVm, ph7_exec_ctx *pCtx, ph7_value *pResumeValu
 		/* Fiber suspended again. Detach the fiber's frame. */
 		pVm->pFrame = pCtx->pFrame->pParent;
 		pCtx->pFrame->pParent = 0;
+		VmParkCtxExceptionHandlers(pVm, pCtx);
 		if( pResult ){
 			PH7_MemObjStore(&pCtx->sSuspendValue, pResult);
 		}
@@ -11074,6 +11131,9 @@ static void VmReleaseExecCtx(ph7_vm *pVm, ph7_exec_ctx *pCtx)
 	PH7_MemObjRelease(&pCtx->sSuspendValue);
 	PH7_MemObjRelease(&pCtx->sRetValue);
 	PH7_MemObjRelease(&pCtx->sDelegate);
+	/* Free only the SySet backing — the parked ph7_exception* entries are owned
+	 * by the compiled function, not by us. */
+	SySetRelease(&pCtx->aSavedException);
 	/* Release the frame if it's detached (not in the VM chain) */
 	if( pCtx->pFrame ){
 		VmSlot *aSlot;

--- a/tests/ph7/002-integration/lang/fiber_suspend_in_try_isolated.phpt
+++ b/tests/ph7/002-integration/lang/fiber_suspend_in_try_isolated.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A fiber suspended inside a try does not corrupt the caller's exception handling
+--FILE--
+<?php
+$f = new Fiber(function () {
+    try { Fiber::suspend(1); }
+    catch (\Throwable $e) { echo "FIBER WRONGLY CAUGHT\n"; }
+});
+$f->start();   // suspends inside the fiber's try
+try { throw new Exception("caller-exc"); }
+catch (Exception $e) { echo "caller caught: ", $e->getMessage(), "\n"; }
+$f->resume();
+echo "done\n";
+?>
+--EXPECT--
+caller caught: caller-exc
+done
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/generator_finally_on_resume.phpt
+++ b/tests/ph7/002-integration/lang/generator_finally_on_resume.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A generator's finally runs when it returns from inside a try after a resume
+--FILE--
+<?php
+function gen() {
+    try { yield 1; return; }
+    finally { echo "FIN\n"; }
+}
+$g = gen();
+echo $g->current(), "\n";   // into the try, suspend
+$g->next();                 // resume, hit 'return' inside the try -> finally runs
+echo "after\n";
+?>
+--EXPECT--
+1
+FIN
+after
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/generator_independent_try_isolated.phpt
+++ b/tests/ph7/002-integration/lang/generator_independent_try_isolated.phpt
@@ -1,0 +1,25 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Two independent generators each suspended inside their own try stay isolated
+--FILE--
+<?php
+function gen($id) {
+    try { yield "$id-a"; yield "$id-b"; }
+    catch (\Throwable $e) { echo "$id GEN WRONGLY CAUGHT\n"; }
+}
+$g1 = gen(1); $g2 = gen(2);
+echo $g1->current(), " ", $g2->current(), "\n";
+try { throw new Exception("x"); } catch (Exception $e) { echo "caught\n"; }
+$g1->next(); $g2->next();
+echo $g1->current(), " ", $g2->current(), "\n";
+echo "done\n";
+?>
+--EXPECT--
+1-a 2-a
+caught
+1-b 2-b
+done
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/generator_suspend_in_try_isolated.phpt
+++ b/tests/ph7/002-integration/lang/generator_suspend_in_try_isolated.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A generator suspended inside a try does not corrupt the caller's exception handling
+--FILE--
+<?php
+function gen() {
+    try { yield 1; yield 2; }
+    catch (\Throwable $e) { echo "GEN WRONGLY CAUGHT: ", $e->getMessage(), "\n"; }
+}
+$g = gen();
+echo $g->current(), "\n";   // advances into the try, suspends at 'yield 1'
+try { throw new Exception("caller-exc"); }
+catch (Exception $e) { echo "caller caught: ", $e->getMessage(), "\n"; }
+echo "done\n";
+?>
+--EXPECT--
+1
+caller caught: caller-exc
+done
+--CLEAN--
+<?php


### PR DESCRIPTION
A generator (or fiber) that suspended inside a try left its exception handlers on the VM-global pVm->aException stack, referencing its now-detached frame. The caller's subsequent try/catch was then mis-routed: e.g. after `$g->current()` on a generator suspended inside a try, a caller `try{ throw } catch{}` silently dropped everything (no output, rc=0). Correctness hazard for any code that uses a generator/fiber and later does try/catch.

Fix: park the body's own handlers (entries above its caller-depth base) into a new ph7_exec_ctx.aSavedException on suspend and truncate the global stack back to the caller depth; re-publish them on resume at the refreshed caller depth. The parked entries are borrowed ph7_exception* (owned by the compiled func), freed only as a SySet on ctx release. Applies to generators and fibers alike.

The delicate part: VmByteCodeExec's finally-drain base (nExceptionBase) is recaptured from SySetUsed at entry, which over-counts once the body's handlers are re-published above the caller depth. For a resumed top-level body (guarded by pVm->pActiveCtx->pFrame == pVm->pFrame, which excludes nested calls and catch/finally mini-programs) take the caller-depth base from the ctx instead, so a generator returning from inside a try-with-finally still drains its finally exactly once.

Verified byte-for-byte vs php 8.5.7: the headline leak, a fiber suspended in a try, a generator's finally running on resume-return, and two independent generators each suspended in their own try interleaved with caller throws. make test (2207 smoke + 746 integration), test-compat (both engines), test-stress (13) all green; the existing generator/fiber/yield suite (incl. yield_from_caught_continues) unregressed.
