### PR TITLE
Discard the original exception when a no-catch finally supersedes it

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -15277,10 +15277,31 @@ static sxi32 VmThrowException(
 		sxi32 rc;
 		/* No catch matched. Execute finally, then propagate to outer try/catch. */
 		if( pException && pException->iHasFinally ){
+			sxu32 nExcBefore = SySetUsed(&pVm->aException);
 			pException->iFinallyDone = 1;
 			rc = VmLocalExec(&(*pVm),&pException->sFinally,0,TRUE);
 			if( rc == SXERR_ABORT ){
 				return SXERR_ABORT;
+			}
+			/* A `return` inside the finally swallows the in-flight exception (PHP
+			 * semantics). pThis is discarded; the enclosing try's OP_THROW /
+			 * OP_POP_EXCEPTION landing pad materializes the pending return. Clear
+			 * VM_FRAME_THROW on the owning frame: this body now returns normally, so
+			 * its caller's OP_CALL must take the return value, not unwind. */
+			if( pVm->bReturnRequested ){
+				VmFrame *pThrowFrame = VmSkipExceptionFrames(pVm->pFrame);
+				if( pException->pFrame == pThrowFrame ){
+					pThrowFrame->iFlags &= ~VM_FRAME_THROW;
+				}
+				return SXRET_OK;
+			}
+			/* The finally threw an exception that superseded pThis — it either
+			 * escaped (PH7_EXCEPTION) or was caught in place by an outer handler
+			 * (which consumed an entry from the exception stack). Either way the
+			 * original pThis is discarded; unwind with the finally's exception (the
+			 * OP_THROW caller resumes at the catching frame or propagates). */
+			if( rc == PH7_EXCEPTION || SySetUsed(&pVm->aException) < nExcBefore ){
+				return PH7_EXCEPTION;
 			}
 		}
 		/* Check if there is an outer exception handler on the stack */

--- a/tests/ph7/002-integration/lang/finally_no_catch_supersedes.phpt
+++ b/tests/ph7/002-integration/lang/finally_no_catch_supersedes.phpt
@@ -1,0 +1,69 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A finally on a try with no matching catch can supersede the in-flight exception
+--FILE--
+<?php
+// On the no-catch path a finally that issues a `return` swallows the in-flight
+// exception, and a finally that throws supersedes it; previously the original
+// exception was re-thrown regardless (leaked as a spurious uncaught / lost return).
+
+// 1) finally `return` swallows the exception (no catch on the try).
+function a() {
+    try { throw new Exception("A"); }
+    finally { return "A-ret\n"; }
+}
+echo a();
+
+// 2) same, but the call sits inside an outer try (the body must RETURN, not unwind).
+function b() {
+    try { throw new Exception("A"); }
+    finally { return "B-ret"; }
+}
+try { echo b(), "\n"; } catch (Exception $e) { echo "unexpected\n"; }
+
+// 3) finally throws; the new exception is the one the outer catch sees.
+function c() {
+    try { throw new Exception("orig"); }
+    finally { throw new Exception("from-finally"); }
+}
+try { c(); } catch (Exception $e) { echo "c:", $e->getMessage(), "\n"; }
+
+// 4) finally throws via a nested call; same result.
+function boom() { throw new Exception("via-call"); }
+function d() {
+    try { throw new Exception("orig"); }
+    finally { boom(); }
+}
+try { d(); } catch (Exception $e) { echo "d:", $e->getMessage(), "\n"; }
+
+// 5) finally's throw caught by an enclosing try of the SAME function; execution
+//    continues to the real return afterwards.
+function e() {
+    try {
+        try { throw new Exception("orig"); }
+        finally { throw new Exception("inner"); }
+    } catch (Exception $ex) { echo "e:", $ex->getMessage(), "\n"; }
+    return "e-end\n";
+}
+echo e();
+
+// 6) control: a finally that completes normally still propagates the original.
+function f() {
+    try { throw new Exception("kept"); }
+    finally { echo "f-finally\n"; }
+}
+try { f(); } catch (Exception $e) { echo "f:", $e->getMessage(), "\n"; }
+?>
+--EXPECT--
+A-ret
+B-ret
+c:from-finally
+d:via-call
+e:inner
+e-end
+f-finally
+f:kept
+--CLEAN--
+<?php


### PR DESCRIPTION
On the no-catch path of VmThrowException (a try whose catch list didn't match the thrown exception but that has a finally), the engine ran the finally and then unconditionally re-threw the original `pThis` — ignoring that the finally may have superseded it. So `try{ throw A; }finally{ return X; }` leaked A as an uncaught fatal instead of returning X, and `try{ throw A; }finally{ throw B; }` (B caught at an outer frame) leaked A alongside B.

After running the no-catch finally, detect supersession:
- a pending `bReturnRequested` means the finally issued a `return` that swallows the in-flight exception (PHP semantics) — clear VM_FRAME_THROW on the owning frame (so the caller's OP_CALL takes the returned value rather than unwinding) and return SXRET_OK so the landing pad materializes the return;
- a PH7_EXCEPTION return, or a shrunk exception stack (the finally's throw consumed an outer handler in place), means the finally's exception superseded pThis — discard the original and unwind with PH7_EXCEPTION.

Verified vs php 8.5.7 across finally-return-swallow (incl. the call sitting in an outer try), finally-throw caught by an outer frame (inline / via a call / caught by an enclosing try of the same function), and the normal-completion control; ASan-clean over the family and 319 exception test bodies; gates green (smoke 2207, integration 762, compat 762 both engines, stress 13). New cross-engine regression: finally_no_catch_supersedes.phpt.
