### PR TITLE
Add first-class callable syntax f(...)

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -3111,6 +3111,19 @@ static sxi32 GenStateResolveNamespaceLiteral(ph7_gen_state *pGen)
 /*
  * Compile a literal which is an identifier(name) for a simple value.
  */
+/*
+ * Compile a first-class-callable marker node `...` (the lone-ellipsis argument list of
+ * `f(...)`). The function-call code generator detects EXPR_NODE_FCC on its single argument
+ * and emits OP_LOAD_FCC instead of compiling this node, so reaching here means the `...`
+ * appeared outside a call argument list — a syntax error (PHP rejects it likewise).
+ */
+PH7_PRIVATE sxi32 PH7_CompileFccMarker(ph7_gen_state *pGen,sxi32 iCompileFlag)
+{
+	SXUNUSED(iCompileFlag);
+	PH7_GenCompileError(&(*pGen),E_ERROR,pGen->pIn ? pGen->pIn->nLine : 0,
+		"Cannot use the first-class callable syntax '...' here");
+	return SXERR_SYNTAX;
+}
 PH7_PRIVATE sxi32 PH7_CompileLiteral(ph7_gen_state *pGen,sxi32 iCompileFlag)
 {
 	sxi32 rc;
@@ -10725,6 +10738,7 @@ static sxi32 GenStateEmitExprCode(
 	sxi32 iVmOp;
 	sxi32 rc;
 	int bIsChainOp = 0; /* Set below once we know pNode->pOp */
+	int bFcc = 0;       /* First-class callable `f(...)`: emit OP_LOAD_FCC, not OP_CALL */
 	sxu32 nRhsNsBase = 0;
 	if( pNode->xCode ){
 		SyToken *pTmpIn,*pTmpEnd;
@@ -10868,6 +10882,13 @@ static sxi32 GenStateEmitExprCode(
 			/* Recurse and generate bytecodes for function arguments */
 			apNode = (ph7_expr_node **)SySetBasePtr(&pNode->aNodeArgs);
 			nArgs = (sxi32)SySetUsed(&pNode->aNodeArgs);
+			/* First-class callable `f(...)`: the sole argument is the lone-ellipsis marker.
+			 * Emit no arguments; the callee (pNode->pLeft) is still compiled below, then we
+			 * emit OP_LOAD_FCC instead of OP_CALL to wrap it in a Closure. */
+			if( nArgs == 1 && apNode[0] && (apNode[0]->iFlags & EXPR_NODE_FCC) ){
+				bFcc = 1;
+				nArgs = 0;
+			}
 			/* Validate: no positional arguments after named arguments */
 			{
 				int seenNamed = 0;
@@ -11272,6 +11293,31 @@ static sxi32 GenStateEmitExprCode(
 					p3 = pInstr->p3;
 					(void)PH7_VmPopInstr(pGen->pVm);
 				}
+			}
+		}
+		/* First-class callable: emit OP_LOAD_FCC to wrap the callee in a Closure instead of
+		 * calling it. For a plain function the callee's OP_LOADC left its name on the stack
+		 * (iP1=1). For a method/static callee the callee compiled to ... OP_MEMBER, which we
+		 * DROP — the OP_MEMBER would dispatch and mangle the method name; popping it leaves
+		 * [target, real-method-name] on the stack for OP_LOAD_FCC to bind (iP1=2). */
+		if( bFcc ){
+			iVmOp = PH7_OP_LOAD_FCC;
+			iP2 = 0;
+			p3 = 0;
+			pInstr = PH7_VmPeekInstr(pGen->pVm);
+			if( pInstr && pInstr->iOp == PH7_OP_MEMBER ){
+				/* A static call with a DYNAMIC method name (`C::$m(...)`) folded that name
+				 * into OP_MEMBER->p3 and left only [class] on the stack (the name's OP_LOAD
+				 * was popped at the static-`::` codegen above). Re-load it so OP_LOAD_FCC
+				 * sees the [target, method-name] pair the iP1=2 handler expects. */
+				void *pMemberName = pInstr->p3;
+				(void)PH7_VmPopInstr(pGen->pVm);
+				if( pMemberName ){
+					PH7_VmEmitInstr(pGen->pVm, PH7_OP_LOAD, 0, 0, pMemberName, 0);
+				}
+				iP1 = 2;
+			}else{
+				iP1 = 1;
 			}
 		}
 		/* Tag CALL/NEW sites with the caller file's strict_types flag.

--- a/src/ph7/parse.c
+++ b/src/ph7/parse.c
@@ -894,6 +894,19 @@ static sxi32 ExprExtractNode(ph7_gen_state *pGen,ph7_expr_node **ppNode,int iLas
 	pCur = pNode->pStart = pGen->pIn;
 	/* Start collecting tokens */
 	if( pCur->nType & PH7_TK_ELLIPSIS ){
+		if( &pCur[1] < pGen->pEnd && (pCur[1].nType & PH7_TK_RPAREN) ){
+			/* First-class callable: `...` is the ENTIRE argument list — the next token is
+			 * ')'. Consume only the '...' and return this node as a self-evaluating FCC
+			 * marker (xCode set so ExprMakeTree accepts it as a lone terminal); the
+			 * function-call code generator turns it into a Closure (OP_LOAD_FCC). */
+			pNode->pEnd = pCur;
+			pCur++;
+			pNode->iFlags |= EXPR_NODE_FCC;
+			pNode->xCode = PH7_CompileFccMarker;
+			pGen->pIn = pCur;
+			*ppNode = pNode;
+			return SXRET_OK;
+		}
 		/* Argument unpacking: ...$expr — skip '...' and extract the expression.
 		 * Mark the node so that the code generator emits PH7_OP_SPREAD after it. */
 		pCur++;

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -352,6 +352,9 @@ struct ph7_expr_node
 #define EXPR_NODE_SPREAD      0x02 /* Argument unpacking: ...$expr */
 #define EXPR_NODE_NAMED_ARG   0x04 /* Named argument: name: $expr */
 #define EXPR_NODE_PARENS      0x08 /* Root of a parenthesized sub-expression */
+#define EXPR_NODE_FCC         0x10 /* First-class callable marker: a lone `...` as the
+                                    * whole argument list, e.g. f(...) — wrap the callee
+                                    * in a Closure instead of calling it. */
 /*
  * A block of instructions is recorded in an instance of the following structure.
  * This structure is used only during compile-time and have no meaning
@@ -1060,6 +1063,7 @@ enum ph7_vm_op {
   PH7_OP_LOAD_MAP,     /* Load hashmap('array') */
   PH7_OP_LOAD_LIST,    /* Load list */
   PH7_OP_LOAD_CLOSURE, /* Load closure */
+  PH7_OP_LOAD_FCC,     /* Load first-class callable: wrap a function/method as a Closure */
   PH7_OP_NOOP,         /* NOOP */
   PH7_OP_JMP,          /* Unconditional jump */
   PH7_OP_JZ,           /* Jump on zero (FALSE jump) */
@@ -1742,6 +1746,7 @@ PH7_PRIVATE sxi32 PH7_CompileLangConstruct(ph7_gen_state *pGen,sxi32 iCompileFla
 PH7_PRIVATE sxi32 PH7_CompileYield(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileVariable(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileLiteral(ph7_gen_state *pGen,sxi32 iCompileFlag);
+PH7_PRIVATE sxi32 PH7_CompileFccMarker(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileSimpleString(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileString(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileHereDoc(ph7_gen_state *pGen,sxi32 iCompileFlag);

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -1221,7 +1221,9 @@ static void VmReleaseExecCtx(ph7_vm *pVm, ph7_exec_ctx *pCtx);
 static ph7_generator * VmGeneratorExtractCtx(ph7_vm *pVm, ph7_value *pGenObj);
 static int VmValueIsClosure(ph7_vm *pVm, ph7_value *pVal);
 static sxi32 VmClosureUnwrap(ph7_vm *pVm, ph7_value *pVal, ph7_value *pOut);
-static ph7_class_instance * VmCreateClosure(ph7_vm *pVm, const SyString *pName);
+static ph7_class_instance * VmCreateClosure(ph7_vm *pVm, const SyString *pName,
+	ph7_class_instance *pBoundThis, const SyString *pScope);
+static ph7_class * VmFccResolveScope(ph7_vm *pVm, ph7_value *pTarget);
 static sxi32 VmIterCallMethod(ph7_vm *pVm,ph7_class_instance *pThis,const char *zName,sxu32 nLen,ph7_value *pResult);
 static sxi32 VmFiberSetupFrame(ph7_vm *pVm, ph7_exec_ctx *pExecCtx,
 	ph7_class_instance *pClosureThis, int nArg, ph7_value **apArg);
@@ -1483,6 +1485,8 @@ static int vm_builtin_Generator_destruct(ph7_context *pCtx, int nArg, ph7_value 
 	"}"\
 	"final class Closure {"\
 	"  private $__fn;"\
+	"  private $__this;"\
+	"  private $__scope;"\
 	"  public function __construct(){ throw new \\Error('Instantiation of class Closure is not allowed'); }"\
 	"}"\
 	"class stdClass{"\
@@ -6161,7 +6165,7 @@ case PH7_OP_LOAD_CLOSURE:{
 	 * path when the closure is dispatched by name. */
 	pTos++;
 	{
-		ph7_class_instance *pCloObj = VmCreateClosure(pVm, &pTarget->sName);
+		ph7_class_instance *pCloObj = VmCreateClosure(pVm, &pTarget->sName, 0, 0);
 		if( pCloObj ){
 			pCloObj->iRef++;
 			pTos->x.pOther = pCloObj;
@@ -6173,6 +6177,79 @@ case PH7_OP_LOAD_CLOSURE:{
 	}
 	break;
 						 }
+/*
+ * LOAD_FCC P1 * *
+ *
+ * First-class callable: wrap the callee in a Closure object instead of calling it.
+ *  P1 == 1: a plain function/host callable — its NAME string is already on the TOS
+ *           (from the callee's OP_LOADC). Replace it in place with a Closure whose
+ *           $__fn is that name; the existing string-callable dispatch resolves it.
+ *           (OOM degrades to leaving the name string on the stack — still callable.)
+ *  P1 == 2: a method/static callee — the stack is [ target (pTos[-1]), real-method-name
+ *           (pTos) ] (the OP_MEMBER was popped at compile time). An object target binds
+ *           $this (scope = its class); a class-name-string target is a static callable
+ *           (scope = that class, self/parent/static resolved now). (OOM degrades to NULL —
+ *           the popped target leaves no name string to keep.)
+ */
+case PH7_OP_LOAD_FCC:{
+	if( pInstr->iP1 == 1 ){
+		/* Plain-callee FCC: TOS holds the callee value. The common case is a function-NAME
+		 * string (from the callee's OP_LOADC) — wrap it in a Closure. Two value-callee cases
+		 * are handled idempotently rather than minting a broken empty-name Closure:
+		 *   - an existing Closure (`$closure(...)`) is left unchanged (PHP: idempotent);
+		 *   - any other non-string value (array callable, scalar via `($expr)(...)`) is left
+		 *     as-is — it stays whatever it was (a [obj,m] array callable remains callable).
+		 * Full first-class-callable wrapping of an arbitrary callable EXPRESSION is a
+		 * follow-up (see PLAN.md). */
+		if( VmValueIsClosure(pVm, pTos) || (pTos->iFlags & MEMOBJ_STRING) == 0 ){
+			break;
+		}
+		{
+			SyString sName;
+			ph7_class_instance *pCloObj;
+			SyStringInitFromBuf(&sName, SyBlobData(&pTos->sBlob), SyBlobLength(&pTos->sBlob));
+			pCloObj = VmCreateClosure(pVm, &sName, 0, 0);
+			if( pCloObj ){
+				PH7_MemObjRelease(pTos);
+				pCloObj->iRef++;
+				pTos->x.pOther = pCloObj;
+				MemObjSetType(pTos, MEMOBJ_OBJ);
+			}
+			/* OOM: leave the name string on the stack — still a usable callable. */
+		}
+	}else{
+		/* iP1 == 2: method/static. Stack is [ target (pTos[-1]), real-method-name (pTos) ]
+		 * left standing by the popped OP_MEMBER. An object target binds $this (scope = its
+		 * class); a class-name string target is a static callable (scope = that class). */
+		ph7_value *pTarget = &pTos[-1];
+		SyString sName;
+		ph7_class_instance *pCloObj;
+		SyStringInitFromBuf(&sName, SyBlobData(&pTos->sBlob), SyBlobLength(&pTos->sBlob));
+		if( pTarget->iFlags & MEMOBJ_OBJ ){
+			ph7_class_instance *pBoundThis = (ph7_class_instance *)pTarget->x.pOther;
+			pCloObj = VmCreateClosure(pVm, &sName, pBoundThis, &pBoundThis->pClass->sName);
+		}else if( pTarget->iFlags & MEMOBJ_STRING ){
+			/* Static `T::m(...)`: resolve T (incl. self/static/parent) to the real class
+			 * now, so the closure binds the concrete scope (matching PHP). */
+			ph7_class *pScopeCls = VmFccResolveScope(pVm, pTarget);
+			pCloObj = pScopeCls ? VmCreateClosure(pVm, &sName, 0, &pScopeCls->sName) : 0;
+		}else{
+			pCloObj = 0;
+		}
+		/* Pop the method name and the target, push the Closure. */
+		PH7_MemObjRelease(pTos);
+		pTos--;
+		PH7_MemObjRelease(pTos);
+		if( pCloObj ){
+			pCloObj->iRef++;
+			pTos->x.pOther = pCloObj;
+			MemObjSetType(pTos, MEMOBJ_OBJ);
+		}else{
+			pTos->nIdx = SXU32_HIGH; /* OOM: NULL */
+		}
+	}
+	break;
+					 }
 /*
  * STORE * P2 P3
  *
@@ -11425,14 +11502,19 @@ static ph7_exec_ctx * VmFiberExtractCtx(ph7_vm *pVm, ph7_value *pFiberObj)
 	}
 	return (ph7_exec_ctx *)pAttr->x.pOther;
 }
+/* ph7_class_instance.iFlags bit: this Closure is a bound/static first-class callable and
+ * carries $__this/$__scope. Lets the hot plain-closure unwrap skip those attribute lookups.
+ * (Distinct from CLASS_INSTANCE_DESTROYED 0x001 and VM_INSTANCE_DUMPING 0x002.) */
+#define VM_INSTANCE_FCC_BOUND 0x004
 /*
  * A PHP closure (and a first-class callable `f(...)`) is a real object: an instance of
  * the built-in final `Closure` class carrying its underlying callable in a private
  * `$__fn` attribute (the callable NAME: a registered `[closure_N]`/`[lambda_N]` or a
- * user/host function name). Storing the callable as a plain attribute (rather than a
- * native resource pointer) means the object owns no `ph7_vm_func` — the per-closure
- * function stays owned by `hFunction`/VM-release exactly as before, so there is no extra
- * free path. (First-class callables `f(...)` will add bound `$this`/scope in a follow-up.)
+ * user/host function name) — plus, for a method/static first-class callable, a bound
+ * `$__this` object and/or a `$__scope` class-name. Storing the callable as plain attributes
+ * (rather than a native resource pointer) means the object owns no `ph7_vm_func` — the
+ * per-closure function stays owned by `hFunction`/VM-release exactly as before, so there is
+ * no extra free path.
  *
  * Returns non-zero iff pVal is a Closure instance.
  */
@@ -11451,9 +11533,11 @@ static int VmValueIsClosure(ph7_vm *pVm, ph7_value *pVal)
 /*
  * Unwrap a Closure value into the simple callable the existing dispatch machinery
  * already understands, written into pOut (which the caller must have initialised):
- * the `$__fn` name string — a registered `[closure_N]`/`[lambda_N]` or a user/host
- * function name, all resolvable by name. (Bound `$this` / scope for first-class
- * callables `f(...)` are a follow-up increment.)
+ *   - bound `$this` set (method first-class callable) -> [ $__this, $__fn ] array callable
+ *   - `$__scope` set (static first-class callable)     -> [ $__scope, $__fn ] array callable
+ *   - neither (plain function / real closure)          -> the `$__fn` name string
+ * The 2-element array form rides the existing MEMOBJ_HASHMAP dispatch, which binds $this
+ * for an object first element and resolves the class for a class-name-string first element.
  * Returns SXRET_OK if pVal was a Closure (pOut filled), SXERR_NOTFOUND otherwise.
  */
 static sxi32 VmClosureUnwrap(ph7_vm *pVm, ph7_value *pVal, ph7_value *pOut)
@@ -11470,15 +11554,87 @@ static sxi32 VmClosureUnwrap(ph7_vm *pVm, ph7_value *pVal, ph7_value *pOut)
 	if( pFn == 0 || (pFn->iFlags & MEMOBJ_STRING) == 0 || SyBlobLength(&pFn->sBlob) == 0 ){
 		return SXERR_NOTFOUND; /* malformed/uninitialised closure */
 	}
+	/* Only a bound/static first-class callable (rare) carries $__this/$__scope; the
+	 * VM_INSTANCE_FCC_BOUND flag (set by VmCreateClosure) keeps the hot plain-closure path
+	 * to the single $__fn lookup above instead of two extra attribute lookups per dispatch. */
+	if( pThis->iFlags & VM_INSTANCE_FCC_BOUND ){
+		ph7_value *pBound, *pScope;
+		int bBoundObj, bScope;
+		SyStringInitFromBuf(&sAttr, "__this", 6);
+		pBound = PH7_ClassInstanceFetchAttr(pThis, &sAttr);
+		SyStringInitFromBuf(&sAttr, "__scope", 7);
+		pScope = PH7_ClassInstanceFetchAttr(pThis, &sAttr);
+		bBoundObj = pBound && (pBound->iFlags & MEMOBJ_OBJ);
+		bScope = pScope && (pScope->iFlags & MEMOBJ_STRING) && SyBlobLength(&pScope->sBlob) > 0;
+		if( bBoundObj || bScope ){
+			/* Method/static first-class callable -> [ target, "method" ] array callable. */
+			ph7_hashmap *pMap = PH7_NewHashmap(&(*pVm), 0, 0);
+			ph7_value sTarget, sMeth;
+			sxi32 rc;
+			if( pMap == 0 ){
+				return SXERR_NOTFOUND;
+			}
+			PH7_MemObjInit(pVm, &sTarget);
+			PH7_MemObjInit(pVm, &sMeth);
+			if( bBoundObj ){
+				PH7_MemObjStore(pBound, &sTarget); /* bound object (iRef++) -> binds $this */
+			}else{
+				PH7_MemObjStringAppend(&sTarget, SyBlobData(&pScope->sBlob), SyBlobLength(&pScope->sBlob));
+			}
+			PH7_MemObjStringAppend(&sMeth, SyBlobData(&pFn->sBlob), SyBlobLength(&pFn->sBlob));
+			rc = PH7_HashmapInsert(pMap, 0, &sTarget);
+			if( rc == SXRET_OK ){
+				rc = PH7_HashmapInsert(pMap, 0, &sMeth);
+			}
+			PH7_MemObjRelease(&sTarget);
+			PH7_MemObjRelease(&sMeth);
+			if( rc != SXRET_OK ){
+				PH7_HashmapRelease(pMap, TRUE); /* free the partial map, no leak */
+				return SXERR_NOTFOUND;
+			}
+			pOut->x.pOther = pMap;
+			MemObjSetType(pOut, MEMOBJ_HASHMAP);
+			return SXRET_OK;
+		}
+	}
 	PH7_MemObjStringAppend(pOut, SyBlobData(&pFn->sBlob), SyBlobLength(&pFn->sBlob));
 	return SXRET_OK;
 }
 /*
- * Create a Closure object wrapping a callable name. Mirrors the Generator/Fiber
- * "object carries its state in a private attribute" pattern.
+ * Resolve the scope class for a STATIC first-class callable `T::m(...)`, where T is a
+ * class-name STRING value: handles the self/static/parent keywords against the live class
+ * context (so the actual class is bound at FCC-creation time, like PHP), and falls back to
+ * an explicit class-name lookup. Mirrors the static OP_MEMBER resolution. Returns 0 if the
+ * class cannot be resolved.
+ */
+static ph7_class * VmFccResolveScope(ph7_vm *pVm, ph7_value *pTarget)
+{
+	const char *zCls = (const char *)SyBlobData(&pTarget->sBlob);
+	sxu32 nCls = (sxu32)SyBlobLength(&pTarget->sBlob);
+	ph7_class *pClass;
+	if( nCls == 4 && SyMemcmp(zCls,"self",4) == 0 ){
+		pClass = PH7_VmPeekDeclaringClass(&(*pVm));
+		if( pClass && (pClass->iFlags & PH7_CLASS_TRAIT) ){
+			pClass = PH7_VmPeekTopClass(&(*pVm)); /* self:: in a trait -> using class */
+		}
+	}else if( nCls == 6 && SyMemcmp(zCls,"static",6) == 0 ){
+		pClass = PH7_VmPeekTopClass(&(*pVm));     /* late static binding */
+	}else if( nCls == 6 && SyMemcmp(zCls,"parent",6) == 0 ){
+		ph7_class *pSelf = PH7_VmPeekDeclaringClass(&(*pVm));
+		pClass = (pSelf && pSelf->pBase) ? pSelf->pBase : 0;
+	}else{
+		pClass = PH7_VmExtractClass(&(*pVm),zCls,nCls,FALSE,0);
+	}
+	return pClass;
+}
+/*
+ * Create a Closure object wrapping a callable name (+ optional bound $this object and/or
+ * scope class-name, for the method/static first-class callables `$o->m(...)`/`C::m(...)`).
+ * Mirrors the Generator/Fiber "object carries its state in private attributes" pattern.
  * Returns the fresh instance (iRef == 0; caller takes the reference), or 0 on OOM.
  */
-static ph7_class_instance * VmCreateClosure(ph7_vm *pVm, const SyString *pName)
+static ph7_class_instance * VmCreateClosure(ph7_vm *pVm, const SyString *pName,
+	ph7_class_instance *pBoundThis, const SyString *pScope)
 {
 	ph7_class_instance *pObj;
 	ph7_value *pAttr;
@@ -11494,6 +11650,27 @@ static ph7_class_instance * VmCreateClosure(ph7_vm *pVm, const SyString *pName)
 	pAttr = PH7_ClassInstanceFetchAttr(pObj, &sAttr);
 	if( pAttr ){
 		PH7_MemObjStringAppend(pAttr, pName->zString, pName->nByte);
+	}
+	if( pBoundThis ){
+		SyStringInitFromBuf(&sAttr, "__this", 6);
+		pAttr = PH7_ClassInstanceFetchAttr(pObj, &sAttr);
+		if( pAttr ){
+			pAttr->x.pOther = pBoundThis;
+			MemObjSetType(pAttr, MEMOBJ_OBJ);
+			pBoundThis->iRef++; /* keep the bound object alive for the closure's lifetime */
+		}
+	}
+	if( pScope && pScope->nByte ){
+		SyStringInitFromBuf(&sAttr, "__scope", 7);
+		pAttr = PH7_ClassInstanceFetchAttr(pObj, &sAttr);
+		if( pAttr ){
+			PH7_MemObjStringAppend(pAttr, pScope->zString, pScope->nByte);
+		}
+	}
+	if( pBoundThis || (pScope && pScope->nByte) ){
+		/* Mark bound/static FCC closures so VmClosureUnwrap can skip the $__this/$__scope
+		 * lookups on the hot plain-closure dispatch path. */
+		pObj->iFlags |= VM_INSTANCE_FCC_BOUND;
 	}
 	return pObj;
 }
@@ -12422,6 +12599,8 @@ static const char * VmInstrToString(sxi32 nOp)
 	case PH7_OP_LOAD_IDX:   zOp = "LOAD_IDX   "; break;
 	case PH7_OP_LOAD_CLOSURE:
 		                    zOp = "LOAD_CLOSR "; break;
+	case PH7_OP_LOAD_FCC:
+		                    zOp = "LOAD_FCC   "; break;
 	case PH7_OP_NOOP:       zOp = "NOOP       "; break;
 	case PH7_OP_JMP:        zOp = "JMP        "; break;
 	case PH7_OP_JZ:         zOp = "JZ         "; break;

--- a/tests/ph7/001-smoke/lang/fcc_dynamic.phpt
+++ b/tests/ph7/001-smoke/lang/fcc_dynamic.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+First-class callable with a dynamic method/class name ($o->$m(...), C::$m(...), $cls::m(...))
+--FILE--
+<?php
+class FccDyn {
+  public $v = 5;
+  function im($x){ return $this->v + $x; }
+  static function sm($x){ return $x * 100; }
+}
+$o = new FccDyn();
+$m = "im"; $f = $o->$m(...); echo $f(3), "\n";
+$s = "sm"; $g = FccDyn::$s(...); echo $g(4), "\n";
+$cls = "FccDyn"; $h = $cls::sm(...); echo $h(2), "\n";
+?>
+--EXPECT--
+8
+400
+200
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/fcc_function.phpt
+++ b/tests/ph7/001-smoke/lang/fcc_function.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+First-class callable of a user function: f(...) wraps it in a callable Closure
+--FILE--
+<?php
+function fcc_dbl($x){ return $x * 2; }
+$f = fcc_dbl(...);
+echo $f(21), "\n";
+echo call_user_func($f, 5), "\n";
+function fcc_sum(...$xs){ return array_sum($xs); }
+$s = fcc_sum(...);
+echo $s(4, 5, 6), "\n";
+?>
+--EXPECT--
+42
+10
+15
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/fcc_host_builtin.phpt
+++ b/tests/ph7/001-smoke/lang/fcc_host_builtin.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+First-class callable of a host builtin: strlen(...), array_map(strtoupper(...))
+--FILE--
+<?php
+$len = strlen(...);
+echo $len("hello"), "\n";
+echo implode(",", array_map(strtoupper(...), ["a", "b", "c"])), "\n";
+$up = strtoupper(...);
+echo $up("php"), "\n";
+?>
+--EXPECT--
+5
+A,B,C
+PHP
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/fcc_is_closure.phpt
+++ b/tests/ph7/001-smoke/lang/fcc_is_closure.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A first-class callable is a Closure object (instanceof / is_callable / gettype)
+--FILE--
+<?php
+function fcc_ic($x){ return $x; }
+$f = fcc_ic(...);
+echo var_export($f instanceof Closure, true), "\n";
+echo var_export(is_callable($f), true), "\n";
+echo gettype($f), "\n";
+$g = strlen(...);
+echo var_export($g instanceof Closure, true), "\n";
+?>
+--EXPECT--
+true
+true
+object
+true
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/fcc_method.phpt
+++ b/tests/ph7/001-smoke/lang/fcc_method.phpt
@@ -1,0 +1,25 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+First-class callable of an instance method binds $this (and keeps it alive)
+--FILE--
+<?php
+class FccM { public $v = 7; function add($x){ return $this->v + $x; } }
+$o = new FccM();
+$f = $o->add(...);
+echo $f(3), "\n";
+echo var_export($f instanceof Closure, true), "\n";
+$o2 = new FccM(); $o2->v = 100;
+$g = $o2->add(...);
+$o2 = null;
+echo $g(1), "\n";
+echo implode(",", array_map($o->add(...), [10, 20])), "\n";
+?>
+--EXPECT--
+10
+true
+101
+17,27
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/fcc_static.phpt
+++ b/tests/ph7/001-smoke/lang/fcc_static.phpt
@@ -1,0 +1,31 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+First-class callable of a static method: Cls::m(...) and self/parent/static
+--FILE--
+<?php
+class FccBase {
+  static function who(){ return "base"; }
+  function selfWho(){ $f = self::who(...); return $f(); }
+}
+class FccChild extends FccBase {
+  static function who(){ return "child"; }
+  function parentWho(){ $f = parent::who(...); return $f(); }
+  function staticWho(){ $f = static::who(...); return $f(); }
+}
+$f = FccBase::who(...);
+echo $f(), "\n";
+$b = new FccBase();
+echo $b->selfWho(), "\n";
+$c = new FccChild();
+echo $c->parentWho(), "\n";
+echo $c->staticWho(), "\n";
+?>
+--EXPECT--
+base
+base
+base
+child
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/fcc_vs_spread.phpt
+++ b/tests/ph7/001-smoke/lang/fcc_vs_spread.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+f(...) is a first-class callable; f(...$args) is still argument spread
+--FILE--
+<?php
+function fcc_vs($a, $b, $c){ return "$a-$b-$c"; }
+$args = [1, 2, 3];
+echo fcc_vs(...$args), "\n";
+$f = fcc_vs(...);
+echo $f(4, 5, 6), "\n";
+echo $f(...$args), "\n";
+echo var_export($f instanceof Closure, true), "\n";
+?>
+--EXPECT--
+1-2-3
+4-5-6
+1-2-3
+true
+--CLEAN--
+<?php


### PR DESCRIPTION
PHP 8.1 first-class callables, each evaluating to a Closure wrapping the callee (not calling it): strlen(...), foo(...), $obj->m(...), Cls::m(...), and self/parent/static::m(...). Now unblocked by the Closure-object foundation.

New PH7_OP_LOAD_FCC opcode. The parser (ExprExtractNode) detects a lone `...` immediately followed by `)` -- one-token lookahead disambiguates the spread `f(...$a)` -- and marks the call EXPR_NODE_FCC; the call code generator skips arguments and emits OP_LOAD_FCC instead of OP_CALL. iP1=1 wraps a plain function/host name (already on the stack from its OP_LOADC). For a method/static callee the generator drops the emitted OP_MEMBER (which would dispatch and mangle the name to the salted sVmName), leaving [target, real-method-name] for iP1=2, which builds a bound (binds $this, scope = its class) or static (scope class, self/parent/static resolved now via VmFccResolveScope) Closure. A dynamic static method name (C::$m(...)) folds into OP_MEMBER->p3, so the generator re-loads it to restore the [target, name] pair. VmClosureUnwrap re-expands a bound/static closure to a [target, method] array callable for the existing HASHMAP dispatch; the $__this/$__scope lookups are gated behind the VM_INSTANCE_FCC_BOUND instance flag so the hot plain-closure path keeps its single $__fn lookup. Bound $this is ref-kept (survives the original variable going out of scope). FCC over an already-Closure value is idempotent; over any other non-name value it leaves the value as-is (still callable) rather than minting a broken empty-name Closure.

Gates green both engines (smoke 2222, integration 767); ASan-clean (FCC bodies + a 300-iter bound-this create/drop stress). 7 new .phpt. High-effort /code-review fixed a hang/stack-corruption on the dynamic static-method-name form (C::$m(...)); /simplify added the hot-path flag gate.

Deferred: private/protected-method FCC invoked outside the declaring class (caller-scope visibility -> Increment 2's scope-rebinding plumbing); full FCC over an arbitrary callable value and the ($obj->prop)(...) form.
