### PR TITLE
Support intersection types A&B (8.1) and DNF types (A&B)|C

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -6099,12 +6099,9 @@ static int SyMemcmpNoCase(const char *zA, const char *zB, sxu32 n)
 #define UTA_VOID_FLAG  ((sxu32)0xFFFFFFF1)  /* the `void` keyword */
 #define UTA_NEVER_FLAG ((sxu32)0xFFFFFFF2)  /* the `never` keyword */
 
-/* Maximum number of alternatives in a single union type declaration.
- * Picked to be larger than any union type seen in real PHP codebases
- * (typical max is 4-6, with the largest internal PHP unions around 8).
- * The atom array lives on the parser stack, so the cost is bounded:
- * 32 * sizeof(PhlTypeAtom) ≈ 1 KiB. */
-#define PHL_UNION_MAX_ALTS 32
+/* PHL_UNION_MAX_ALTS (max alternatives in one type declaration) is defined in
+ * ph7int.h so the runtime enforcer (vm.c) shares the same bound. The atom array
+ * below lives on the parser stack, so the cost is bounded: ~1 KiB. */
 
 typedef struct PhlTypeAtom PhlTypeAtom;
 struct PhlTypeAtom {
@@ -6112,6 +6109,8 @@ struct PhlTypeAtom {
 	SyString sClass;   /* class name when nType == SXU32_HIGH */
 	const char *zCanon;/* canonical lowercase name for scalar/builtin atoms */
 	sxu32 nCanon;
+	sxu32 nGroup;      /* intersection-group id: atoms sharing it are ANDed (A&B),
+	                    * distinct groups are ORed; pure unions use one atom per group */
 };
 
 /*
@@ -6210,10 +6209,61 @@ static void GenBuildUnionTypeText(SyBlob *pBlob, PhlTypeAtom *aAtoms, int nAtoms
 {
 	int i;
 	int nNonNull = 0;
+	int bAnyIntersection = 0;
+	sxu32 aGroupCount[PHL_UNION_MAX_ALTS];
+	sxu32 nMaxGroup = 0;
+	for( i = 0; i < PHL_UNION_MAX_ALTS; i++ ) aGroupCount[i] = 0;
 	for( i = 0; i < nAtoms; i++ ){
 		if( aAtoms[i].nType != UTA_NULL_FLAG ){
 			nNonNull++;
+			if( aAtoms[i].nGroup < PHL_UNION_MAX_ALTS ){
+				aGroupCount[aAtoms[i].nGroup]++;
+				if( aAtoms[i].nGroup > nMaxGroup ) nMaxGroup = aAtoms[i].nGroup;
+			}
 		}
+	}
+	for( i = 0; i < nAtoms; i++ ){
+		if( aAtoms[i].nType != UTA_NULL_FLAG && aGroupCount[aAtoms[i].nGroup] >= 2 ){
+			bAnyIntersection = 1;
+			break;
+		}
+	}
+	if( bAnyIntersection ){
+		/* Intersection / DNF rendering, in declaration (group) order: each group's
+		 * members joined by `&`; a ≥2-member group is wrapped in `()` only when the
+		 * whole type has more than one group (so a standalone `A&B` stays bare). */
+		sxu32 g, nGroups = 0;
+		int bFirstGroup = 1;
+		for( g = 0; g <= nMaxGroup; g++ ){ if( aGroupCount[g] > 0 ) nGroups++; }
+		for( g = 0; g <= nMaxGroup; g++ ){
+			int bFirstMember = 1;
+			int bWrap;
+			if( aGroupCount[g] == 0 ) continue;
+			/* Wrap a ≥2-member group in `()` whenever it shares the type with any
+			 * other alternative — another group OR a trailing `null` (which is not
+			 * counted in nGroups). So `A&B` stays bare but `(A&B)|null` keeps its
+			 * parens, matching PHP's canonical text. */
+			bWrap = (aGroupCount[g] >= 2 && (nGroups > 1 || bNullable));
+			if( !bFirstGroup ) SyBlobAppend(pBlob, "|", 1);
+			if( bWrap ) SyBlobAppend(pBlob, "(", 1);
+			for( i = 0; i < nAtoms; i++ ){
+				if( aAtoms[i].nType == UTA_NULL_FLAG || aAtoms[i].nGroup != g ) continue;
+				if( !bFirstMember ) SyBlobAppend(pBlob, "&", 1);
+				if( aAtoms[i].nType == SXU32_HIGH ){
+					SyBlobAppend(pBlob, aAtoms[i].sClass.zString, aAtoms[i].sClass.nByte);
+				}else{
+					SyBlobAppend(pBlob, aAtoms[i].zCanon, aAtoms[i].nCanon);
+				}
+				bFirstMember = 0;
+			}
+			if( bWrap ) SyBlobAppend(pBlob, ")", 1);
+			bFirstGroup = 0;
+		}
+		if( bNullable ){
+			SyBlobAppend(pBlob, "|", 1);
+			SyBlobAppend(pBlob, "null", 4);
+		}
+		return;
 	}
 	if( nNonNull == 1 && bNullable ){
 		/* Shorthand: ?T */
@@ -6260,6 +6310,75 @@ static void GenBuildUnionTypeText(SyBlob *pBlob, PhlTypeAtom *aAtoms, int nAtoms
 			SyBlobAppend(pBlob, "null", 4);
 		}
 	}
+}
+
+/*
+ * Parse one `|`-separated part of a type declaration into aAtoms[*pnAtoms..],
+ * tagging each appended atom with group id iGroup. A part is one of:
+ *   - a parenthesized intersection  `(` atom (`&` atom)+ `)`   (DNF group), or
+ *   - a bare atom, optionally followed by a top-level intersection atom (`&` atom)+.
+ * On return *pnMembers is the number of atoms in this part and *pbParen records
+ * whether it was parenthesized.
+ *
+ * The `&`-vs-by-reference ambiguity (`A&B $x` intersection vs `A &$x` by-ref) is
+ * resolved by a one-token lookahead: `&` continues the intersection only when it
+ * is followed by a type atom (namespace separator / identifier / keyword);
+ * otherwise it belongs to a by-ref parameter marker and the part ends, leaving
+ * the `&` for the caller (compile.c param loop) to consume.
+ */
+static sxi32 GenStateParsePart(
+	ph7_gen_state *pGen, PhlTypeAtom *aAtoms, int *pnAtoms, sxu32 iGroup,
+	int *pnMembers, int *pbParen, sxu32 nLine)
+{
+	sxi32 rc;
+	int nMembers = 0;
+	int bParen = 0;
+	*pnMembers = 0;
+	*pbParen = 0;
+	if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_LPAREN) ){
+		bParen = 1;
+		pGen->pIn++; /* skip '(' */
+	}
+	for(;;){
+		if( *pnAtoms >= PHL_UNION_MAX_ALTS ){
+			rc = PH7_GenCompileError(pGen, E_ERROR, nLine,
+				"Too many alternatives in type (limit %d)", PHL_UNION_MAX_ALTS);
+			return (rc == SXERR_ABORT) ? SXERR_ABORT : SXERR_SYNTAX;
+		}
+		rc = GenStateParseOneTypeAtom(pGen, &aAtoms[*pnAtoms]);
+		if( rc != SXRET_OK ){
+			return rc;
+		}
+		aAtoms[*pnAtoms].nGroup = iGroup;
+		(*pnAtoms)++;
+		nMembers++;
+		/* Continue the intersection while `&` is followed by another type atom. */
+		if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_AMPER) ){
+			SyToken *pNext = &pGen->pIn[1];
+			if( pNext < pGen->pEnd
+			 && (pNext->nType & (PH7_TK_NSSEP|PH7_TK_ID|PH7_TK_KEYWORD)) ){
+				pGen->pIn++; /* skip '&' */
+				continue;
+			}
+		}
+		break;
+	}
+	if( bParen ){
+		if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_RPAREN) == 0 ){
+			rc = PH7_GenCompileError(pGen, E_ERROR, nLine,
+				"Malformed DNF type: expecting ')'");
+			return (rc == SXERR_ABORT) ? SXERR_ABORT : SXERR_SYNTAX;
+		}
+		pGen->pIn++; /* skip ')' */
+		if( nMembers < 2 ){
+			rc = PH7_GenCompileError(pGen, E_ERROR, nLine,
+				"Parenthesized type must be an intersection of at least two types");
+			return (rc == SXERR_ABORT) ? SXERR_ABORT : SXERR_SYNTAX;
+		}
+	}
+	*pnMembers = nMembers;
+	*pbParen = bParen;
+	return SXRET_OK;
 }
 
 /*
@@ -6314,34 +6433,47 @@ static sxi32 GenStateParseUnionTypeDecl(
 			return SXERR_SYNTAX;
 		}
 	}
-	/* First atom is mandatory */
-	rc = GenStateParseOneTypeAtom(pGen, &aAtoms[0]);
-	if( rc != SXRET_OK ){
-		return rc;
-	}
-	nAtoms = 1;
-	/* Subsequent atoms separated by `|` */
-	while( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_OP)
-		&& pGen->pIn->sData.nByte == 1 && pGen->pIn->sData.zString[0] == '|' ){
-		if( bShortNullable ){
-			/* Match PHP's wording — `?T|X` is rejected as a parse error.
-			 * Return SXERR_CORRUPT as a sentinel meaning "syntax error
-			 * already reported" so callers skip their own error emission. */
-			rc = PH7_GenCompileError(pGen, E_PARSE, pGen->pIn->nLine,
-				"syntax error, unexpected token \"|\", expecting variable");
-			return (rc == SXERR_ABORT) ? SXERR_ABORT : SXERR_CORRUPT;
-		}
-		if( nAtoms >= PHL_UNION_MAX_ALTS ){
-			rc = PH7_GenCompileError(pGen, E_ERROR, nLine,
-				"Too many alternatives in union type (limit %d)", PHL_UNION_MAX_ALTS);
-			return (rc == SXERR_ABORT) ? SXERR_ABORT : SXERR_SYNTAX;
-		}
-		pGen->pIn++; /* skip `|` */
-		rc = GenStateParseOneTypeAtom(pGen, &aAtoms[nAtoms]);
+	/* Parse the first part (a single atom, a bare top-level intersection, or a
+	 * parenthesized DNF intersection), then any further `|`-separated parts. Each
+	 * part is one OR-group; atoms within an intersection share the group id. */
+	{
+		int nMembers, bParen;
+		sxu32 iGroup = 0;
+		rc = GenStateParsePart(pGen, aAtoms, &nAtoms, iGroup, &nMembers, &bParen, nLine);
 		if( rc != SXRET_OK ){
 			return rc;
 		}
-		nAtoms++;
+		/* Subsequent parts separated by `|`. A bare (unparenthesized) intersection
+		 * is legal only as the sole part; once a `|` makes this a union every part
+		 * must be a single type or a parenthesized intersection (`A&B|C` is invalid,
+		 * write `(A&B)|C`). The loop-top check rejects a bare intersection followed
+		 * by `|`; the after-loop check rejects one as the trailing part of a union. */
+		while( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_OP)
+			&& pGen->pIn->sData.nByte == 1 && pGen->pIn->sData.zString[0] == '|' ){
+			if( bShortNullable ){
+				/* Match PHP's wording — `?T|X` is rejected as a parse error.
+				 * Return SXERR_CORRUPT as a sentinel meaning "syntax error
+				 * already reported" so callers skip their own error emission. */
+				rc = PH7_GenCompileError(pGen, E_PARSE, pGen->pIn->nLine,
+					"syntax error, unexpected token \"|\", expecting variable");
+				return (rc == SXERR_ABORT) ? SXERR_ABORT : SXERR_CORRUPT;
+			}
+			if( nMembers >= 2 && !bParen ){
+				rc = PH7_GenCompileError(pGen, E_ERROR, pGen->pIn->nLine,
+					"Unparenthesized intersection type cannot be part of a union; wrap it in parentheses");
+				return (rc == SXERR_ABORT) ? SXERR_ABORT : SXERR_SYNTAX;
+			}
+			pGen->pIn++; /* skip `|` */
+			rc = GenStateParsePart(pGen, aAtoms, &nAtoms, ++iGroup, &nMembers, &bParen, nLine);
+			if( rc != SXRET_OK ){
+				return rc;
+			}
+		}
+		if( iGroup > 0 && nMembers >= 2 && !bParen ){
+			rc = PH7_GenCompileError(pGen, E_ERROR, nLine,
+				"Unparenthesized intersection type cannot be part of a union; wrap it in parentheses");
+			return (rc == SXERR_ABORT) ? SXERR_ABORT : SXERR_SYNTAX;
+		}
 	}
 	/* Validation pass.
 	 *
@@ -6352,7 +6484,52 @@ static sxi32 GenStateParseUnionTypeDecl(
 	{
 		int i, j;
 		int bHasNonNull = 0;
+		int bAnyIntersection = 0;
+		sxu32 aGroupCount[PHL_UNION_MAX_ALTS];
+		/* Tally how many atoms each OR-group holds; a group of ≥2 is an
+		 * intersection. (Group ids are 0..parts-1, bounded by nAtoms.) */
+		for( i = 0; i < PHL_UNION_MAX_ALTS; i++ ) aGroupCount[i] = 0;
 		for( i = 0; i < nAtoms; i++ ){
+			if( aAtoms[i].nGroup < PHL_UNION_MAX_ALTS ) aGroupCount[aAtoms[i].nGroup]++;
+		}
+		for( i = 0; i < nAtoms; i++ ){
+			if( aGroupCount[aAtoms[i].nGroup] >= 2 ){ bAnyIntersection = 1; break; }
+		}
+		/* PHP forbids a nullable intersection via the `?` shorthand — `?A&B` must
+		 * be written `(A&B)|null` (handled by the explicit-null DNF path). */
+		if( bShortNullable && bAnyIntersection ){
+			PH7_GenCompileError(pGen, E_ERROR, nLine,
+				"Nullable intersection types are not supported; use (A&B)|null instead");
+			return SXERR_SYNTAX;
+		}
+		for( i = 0; i < nAtoms; i++ ){
+			/* Intersection members must be class/interface types (PHP rejects
+			 * scalars, `object`, and the pseudo-types `iterable`/`callable`/
+			 * `true`/`false` in an intersection). */
+			if( aGroupCount[aAtoms[i].nGroup] >= 2 ){
+				int bClassLike = (aAtoms[i].nType == SXU32_HIGH);
+				if( bClassLike ){
+					SyString *pC = &aAtoms[i].sClass;
+					if( (pC->nByte == 8 && SyMemcmpNoCase(pC->zString,"iterable",8) == 0)
+					 || (pC->nByte == 8 && SyMemcmpNoCase(pC->zString,"callable",8) == 0)
+					 || (pC->nByte == 4 && SyMemcmpNoCase(pC->zString,"true",4) == 0)
+					 || (pC->nByte == 5 && SyMemcmpNoCase(pC->zString,"false",5) == 0) ){
+						bClassLike = 0;
+					}
+				}
+				if( !bClassLike ){
+					const char *zName; sxu32 nName;
+					if( aAtoms[i].nType == SXU32_HIGH ){
+						zName = aAtoms[i].sClass.zString; nName = aAtoms[i].sClass.nByte;
+					}else{
+						zName = aAtoms[i].zCanon; nName = aAtoms[i].nCanon;
+					}
+					PH7_GenCompileError(pGen, E_ERROR, nLine,
+						"Type %.*s cannot be part of an intersection type",
+						(int)nName, zName);
+					return SXERR_SYNTAX;
+				}
+			}
 			if( aAtoms[i].nType == UTA_VOID_FLAG ){
 				if( nAtoms > 1 ){
 					PH7_GenCompileError(pGen, E_ERROR, nLine,
@@ -6390,9 +6567,17 @@ static sxi32 GenStateParseUnionTypeDecl(
 			}else{
 				bHasNonNull = 1;
 			}
-			/* Duplicate detection */
+			/* Duplicate detection. Flag a repeat only within the same group
+			 * (intersection dup `A&A`) or between two singleton groups (union dup
+			 * `int|int` / `A|A`); a class appearing in two distinct intersection
+			 * groups (`(A&B)|(A&C)`) is legal, so skip those pairs. (Exhaustive DNF
+			 * subsumption — e.g. `(A&B)|A` — is deferred.) */
 			for( j = 0; j < i; j++ ){
 				int bDup = 0;
+				int bSameGroup = (aAtoms[i].nGroup == aAtoms[j].nGroup);
+				int bBothSingleton = (aGroupCount[aAtoms[i].nGroup] == 1
+				                   && aGroupCount[aAtoms[j].nGroup] == 1);
+				if( !bSameGroup && !bBothSingleton ) continue;
 				if( aAtoms[i].nType == aAtoms[j].nType ){
 					if( aAtoms[i].nType == SXU32_HIGH ){
 						if( aAtoms[i].sClass.nByte == aAtoms[j].sClass.nByte
@@ -6492,6 +6677,7 @@ static sxi32 GenStateParseUnionTypeDecl(
 				ph7_type_alt sAlt;
 				if( aAtoms[i].nType == UTA_NULL_FLAG ) continue;
 				SyZero(&sAlt, sizeof(sAlt));
+				sAlt.nGroup = aAtoms[i].nGroup; /* preserve intersection grouping */
 				if( aAtoms[i].nType == SXU32_HIGH ){
 					char *zDup = SyMemBackendStrDup(&pGen->pVm->sAllocator,
 						aAtoms[i].sClass.zString, aAtoms[i].sClass.nByte);
@@ -7096,44 +7282,63 @@ Synchronize:
 static int GenStateLooksLikeTypedProperty(SyToken *pStart,SyToken *pEnd)
 {
 	SyToken *p = pStart;
+	int bFirst = 1;
 	if( p >= pEnd ) return 0;
+	/* Optional nullable `?` shorthand. */
 	if( (p->nType & PH7_TK_OP) && p->sData.nByte == 1 && p->sData.zString[0] == '?' ){
 		p++;
 		if( p >= pEnd ) return 0;
 	}
-	if( p->nType & PH7_TK_NSSEP ){
-		p++;
-		if( p >= pEnd ) return 0;
-	}
-	if( (p->nType & (PH7_TK_ID|PH7_TK_KEYWORD)) == 0 ){
-		return 0;
-	}
-	/* Reject class-body modifier keywords that aren't types. Visibility
-	 * (public/private/protected) has already been consumed by the caller,
-	 * but static/final/abstract may still appear here for the initial
-	 * dispatch site. */
-	if( p->nType & PH7_TK_KEYWORD ){
-		sxu32 k = (sxu32)(SX_PTR_TO_INT(p->pUserData));
-		if( k == PH7_TKWRD_FUNCTION || k == PH7_TKWRD_VAR || k == PH7_TKWRD_CONST
-		 || k == PH7_TKWRD_STATIC || k == PH7_TKWRD_FINAL || k == PH7_TKWRD_ABSTRACT ){
-			return 0;
+	/* Skip a (possibly union / intersection / DNF) type to find the `$name`.
+	 * One or more `|`-separated parts; each part is either a parenthesized
+	 * intersection `( … )` or an atom optionally followed by a bare `&`
+	 * intersection. We only need to land on the `$` to classify the member. */
+	for(;;){
+		if( p < pEnd && (p->nType & PH7_TK_LPAREN) ){
+			/* Parenthesized DNF group — skip to the matching `)`. */
+			p++;
+			while( p < pEnd && (p->nType & PH7_TK_RPAREN) == 0 ){ p++; }
+			if( p >= pEnd ) return 0;
+			p++; /* skip ')' */
+		}else{
+			/* A type atom: optional `\`, an identifier/keyword, namespace path,
+			 * then any `&`-joined intersection members. */
+			if( p < pEnd && (p->nType & PH7_TK_NSSEP) ){ p++; }
+			if( p >= pEnd || (p->nType & (PH7_TK_ID|PH7_TK_KEYWORD)) == 0 ){
+				return 0;
+			}
+			/* Reject class-body modifier keywords that aren't types (only on the
+			 * first atom; visibility is already consumed, but static/final/abstract
+			 * may still appear at the initial dispatch site). */
+			if( bFirst && (p->nType & PH7_TK_KEYWORD) ){
+				sxu32 k = (sxu32)(SX_PTR_TO_INT(p->pUserData));
+				if( k == PH7_TKWRD_FUNCTION || k == PH7_TKWRD_VAR || k == PH7_TKWRD_CONST
+				 || k == PH7_TKWRD_STATIC || k == PH7_TKWRD_FINAL || k == PH7_TKWRD_ABSTRACT ){
+					return 0;
+				}
+			}
+			p++;
+			while( p + 1 < pEnd && (p->nType & PH7_TK_NSSEP) && (p[1].nType & (PH7_TK_ID|PH7_TK_KEYWORD)) ){
+				p += 2;
+			}
+			while( p + 1 < pEnd && (p->nType & PH7_TK_AMPER)
+				&& (p[1].nType & (PH7_TK_NSSEP|PH7_TK_ID|PH7_TK_KEYWORD)) ){
+				p++; /* skip '&' */
+				if( p < pEnd && (p->nType & PH7_TK_NSSEP) ){ p++; }
+				if( p >= pEnd || (p->nType & (PH7_TK_ID|PH7_TK_KEYWORD)) == 0 ) return 0;
+				p++;
+				while( p + 1 < pEnd && (p->nType & PH7_TK_NSSEP) && (p[1].nType & (PH7_TK_ID|PH7_TK_KEYWORD)) ){
+					p += 2;
+				}
+			}
 		}
-	}
-	p++;
-	/* Consume optional namespace path */
-	while( p + 1 < pEnd && (p->nType & PH7_TK_NSSEP) && (p[1].nType & (PH7_TK_ID|PH7_TK_KEYWORD)) ){
-		p += 2;
-	}
-	/* Consume any `| Type` union alternatives */
-	while( p < pEnd && (p->nType & PH7_TK_OP) && p->sData.nByte == 1
-		&& p->sData.zString[0] == '|' ){
-		p++;
-		if( p < pEnd && (p->nType & PH7_TK_NSSEP) ){ p++; }
-		if( p >= pEnd || (p->nType & (PH7_TK_ID|PH7_TK_KEYWORD)) == 0 ) return 0;
-		p++;
-		while( p + 1 < pEnd && (p->nType & PH7_TK_NSSEP) && (p[1].nType & (PH7_TK_ID|PH7_TK_KEYWORD)) ){
-			p += 2;
+		bFirst = 0;
+		if( p < pEnd && (p->nType & PH7_TK_OP) && p->sData.nByte == 1
+			&& p->sData.zString[0] == '|' ){
+			p++; /* next `|`-separated part */
+			continue;
 		}
+		break;
 	}
 	if( p >= pEnd ) return 0;
 	return (p->nType & PH7_TK_DOLLAR) ? 1 : 0;
@@ -8685,7 +8890,7 @@ static sxi32 GenStateCompileClassEx(ph7_gen_state *pGen,sxi32 iFlags,
 					pGen->pIn++; /* Jump the 'readonly' modifier */
 				}
 				if( pGen->pIn >= pGen->pEnd
-					|| (pGen->pIn->nType & (PH7_TK_KEYWORD|PH7_TK_DOLLAR|PH7_TK_ID|PH7_TK_OP|PH7_TK_NSSEP)) == 0 ){
+					|| (pGen->pIn->nType & (PH7_TK_KEYWORD|PH7_TK_DOLLAR|PH7_TK_ID|PH7_TK_OP|PH7_TK_NSSEP|PH7_TK_LPAREN)) == 0 ){
 					rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,
 						"Unexpected token '%z'. Expecting attribute declaration inside class '%z'",
 						&pGen->pIn->sData,pName);
@@ -8750,7 +8955,7 @@ static sxi32 GenStateCompileClassEx(ph7_gen_state *pGen,sxi32 iFlags,
 						pGen->pIn++; /* Jump the 'readonly' modifier */
 					}
 					if( pGen->pIn >= pGen->pEnd
-						|| (pGen->pIn->nType & (PH7_TK_KEYWORD|PH7_TK_DOLLAR|PH7_TK_ID|PH7_TK_OP|PH7_TK_NSSEP)) == 0 ){
+						|| (pGen->pIn->nType & (PH7_TK_KEYWORD|PH7_TK_DOLLAR|PH7_TK_ID|PH7_TK_OP|PH7_TK_NSSEP|PH7_TK_LPAREN)) == 0 ){
 						rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,
 							"Unexpected token '%z',Expecting method,attribute or constant declaration inside class '%z'",
 							&pGen->pIn->sData,pName);
@@ -9496,7 +9701,7 @@ static sxi32 PH7_CompileTrait(ph7_gen_state *pGen)
 				iProtection = nKwrd;
 				pGen->pIn++;
 				if( pGen->pIn >= pGen->pEnd
-					|| (pGen->pIn->nType & (PH7_TK_KEYWORD|PH7_TK_DOLLAR|PH7_TK_ID|PH7_TK_OP|PH7_TK_NSSEP)) == 0 ){
+					|| (pGen->pIn->nType & (PH7_TK_KEYWORD|PH7_TK_DOLLAR|PH7_TK_ID|PH7_TK_OP|PH7_TK_NSSEP|PH7_TK_LPAREN)) == 0 ){
 					rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,
 						"Unexpected token '%z'. Expecting attribute declaration inside trait '%z'",
 						&pGen->pIn->sData,pName);
@@ -9546,7 +9751,7 @@ static sxi32 PH7_CompileTrait(ph7_gen_state *pGen)
 						}
 					}
 					if( pGen->pIn >= pGen->pEnd
-						|| (pGen->pIn->nType & (PH7_TK_KEYWORD|PH7_TK_DOLLAR|PH7_TK_ID|PH7_TK_OP|PH7_TK_NSSEP)) == 0 ){
+						|| (pGen->pIn->nType & (PH7_TK_KEYWORD|PH7_TK_DOLLAR|PH7_TK_ID|PH7_TK_OP|PH7_TK_NSSEP|PH7_TK_LPAREN)) == 0 ){
 						rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,
 							"Unexpected token '%z',Expecting method or attribute declaration inside trait '%z'",
 							&pGen->pIn->sData,pName);

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -531,14 +531,21 @@ struct ph7_vm_func_arg
 };
 /*
  * One alternative within a union type declaration. Used by parameters,
- * return types, and properties when the declaration is `T1|T2|...`.
+ * return types, and properties when the declaration is `T1|T2|...`,
+ * `A&B` (intersection), or `(A&B)|C` (DNF).
  */
 typedef struct ph7_type_alt ph7_type_alt;
 struct ph7_type_alt
 {
 	sxu32 nType;     /* MEMOBJ_* bitmask, or SXU32_HIGH for a class/interface alternative */
 	SyString sClass; /* Class/interface name when nType == SXU32_HIGH */
+	sxu32 nGroup;    /* Intersection-group id: atoms sharing a group are ANDed (A&B),
+	                  * distinct groups are ORed. A pure union is one atom per group. */
 };
+/* Maximum alternatives in one type declaration; bounds the on-stack atom array
+ * in the parser and the per-group tally in the enforcer. Larger than any real
+ * union/DNF type. */
+#define PHL_UNION_MAX_ALTS 32
 /*
  * Each static variable is parsed out and remembered in an instance
  * of the following structure.

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -3473,21 +3473,83 @@ static int VmCheckPseudoType(ph7_vm *pVm, ph7_value *pValue, const SyString *pCl
  * The class match for object values consults the active VM self-stack to
  * resolve `self`/`parent` aliases when present.
  */
+/*
+ * Resolve a class/interface name from a type declaration to its ph7_class*,
+ * handling the `self`/`parent` aliases against the supplied scope class pSelf
+ * (the active self for params/returns/properties, or the declaring class for a
+ * class constant). Used by every type-enforcement site so the resolution rule —
+ * including the iLoadable flag — lives in one place.
+ *
+ * iLoadable: pass FALSE for an instanceof/type-compatibility target (the type
+ * may legitimately be an interface or abstract class); TRUE only filters to
+ * instantiable classes.
+ */
+static ph7_class *VmResolveTypeClass(ph7_vm *pVm, const SyString *pCN, ph7_class *pSelf, int iLoadable)
+{
+	if( pCN->nByte == 4 && SyMemcmp(pCN->zString,"self",4) == 0 ){
+		return pSelf;
+	}
+	if( pCN->nByte == 6 && SyMemcmp(pCN->zString,"parent",6) == 0 ){
+		return pSelf ? pSelf->pBase : 0;
+	}
+	return PH7_VmExtractClass(pVm,pCN->zString,pCN->nByte,iLoadable,0);
+}
 static sxi32 VmCoerceToUnion(ph7_vm *pVm, ph7_value *pValue, SySet *pAlts, int bNullable, int bStrict)
 {
 	sxu32 i;
+	sxu32 nAlts;
 	ph7_type_alt *aAlts;
 	int bHasArray, bHasObjAlt, bHasClassAlt;
 	int bHasInt, bHasFloat, bHasString, bHasBool;
+	int bHasIntersection = 0;
+	sxu32 aGroupCount[PHL_UNION_MAX_ALTS];
 	if( pValue->iFlags & MEMOBJ_NULL ){
 		return bNullable ? SXRET_OK : SXERR_INVALID;
 	}
 	aAlts = (ph7_type_alt *)SySetBasePtr(pAlts);
+	nAlts = SySetUsed(pAlts);
+	/* Tally OR-group sizes: a group of ≥2 alternatives is an intersection (the
+	 * value must match ALL its members); singleton groups are ordinary union
+	 * alternatives (match ANY). Group ids are NOT dense in the stored set —
+	 * `null`-only parts are dropped at store time, leaving gaps — so an id can be
+	 * up to (parts-1) ≥ nAlts; index the full PHL_UNION_MAX_ALTS-wide tally. */
+	for( i = 0; i < PHL_UNION_MAX_ALTS; i++ ) aGroupCount[i] = 0;
+	for( i = 0; i < nAlts; i++ ){
+		if( aAlts[i].nGroup < PHL_UNION_MAX_ALTS && ++aGroupCount[aAlts[i].nGroup] == 2 ){
+			bHasIntersection = 1;
+		}
+	}
+	/* Intersection phase: an object satisfies an intersection group iff it is
+	 * instanceof every member. Members are always class types (enforced at parse),
+	 * so a non-object value can never satisfy a group. Skipped entirely for a pure
+	 * union (the common case), which then pays nothing for the group machinery. */
+	if( bHasIntersection && (pValue->iFlags & MEMOBJ_OBJ) ){
+		ph7_class_instance *pInst = (ph7_class_instance *)pValue->x.pOther;
+		ph7_class *pSelfNow = VmCurrentSelf(pVm);
+		sxu32 g;
+		for( g = 0; g < PHL_UNION_MAX_ALTS; g++ ){
+			int bAll;
+			if( aGroupCount[g] < 2 ) continue;
+			bAll = 1;
+			for( i = 0; i < nAlts; i++ ){
+				ph7_class *pExpected;
+				if( aAlts[i].nGroup != g ) continue;
+				if( aAlts[i].nType != SXU32_HIGH ){ bAll = 0; break; }
+				pExpected = VmResolveTypeClass(pVm,&aAlts[i].sClass,pSelfNow,FALSE);
+				if( pExpected == 0 || !PH7_VmInstanceOf(pInst->pClass,pExpected) ){
+					bAll = 0;
+					break;
+				}
+			}
+			if( bAll ) return SXRET_OK;
+		}
+	}
 	/* Pseudo-type alternatives (true/false/iterable; `mixed` never unions) are
 	 * stored as SXU32_HIGH name atoms and need value-checking, not instanceof.
 	 * A match on any one accepts the value (handles e.g. `true|int`, `?true`,
-	 * `iterable|Foo`). */
-	for( i = 0; i < SySetUsed(pAlts); i++ ){
+	 * `iterable|Foo`). Only singleton-group (ordinary union) atoms apply here. */
+	for( i = 0; i < nAlts; i++ ){
+		if( aGroupCount[aAlts[i].nGroup] >= 2 ) continue;
 		if( aAlts[i].nType == SXU32_HIGH
 		 && VmCheckPseudoType(pVm, pValue, &aAlts[i].sClass) == 1 ){
 			return SXRET_OK;
@@ -3495,7 +3557,8 @@ static sxi32 VmCoerceToUnion(ph7_vm *pVm, ph7_value *pValue, SySet *pAlts, int b
 	}
 	bHasArray = bHasObjAlt = bHasClassAlt = 0;
 	bHasInt = bHasFloat = bHasString = bHasBool = 0;
-	for( i = 0; i < SySetUsed(pAlts); i++ ){
+	for( i = 0; i < nAlts; i++ ){
+		if( aGroupCount[aAlts[i].nGroup] >= 2 ) continue;
 		if( aAlts[i].nType == SXU32_HIGH ) bHasClassAlt = 1;
 		else if( aAlts[i].nType == MEMOBJ_OBJ ) bHasObjAlt = 1;
 		else if( aAlts[i].nType == MEMOBJ_HASHMAP ) bHasArray = 1;
@@ -3510,18 +3573,13 @@ static sxi32 VmCoerceToUnion(ph7_vm *pVm, ph7_value *pValue, SySet *pAlts, int b
 		if( bHasClassAlt ){
 			ph7_class_instance *pInst = (ph7_class_instance *)pValue->x.pOther;
 			ph7_class *pSelfNow = VmCurrentSelf(pVm);
-			for( i = 0; i < SySetUsed(pAlts); i++ ){
+			for( i = 0; i < nAlts; i++ ){
 				ph7_class *pExpected;
-				SyString *pCN;
+				if( aGroupCount[aAlts[i].nGroup] >= 2 ) continue;
 				if( aAlts[i].nType != SXU32_HIGH ) continue;
-				pCN = &aAlts[i].sClass;
-				if( pCN->nByte == 4 && SyMemcmp(pCN->zString,"self",4) == 0 ){
-					pExpected = pSelfNow;
-				}else if( pCN->nByte == 6 && SyMemcmp(pCN->zString,"parent",6) == 0 ){
-					pExpected = pSelfNow ? pSelfNow->pBase : 0;
-				}else{
-					pExpected = PH7_VmExtractClass(pVm,pCN->zString,pCN->nByte,TRUE,0);
-				}
+				/* iLoadable=FALSE: an instanceof target may be an interface or
+				 * abstract class (TRUE would filter those out → never match). */
+				pExpected = VmResolveTypeClass(pVm,&aAlts[i].sClass,pSelfNow,FALSE);
 				if( pExpected && PH7_VmInstanceOf(pInst->pClass,pExpected) ){
 					return SXRET_OK;
 				}
@@ -3779,16 +3837,7 @@ static sxi32 VmEnforcePropertyTypeOnStore(ph7_vm *pVm,sxu32 nIdx,ph7_value *pVal
 	if( pAttr->nType == SXU32_HIGH ){
 		/* Class / interface type. Resolve self/parent relative to the class
 		 * currently active on the self-stack. */
-		ph7_class *pExpected = 0;
-		SyString *pClassName = &pAttr->sClass;
-		ph7_class *pSelfNow = VmCurrentSelf(pVm);
-		if( pClassName->nByte == 4 && SyMemcmp(pClassName->zString,"self",4) == 0 ){
-			pExpected = pSelfNow;
-		}else if( pClassName->nByte == 6 && SyMemcmp(pClassName->zString,"parent",6) == 0 ){
-			pExpected = pSelfNow ? pSelfNow->pBase : 0;
-		}else{
-			pExpected = PH7_VmExtractClass(&(*pVm),pClassName->zString,pClassName->nByte,TRUE,0);
-		}
+		ph7_class *pExpected = VmResolveTypeClass(pVm,&pAttr->sClass,VmCurrentSelf(pVm),TRUE);
 		if( (pValue->iFlags & MEMOBJ_OBJ) == 0 ){
 			return VmThrowPropertyTypeError(pVm,pVmAttr,ph7_type_name(pValue));
 		}
@@ -3925,15 +3974,8 @@ static sxi32 VmEnforceConstantType(ph7_vm *pVm,ph7_class *pClass,ph7_class_attr 
 			return VmConstantTypeError(&(*pVm),pClass,pAttr,pValue);
 		}
 		{
-			SyString *pCN = &pAttr->sClass;
-			ph7_class *pExpected;
-			if( pCN->nByte == 4 && SyMemcmp(pCN->zString,"self",4) == 0 ){
-				pExpected = pClass;
-			}else if( pCN->nByte == 6 && SyMemcmp(pCN->zString,"parent",6) == 0 ){
-				pExpected = pClass->pBase;
-			}else{
-				pExpected = PH7_VmExtractClass(&(*pVm),pCN->zString,pCN->nByte,TRUE,0);
-			}
+			/* A class constant's self/parent resolve against the declaring class. */
+			ph7_class *pExpected = VmResolveTypeClass(pVm,&pAttr->sClass,pClass,TRUE);
 			if( pExpected ){
 				ph7_class_instance *pInst = (ph7_class_instance *)pValue->x.pOther;
 				if( !PH7_VmInstanceOf(pInst->pClass,pExpected) ){
@@ -4271,15 +4313,7 @@ static sxi32 VmEnforceReturnType(ph7_vm *pVm, ph7_vm_func *pFunc, ph7_value *pVa
 	if( pFunc->nReturnType == SXU32_HIGH ){
 		SyString *pClassName = &pFunc->sReturnClass;
 		const char *zExpected;
-		ph7_class *pExpected;
-		ph7_class *pSelfNow = VmCurrentSelf(pVm);
-		if( pClassName->nByte == 4 && SyMemcmp(pClassName->zString,"self",4) == 0 ){
-			pExpected = pSelfNow;
-		}else if( pClassName->nByte == 6 && SyMemcmp(pClassName->zString,"parent",6) == 0 ){
-			pExpected = pSelfNow ? pSelfNow->pBase : 0;
-		}else{
-			pExpected = PH7_VmExtractClass(&(*pVm),pClassName->zString,pClassName->nByte,TRUE,0);
-		}
+		ph7_class *pExpected = VmResolveTypeClass(pVm,pClassName,VmCurrentSelf(pVm),TRUE);
 		zExpected = VmSyStringToCStr(pClassName, zTypeBuf, sizeof(zTypeBuf));
 		if( (pValue->iFlags & MEMOBJ_OBJ) == 0 ){
 			zGiven = (pValue->iFlags & MEMOBJ_NULL) ? "null" : ph7_type_name(pValue);

--- a/tests/ph7/002-integration/lang/intersection_dnf.phpt
+++ b/tests/ph7/002-integration/lang/intersection_dnf.phpt
@@ -1,0 +1,26 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+DNF type (A&B)|C selects the right branch and rejects values matching neither
+--FILE--
+<?php
+interface DnfA {}
+interface DnfB {}
+class DnfC {}
+class DnfAB implements DnfA, DnfB {}
+function dnf_f((DnfA&DnfB)|DnfC $x): string { return get_class($x); }
+echo dnf_f(new DnfAB), "\n";   // matches the intersection branch
+echo dnf_f(new DnfC), "\n";    // matches the single-type branch
+try {
+    dnf_f(new class implements DnfA {});  // only DnfA → neither branch
+} catch (\TypeError $e) {
+    echo "rejected\n";
+}
+?>
+--EXPECT--
+DnfAB
+DnfC
+rejected
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/intersection_param.phpt
+++ b/tests/ph7/002-integration/lang/intersection_param.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Intersection type A&B on a parameter accepts an object implementing both, rejects otherwise
+--FILE--
+<?php
+interface IxCountable {}
+interface IxStringy {}
+class IxBoth implements IxCountable, IxStringy {}
+class IxOnlyOne implements IxCountable {}
+function ix_need(IxCountable&IxStringy $x): string { return get_class($x); }
+echo ix_need(new IxBoth), "\n";
+try {
+    ix_need(new IxOnlyOne);
+} catch (\TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECTF--
+IxBoth
+ix_need(): Argument #1 ($x) must be of type IxCountable&IxStringy, IxOnlyOne given%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/intersection_property_return.phpt
+++ b/tests/ph7/002-integration/lang/intersection_property_return.phpt
@@ -1,0 +1,34 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Intersection and DNF types are enforced on properties and return types
+--FILE--
+<?php
+interface PrA {}
+interface PrB {}
+class PrAB implements PrA, PrB {}
+class PrBox {
+    public PrA&PrB $both;
+    public int|(PrA&PrB) $either = 1;
+}
+function pr_make(): PrA&PrB { return new PrAB; }
+$b = new PrBox;
+$b->both = pr_make();
+echo get_class($b->both), "\n";
+echo $b->either, "\n";          // initial int
+$b->either = new PrAB;          // DNF object branch
+echo get_class($b->either), "\n";
+try {
+    $b->both = new class implements PrA {};
+} catch (\TypeError $e) {
+    echo "prop rejected\n";
+}
+?>
+--EXPECT--
+PrAB
+1
+PrAB
+prop rejected
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/intersection_scalar_rejected.phpt
+++ b/tests/ph7/002-integration/lang/intersection_scalar_rejected.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A scalar in an intersection type is rejected at compile time
+--SKIPIF--
+<?php if (function_exists('zend_version')) echo 'skip PHL-specific diagnostic wording'; ?>
+--FILE--
+<?php
+function bad(int&string $x) {}
+echo "unreachable\n";
+?>
+--EXPECTF--
+%AType int cannot be part of an intersection type%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/union_null_not_last.phpt
+++ b/tests/ph7/002-integration/lang/union_null_not_last.phpt
@@ -1,0 +1,31 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A union with null in a non-trailing position (int|null|string) accepts every member
+--FILE--
+<?php
+function un_f(int|null|string $x): string {
+    return is_null($x) ? "null" : (is_int($x) ? "int" : "string");
+}
+echo un_f("abc"), "\n";
+echo un_f(42), "\n";
+echo un_f(null), "\n";
+
+class UnBox {
+    public int|null|string $v;
+}
+$b = new UnBox;
+$b->v = "xyz"; echo $b->v, "\n";
+$b->v = 9;     echo $b->v, "\n";
+$b->v = null;  var_export($b->v); echo "\n";
+?>
+--EXPECT--
+string
+int
+null
+xyz
+9
+NULL
+--CLEAN--
+<?php


### PR DESCRIPTION
Model a type declaration as a union of groups: a new sxu32 nGroup on ph7_type_alt tags each alternative; atoms sharing a group are ANDed (intersection), distinct groups are ORed (union). A pure union is one atom per group, so the existing union path is byte-identical.

Parser (compile.c): GenStateParseUnionTypeDecl + a new GenStateParsePart parse '|'-separated parts, each a parenthesized intersection `( ... )` or a bare `atom (& atom)+`; the &-vs-by-ref ambiguity (`A&B $x` vs `A &$x`) is resolved by a one-token lookahead, so all four type contexts (param/return/property/const) work with no call-site change. The typed-property look-ahead (GenStateLooksLikeTypedProperty) and the class-body dispatch gates learn `&`/`(` so `public A&B $p` / `public (A&B)|int $q` classify as typed properties. Validation rejects scalars/object/callable/iterable in an intersection, unparenthesized `A&B|C`, `?A&B`, and single-member `(A)` groups.

Enforcement (vm.c): VmCoerceToUnion gains an intersection phase (an object must be instanceof every group member), gated behind a per-call "any intersection?" check so pure unions pay nothing; the singleton-union phase is unchanged. GenBuildUnionTypeText renders `A&B` / `(A&B)|C`.

Also fixes a pre-existing bug: a union/intersection alternative that is an interface or abstract class never matched, because the class was resolved with PH7_VmExtractClass(..., iLoadable=TRUE, ...) which filters those out. Extracted a shared VmResolveTypeClass helper (the self/parent/extract dance was copied at five enforcement sites) and pass iLoadable=FALSE for instanceof targets.

Tests: intersection_{param,dnf,property_return}, intersection_scalar_rejected (PHL-only diagnostic), and union_null_not_last (a non-trailing null in a union), all vs php 8.5.7.
