### PR TITLE
Enforce union/intersection return types and promoted-property unions

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -6726,11 +6726,11 @@ static sxi32 GenStateParseReturnType(ph7_gen_state *pGen, ph7_vm_func *pFunc)
 		&pFunc->aReturnUnion,
 		&iFlags,
 		&pFunc->sReturnTypeName,
-		/* iNullableFlag */ 0, /* nullability for returns rides on aReturnUnion contents only */
+		VM_FUNC_RETURN_NULLABLE, /* nullability flag — a null alternative isn't stored
+		                          * in aReturnUnion, so the func carries it explicitly */
 		/* iUnionFlag */ 0,
 		/* bAllowVoid */ 1,
 		nLine);
-	(void)iFlags;
 	if( rc == SXERR_ABORT ){
 		return SXERR_ABORT;
 	}
@@ -6749,6 +6749,7 @@ static sxi32 GenStateParseReturnType(ph7_gen_state *pGen, ph7_vm_func *pFunc)
 		}
 		return SXERR_SYNTAX;
 	}
+	pFunc->iFlags |= (iFlags & VM_FUNC_RETURN_NULLABLE);
 	return SXRET_OK;
 }
 
@@ -7814,9 +7815,15 @@ static sxi32 GenStateCompileClassMethod(
 			ph7_vm_func_arg *pArg = (ph7_vm_func_arg *)SySetAt(&pMeth->sFunc.aArgs,i);
 			ph7_class_attr *pAttr;
 			sxi32 iAttrFlags = 0;
+			int bArgTyped;
 			if( (pArg->iFlags & VM_FUNC_ARG_PROMOTED) == 0 ){
 				continue;
 			}
+			/* "typed" = a single type or class name, OR a union/intersection,
+			 * which leaves nType=0 / empty sClass and stores its alts in
+			 * aUnionAlts. Used both to validate the type and to mark the attr. */
+			bArgTyped = pArg->nType > 0 || SyStringLength(&pArg->sClass) > 0
+			         || (pArg->iFlags & VM_FUNC_ARG_UNION);
 			if( pArg->iFlags & VM_FUNC_ARG_VARIADIC ){
 				rc = PH7_GenCompileError(pGen,E_ERROR,nLine,
 					"Cannot declare variadic promoted property");
@@ -7828,8 +7835,7 @@ static sxi32 GenStateCompileClassMethod(
 			/* Reject the same disallowed pseudo-types (callable/mixed/iterable)
 			 * that GenStateCompileClassAttr rejects — including when they
 			 * appear as an alternative of a union type. */
-			if( pArg->nType > 0 || SyStringLength(&pArg->sClass) > 0
-			 || (pArg->iFlags & VM_FUNC_ARG_UNION) ){
+			if( bArgTyped ){
 				rc = GenStateValidateMemberType(pGen,pClass,&pArg->sName,
 					pArg->nType,&pArg->sClass,&pArg->sTypeName,
 					(pArg->iFlags & VM_FUNC_ARG_UNION) ? &pArg->aUnionAlts : 0,
@@ -7849,7 +7855,7 @@ static sxi32 GenStateCompileClassMethod(
 				}
 				goto Synchronize;
 			}
-			if( pArg->nType > 0 || SyStringLength(&pArg->sClass) > 0 ){
+			if( bArgTyped ){
 				iAttrFlags |= PH7_CLASS_ATTR_TYPED;
 			}
 			if( pArg->iFlags & VM_FUNC_ARG_NULLABLE ){

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -595,7 +595,8 @@ struct ph7_vm_func_closure_env
 #define VM_FUNC_ARG_UNION    0x200 /* Argument has a union type (use aUnionAlts) */
 #define VM_FUNC_ARG_PROMOTED 0x400 /* Constructor promoted property (iPromoteVis holds visibility) */
 #define VM_FUNC_ARG_READONLY 0x800 /* Promoted property is readonly (PHP 8.1) */
-/* next free bit: 0x1000 */
+#define VM_FUNC_RETURN_NULLABLE 0x1000 /* Return type is nullable (?T, T|null, A|B|null) — func-level */
+/* next free bit: 0x2000 */
 /*
  * Each user defined function is parsed out and stored in an instance
  * of the following structure.

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -4221,14 +4221,25 @@ static const char *VmSyStringToCStr(const SyString *pStr, char *zBuf, sxu32 nBuf
 	return zBuf;
 }
 
+/*
+ * TRUE if a function declares a return type that must be enforced — a single
+ * type (nReturnType) OR a union/intersection (aReturnUnion, where nReturnType is
+ * left 0). The return-enforcement gates must consult both, not just the single
+ * type field.
+ */
+static int VmFuncHasReturnType(ph7_vm_func *pFunc)
+{
+	return pFunc->nReturnType > 0 || SySetUsed(&pFunc->aReturnUnion) > 0;
+}
 static sxi32 VmEnforceReturnType(ph7_vm *pVm, ph7_vm_func *pFunc, ph7_value *pValue)
 {
 	int bStrict = pFunc->bStrictTypes ? 1 : 0;
+	int bNullable = (pFunc->iFlags & VM_FUNC_RETURN_NULLABLE) ? 1 : 0;
 	const char *zGiven;
 	char zBuf[128];
 	char zTypeBuf[128];
-	/* Untyped function: no enforcement. */
-	if( pFunc->nReturnType == 0 ){
+	/* Untyped function: no enforcement (no single type and no union/intersection). */
+	if( !VmFuncHasReturnType(pFunc) ){
 		return SXRET_OK;
 	}
 	/* void return type: the function must not produce a value. */
@@ -4241,9 +4252,9 @@ static sxi32 VmEnforceReturnType(ph7_vm *pVm, ph7_vm_func *pFunc, ph7_value *pVa
 		zGiven = (pValue->iFlags & MEMOBJ_NULL) ? "null" : ph7_type_name(pValue);
 		return VmThrowTypeErrorForReturn(pVm,&pFunc->sName,"void",zGiven);
 	}
-	/* Function fell off the end without an explicit return: PHP implicitly
-	 * returns null. For a typed non-nullable return (including `mixed`, which
-	 * requires an explicit returned value), that's a TypeError. */
+	/* Fell off the end or a bare `return;` with no value: PHP requires any typed
+	 * return (even a nullable one) to return a value explicitly — only an explicit
+	 * `return null;` satisfies a nullable type, which is handled below. */
 	if( pValue == 0 ){
 		const char *zExpected = "value";
 		if( SyStringLength(&pFunc->sReturnTypeName) > 0 ){
@@ -4261,6 +4272,12 @@ static sxi32 VmEnforceReturnType(ph7_vm *pVm, ph7_vm_func *pFunc, ph7_value *pVa
 		return VmThrowTypeErrorForReturn(pVm,&pFunc->sName,"null",
 			VmValueGivenName(pValue,zBuf,sizeof(zBuf)));
 	}
+	/* An explicit `return null` satisfies any nullable return type (`?T`, `T|null`,
+	 * `A|B|null`) uniformly — handle it before the per-shape branches below, none
+	 * of which (scalar/class/union) carry their own nullable check. */
+	if( (pValue->iFlags & MEMOBJ_NULL) && bNullable ){
+		return SXRET_OK;
+	}
 	/* Pseudo-types parsed as class-name atoms: `mixed` (any value),
 	 * `true`/`false` (the matching bool literal), `iterable` (array|Traversable).
 	 * Check by value before the real-class instanceof branch below. */
@@ -4276,21 +4293,12 @@ static sxi32 VmEnforceReturnType(ph7_vm *pVm, ph7_vm_func *pFunc, ph7_value *pVa
 		}
 		/* rcPseudo == -1: a real class — fall through to the instanceof branch. */
 	}
-	/* Union return type — delegate. The function has no flag for nullable
-	 * unions; a null alternative is represented inside aReturnUnion, so pass
-	 * bNullable=0 here. */
+	/* Union/intersection return type — delegate. A null alternative is not stored
+	 * in aReturnUnion (dropped at parse), so nullability comes from the func's
+	 * VM_FUNC_RETURN_NULLABLE flag (already consumed above for an explicit null). */
 	if( SySetUsed(&pFunc->aReturnUnion) > 0 ){
 		sxi32 rcU;
-		int bNullable = 0;
 		const char *zExpected = "union";
-		/* Scan alternatives for MEMOBJ_NULL, which serves as `T|null`. */
-		{
-			sxu32 i;
-			ph7_type_alt *aAlts = (ph7_type_alt *)SySetBasePtr(&pFunc->aReturnUnion);
-			for( i = 0; i < SySetUsed(&pFunc->aReturnUnion); i++ ){
-				if( aAlts[i].nType == MEMOBJ_NULL ){ bNullable = 1; break; }
-			}
-		}
 		rcU = VmCoerceToUnion(pVm, pValue, &pFunc->aReturnUnion, bNullable, bStrict);
 		if( rcU == SXRET_OK ){
 			return SXRET_OK;
@@ -4328,15 +4336,10 @@ static sxi32 VmEnforceReturnType(ph7_vm *pVm, ph7_vm_func *pFunc, ph7_value *pVa
 		}
 		return SXRET_OK;
 	}
-	/* Scalar return type. Allow null pass-through if the function is
-	 * nullable (textual "?T" gets that flag, though union+null is handled
-	 * above). There's no explicit nullable flag on ph7_vm_func, so detect
-	 * via the type-text leading '?'. */
-	if( (pValue->iFlags & MEMOBJ_NULL) ){
-		if( SyStringLength(&pFunc->sReturnTypeName) > 0
-		 && pFunc->sReturnTypeName.zString[0] == '?' ){
-			return SXRET_OK;
-		}
+	/* Scalar return type. A nullable scalar accepting null was already handled by
+	 * the unified MEMOBJ_NULL+bNullable check above, so any null reaching here is a
+	 * non-nullable scalar return — a TypeError. */
+	if( pValue->iFlags & MEMOBJ_NULL ){
 		return VmThrowTypeErrorForReturn(pVm,&pFunc->sName,
 			VmScalarTypeName(pFunc->nReturnType,&pFunc->sReturnTypeName,zTypeBuf,sizeof(zTypeBuf)),
 			"null");
@@ -4939,7 +4942,7 @@ case PH7_OP_DONE:
 	 * the fiber start/resume paths) set pEnforceRetFunc, so this branch is
 	 * skipped for default-value bytecode, class-method mini-programs,
 	 * callback trampolines, and the main script. */
-	if( pEnforceRetFunc && pEnforceRetFunc->nReturnType > 0
+	if( pEnforceRetFunc && VmFuncHasReturnType(pEnforceRetFunc)
 	 && !(VmSkipExceptionFrames(pVm->pFrame)->iFlags & VM_FRAME_THROW) ){
 		/* The VM_FRAME_THROW guard skips enforcement when the function is
 		 * unwinding because an exception was thrown (the compiler routes an
@@ -10591,7 +10594,7 @@ SkipFuncBody:
 		if( rc != PH7_EXCEPTION ){
 			/* Execute function body */
 			rc = VmByteCodeExec(&(*pVm),(VmInstr *)SySetBasePtr(&pVmFunc->aByteCode),pFrameStack,-1,pTos,&n,FALSE,0,
-				pVmFunc->nReturnType > 0 ? pVmFunc : 0, FALSE);
+				VmFuncHasReturnType(pVmFunc) ? pVmFunc : 0, FALSE);
 		}
 		/* Decrement nesting level */
 		pVm->nRecursionDepth--;
@@ -11039,7 +11042,7 @@ static sxi32 VmStartCtx(ph7_vm *pVm, ph7_exec_ctx *pCtx, ph7_value *pResult)
 	/* Execute from the beginning */
 	rc = VmByteCodeExec(pVm, (VmInstr *)SySetBasePtr(&pCtx->pFunc->aByteCode),
 		pCtx->pStack, -1, &pCtx->sRetValue, 0, FALSE, 0,
-		pCtx->pFunc->nReturnType > 0 ? pCtx->pFunc : 0, FALSE);
+		VmFuncHasReturnType(pCtx->pFunc) ? pCtx->pFunc : 0, FALSE);
 	pVm->nRecursionDepth--;
 	/* Restore the previous context */
 	pVm->pActiveCtx = pOldCtx;
@@ -11114,7 +11117,7 @@ static sxi32 VmResumeCtx(ph7_vm *pVm, ph7_exec_ctx *pCtx, ph7_value *pResumeValu
 	/* Resume execution from saved PC */
 	rc = VmByteCodeExec(pVm, (VmInstr *)SySetBasePtr(&pCtx->pFunc->aByteCode),
 		pCtx->pStack, pCtx->nTos, &pCtx->sRetValue, 0, FALSE, pCtx->pc,
-		pCtx->pFunc->nReturnType > 0 ? pCtx->pFunc : 0, FALSE);
+		VmFuncHasReturnType(pCtx->pFunc) ? pCtx->pFunc : 0, FALSE);
 	pVm->nRecursionDepth--;
 	/* Restore the previous context */
 	pVm->pActiveCtx = pOldCtx;

--- a/tests/ph7/002-integration/lang/promoted_property_union.phpt
+++ b/tests/ph7/002-integration/lang/promoted_property_union.phpt
@@ -1,0 +1,35 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A constructor-promoted property with a union/intersection type is enforced on a later store
+--FILE--
+<?php
+interface PpA {}
+interface PpB {}
+class PpAB implements PpA, PpB {}
+
+class PpUnion {
+    public function __construct(public int|string $x) {}
+}
+$u = new PpUnion(5);
+echo $u->x, "\n";
+$u->x = "ok";
+echo $u->x, "\n";
+try { $u->x = [1, 2, 3]; } catch (\TypeError $e) { echo "union store TE\n"; }
+
+class PpIsect {
+    public function __construct(public PpA&PpB $y) {}
+}
+$i = new PpIsect(new PpAB);
+echo get_class($i->y), "\n";
+try { $i->y = new class implements PpA {}; } catch (\TypeError $e) { echo "isect store TE\n"; }
+?>
+--EXPECT--
+5
+ok
+union store TE
+PpAB
+isect store TE
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/return_nullable.phpt
+++ b/tests/ph7/002-integration/lang/return_nullable.phpt
@@ -1,0 +1,41 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nullable return types (?T, T|null) accept an explicit null and still reject mismatches
+--FILE--
+<?php
+class RnX {}
+
+function rn_q(): ?RnX { return null; }
+var_export(rn_q()); echo "\n";
+
+function rn_class_null(): RnX|null { return new RnX; }
+echo get_class(rn_class_null()), "\n";
+
+function rn_scalar_null(): int|null { return null; }
+var_export(rn_scalar_null()); echo "\n";
+
+function rn_scalar_val(): int|null { return 7; }
+var_export(rn_scalar_val()); echo "\n";
+
+// A nullable return still rejects a wrong non-null value.
+function rn_bad(): ?RnX { return 42; }
+try { rn_bad(); } catch (\TypeError $e) { echo "nullable-mismatch TE\n"; }
+
+// A non-nullable return still rejects null.
+function rn_nonnull(): RnX { return new RnX; }
+echo get_class(rn_nonnull()), "\n";
+function rn_nonnull_bad(): RnX { return null; }
+try { rn_nonnull_bad(); } catch (\TypeError $e) { echo "nonnull-null TE\n"; }
+?>
+--EXPECT--
+NULL
+RnX
+NULL
+7
+nullable-mismatch TE
+RnX
+nonnull-null TE
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/return_union_intersection.phpt
+++ b/tests/ph7/002-integration/lang/return_union_intersection.phpt
@@ -1,0 +1,35 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Union and intersection return types are enforced
+--FILE--
+<?php
+interface RA {}
+interface RB {}
+class RAB implements RA, RB {}
+class RNotA {}
+
+function r_union(): RA|RB { return new RAB; }
+echo get_class(r_union()), "\n";
+
+function r_union_bad(): RA|RB { return 42; }
+try { r_union_bad(); } catch (\TypeError $e) { echo "union TE\n"; }
+
+function r_isect(): RA&RB { return new RAB; }
+echo get_class(r_isect()), "\n";
+
+function r_isect_bad(): RA&RB { return new RNotA; }
+try { r_isect_bad(); } catch (\TypeError $e) { echo "isect TE\n"; }
+
+function r_dnf_null(): RA|RB|null { return null; }
+var_export(r_dnf_null()); echo "\n";
+?>
+--EXPECT--
+RAB
+union TE
+RAB
+isect TE
+NULL
+--CLEAN--
+<?php


### PR DESCRIPTION
Two correctness gaps (silent wrong answers) in the union/intersection type machinery, both pre-existing and surfaced reviewing the intersection/DNF work:

- A union/intersection RETURN type wasn't enforced — the four return-enforcement gates and VmEnforceReturnType's own early-out keyed off nReturnType > 0, which a union leaves at 0 (the type lives in aReturnUnion). Added a VmFuncHasReturnType() predicate used at every gate; the existing VmCoerceToUnion path then does the work.
- A constructor-promoted property with a union/intersection type wasn't enforced on a later store, because the promotion synthesis marked the attr typed only from the single-type fields (0/empty for a union). One VM_FUNC_ARG_UNION clause fixes it; the alts copy below was already correct.

Also fixes nullable return types (?T, T|null, A|B|null), which never accepted null: returns carried no nullable signal (the parser intended null to ride in aReturnUnion, but null atoms are dropped there). Added a func-level VM_FUNC_RETURN_NULLABLE flag, set by GenStateParseReturnType, and one unified explicit-`return null` check in VmEnforceReturnType — so scalar/class/union nullable returns all accept an explicit null while a bare return;/fall-off still requires a value, matching PHP. This subsumes the old (broken) per-shape null handling, removing the scalar '?'-text check and the union null-atom scan.

Verified vs php 8.5.7: return_union_intersection, return_nullable, promoted_property_union.
