### PR TITLE
Implement stdClass dynamic properties + (object) cast; fix object-inv…

### DIFF
--- a/src/ph7/memobj.c
+++ b/src/ph7/memobj.c
@@ -516,56 +516,72 @@ PH7_PRIVATE sxi32 PH7_MemObjToHashmap(ph7_value *pObj)
 	}
 	return SXRET_OK;
 }
+/* Per-entry callback for the array branch of the (object) cast: add one dynamic
+ * property to the target stdClass, named by the array key (rendered as a string,
+ * matching PHP) and holding a copy of the value. */
+struct VmObjCastData { ph7_vm *pVm; ph7_class_instance *pStd; };
+static int VmArrayToObjectWalk(ph7_value *pKey,ph7_value *pValue,void *pUserData)
+{
+	struct VmObjCastData *pData = (struct VmObjCastData *)pUserData;
+	ph7_value *pSlot;
+	/* pKey and pValue are walk-owned temporaries (PH7_HashmapWalk passes pointers to
+	 * its own stack-local sKey/sValue, not slots inside pVm->aMemObj), so they survive
+	 * the slot reservation inside PH7_VmCreateDynamicAttr — no snapshot needed. pKey is
+	 * safe to coerce in place. */
+	PH7_MemObjToString(pKey);
+	pSlot = PH7_VmCreateDynamicAttr(pData->pVm,pData->pStd,
+		(const char *)SyBlobData(&pKey->sBlob),(sxu32)SyBlobLength(&pKey->sBlob),0);
+	if( pSlot ){
+		PH7_MemObjStore(pValue,pSlot);
+	}
+	return SXRET_OK;
+}
 /*
- * Convert a ph7_value to type object.Invalidate any prior representations.
- * The new object is instantiated from the builtin stdClass().
- * The stdClass() class have a single attribute which is '$value'. This attribute
- * hold a copy of the converted ph7_value.
- * The internal of the stdClass is as follows:
- * class stdClass{
- *	 public $value;
- *	 public function __toInt(){ return (int)$this->value; }
- *	 public function __toBool(){ return (bool)$this->value; }
- *	 public function __toFloat(){ return (float)$this->value; }
- *	 public function __toString(){ return (string)$this->value; }
- *	 function __construct($v){ $this->value = $v; }"
- *  }
- * Refer to the official documentation for more information.
+ * Convert a ph7_value to type object, invalidating any prior representation.
+ * The new object is a (PHP-empty) stdClass populated with dynamic properties,
+ * matching PHP's (object) cast:
+ *   - array  -> one property per entry (key rendered as a string -> name).
+ *   - scalar -> a single property named "scalar".
+ *   - null   -> an empty stdClass (no properties).
+ *   - object -> returned unchanged (the MEMOBJ_OBJ guard below).
  */
 PH7_PRIVATE sxi32 PH7_MemObjToObject(ph7_value *pObj)
 {
 	if( (pObj->iFlags & MEMOBJ_OBJ) == 0 ){
 		ph7_class_instance *pStd;
-		ph7_class_method *pCons;
 		ph7_class *pClass;
 		ph7_vm *pVm;
-		/* Point to the underlying VM */
+		/* Point to the underlying VM + the stdClass */
 		pVm = pObj->pVm;
-		/* Point to the stdClass() */
-		pClass = PH7_VmExtractClass(pVm,"stdClass",sizeof("stdClass")-1,0,0);
+		pClass = pVm->pStdClass ? pVm->pStdClass
+			: PH7_VmExtractClass(pVm,"stdClass",sizeof("stdClass")-1,0,0);
 		if( pClass == 0 ){
 			/* Can't happen,load null instead */
 			PH7_MemObjRelease(pObj);
 			return SXRET_OK;
 		}
-		/* Instanciate a new stdClass() object */
+		/* Instanciate a new (empty) stdClass object */
 		pStd = PH7_NewClassInstance(pVm,pClass);
 		if( pStd == 0 ){
 			/* Out of memory */
 			PH7_MemObjRelease(pObj);
 			return SXRET_OK;
 		}
-		/* Check if a constructor is available */
-		pCons = PH7_ClassExtractMethod(pClass,"__construct",sizeof("__construct")-1);
-		if( pCons ){
-			ph7_value *apArg[2];
-			/* Invoke the constructor with one argument */
-			apArg[0] = pObj;
-			PH7_VmCallClassMethod(pVm,pStd,pCons,0,1,apArg);
-			if( pStd->iRef < 1 ){
-				pStd->iRef = 1;
+		pStd->iRef = 1;
+		if( pObj->iFlags & MEMOBJ_HASHMAP ){
+			/* Array: one dynamic property per entry. */
+			struct VmObjCastData sData;
+			sData.pVm = pVm;
+			sData.pStd = pStd;
+			ph7_array_walk(pObj,VmArrayToObjectWalk,&sData);
+		}else if( (pObj->iFlags & MEMOBJ_NULL) == 0 ){
+			/* Scalar (int/float/bool/string): a single "scalar" property. */
+			ph7_value *pSlot = PH7_VmCreateDynamicAttr(pVm,pStd,"scalar",sizeof("scalar")-1,0);
+			if( pSlot ){
+				PH7_MemObjStore(pObj,pSlot);
 			}
 		}
+		/* (A NULL source yields an empty stdClass — nothing to populate.) */
 		/* Invalidate any prior representation */
 		PH7_MemObjRelease(pObj);
 		/* Save the new instance */

--- a/src/ph7/oo.c
+++ b/src/ph7/oo.c
@@ -988,25 +988,43 @@ PH7_PRIVATE ph7_class_instance * PH7_CloneClassInstance(ph7_class_instance *pSrc
 		SyMemBackendPoolFree(&pVm->sAllocator,pClone);
 		return 0;
 	}
-	/* Duplicate object values */
+	/* Duplicate object values. Iterate the SOURCE attributes and copy each into
+	 * the clone's same-named slot (looked up by name, so order/count differences
+	 * from dynamic properties don't matter). A dynamic (runtime-added) property
+	 * has no declared counterpart in the clone, so synthesize it first — without
+	 * this, a clone of a stdClass would silently lose all its dynamic properties. */
 	SyHashResetLoopCursor(&pSrc->hAttr);
-	SyHashResetLoopCursor(&pClone->hAttr);
-	while((pEntry = SyHashGetNextEntry(&pSrc->hAttr)) != 0 && (pEntry2 = SyHashGetNextEntry(&pClone->hAttr)) != 0 ){
+	while((pEntry = SyHashGetNextEntry(&pSrc->hAttr)) != 0 ){
 		VmClassAttr *pSrcAttr = (VmClassAttr *)pEntry->pUserData;
-		VmClassAttr *pDestAttr = (VmClassAttr *)pEntry2->pUserData;
+		VmClassAttr *pDestAttr = 0;
+		ph7_value *pvSrc,*pvDest = 0;
 		/* Duplicate non-static attribute */
-		if( (pSrcAttr->pAttr->iFlags & (PH7_CLASS_ATTR_STATIC|PH7_CLASS_ATTR_CONSTANT)) == 0 ){
-			ph7_value *pvSrc,*pvDest;
-			pvSrc = ExtractClassAttrValue(pVm,pSrcAttr);
+		if( pSrcAttr->pAttr->iFlags & (PH7_CLASS_ATTR_STATIC|PH7_CLASS_ATTR_CONSTANT) ){
+			continue;
+		}
+		pEntry2 = SyHashGet(&pClone->hAttr,SyStringData(&pSrcAttr->pAttr->sName),SyStringLength(&pSrcAttr->pAttr->sName));
+		if( pEntry2 ){
+			pDestAttr = (VmClassAttr *)pEntry2->pUserData;
 			pvDest = ExtractClassAttrValue(pVm,pDestAttr);
-			if( pvSrc && pvDest ){
-				PH7_MemObjStore(pvSrc,pvDest);
-			}
-			/* Carry over the per-instance state so the clone matches the source:
-			 * VM_CLASS_ATTR_UNINIT marks a typed property as not-yet-initialized
-			 * and doubles as the readonly write-once latch — without this a clone
-			 * would reset to uninitialized (losing the value's readiness) and a
-			 * readonly property would become writable again. */
+		}else if( pSrcAttr->pAttr->iFlags & PH7_CLASS_ATTR_DYNAMIC ){
+			/* Dynamic property: synthesize the matching slot on the clone. */
+			pvDest = PH7_VmCreateDynamicAttr(pVm,pClone,
+				SyStringData(&pSrcAttr->pAttr->sName),SyStringLength(&pSrcAttr->pAttr->sName),&pDestAttr);
+		}
+		/* Fetch the source value LAST: PH7_VmCreateDynamicAttr above may have
+		 * reserved a slot and reallocated pVm->aMemObj, which would dangle any
+		 * ph7_value* obtained before it. pvDest from the synth path already points
+		 * into the post-realloc aMemObj; resolve pvSrc now so both are current. */
+		pvSrc = ExtractClassAttrValue(pVm,pSrcAttr);
+		if( pvSrc && pvDest ){
+			PH7_MemObjStore(pvSrc,pvDest);
+		}
+		/* Carry over the per-instance state so the clone matches the source:
+		 * VM_CLASS_ATTR_UNINIT marks a typed property as not-yet-initialized
+		 * and doubles as the readonly write-once latch — without this a clone
+		 * would reset to uninitialized (losing the value's readiness) and a
+		 * readonly property would become writable again. */
+		if( pDestAttr ){
 			pDestAttr->iState = pSrcAttr->iState;
 		}
 	}
@@ -1070,6 +1088,12 @@ static void PH7_ClassInstanceRelease(ph7_class_instance *pThis)
 					(const void *)&pVmAttr->nIdx,sizeof(sxu32),0);
 			}
 			PH7_VmUnsetMemObj(pVm,pVmAttr->nIdx,TRUE);
+		}
+		/* A dynamic (runtime-added) property owns its synthesized ph7_class_attr
+		 * (struct + inline name in one block); free it here — the only place a
+		 * per-instance pAttr is freed (declared attrs are class-owned). */
+		if( pVmAttr->pAttr->iFlags & PH7_CLASS_ATTR_DYNAMIC ){
+			SyMemBackendFree(&pVm->sAllocator,pVmAttr->pAttr);
 		}
 		SyMemBackendPoolFree(&pVm->sAllocator,pVmAttr);
 	}
@@ -1208,30 +1232,45 @@ PH7_PRIVATE sxi32 PH7_ClassInstanceCmp(ph7_class_instance *pLeft,ph7_class_insta
 	if( pLeft->pVm->pClosureClass && pLeft->pClass == pLeft->pVm->pClosureClass ){
 		return 1;
 	}
-	SyHashResetLoopCursor(&pLeft->hAttr);
-	SyHashResetLoopCursor(&pRight->hAttr);
+	/* Same class but a different number of attributes ⇒ different property sets
+	 * (dynamic properties can give two same-class instances different counts). */
+	if( pLeft->hAttr.nEntry != pRight->hAttr.nEntry ){
+		return 1;
+	}
 	PH7_MemObjInit(pLeft->pVm,&sV1);
 	PH7_MemObjInit(pLeft->pVm,&sV2);
 	sV1.nIdx = sV2.nIdx = SXU32_HIGH;
-	while((pEntry = SyHashGetNextEntry(&pLeft->hAttr)) != 0 && (pEntry2 = SyHashGetNextEntry(&pRight->hAttr)) != 0 ){
+	/* Compare each left attribute against the RIGHT attribute of the SAME NAME
+	 * (not in lockstep): dynamic properties may be stored in a different order
+	 * on the two instances. Counts already match, so if every left attribute has
+	 * an equal-valued same-named right attribute the property sets are equal. */
+	SyHashResetLoopCursor(&pLeft->hAttr);
+	while((pEntry = SyHashGetNextEntry(&pLeft->hAttr)) != 0 ){
 		VmClassAttr *p1 = (VmClassAttr *)pEntry->pUserData;
-		VmClassAttr *p2 = (VmClassAttr *)pEntry2->pUserData;
+		VmClassAttr *p2;
+		ph7_value *pL,*pR;
 		/* Compare only non-static attribute */
-		if( (p1->pAttr->iFlags & (PH7_CLASS_ATTR_CONSTANT|PH7_CLASS_ATTR_STATIC)) == 0 ){
-			ph7_value *pL,*pR;
-			pL = ExtractClassAttrValue(pLeft->pVm,p1);
-			pR = ExtractClassAttrValue(pRight->pVm,p2);
-			if( pL && pR ){
-				PH7_MemObjLoad(pL,&sV1);
-				PH7_MemObjLoad(pR,&sV2);
-				/* Compare the two values now */
-				rc = PH7_MemObjCmp(&sV1,&sV2,bStrict,iNest+1);
-				PH7_MemObjRelease(&sV1);
-				PH7_MemObjRelease(&sV2);
-				if( rc != 0 ){
-					/* Not equals */
-					return rc;
-				}
+		if( p1->pAttr->iFlags & (PH7_CLASS_ATTR_CONSTANT|PH7_CLASS_ATTR_STATIC) ){
+			continue;
+		}
+		pEntry2 = SyHashGet(&pRight->hAttr,SyStringData(&p1->pAttr->sName),SyStringLength(&p1->pAttr->sName));
+		if( pEntry2 == 0 ){
+			/* Left has a property the right lacks ⇒ not equal. */
+			return 1;
+		}
+		p2 = (VmClassAttr *)pEntry2->pUserData;
+		pL = ExtractClassAttrValue(pLeft->pVm,p1);
+		pR = ExtractClassAttrValue(pRight->pVm,p2);
+		if( pL && pR ){
+			PH7_MemObjLoad(pL,&sV1);
+			PH7_MemObjLoad(pR,&sV2);
+			/* Compare the two values now */
+			rc = PH7_MemObjCmp(&sV1,&sV2,bStrict,iNest+1);
+			PH7_MemObjRelease(&sV1);
+			PH7_MemObjRelease(&sV2);
+			if( rc != 0 ){
+				/* Not equals */
+				return rc;
 			}
 		}
 	}

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -716,7 +716,10 @@ struct ph7_class_attr
 #define PH7_CLASS_ATTR_NULLABLE     0x020  /* Type allows null (?type prefix or T|null union) */
 #define PH7_CLASS_ATTR_UNION        0x040  /* Property has a union type (use aUnionAlts) */
 #define PH7_CLASS_ATTR_READONLY     0x080  /* readonly property (PHP 8.1) */
-/* next free bit: 0x100 */
+#define PH7_CLASS_ATTR_DYNAMIC      0x100  /* Runtime-added (dynamic) property: the ph7_class_attr is
+                                            * instance-owned (synthesized, not class-declared) and must
+                                            * be freed when the instance is released. */
+/* next free bit: 0x200 */
 /*
  * Each class method is parsed out and stored in an instance of the following
  * structure.
@@ -985,6 +988,7 @@ struct ph7_vm
 	ph7_class *pFiberClass;    /* Cached Fiber class pointer for fast dispatch */
 	ph7_class *pGeneratorClass; /* Cached Generator class pointer */
 	ph7_class *pClosureClass;  /* Cached Closure class pointer (closures are instances of it) */
+	ph7_class *pStdClass;      /* Cached stdClass pointer (target of (object) cast + dynamic props) */
 	ph7_class *pArrayAccessClass; /* Cached ArrayAccess interface pointer */
 	ph7_class *pCountableClass;   /* Cached Countable interface pointer */
 	ph7_class *pStringableClass;  /* Cached Stringable interface pointer */
@@ -1487,6 +1491,7 @@ PH7_PRIVATE sxi32 PH7_VmInitFuncState(ph7_vm *pVm,ph7_vm_func *pFunc,const char 
 	sxi32 iFlags,void *pUserData);
 PH7_PRIVATE sxi32 PH7_VmInstallUserFunction(ph7_vm *pVm,ph7_vm_func *pFunc,SyString *pName);
 PH7_PRIVATE sxi32 PH7_VmCreateClassInstanceFrame(ph7_vm *pVm,ph7_class_instance *pObj);
+PH7_PRIVATE ph7_value * PH7_VmCreateDynamicAttr(ph7_vm *pVm,ph7_class_instance *pThis,const char *zName,sxu32 nName,VmClassAttr **ppAttr);
 PH7_PRIVATE sxi32 PH7_VmRefObjRemove(ph7_vm *pVm,sxu32 nIdx,SyHashEntry *pEntry,ph7_hashmap_node *pMapEntry);
 PH7_PRIVATE sxi32 PH7_VmRefObjInstall(ph7_vm *pVm,sxu32 nIdx,SyHashEntry *pEntry,ph7_hashmap_node *pMapEntry,sxi32 iFlags);
 PH7_PRIVATE sxi32 PH7_VmPushFilePath(ph7_vm *pVm,const char *zPath,int nLen,sxu8 bMain,sxi32 *pNew);
@@ -1911,6 +1916,7 @@ PH7_PRIVATE sxi32 SyStrToInt32(const char *zSrc,sxu32 nLen,void *pOutVal,const c
 PH7_PRIVATE sxi32 SyStrIsNumeric(const char *zSrc,sxu32 nLen,sxu8 *pReal,const char **pzTail);
 PH7_PRIVATE SyHashEntry *SyHashLastEntry(SyHash *pHash);
 PH7_PRIVATE sxi32 SyHashInsert(SyHash *pHash,const void *pKey,sxu32 nKeyLen,void *pUserData);
+PH7_PRIVATE sxi32 SyHashInsertTail(SyHash *pHash,const void *pKey,sxu32 nKeyLen,void *pUserData);
 PH7_PRIVATE sxi32 SyHashForEach(SyHash *pHash,sxi32(*xStep)(SyHashEntry *,void *),void *pUserData);
 PH7_PRIVATE SyHashEntry *SyHashGetNextEntry(SyHash *pHash);
 PH7_PRIVATE sxi32 SyHashResetLoopCursor(SyHash *pHash);

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -1149,6 +1149,89 @@ PH7_PRIVATE sxi32 PH7_VmCreateClassInstanceFrame(
 	}
 	return SXRET_OK;
 }
+/*
+ * Whether [pClass] permits runtime-created (dynamic) properties. Scoped to
+ * stdClass for now; the future general-dynamic-props work (PLAN.md §3.1) turns
+ * this into a class-flag / #[AllowDynamicProperties] check at this one site.
+ */
+static int VmClassAllowsDynamicProps(ph7_vm *pVm,ph7_class *pClass)
+{
+	return pVm->pStdClass != 0 && pClass == pVm->pStdClass;
+}
+/*
+ * Create a dynamic (runtime-added) property named [zName:nName] on a class
+ * instance and return its freshly reserved value slot (the caller stores the
+ * value via PH7_MemObjStore). If [ppAttr] is non-NULL it receives the new
+ * VmClassAttr (saving the caller a re-lookup). Returns NULL on OOM.
+ *
+ * Mirrors the non-static declared-attribute path in PH7_VmCreateClassInstanceFrame,
+ * but the ph7_class_attr is SYNTHESIZED and instance-owned: a single allocation
+ * holds the attr struct followed by the name bytes (so the SyHash key, which
+ * SyHashInsert stores by pointer, stays valid for the entry's lifetime). The
+ * attr carries PH7_CLASS_ATTR_DYNAMIC; PH7_ClassInstanceRelease frees it (and its
+ * inline name) on that flag — the only place a per-instance pAttr is freed.
+ * The property is public + untyped, so the iFlags/sName dereferences in the
+ * member-read, type-enforcement and destruction paths all behave normally.
+ */
+PH7_PRIVATE ph7_value * PH7_VmCreateDynamicAttr(ph7_vm *pVm,ph7_class_instance *pThis,const char *zName,sxu32 nName,VmClassAttr **ppAttr)
+{
+	ph7_class_attr *pAttr;
+	VmClassAttr *pVmAttr = 0;
+	ph7_value *pMemObj = 0;
+	char *zCopy;
+	/* One block: ph7_class_attr struct + inline NUL-terminated name. */
+	pAttr = (ph7_class_attr *)SyMemBackendAlloc(&pVm->sAllocator,sizeof(ph7_class_attr) + nName + 1);
+	if( pAttr == 0 ){
+		return 0;
+	}
+	SyZero(pAttr,sizeof(ph7_class_attr));
+	zCopy = (char *)&pAttr[1];
+	if( nName > 0 ){
+		SyMemcpy((const void *)zName,(void *)zCopy,nName);
+	}
+	zCopy[nName] = 0;
+	SyStringInitFromBuf(&pAttr->sName,zCopy,nName);
+	pAttr->iFlags = PH7_CLASS_ATTR_DYNAMIC;
+	pAttr->iProtection = PH7_CLASS_PROT_PUBLIC;
+	pAttr->pDeclClass = pThis->pClass;
+	/* nType / aByteCode / aUnionAlts left zeroed by SyZero: untyped, no default
+	 * value, never a union. */
+	pVmAttr = (VmClassAttr *)SyMemBackendPoolAlloc(&pVm->sAllocator,sizeof(VmClassAttr));
+	if( pVmAttr == 0 ){
+		goto fail_attr;
+	}
+	pMemObj = PH7_ReserveMemObj(&(*pVm));
+	if( pMemObj == 0 ){
+		goto fail_vmattr;
+	}
+	pVmAttr->pAttr = pAttr;
+	pVmAttr->nIdx = pMemObj->nIdx;
+	pVmAttr->iState = 0;
+	pVmAttr->pOwner = pThis->pClass;
+	/* Tail-insert so iteration (json_encode/foreach/(array)/var_dump) follows
+	 * property-creation order, matching PHP. */
+	if( SyHashInsertTail(&pThis->hAttr,SyStringData(&pAttr->sName),SyStringLength(&pAttr->sName),pVmAttr) != SXRET_OK ){
+		goto fail_slot;
+	}
+	/* Install in the reference table so COW/refcount tracks the slot. */
+	PH7_VmRefObjInstall(&(*pVm),pMemObj->nIdx,0,0,VM_REF_IDX_KEEP);
+	if( ppAttr ){
+		*ppAttr = pVmAttr;
+	}
+	return pMemObj;
+fail_slot:
+	{
+		VmSlot sSlot;
+		sSlot.nIdx = pMemObj->nIdx;
+		sSlot.pUserData = 0;
+		SySetPut(&pVm->aFreeObj,(const void *)&sSlot);
+	}
+fail_vmattr:
+	SyMemBackendPoolFree(&pVm->sAllocator,pVmAttr);
+fail_attr:
+	SyMemBackendFree(&pVm->sAllocator,pAttr);
+	return 0;
+}
 /* Forward declaration */
 static VmRefObj * VmRefObjExtract(ph7_vm *pVm,sxu32 nObjIdx);
 static sxi32 VmRefObjUnlink(ph7_vm *pVm,VmRefObj *pRef);
@@ -1489,14 +1572,8 @@ static int vm_builtin_Generator_destruct(ph7_context *pCtx, int nArg, ph7_value 
 	"  private $__scope;"\
 	"  public function __construct(){ throw new \\Error('Instantiation of class Closure is not allowed'); }"\
 	"}"\
+	/* stdClass is empty (PHP-exact): holds only dynamic (runtime-added) properties. */\
 	"class stdClass{"\
-	"  public $value;"\
-	" /* Magic methods */"\
-	" public function __toInt(){ return (int)$this->value; }"\
-	" public function __toBool(){ return (bool)$this->value; }"\
-	" public function __toFloat(){ return (float)$this->value; }"\
-	" public function __toString(){ return (string)$this->value; }"\
-	" function __construct($v){ $this->value = $v; }"\
 	"}"\
 	"function dir(string $path){"\
 	"   return new Directory($path);"\
@@ -1863,6 +1940,8 @@ PH7_PRIVATE sxi32 PH7_VmInit(
 	ph7_create_function(pVm,"__fiber_destruct",vm_builtin_Fiber_destruct,0);
 	/* Cache the Closure class pointer (closures are instances of it) */
 	pVm->pClosureClass = PH7_VmExtractClass(pVm,"Closure",7,0,0);
+	/* Cache the stdClass pointer ((object) cast target + dynamic-property owner) */
+	pVm->pStdClass = PH7_VmExtractClass(pVm,"stdClass",sizeof("stdClass")-1,0,0);
 	/* Cache the Generator class pointer and register generator functions */
 	pVm->pGeneratorClass = PH7_VmExtractClass(pVm,"Generator",9,0,0);
 	ph7_create_function(pVm,"__gen_rewind",vm_builtin_Generator_rewind,0);
@@ -8937,6 +9016,16 @@ case PH7_OP_MEMBER: {
 						pObjAttr = (VmClassAttr *)pEntry->pUserData;
 					}
 				}
+				if( pObjAttr == 0 && sName.nByte > 0 && VmClassAllowsDynamicProps(pVm,pThis->pClass) ){
+					/* Dynamic property: when this member is the LHS of an assignment
+					 * (next instr is a member store), create the property so the store
+					 * lands. Detected via one-token lookahead — the compiler always
+					 * emits a terminating PH7_OP_DONE, so pInstr+1 is in-bounds. */
+					VmInstr *pNext = pInstr + 1;
+					if( pNext->iOp == PH7_OP_STORE && pNext->iP2 ){
+						PH7_VmCreateDynamicAttr(&(*pVm),pThis,sName.zString,sName.nByte,&pObjAttr);
+					}
+				}
 				if( pObjAttr == 0 ){
 					/* No such attribute,load null */
 					VmErrorFormat(&(*pVm),PH7_CTX_ERR,"Undefined class attribute '%z->%z',PH7 is loading NULL",
@@ -9833,16 +9922,22 @@ case PH7_OP_CALL: {
 				&sResult,
 				(VmCallArgMap *)pInstr->p3);
 			SySetReset(&aArg);
+			/* Pin pThis BEFORE popping operands: VmPopOperand releases the callable
+			 * slot itself (it pops top-down and the callable IS pTos), which for a
+			 * temporary like (new Plain())(...) holds the only reference — popping it
+			 * would free pThis before VmRaiseNotCallable reads its class name below.
+			 * Only the not-callable branch dereferences pThis afterwards, so pin just
+			 * for that case; the matching PH7_ClassInstanceUnref drops it (destroying
+			 * the temporary). The other branches let the pop free the temp as before. */
+			if( rcInv == SXERR_INVALID ){
+				pThis->iRef++;
+			}
 			if( nCallArgs > 0 ){
 				VmPopOperand(&pTos,nCallArgs);
 			}
 			if( rcInv == SXERR_INVALID ){
 				/* No __invoke: raise a catchable Error and route through try/catch.
-				 * sResult was already released by VmCallObjectInvoke.
-				 * Pin pThis: the release below would otherwise drop the last ref
-				 * to a temporary callable like (new Plain())(...), freeing the
-				 * instance before VmRaiseNotCallable reads its class name. */
-				pThis->iRef++;
+				 * sResult was already released by VmCallObjectInvoke. */
 				PH7_MemObjRelease(pTos);
 				rc = VmRaiseNotCallable(&(*pVm),pThis);
 				PH7_ClassInstanceUnref(pThis);
@@ -17500,6 +17595,12 @@ static int vm_builtin_spl_autoload(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		}
 		/* Append extension */
 		SyBlobAppend(&sPath,(const void *)zCur,(sxu32)(zComma - zCur));
+		/* NUL-terminate: the include path flows down to PH7_StreamOpenHandle,
+		 * which does SyStrlen() on it as a C string. SyBlobAppend does not add a
+		 * terminator, so without this the strlen reads past the buffer (a
+		 * heap-buffer-overflow whose visibility depends on heap layout). The NUL
+		 * is not counted in SyBlobLength(), so the SyString length stays correct. */
+		SyBlobNullAppend(&sPath);
 		/* Try to include the file */
 		SyStringInitFromBuf(&sFile,(const char *)SyBlobData(&sPath),SyBlobLength(&sPath));
 		rc = VmExecIncludedFile(pCtx,&sFile,FALSE);

--- a/src/sx/sxds.c
+++ b/src/sx/sxds.c
@@ -176,7 +176,7 @@ PH7_PRIVATE sxi32 SyHashInit(SyHash *pHash,SyMemBackend *pAllocator,ProcHash xHa
 	pHash->pAllocator = &(*pAllocator);
 	pHash->xHash = xHash ? xHash : SyBinHash;
 	pHash->xCmp = xCmp ? xCmp : SyMemcmp;
-	pHash->pCurrent = pHash->pList = 0;
+	pHash->pCurrent = pHash->pList = pHash->pLast = 0;
 	pHash->nEntry = 0;
 	pHash->apBucket = apNew;
 	pHash->nBucketSize = SXHASH_BUCKET_SIZE;
@@ -256,6 +256,10 @@ static sxi32 HashDeleteEntry(SyHash *pHash,SyHashEntry_Pr *pEntry,void **ppUserD
 	}
 	if( pEntry->pNextCollide ){
 		pEntry->pNextCollide->pPrevCollide = pEntry->pPrevCollide;
+	}
+	/* Keep the tail pointer valid when the last entry is the one removed. */
+	if( pHash->pLast == pEntry ){
+		pHash->pLast = pEntry->pPrev;
 	}
 	MACRO_LD_REMOVE(pHash->pList,pEntry);
 	pHash->nEntry--;
@@ -379,7 +383,7 @@ static sxi32 HashGrowTable(SyHash *pHash)
 	pHash->nBucketSize = nNewSize;
 	return SXRET_OK;
 }
-static sxi32 HashInsert(SyHash *pHash,SyHashEntry_Pr *pEntry)
+static sxi32 HashInsert(SyHash *pHash,SyHashEntry_Pr *pEntry,int bTail)
 {
 	sxu32 iBucket = pEntry->nHash & (pHash->nBucketSize - 1);
 	/* Insert the entry in its corresponding bucket */
@@ -388,15 +392,25 @@ static sxi32 HashInsert(SyHash *pHash,SyHashEntry_Pr *pEntry)
 		pHash->apBucket[iBucket]->pPrevCollide = pEntry;
 	}
 	pHash->apBucket[iBucket] = pEntry;
-	/* Link to the entry list */
-	MACRO_LD_PUSH(pHash->pList,pEntry);
+	/* Link to the entry list. The default is head-insert (LIFO); bTail appends
+	 * to the tail (O(1) via pLast) so iteration follows insertion order — for
+	 * callers that need a FIFO traversal. */
+	if( bTail && pHash->pLast != 0 ){
+		pHash->pLast->pNext = pEntry;
+		pEntry->pPrev = pHash->pLast;
+		pHash->pLast = pEntry;
+	}else{
+		MACRO_LD_PUSH(pHash->pList,pEntry);
+	}
 	if( pHash->nEntry == 0 ){
+		/* First entry: it is simultaneously the head, the tail and the cursor. */
 		pHash->pCurrent = pHash->pList;
+		pHash->pLast = pEntry;
 	}
 	pHash->nEntry++;
 	return SXRET_OK;
 }
-PH7_PRIVATE sxi32 SyHashInsert(SyHash *pHash,const void *pKey,sxu32 nKeyLen,void *pUserData)
+static sxi32 SyHashInsertCore(SyHash *pHash,const void *pKey,sxu32 nKeyLen,void *pUserData,int bTail)
 {
 	SyHashEntry_Pr *pEntry;
 	sxi32 rc;
@@ -424,8 +438,22 @@ PH7_PRIVATE sxi32 SyHashInsert(SyHash *pHash,const void *pKey,sxu32 nKeyLen,void
 	pEntry->pUserData = pUserData;
 	pEntry->nHash = pHash->xHash(pEntry->pKey,pEntry->nKeyLen);
 	/* Finally insert the entry in its corresponding bucket */
-	rc = HashInsert(&(*pHash),pEntry);
+	rc = HashInsert(&(*pHash),pEntry,bTail);
 	return rc;
+}
+PH7_PRIVATE sxi32 SyHashInsert(SyHash *pHash,const void *pKey,sxu32 nKeyLen,void *pUserData)
+{
+	return SyHashInsertCore(&(*pHash),pKey,nKeyLen,pUserData,0);
+}
+/*
+ * Like SyHashInsert but appends the entry to the tail of the iteration list, so
+ * SyHashGetNextEntry() yields entries in insertion order (FIFO) rather than the
+ * default reverse-insertion (LIFO). Used for ordered collections such as dynamic
+ * object properties, where PHP preserves property-creation order.
+ */
+PH7_PRIVATE sxi32 SyHashInsertTail(SyHash *pHash,const void *pKey,sxu32 nKeyLen,void *pUserData)
+{
+	return SyHashInsertCore(&(*pHash),pKey,nKeyLen,pUserData,1);
 }
 PH7_PRIVATE SyHashEntry * SyHashLastEntry(SyHash *pHash)
 {

--- a/src/sx/sxhashtable.h
+++ b/src/sx/sxhashtable.h
@@ -37,6 +37,7 @@ struct SyHash
 	ProcHash xHash;                   /* Hash function */
 	ProcCmp xCmp;                     /* Comparison function */
 	SyHashEntry_Pr *pList,*pCurrent;  /* Linked list of hash entries for linear traversal */
+	SyHashEntry_Pr *pLast;            /* Tail of pList — O(1) append for the tail-insert path */
 	sxu32 nEntry;                     /* Total number of entries */
 	SyHashEntry_Pr **apBucket;        /* Hash buckets */
 	sxu32 nBucketSize;                /* Current bucket size */

--- a/tests/ph7/001-smoke/lang/object_cast.phpt
+++ b/tests/ph7/001-smoke/lang/object_cast.phpt
@@ -1,40 +1,33 @@
 --CREDITS--
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --TEST--
-Object type casting for scalar values
+Object type casting for scalar values: a single "scalar" property (PHP-exact)
 --FILE--
 <?php
-// Test casting scalar values to object
+// (object)$scalar produces a stdClass with one property named "scalar".
+$obj_str = (object)"hello";
+echo "string to object: " . (is_object($obj_str) && isset($obj_str->scalar) && $obj_str->scalar === "hello" ? 'ok' : 'fail') . "\n";
 
-// String to object
-$str = "hello";
-$obj_str = (object)$str;
-echo "string to object: " . (is_object($obj_str) && isset($obj_str->value) && $obj_str->value === "hello" ? 'ok' : 'fail') . "\n";
+$obj_int = (object)42;
+echo "int to object: " . (is_object($obj_int) && isset($obj_int->scalar) && $obj_int->scalar === 42 ? 'ok' : 'fail') . "\n";
 
-// Int to object
-$int = 42;
-$obj_int = (object)$int;
-echo "int to object: " . (is_object($obj_int) && isset($obj_int->value) && $obj_int->value === 42 ? 'ok' : 'fail') . "\n";
+$obj_float = (object)3.14;
+echo "float to object: " . (is_object($obj_float) && isset($obj_float->scalar) && $obj_float->scalar === 3.14 ? 'ok' : 'fail') . "\n";
 
-// Float to object
-$float = 3.14;
-$obj_float = (object)$float;
-echo "float to object: " . (is_object($obj_float) && isset($obj_float->value) && $obj_float->value == 3.14 ? 'ok' : 'fail') . "\n";
+$obj_bool = (object)true;
+echo "bool to object: " . (is_object($obj_bool) && isset($obj_bool->scalar) && $obj_bool->scalar === true ? 'ok' : 'fail') . "\n";
 
-// Bool to object
-$bool = true;
-$obj_bool = (object)$bool;
-echo "bool to object: " . (is_object($obj_bool) && isset($obj_bool->value) && $obj_bool->value === true ? 'ok' : 'fail') . "\n";
-
+// (object)null produces an empty stdClass (no properties).
+$obj_null = (object)null;
+echo "null to object: " . (is_object($obj_null) && count(get_object_vars($obj_null)) === 0 ? 'ok' : 'fail') . "\n";
 ?>
 --EXPECT--
 string to object: ok
 int to object: ok
 float to object: ok
 bool to object: ok
+null to object: ok
 --CLEAN--
 <?php
-unset($str, $obj_str, $int, $obj_int, $float, $obj_float, $bool, $obj_bool);
+unset($obj_str, $obj_int, $obj_float, $obj_bool, $obj_null);

--- a/tests/ph7/001-smoke/lang/object_cast_array.phpt
+++ b/tests/ph7/001-smoke/lang/object_cast_array.phpt
@@ -1,0 +1,25 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+(object) cast of an array exposes keys as dynamic properties (insertion order)
+--FILE--
+<?php
+$oca_o = (object)["id" => 1, "name" => "x", "age" => 3];
+echo $oca_o->id, " ", $oca_o->name, " ", $oca_o->age, "\n";
+echo count(get_object_vars($oca_o)), "\n";
+echo json_encode($oca_o), "\n";
+echo implode(",", array_keys((array)$oca_o)), "\n";
+// integer key becomes a string property name
+$oca_n = (object)[0 => "a", 1 => "b"];
+echo $oca_n->{'0'}, $oca_n->{'1'}, "\n";
+?>
+--EXPECT--
+1 x 3
+3
+{"id":1,"name":"x","age":3}
+id,name,age
+ab
+--CLEAN--
+<?php
+unset($oca_o, $oca_n);

--- a/tests/ph7/001-smoke/lang/stdclass_clone_eq.phpt
+++ b/tests/ph7/001-smoke/lang/stdclass_clone_eq.phpt
@@ -1,0 +1,30 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+clone and == on a dynamic-property stdClass (deep-copy independence; by-name ==)
+--FILE--
+<?php
+$sce_a = (object)["x" => 1, "y" => 2];
+$sce_a->z = 3;
+$sce_b = clone $sce_a;
+echo $sce_b->x, $sce_b->y, $sce_b->z, "\n";
+$sce_b->x = 99;                 // clone is independent
+echo $sce_a->x, ",", $sce_b->x, "\n";
+// == compares by name (order-independent), and by full property set
+var_export((object)["x"=>1,"y"=>2] == (object)["y"=>2,"x"=>1]);
+echo "\n";
+var_export((object)["x"=>1] == (object)["x"=>1,"y"=>9]);
+echo "\n";
+var_export($sce_a == clone $sce_a);
+echo "\n";
+?>
+--EXPECT--
+123
+1,99
+true
+false
+true
+--CLEAN--
+<?php
+unset($sce_a, $sce_b);

--- a/tests/ph7/001-smoke/lang/stdclass_dynamic_write.phpt
+++ b/tests/ph7/001-smoke/lang/stdclass_dynamic_write.phpt
@@ -1,0 +1,27 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Dynamic property writes on a stdClass: create, read, reassign, isset, unset
+--FILE--
+<?php
+$sdw_o = new stdClass;
+$sdw_o->a = 1;
+$sdw_o->b = "two";
+echo $sdw_o->a, $sdw_o->b, "\n";
+$sdw_o->a = 99;            // reassign keeps the same property
+echo $sdw_o->a, "\n";
+echo json_encode($sdw_o), "\n";
+echo isset($sdw_o->a) ? "set" : "no", "\n";
+unset($sdw_o->a);
+echo isset($sdw_o->a) ? "set" : "no", "\n";
+?>
+--EXPECT--
+1two
+99
+{"a":99,"b":"two"}
+set
+no
+--CLEAN--
+<?php
+unset($sdw_o);

--- a/tests/ph7/001-smoke/lang/stdclass_iterate.phpt
+++ b/tests/ph7/001-smoke/lang/stdclass_iterate.phpt
@@ -1,0 +1,25 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Iterating a dynamic-property stdClass: foreach, get_object_vars, (array), json
+--FILE--
+<?php
+$sci_o = (object)["x" => 10, "y" => 20];
+$sci_o->z = 30;
+foreach ($sci_o as $sci_k => $sci_v) { echo "$sci_k=$sci_v;"; }
+echo "\n";
+$sci_gv = get_object_vars($sci_o);
+echo implode(",", array_keys($sci_gv)), " => ", implode(",", array_values($sci_gv)), "\n";
+$sci_a = (array)$sci_o;
+echo $sci_a["x"], $sci_a["y"], $sci_a["z"], "\n";
+echo json_encode($sci_o), "\n";
+?>
+--EXPECT--
+x=10;y=20;z=30;
+x,y,z => 10,20,30
+102030
+{"x":10,"y":20,"z":30}
+--CLEAN--
+<?php
+unset($sci_o, $sci_k, $sci_v, $sci_gv, $sci_a);

--- a/tests/ph7/002-integration/array/array_invalid_key.phpt
+++ b/tests/ph7/002-integration/array/array_invalid_key.phpt
@@ -13,7 +13,6 @@ $arr = array($obj => 'value');
 var_dump($arr);
 ?>
 --EXPECTF--
-%s Notice:  Missing constructor argument 1($v) for class 'stdClass'
 array(1) {
  [Object] =>
   string(5) "value"

--- a/tests/ph7/002-integration/error/invalid_property_assignment.phpt
+++ b/tests/ph7/002-integration/error/invalid_property_assignment.phpt
@@ -2,18 +2,17 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-undefined object property assignment error
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+Assigning an undefined property on a stdClass creates a dynamic property
 --FILE--
 <?php
 $obj = new stdClass();
 $obj->nonexistent = "value";
+echo $obj->nonexistent, "\n";
+echo json_encode($obj), "\n";
 ?>
---EXPECTF--
-%s Notice:  Missing constructor argument 1($v) for class 'stdClass'
-%s Error:  Undefined class attribute 'stdClass->nonexistent',PH7 is loading NULL
-%s Error:  Cannot perform assignment on a constant class attribute,PH7 is loading NULL
+--EXPECT--
+value
+{"nonexistent":"value"}
 --CLEAN--
 <?php
 unset($obj);


### PR DESCRIPTION
…oke UAF

Make stdClass a real empty class and add a per-instance dynamic-property mechanism: PH7_VmCreateDynamicAttr synthesizes an instance-owned ph7_class_attr (new PH7_CLASS_ATTR_DYNAMIC flag) + reserved memobj slot, tail-inserted into hAttr so iteration follows PHP's creation order. Wired through:
  - (object) cast: array -> one prop per entry, scalar -> "scalar", null ->
    empty, object -> unchanged (PH7_MemObjToObject rewrite).
  - OP_MEMBER write-miss on stdClass: `$o->p = v` creates the property.
  - clone / == / destruction made dynamic-prop aware (by-name attr matching; the synth attr is freed only via the DYNAMIC flag at instance release).
  - reads / foreach / get_object_vars / (array) / json_encode / var_dump come for free once hAttr has entries.

SyHash gains an O(1) tail pointer (pLast) + SyHashInsertTail so the new properties keep FIFO order; pLast is maintained on insert/delete/grow and zero-initialized in SyHashInit (every SyHash is born through it).

Also fixes a pre-existing use-after-free in OP_CALL's object-invoke branch: VmPopOperand releases the callable slot (which IS pTos) before pThis was pinned, so invoking a non-callable temporary like (new Plain())(...) freed the instance before VmRaiseNotCallable read its class name. The pool allocator masked it until growing sizeof(SyHash) shifted bucket sizing; pinning pThis before the pop (guarded to the not-callable branch) fixes it. Found via a Linux/ASan build with the pool routed through malloc.

Tests: object_cast (rewritten to PHP-exact scalar prop) + new object_cast_array, stdclass_dynamic_write, stdclass_iterate, stdclass_clone_eq; integration invalid_property_assignment / array_invalid_key updated to assert success.

Gates: smoke 2230/2230 and integration 767/767 on both phl and PHP 8.5; stress 13/13; ASan clean. Deferred (recorded in PLAN.md, P2): general non-stdClass dynamic props, unset-removes-from-iteration, isset-on-missing warning, compound/append auto-vivify.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
