### PR TITLE
Make closures real Closure objects (Closure class foundation)

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -1956,22 +1956,14 @@ PH7_PRIVATE sxi32 PH7_CompileAnnonFunc(ph7_gen_state *pGen,sxi32 iCompileFlag)
 	static int iCnt = 1;     /* There is no worry about thread-safety here,because only
 							  * one thread is allowed to compile the script.
 						      */
-	ph7_value *pObj;
 	SyString sName;
-	sxu32 nIdx;
 	sxu32 nLen;
 	sxi32 rc;
+	SXUNUSED(iCompileFlag); /* cc warning */
 
 	pGen->pIn++; /* Jump the 'function' keyword */
 	if( pGen->pIn->nType & (PH7_TK_ID|PH7_TK_KEYWORD) ){
 		pGen->pIn++;
-	}
-	/* Reserve a constant for the lambda */
-	pObj = PH7_ReserveConstObj(pGen->pVm,&nIdx);
-	if( pObj == 0 ){
-		PH7_GenCompileError(&(*pGen),E_ERROR,1,"Fatal, PH7 engine is running out of memory");
-		SXUNUSED(iCompileFlag); /* cc warning */
-		return SXERR_ABORT;
 	}
 	/* Generate a unique name */
 	nLen = SyBufferFormat(zName,sizeof(zName),"[lambda_%d]",iCnt++);
@@ -1980,19 +1972,15 @@ PH7_PRIVATE sxi32 PH7_CompileAnnonFunc(ph7_gen_state *pGen,sxi32 iCompileFlag)
 		nLen = SyBufferFormat(zName,sizeof(zName),"[lambda_%d]",iCnt++);
 	}
 	SyStringInitFromBuf(&sName,zName,nLen);
-	PH7_MemObjInitFromString(pGen->pVm,pObj,&sName);
 	/* Compile the lambda body */
 	rc = GenStateCompileFunc(&(*pGen),&sName,0,TRUE,&pAnnonFunc);
 	if( rc == SXERR_ABORT ){
 		return SXERR_ABORT;
 	}
-	if( pAnnonFunc->iFlags & VM_FUNC_CLOSURE ){
-		/* Emit the load closure instruction */
-		PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOAD_CLOSURE,0,0,pAnnonFunc,0);
-	}else{
-		/* Emit the load constant instruction */
-		PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOADC,0,nIdx,0,0);
-	}
+	/* Every anonymous function is a Closure object in PHP, so emit OP_LOAD_CLOSURE for
+	 * both real closures (per-instantiation captured env) and plain lambdas (no captures);
+	 * the handler wraps either in a Closure instance. */
+	PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOAD_CLOSURE,0,0,pAnnonFunc,0);
 	/* Node successfully compiled */
 	return SXRET_OK;
 }

--- a/src/ph7/oo.c
+++ b/src/ph7/oo.c
@@ -1200,6 +1200,14 @@ PH7_PRIVATE sxi32 PH7_ClassInstanceCmp(ph7_class_instance *pLeft,ph7_class_insta
 		/* Same instance,don't bother processing,object are equals */
 		return 0;
 	}
+	/* Closures compare by IDENTITY under == as well (not by attributes): two distinct
+	 * Closure instances are never equal, even when they wrap the same underlying function
+	 * (PHP semantics). pLeft != pRight here, so a Closure pair is unequal. Without this,
+	 * two capture-less lambdas of the same `function(){}` share the template's `$__fn`
+	 * name and would compare equal. */
+	if( pLeft->pVm->pClosureClass && pLeft->pClass == pLeft->pVm->pClosureClass ){
+		return 1;
+	}
 	SyHashResetLoopCursor(&pLeft->hAttr);
 	SyHashResetLoopCursor(&pRight->hAttr);
 	PH7_MemObjInit(pLeft->pVm,&sV1);

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -981,6 +981,7 @@ struct ph7_vm
 	ph7_exec_ctx *pActiveCtx;  /* Currently executing fiber/generator context (NULL in normal code) */
 	ph7_class *pFiberClass;    /* Cached Fiber class pointer for fast dispatch */
 	ph7_class *pGeneratorClass; /* Cached Generator class pointer */
+	ph7_class *pClosureClass;  /* Cached Closure class pointer (closures are instances of it) */
 	ph7_class *pArrayAccessClass; /* Cached ArrayAccess interface pointer */
 	ph7_class *pCountableClass;   /* Cached Countable interface pointer */
 	ph7_class *pStringableClass;  /* Cached Stringable interface pointer */

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -1219,6 +1219,9 @@ static int vm_builtin_Fiber_destruct(ph7_context *pCtx, int nArg, ph7_value **ap
 static ph7_exec_ctx * VmNewExecCtx(ph7_vm *pVm, ph7_vm_func *pFunc);
 static void VmReleaseExecCtx(ph7_vm *pVm, ph7_exec_ctx *pCtx);
 static ph7_generator * VmGeneratorExtractCtx(ph7_vm *pVm, ph7_value *pGenObj);
+static int VmValueIsClosure(ph7_vm *pVm, ph7_value *pVal);
+static sxi32 VmClosureUnwrap(ph7_vm *pVm, ph7_value *pVal, ph7_value *pOut);
+static ph7_class_instance * VmCreateClosure(ph7_vm *pVm, const SyString *pName);
 static sxi32 VmIterCallMethod(ph7_vm *pVm,ph7_class_instance *pThis,const char *zName,sxu32 nLen,ph7_value *pResult);
 static sxi32 VmFiberSetupFrame(ph7_vm *pVm, ph7_exec_ctx *pExecCtx,
 	ph7_class_instance *pClosureThis, int nArg, ph7_value **apArg);
@@ -1477,6 +1480,10 @@ static int vm_builtin_Generator_destruct(ph7_context *pCtx, int nArg, ph7_value 
 	"  public function throw(Throwable $exception){ return __gen_throw($this,$exception); }"\
 	"  public function getReturn(){ return __gen_getReturn($this); }"\
 	"  public function __destruct(){ __gen_destruct($this); }"\
+	"}"\
+	"final class Closure {"\
+	"  private $__fn;"\
+	"  public function __construct(){ throw new \\Error('Instantiation of class Closure is not allowed'); }"\
 	"}"\
 	"class stdClass{"\
 	"  public $value;"\
@@ -1850,6 +1857,8 @@ PH7_PRIVATE sxi32 PH7_VmInit(
 	ph7_create_function(pVm,"__fiber_isSuspended",vm_builtin_Fiber_isSuspended,0);
 	ph7_create_function(pVm,"__fiber_isTerminated",vm_builtin_Fiber_isTerminated,0);
 	ph7_create_function(pVm,"__fiber_destruct",vm_builtin_Fiber_destruct,0);
+	/* Cache the Closure class pointer (closures are instances of it) */
+	pVm->pClosureClass = PH7_VmExtractClass(pVm,"Closure",7,0,0);
 	/* Cache the Generator class pointer and register generator functions */
 	pVm->pGeneratorClass = PH7_VmExtractClass(pVm,"Generator",9,0,0);
 	ph7_create_function(pVm,"__gen_rewind",vm_builtin_Generator_rewind,0);
@@ -6082,6 +6091,10 @@ case PH7_OP_LOAD_IDX: {
  */
 case PH7_OP_LOAD_CLOSURE:{
 	ph7_vm_func *pFunc = (ph7_vm_func *)pInstr->p3;
+	/* The function whose name the Closure object will wrap: a fresh per-instantiation
+	 * copy for a real closure (built below), or the shared lambda function itself for a
+	 * plain anonymous function with no captured environment. */
+	ph7_vm_func *pTarget = pFunc;
 	if( pFunc->iFlags & VM_FUNC_CLOSURE ){
 		ph7_vm_func_closure_env *aEnv,*pEnv,sEnv;
 		ph7_vm_func *pClosure;
@@ -6141,9 +6154,22 @@ case PH7_OP_LOAD_CLOSURE:{
 			/* Insert the imported variable */
 			SySetPut(&pClosure->aClosureEnv,(const void *)&sEnv);
 		}
-		/* Finally,load the closure name on the stack */
-		pTos++;
-		PH7_MemObjStringAppend(pTos,zName,mLen);
+		pTarget = pClosure;
+	}
+	/* Wrap the target function in a Closure object and push it. Its captured environment
+	 * (incl. any `$this`) stays in pTarget->aClosureEnv and is delivered by the normal call
+	 * path when the closure is dispatched by name. */
+	pTos++;
+	{
+		ph7_class_instance *pCloObj = VmCreateClosure(pVm, &pTarget->sName);
+		if( pCloObj ){
+			pCloObj->iRef++;
+			pTos->x.pOther = pCloObj;
+			MemObjSetType(pTos, MEMOBJ_OBJ);
+		}else{
+			/* OOM fallback: the name string is still a usable callable. */
+			PH7_MemObjStringAppend(pTos, pTarget->sName.zString, pTarget->sName.nByte);
+		}
 	}
 	break;
 						 }
@@ -9663,6 +9689,19 @@ case PH7_OP_CALL: {
 	pArg = &pTos[-nCallArgs];
 	SyHashEntry *pEntry;
 	SyString sName;
+	/* A Closure object is callable: unwrap it to its underlying string callable so the
+	 * dispatch below handles it (rather than treating it as a generic object and looking
+	 * for __invoke). pTos here is a stack copy of the call target. Gated on VmValueIsClosure
+	 * so a plain __invoke object skips the temp-value work entirely. */
+	if( VmValueIsClosure(pVm,pTos) ){
+		ph7_value sCallable;
+		PH7_MemObjInit(pVm,&sCallable);
+		if( VmClosureUnwrap(pVm,pTos,&sCallable) == SXRET_OK ){
+			PH7_MemObjRelease(pTos);
+			PH7_MemObjStore(&sCallable,pTos);
+		}
+		PH7_MemObjRelease(&sCallable);
+	}
 	/* Extract function name */
 	if( (pTos->iFlags & MEMOBJ_STRING) == 0 ){
 		if( pTos->iFlags & MEMOBJ_HASHMAP ){
@@ -11387,6 +11426,78 @@ static ph7_exec_ctx * VmFiberExtractCtx(ph7_vm *pVm, ph7_value *pFiberObj)
 	return (ph7_exec_ctx *)pAttr->x.pOther;
 }
 /*
+ * A PHP closure (and a first-class callable `f(...)`) is a real object: an instance of
+ * the built-in final `Closure` class carrying its underlying callable in a private
+ * `$__fn` attribute (the callable NAME: a registered `[closure_N]`/`[lambda_N]` or a
+ * user/host function name). Storing the callable as a plain attribute (rather than a
+ * native resource pointer) means the object owns no `ph7_vm_func` — the per-closure
+ * function stays owned by `hFunction`/VM-release exactly as before, so there is no extra
+ * free path. (First-class callables `f(...)` will add bound `$this`/scope in a follow-up.)
+ *
+ * Returns non-zero iff pVal is a Closure instance.
+ */
+static int VmValueIsClosure(ph7_vm *pVm, ph7_value *pVal)
+{
+	ph7_class_instance *pThis;
+	/* Flag test first: a non-object call target (the hot common case) bails before any
+	 * pVm dereference; pClosureClass==0 is a one-time pre-init concern, so it goes last. */
+	if( (pVal->iFlags & MEMOBJ_OBJ) == 0 || pVal->x.pOther == 0 || pVm->pClosureClass == 0 ){
+		return 0;
+	}
+	pThis = (ph7_class_instance *)pVal->x.pOther;
+	/* Closure is final, so an exact class match is correct (no subclasses possible). */
+	return pThis->pClass == pVm->pClosureClass;
+}
+/*
+ * Unwrap a Closure value into the simple callable the existing dispatch machinery
+ * already understands, written into pOut (which the caller must have initialised):
+ * the `$__fn` name string — a registered `[closure_N]`/`[lambda_N]` or a user/host
+ * function name, all resolvable by name. (Bound `$this` / scope for first-class
+ * callables `f(...)` are a follow-up increment.)
+ * Returns SXRET_OK if pVal was a Closure (pOut filled), SXERR_NOTFOUND otherwise.
+ */
+static sxi32 VmClosureUnwrap(ph7_vm *pVm, ph7_value *pVal, ph7_value *pOut)
+{
+	ph7_class_instance *pThis;
+	ph7_value *pFn;
+	SyString sAttr;
+	if( !VmValueIsClosure(pVm, pVal) ){
+		return SXERR_NOTFOUND;
+	}
+	pThis = (ph7_class_instance *)pVal->x.pOther;
+	SyStringInitFromBuf(&sAttr, "__fn", 4);
+	pFn = PH7_ClassInstanceFetchAttr(pThis, &sAttr);
+	if( pFn == 0 || (pFn->iFlags & MEMOBJ_STRING) == 0 || SyBlobLength(&pFn->sBlob) == 0 ){
+		return SXERR_NOTFOUND; /* malformed/uninitialised closure */
+	}
+	PH7_MemObjStringAppend(pOut, SyBlobData(&pFn->sBlob), SyBlobLength(&pFn->sBlob));
+	return SXRET_OK;
+}
+/*
+ * Create a Closure object wrapping a callable name. Mirrors the Generator/Fiber
+ * "object carries its state in a private attribute" pattern.
+ * Returns the fresh instance (iRef == 0; caller takes the reference), or 0 on OOM.
+ */
+static ph7_class_instance * VmCreateClosure(ph7_vm *pVm, const SyString *pName)
+{
+	ph7_class_instance *pObj;
+	ph7_value *pAttr;
+	SyString sAttr;
+	if( pVm->pClosureClass == 0 ){
+		return 0;
+	}
+	pObj = PH7_NewClassInstance(&(*pVm), pVm->pClosureClass);
+	if( pObj == 0 ){
+		return 0;
+	}
+	SyStringInitFromBuf(&sAttr, "__fn", 4);
+	pAttr = PH7_ClassInstanceFetchAttr(pObj, &sAttr);
+	if( pAttr ){
+		PH7_MemObjStringAppend(pAttr, pName->zString, pName->nByte);
+	}
+	return pObj;
+}
+/*
  * Fiber::suspend($value = null) — static method.
  * Suspends the currently running fiber and passes $value to the caller.
  */
@@ -11474,9 +11585,28 @@ static ph7_vm_func * VmFiberResolveCallable(ph7_context *pCtx, ph7_class_instanc
 		pFunc = (ph7_vm_func *)pEntry->pUserData;
 		return pFunc;
 	}else{
-		/* Object callable (closure) — resolve __invoke method */
 		ph7_class_instance *pClosure = (ph7_class_instance *)pCallable->x.pOther;
-		ph7_class_method *pMethod = PH7_ClassExtractMethod(pClosure->pClass, "__invoke",
+		ph7_class_method *pMethod;
+		if( VmValueIsClosure(pVm, pCallable) ){
+			/* A real Closure object: unwrap to its underlying callable name (the single
+			 * source of truth, VmClosureUnwrap) and resolve that function. Its captured
+			 * environment (including any `$this`) rides along in the named function's
+			 * aClosureEnv, installed by VmFiberSetupFrame, so *ppThis stays 0. */
+			ph7_value sName;
+			SyHashEntry *pEntry = 0;
+			PH7_MemObjInit(pVm, &sName);
+			if( VmClosureUnwrap(pVm, pCallable, &sName) == SXRET_OK ){
+				pEntry = SyHashGet(&pVm->hFunction, SyBlobData(&sName.sBlob), SyBlobLength(&sName.sBlob));
+			}
+			PH7_MemObjRelease(&sName);
+			if( pEntry ){
+				return (ph7_vm_func *)pEntry->pUserData;
+			}
+			PH7_VmThrowException(pCtx, "FiberError", "Fiber callable closure could not be resolved");
+			return 0;
+		}
+		/* Object callable — resolve __invoke method */
+		pMethod = PH7_ClassExtractMethod(pClosure->pClass, "__invoke",
 			sizeof("__invoke") - 1);
 		if( pMethod == 0 ){
 			PH7_VmThrowException(pCtx, "FiberError",
@@ -12638,7 +12768,10 @@ PH7_PRIVATE int PH7_VmIsCallable(ph7_vm *pVm,ph7_value *pValue,int CallInvoke)
 		 * formerly invoked __invoke as a runtime predicate, which is not
 		 * standard PHP behavior. */
 		ph7_class_instance *pThis = (ph7_class_instance *)pValue->x.pOther;
-		if( PH7_ClassExtractMethod(pThis->pClass,"__invoke",sizeof("__invoke")-1) ){
+		if( VmValueIsClosure(pVm,pValue) ){
+			/* A Closure (incl. a first-class callable) is always callable. */
+			res = 1;
+		}else if( PH7_ClassExtractMethod(pThis->pClass,"__invoke",sizeof("__invoke")-1) ){
 			res = 1;
 		}
 		(void)CallInvoke;
@@ -12799,8 +12932,9 @@ static int vm_builtin_register_shutdown_function(ph7_context *pCtx,int nArg,ph7_
 {
 	VmShutdownCB sEntry;
 	int i,j;
-	if( nArg < 1 || (apArg[0]->iFlags & (MEMOBJ_STRING|MEMOBJ_HASHMAP)) == 0 ){
-		/* Missing/Invalid arguments,return immediately */
+	if( nArg < 1 || (apArg[0]->iFlags & (MEMOBJ_STRING|MEMOBJ_HASHMAP|MEMOBJ_OBJ)) == 0 ){
+		/* Missing/Invalid arguments,return immediately. MEMOBJ_OBJ covers a Closure (and
+		 * any __invoke object) callback; it is resolved/validated at shutdown. */
 		return PH7_OK;
 	}
 	/* Zero the Entry */
@@ -13183,8 +13317,22 @@ PH7_PRIVATE sxi32 PH7_VmCallUserFunction(
 	ph7_value *aStack;
 	VmInstr aInstr[2];
 	int i;
+	if( VmValueIsClosure(pVm,pFunc) ){
+		/* A Closure object: unwrap to its underlying string/array callable and dispatch
+		 * that (call_user_func / array_map / usort / the C API all funnel here). */
+		ph7_value sCallable;
+		sxi32 rcClo;
+		PH7_MemObjInit(pVm,&sCallable);
+		if( VmClosureUnwrap(pVm,pFunc,&sCallable) == SXRET_OK ){
+			rcClo = PH7_VmCallUserFunction(pVm,&sCallable,nArg,apArg,pResult);
+			PH7_MemObjRelease(&sCallable);
+			return rcClo;
+		}
+		PH7_MemObjRelease(&sCallable);
+	}
 	if( pFunc->iFlags & MEMOBJ_OBJ ){
-		/* Object callable: dispatch through __invoke when available.
+		/* Object callable: dispatch through __invoke when available (Closures were already
+		 * unwrapped above, so only non-Closure __invoke objects reach here).
 		 * No VmCallArgMap: call_user_func / array_map / usort and the C API
 		 * pass arguments positionally and inherit no strict-types context. */
 		return VmCallObjectInvoke(&(*pVm),

--- a/src/ph7/vm_builtin_ob.c
+++ b/src/ph7/vm_builtin_ob.c
@@ -248,8 +248,8 @@ PH7_PRIVATE int vm_builtin_ob_start(ph7_context *pCtx,int nArg,ph7_value **apArg
 	/* Initialize the OB entry */
 	PH7_MemObjInit(pCtx->pVm,&sOb.sCallback);
 	SyBlobInit(&sOb.sOB,&pVm->sAllocator);
-	if( nArg > 0 && (apArg[0]->iFlags & (MEMOBJ_STRING|MEMOBJ_HASHMAP)) ){
-		/* Save the callback name for later invocation */
+	if( nArg > 0 && (apArg[0]->iFlags & (MEMOBJ_STRING|MEMOBJ_HASHMAP|MEMOBJ_OBJ)) ){
+		/* Save the callback name for later invocation (MEMOBJ_OBJ = a Closure callback). */
 		PH7_MemObjStore(apArg[0],&sOb.sCallback);
 	}
 	/* Push in the stack */

--- a/src/ph7/vm_serialize.c
+++ b/src/ph7/vm_serialize.c
@@ -215,6 +215,14 @@ static sxi32 VmSerializeObject(ph7_value *pIn, serialize_data *pData)
 		pData->exc = 1;
 		return PH7_EXCEPTION;
 	}
+	/* Closures cannot be serialized either (PHP throws). Guard before the generic
+	 * object path would otherwise emit the Closure object's private callable attributes. */
+	if( pThis->pClass == pVm->pClosureClass ){
+		PH7_VmThrowException(pData->pCtx,"Exception",
+			"Serialization of 'Closure' is not allowed");
+		pData->exc = 1;
+		return PH7_EXCEPTION;
+	}
 	SyBlobInit(&sBody,&pVm->sAllocator);
 	pSave = pData->pOut;
 	pData->pOut = &sBody;     /* recursion appends to the body blob */

--- a/tests/ph7/001-smoke/lang/closure_callbacks.phpt
+++ b/tests/ph7/001-smoke/lang/closure_callbacks.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Closures work as callbacks for array_map / array_filter / usort / call_user_func / array_reduce
+--FILE--
+<?php
+echo implode(",", array_map(fn($x) => $x * 2, [1,2,3])), "\n";
+echo implode(",", array_filter([1,2,3,4], function($x){ return $x % 2 === 0; })), "\n";
+$a = [3,1,2]; usort($a, fn($x,$y) => $x - $y); echo implode(",", $a), "\n";
+echo call_user_func(fn($x) => $x . "!", "ok"), "\n";
+echo array_reduce([1,2,3,4], fn($c,$x) => $c + $x, 0), "\n";
+?>
+--EXPECT--
+2,4,6
+2,4
+1,2,3
+ok!
+10
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/closure_compare.phpt
+++ b/tests/ph7/001-smoke/lang/closure_compare.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Closures compare by identity (== and ===): distinct instances are never equal
+--FILE--
+<?php
+function ccmp_mk(){ return function(){ return 42; }; }
+$a = ccmp_mk(); $b = ccmp_mk(); $c = $a;
+echo var_export($a == $b, true), "\n";   // distinct capture-less lambdas -> false
+echo var_export($a === $b, true), "\n";  // false
+echo var_export($a == $c, true), "\n";   // same instance -> true
+echo var_export($a === $c, true), "\n";  // true
+$x = fn() => 1; $y = fn() => 1;
+echo var_export($x == $y, true), "\n";   // false
+?>
+--EXPECT--
+false
+false
+true
+true
+false
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/closure_invokable_not_closure.phpt
+++ b/tests/ph7/001-smoke/lang/closure_invokable_not_closure.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+An object with __invoke is callable but is NOT an instanceof Closure
+--FILE--
+<?php
+class CincAdder { public function __invoke($x){ return $x + 100; } }
+$o = new CincAdder();
+echo var_export($o instanceof Closure, true), "\n";
+echo var_export(is_callable($o), true), "\n";
+echo $o(1), "\n";
+echo call_user_func($o, 2), "\n";
+?>
+--EXPECT--
+false
+true
+101
+102
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/closure_is_callable.phpt
+++ b/tests/ph7/001-smoke/lang/closure_is_callable.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A Closure is callable (is_callable + callable type-hint)
+--FILE--
+<?php
+$f = fn() => 42;
+echo var_export(is_callable($f), true), "\n";
+function cic_run(callable $c){ return $c(); }
+echo cic_run($f), "\n";
+echo cic_run(function(){ return "hi"; }), "\n";
+?>
+--EXPECT--
+true
+42
+hi
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/closure_is_object.phpt
+++ b/tests/ph7/001-smoke/lang/closure_is_object.phpt
@@ -1,0 +1,26 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Anonymous functions and arrow functions are Closure objects (instanceof / gettype)
+--FILE--
+<?php
+$a = function($x){ return $x; };
+$b = fn($x) => $x;
+$c = function() use ($a) { return $a; };
+echo var_export($a instanceof Closure, true), "\n";
+echo var_export($b instanceof Closure, true), "\n";
+echo var_export($c instanceof Closure, true), "\n";
+echo gettype($a), "\n";
+echo var_export(is_string($a), true), "\n";
+echo get_class($b), "\n";
+?>
+--EXPECT--
+true
+true
+true
+object
+false
+Closure
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/closure_new_throws.phpt
+++ b/tests/ph7/001-smoke/lang/closure_new_throws.phpt
@@ -1,0 +1,15 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Closure cannot be instantiated with new
+--FILE--
+<?php
+echo var_export(class_exists("Closure"), true), "\n";
+try { $c = new Closure(); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+?>
+--EXPECT--
+true
+Error: Instantiation of class Closure is not allowed
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/closure_serialize_throws.phpt
+++ b/tests/ph7/001-smoke/lang/closure_serialize_throws.phpt
@@ -1,0 +1,15 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Closures cannot be serialized (Exception, no internals leaked)
+--FILE--
+<?php
+try { serialize(fn() => 1); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+try { serialize(function(){}); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+?>
+--EXPECT--
+Exception: Serialization of 'Closure' is not allowed
+Exception: Serialization of 'Closure' is not allowed
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/closure_typehint.phpt
+++ b/tests/ph7/001-smoke/lang/closure_typehint.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Closure type-hints (param, return, property) accept closures
+--FILE--
+<?php
+function cth_take(Closure $c){ return $c(10); }
+echo cth_take(fn($x) => $x * 2), "\n";
+echo cth_take(function($x){ return $x + 1; }), "\n";
+function cth_make(): Closure { return fn() => "ret"; }
+$m = cth_make(); echo $m(), "\n";
+class CthBox { public Closure $fn; }
+$b = new CthBox(); $b->fn = fn() => "prop";
+$f = $b->fn; echo $f(), "\n";
+?>
+--EXPECT--
+20
+11
+ret
+prop
+--CLEAN--
+<?php


### PR DESCRIPTION
Closures were a MEMOBJ_STRING (the internal [closure_N]/[lambda_N] name), so `$x instanceof Closure`, `Closure $c` type-hints, and gettype() were all wrong. Now every anonymous function -- including a plain function(){} without captures (previously OP_LOADC) -- is an instance of the built-in `final class Closure`, carrying its callable name in a private $__fn attribute (attribute-based model, so the object owns no ph7_vm_func: lifetime is unchanged and there is no extra free path).

OP_LOAD_CLOSURE wraps the function (VmCreateClosure); the dispatch sites unwrap a Closure to its name via VmClosureUnwrap and reuse the existing string-callable path: OP_CALL, PH7_VmCallUserFunction, VmFiberResolveCallable. is_callable / PH7_VmIsCallable plus the two inline-checking callback builtins (register_shutdown_function, ob_start) were widened to accept MEMOBJ_OBJ; all other callback builtins already route through is_callable / PH7_VmCallUserFunction.

Now correct vs php 8.5.7: instanceof Closure; Closure param/return/property type-hints; is_callable; callable hints; gettype->object; is_string->false; new Closure() throws "Instantiation of class Closure is not allowed"; serialize(Closure) throws "Serialization of 'Closure' is not allowed" (vs leaking internals); and == compares closures by identity (distinct instances never equal, matching ===).

Deferred to follow-ups: first-class callable f(...) (Increment 1b, now unblocked); Closure::bind/bindTo/call/fromCallable (Increment 2); var_dump/print_r/var_export closure rendering (var_dump-fidelity task). Pre-existing gaps surfaced (not regressions): non-arrow function(){ $this } in a method doesn't auto-bind $this; ($obj->prop)() mis-parses; class-hint mismatch warns instead of TypeError.

Gates green both engines (smoke 2215, integration 767); ASan-clean over the closure/callback/fiber/generator bodies + create/drop stress. 8 new .phpt.
