### PR TITLE
Generator::throw(): propagate the real exception + validate Throwable

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -1413,7 +1413,7 @@ static int vm_builtin_Generator_destruct(ph7_context *pCtx, int nArg, ph7_value 
 	"  public function rewind(){ return __gen_rewind($this); }"\
 	"  public function valid(){ return __gen_valid($this); }"\
 	"  public function send($value = null){ return __gen_send($this,$value); }"\
-	"  public function throw($exception){ return __gen_throw($this,$exception); }"\
+	"  public function throw(Throwable $exception){ return __gen_throw($this,$exception); }"\
 	"  public function getReturn(){ return __gen_getReturn($this); }"\
 	"  public function __destruct(){ __gen_destruct($this); }"\
 	"}"\
@@ -11928,49 +11928,72 @@ static int vm_builtin_Generator_send(ph7_context *pCtx, int nArg, ph7_value **ap
 /*
  * Generator::throw($exception) — throw an exception into the generator.
  *
- * TODO: Full PHP semantics require injecting the exception at the yield
- * point so the generator's own try/catch can handle it. This needs a
- * pending-exception field on ph7_exec_ctx and a check at the start of
- * VmByteCodeExec resume. For now we close the generator and propagate
- * the exception to the caller.
+ * Full PHP semantics inject the exception at the suspended yield point so the
+ * generator's OWN try/catch can handle it and execution resumes. That requires
+ * keeping the generator's exception (try) frame — and thus its resume landing
+ * pad — live across suspend/resume, which the current generator frame model
+ * discards on resume (it saves only the body frame). Until that frame-model
+ * rework lands (see PLAN.md), we close the generator and propagate the ACTUAL
+ * exception object (preserving its class/type, message and trace) to the
+ * throw() caller — byte-for-byte correct whenever the generator would not have
+ * caught the exception itself (incl. a finished generator), and the documented
+ * limitation only when the generator has a try/catch around the yield.
+ *
+ * PHL does not enforce the Throwable parameter hint (interface/class hints are
+ * not checked on call), so the Throwable validation — and its PHP TypeError —
+ * are done here.
  */
 static int vm_builtin_Generator_throw(ph7_context *pCtx, int nArg, ph7_value **apArg)
 {
 	ph7_generator *pGen;
-	const char *zMsg;
-	int nLen;
+	ph7_class_instance *pInj;
+	ph7_class *pThrowable;
+	VmFrame *pFrame;
+	sxi32 rc;
 	if( nArg < 2 ) return PH7_OK;
+	/* Argument #1 must be a Throwable; otherwise PHP raises a TypeError naming
+	 * the given type (class name for objects, "null"/"string"/... for scalars). */
+	pThrowable = PH7_VmExtractClass(pCtx->pVm, "Throwable", sizeof("Throwable")-1, 0, 0);
+	if( (apArg[1]->iFlags & MEMOBJ_OBJ) == 0
+	 || (pThrowable && !PH7_VmInstanceOf(((ph7_class_instance *)apArg[1]->x.pOther)->pClass, pThrowable)) ){
+		char zCls[128];
+		const char *zGiven = (apArg[1]->iFlags & MEMOBJ_OBJ)
+			? VmFormatValueClassName(apArg[1], zCls, sizeof(zCls))
+			: ((apArg[1]->iFlags & MEMOBJ_NULL) ? "null" : ph7_type_name(apArg[1]));
+		return PH7_VmThrowException(pCtx, "TypeError",
+			"Generator::throw(): Argument #1 ($exception) must be of type Throwable, %s given", zGiven);
+	}
 	pGen = VmGeneratorExtractCtx(pCtx->pVm, apArg[0]);
 	if( pGen == 0 ) return PH7_OK;
-	if( pGen->pCtx->iState == PH7_CTX_STATE_COMPLETED ||
-		pGen->pCtx->iState == PH7_CTX_STATE_CLOSED ){
+	/* PHP forbids resuming/throwing into a generator that is currently executing. */
+	if( pGen->pCtx->iState == PH7_CTX_STATE_RUNNING ){
 		return PH7_VmThrowException(pCtx, "Error",
-			"Cannot throw into a closed generator");
+			"Cannot resume an already running generator");
 	}
-	/* Close the generator. Re-throw the exception properly via
-	 * PH7_VmThrowException so that VM_FRAME_THROW is set and the
-	 * exception dispatch path works correctly. Extract the message
-	 * from the passed exception object if possible. */
-	pGen->pCtx->iState = PH7_CTX_STATE_CLOSED;
-	zMsg = "Unknown exception thrown into generator";
-	nLen = 0;
-	if( apArg[1]->iFlags & MEMOBJ_OBJ ){
-		/* Try to get the exception's message */
-		SyString sAttr;
-		ph7_value *pMsgAttr;
-		SyStringInitFromBuf(&sAttr, "message", 7);
-		pMsgAttr = PH7_ClassInstanceFetchAttr(
-			(ph7_class_instance *)apArg[1]->x.pOther, &sAttr);
-		if( pMsgAttr && (pMsgAttr->iFlags & MEMOBJ_STRING) ){
-			zMsg = (const char *)SyBlobData(&pMsgAttr->sBlob);
-			nLen = (int)SyBlobLength(&pMsgAttr->sBlob);
-		}
-	}else if( apArg[1]->iFlags & MEMOBJ_STRING ){
-		zMsg = (const char *)SyBlobData(&apArg[1]->sBlob);
-		nLen = (int)SyBlobLength(&apArg[1]->sBlob);
+	/* A still-active (created/suspended) generator can no longer catch the
+	 * injected exception (inject-at-yield is deferred), so close it. A generator
+	 * that already finished keeps its terminal state — and thus its return value,
+	 * which getReturn() still reads — and we simply propagate the exception.
+	 * Re-throw the supplied instance through the normal dispatch path so the
+	 * throw() call site's try/catch (and the uncaught handler) see the real
+	 * object. Hold a ref across VmThrowException, which may run catch blocks. */
+	if( pGen->pCtx->iState != PH7_CTX_STATE_COMPLETED
+	 && pGen->pCtx->iState != PH7_CTX_STATE_CLOSED ){
+		pGen->pCtx->iState = PH7_CTX_STATE_CLOSED;
 	}
-	(void)nLen;
-	return PH7_VmThrowException(pCtx, "Exception", "%s", zMsg);
+	pInj = (ph7_class_instance *)apArg[1]->x.pOther;
+	pInj->iRef++;
+	pFrame = pCtx->pVm->pFrame;
+	if( pFrame ){
+		pFrame = VmSkipExceptionFrames(pFrame);
+		pFrame->iFlags |= VM_FRAME_THROW;
+	}
+	rc = VmThrowException(pCtx->pVm, pInj);
+	PH7_ClassInstanceUnref(pInj);
+	if( rc == SXERR_ABORT ){
+		return PH7_ABORT;
+	}
+	return PH7_EXCEPTION;
 }
 /*
  * Generator::getReturn() — get the return value after the generator has finished.

--- a/tests/ph7/002-integration/lang/generator_throw_propagates.phpt
+++ b/tests/ph7/002-integration/lang/generator_throw_propagates.phpt
@@ -1,0 +1,59 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Generator::throw() propagates the actual exception object (class + message) to the caller
+--FILE--
+<?php
+function gen() { yield 1; yield 2; }
+$g = gen();
+echo $g->current(), "\n";
+try {
+    $g->throw(new RuntimeException("boom"));
+} catch (RuntimeException $e) {
+    echo "caught ", get_class($e), ": ", $e->getMessage(), "\n";
+}
+// Throwing into an already-finished generator also propagates the object.
+function done() { if (false) { yield; } }
+$d = done();
+$d->current();
+try {
+    $d->throw(new LogicException("after-end"));
+} catch (LogicException $e) {
+    echo "caught ", get_class($e), ": ", $e->getMessage(), "\n";
+}
+// Throwing into a *completed* generator must not destroy its return value.
+function ret() { yield 1; return 42; }
+$r = ret();
+$r->current();
+$r->next();                       // runs to completion (return 42)
+try {
+    $r->throw(new RuntimeException("late"));
+} catch (RuntimeException $e) {
+    echo "caught ", $e->getMessage(), "\n";
+}
+echo "getReturn=", $r->getReturn(), "\n";   // still 42, state preserved
+// Throwing into a generator that is currently executing is an Error.
+$run = (function () {
+    $me = yield 1;
+    try {
+        $me->throw(new RuntimeException("boom"));
+    } catch (\Error $e) {
+        echo "running: ", $e->getMessage(), "\n";
+    }
+    yield 2;
+})();
+$run->current();
+$run->send($run);
+echo "end\n";
+?>
+--EXPECT--
+1
+caught RuntimeException: boom
+caught LogicException: after-end
+caught late
+getReturn=42
+running: Cannot resume an already running generator
+end
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/generator_throw_typeerror.phpt
+++ b/tests/ph7/002-integration/lang/generator_throw_typeerror.phpt
@@ -1,0 +1,26 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Generator::throw() raises a TypeError when the argument is not a Throwable
+--FILE--
+<?php
+class Plain {}
+function gen() { yield 1; }
+foreach ([ "nope", null, 42, new Plain() ] as $bad) {
+    $g = gen();
+    $g->current();
+    try {
+        $g->throw($bad);
+    } catch (\TypeError $e) {
+        echo $e->getMessage(), "\n";
+    }
+}
+?>
+--EXPECT--
+Generator::throw(): Argument #1 ($exception) must be of type Throwable, string given
+Generator::throw(): Argument #1 ($exception) must be of type Throwable, null given
+Generator::throw(): Argument #1 ($exception) must be of type Throwable, int given
+Generator::throw(): Argument #1 ($exception) must be of type Throwable, Plain given
+--CLEAN--
+<?php


### PR DESCRIPTION
The old builtin re-wrapped the thrown exception as a generic Exception (losing its class/type) and raised a spurious "Cannot throw into a closed generator" Error for finished generators. Rewrite it to PHP semantics for the cases the engine can support today:

- Validate argument 1 is a Throwable, else a PHP-exact TypeError naming the given type (PHL does not enforce interface param hints, so it is checked in C).
- Throwing into a currently-running generator raises Error "Cannot resume an already running generator".
- Otherwise re-throw the ACTUAL exception instance (class, message and trace preserved) to the throw() call site via the normal dispatch path. A still- active generator is closed first; a generator that already finished keeps its terminal state, so its return value stays readable via getReturn().

Full inject-at-yield (the generator's own try/catch catches the exception and execution resumes) stays deferred: it needs the generator frame model to keep the exception frame live across resume (see PLAN.md). Until then PHL propagates instead of catching in-generator — correct unless the generator has a try/catch around the suspended yield.
