### PR TITLE
Forward named arguments when invoking a first-class-callable Closure

### DIFF
--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1538,6 +1538,7 @@ PH7_PRIVATE sxu32 PH7_VmRandomNum(ph7_vm *pVm);
 PH7_PRIVATE sxi32 PH7_VmCallClassMethod(ph7_vm *pVm,ph7_class_instance *pThis,ph7_class_method *pMethod,
 	ph7_value *pResult,int nArg,ph7_value **apArg);
 PH7_PRIVATE sxi32 PH7_VmCallUserFunction(ph7_vm *pVm,ph7_value *pFunc,int nArg,ph7_value **apArg,ph7_value *pResult);
+PH7_PRIVATE sxi32 PH7_VmCallUserFunctionWithMap(ph7_vm *pVm,ph7_value *pFunc,int nArg,ph7_value **apArg,ph7_value *pResult,VmCallArgMap *pArgMap);
 /* Per-element callback for PH7_VmIteratorWalk: return SXRET_OK to continue,
  * SXERR_EOF to stop early (not an error), or PH7_EXCEPTION/PH7_ABORT to propagate. */
 typedef sxi32 (*ProcIterStep)(ph7_vm *pVm,ph7_value *pKey,ph7_value *pValue,void *pUserData);

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -9874,8 +9874,10 @@ case PH7_OP_CALL: {
 				pArg++;
 			}
 			PH7_MemObjInit(pVm,&sResult);
-			/* May be a class instance and it's static method */
-			rcArr = PH7_VmCallUserFunction(pVm,pTos,(int)SySetUsed(&aArg),(ph7_value **)SySetBasePtr(&aArg),&sResult);
+			/* May be a class instance and it's static method. Forward this call's named-arg map
+			 * (pInstr->p3) so an FCC array callable invoked as `$c(name: …)` binds by name —
+			 * mirroring the __invoke-object branch below. */
+			rcArr = PH7_VmCallUserFunctionWithMap(pVm,pTos,(int)SySetUsed(&aArg),(ph7_value **)SySetBasePtr(&aArg),&sResult,(VmCallArgMap *)pInstr->p3);
 			SySetReset(&aArg);
 			/* Pop given arguments */
 			if( nCallArgs > 0 ){
@@ -13654,12 +13656,13 @@ static sxi32 VmRaiseNotCallable(ph7_vm *pVm, ph7_class_instance *pThis)
  * Return SXRET_OK if the function was successfuly called.Any other
  * return value indicates failure.
  */
-PH7_PRIVATE sxi32 PH7_VmCallUserFunction(
+PH7_PRIVATE sxi32 PH7_VmCallUserFunctionWithMap(
 	ph7_vm *pVm,       /* Target VM */
 	ph7_value *pFunc,  /* Callback name */
 	int nArg,          /* Total number of given arguments */
 	ph7_value **apArg, /* Callback arguments */
-	ph7_value *pResult /* Store callback return value here. NULL otherwise */
+	ph7_value *pResult,  /* Store callback return value here. NULL otherwise */
+	VmCallArgMap *pArgMap/* Named-argument map (call-site `p3`), or 0 for a positional call */
 	)
 {
 	ph7_value *aStack;
@@ -13667,12 +13670,13 @@ PH7_PRIVATE sxi32 PH7_VmCallUserFunction(
 	int i;
 	if( VmValueIsClosure(pVm,pFunc) ){
 		/* A Closure object: unwrap to its underlying string/array callable and dispatch
-		 * that (call_user_func / array_map / usort / the C API all funnel here). */
+		 * that (call_user_func / array_map / usort / the C API all funnel here). Forward the
+		 * named-arg map so a first-class-callable invoked as `$c(name: …)` binds by name. */
 		ph7_value sCallable;
 		sxi32 rcClo;
 		PH7_MemObjInit(pVm,&sCallable);
 		if( VmClosureUnwrap(pVm,pFunc,&sCallable) == SXRET_OK ){
-			rcClo = PH7_VmCallUserFunction(pVm,&sCallable,nArg,apArg,pResult);
+			rcClo = PH7_VmCallUserFunctionWithMap(pVm,&sCallable,nArg,apArg,pResult,pArgMap);
 			PH7_MemObjRelease(&sCallable);
 			return rcClo;
 		}
@@ -13680,12 +13684,12 @@ PH7_PRIVATE sxi32 PH7_VmCallUserFunction(
 	}
 	if( pFunc->iFlags & MEMOBJ_OBJ ){
 		/* Object callable: dispatch through __invoke when available (Closures were already
-		 * unwrapped above, so only non-Closure __invoke objects reach here).
-		 * No VmCallArgMap: call_user_func / array_map / usort and the C API
-		 * pass arguments positionally and inherit no strict-types context. */
+		 * unwrapped above, so only non-Closure __invoke objects reach here). pArgMap is 0 for the
+		 * positional callers (call_user_func / array_map / usort / C API) and carries the
+		 * named-arg map only for an `__invoke`-object first-class-callable invocation. */
 		return VmCallObjectInvoke(&(*pVm),
 			(ph7_class_instance *)pFunc->x.pOther,
-			nArg,apArg,pResult,0);
+			nArg,apArg,pResult,pArgMap);
 	}
 	if((pFunc->iFlags & (MEMOBJ_STRING|MEMOBJ_HASHMAP)) == 0 ){
 		/* Don't bother processing,it's invalid anyway */
@@ -13742,8 +13746,9 @@ PH7_PRIVATE sxi32 PH7_VmCallUserFunction(
 			}
 			return SXRET_OK;
 		}
-		/* Call the class method */
-		rc = PH7_VmCallClassMethod(&(*pVm),pThis,pMethod,pResult,nArg,apArg);
+		/* Call the class method, forwarding the named-arg map (a `[obj,m]`/`[class,m]`
+		 * first-class-callable invoked as `$c(name: …)` must bind by name, like a direct call). */
+		rc = VmCallClassMethodWithMap(&(*pVm),pThis,pMethod,pResult,nArg,apArg,pArgMap);
 		return rc;
 	}
 	/* Create a new operand stack */
@@ -13773,7 +13778,7 @@ PH7_PRIVATE sxi32 PH7_VmCallUserFunction(
 	aInstr[0].iOp = PH7_OP_CALL;
 	aInstr[0].iP1 = nArg; /* Total number of given arguments */
 	aInstr[0].iP2 = 0;
-	aInstr[0].p3  = 0;
+	aInstr[0].p3  = (void *)pArgMap; /* Named-arg map (0 for positional callers) */
 	/* Emit the DONE instruction */
 	aInstr[1].iOp = PH7_OP_DONE;
 	aInstr[1].iP1 = 1;   /* Extract function return value if available */
@@ -13788,6 +13793,22 @@ PH7_PRIVATE sxi32 PH7_VmCallUserFunction(
 		/* Propagate PH7_EXCEPTION/PH7_ABORT so a callback that raised unwinds. */
 		return rcExec;
 	}
+}
+/*
+ * Positional-call wrapper around PH7_VmCallUserFunctionWithMap (mirrors the
+ * PH7_VmCallClassMethod -> VmCallClassMethodWithMap pattern). call_user_func,
+ * array_map, usort and the whole C API funnel here and pass arguments by
+ * position, so they need no named-argument map.
+ */
+PH7_PRIVATE sxi32 PH7_VmCallUserFunction(
+	ph7_vm *pVm,       /* Target VM */
+	ph7_value *pFunc,  /* Callback name */
+	int nArg,          /* Total number of given arguments */
+	ph7_value **apArg, /* Callback arguments */
+	ph7_value *pResult /* Store callback return value here. NULL otherwise */
+	)
+{
+	return PH7_VmCallUserFunctionWithMap(&(*pVm),pFunc,nArg,apArg,pResult,0);
 }
 /*
  * Call a user defined or foreign function whith a varibale number

--- a/tests/ph7/001-smoke/lang/fcc_named_args.phpt
+++ b/tests/ph7/001-smoke/lang/fcc_named_args.phpt
@@ -1,0 +1,59 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Named arguments bind by name when invoking a first-class-callable Closure
+--FILE--
+<?php
+class FccNamed {
+  public $tag = "T";
+  function m($greeting, $name){ return "$greeting, $name"; }
+  static function sm($greeting, $name){ return "s:$greeting, $name"; }
+  function withDefault($a, $b = "def", $c = "C"){ return "$a/$b/$c"; }
+}
+class FccNamedInv { function __invoke($greeting, $name){ return "i:$greeting, $name"; } }
+
+$o = new FccNamed();
+
+/* instance-method FCC, names supplied out of order */
+$cm = $o->m(...);
+echo $cm(name: "Bob", greeting: "Hi"), "\n";
+
+/* static-method FCC */
+$cs = FccNamed::sm(...);
+echo $cs(name: "Sue", greeting: "Yo"), "\n";
+
+/* value array callable [obj, method] */
+$cb = [$o, "m"]; $cv = $cb(...);
+echo $cv(name: "Al", greeting: "Hey"), "\n";
+
+/* value array callable [class, staticmethod] */
+$cb2 = ["FccNamed", "sm"]; $cv2 = $cb2(...);
+echo $cv2(name: "Di", greeting: "Ho"), "\n";
+
+/* __invoke object FCC */
+$iv = new FccNamedInv(); $ci = $iv(...);
+echo $ci(name: "Zoe", greeting: "Hej"), "\n";
+
+/* mixed positional + named */
+$cm2 = $o->m(...);
+echo $cm2("Hello", name: "Mo"), "\n";
+
+/* a named argument that skips an optional parameter (b keeps its default) */
+$cd = $o->withDefault(...);
+echo $cd("X", c: "Z"), "\n";
+
+/* positional-only invocation of an FCC still works (no regression) */
+echo $cm("A", "B"), "\n";
+?>
+--EXPECT--
+Hi, Bob
+s:Yo, Sue
+Hey, Al
+s:Ho, Di
+i:Hej, Zoe
+Hello, Mo
+X/def/Z
+A, B
+--CLEAN--
+<?php


### PR DESCRIPTION
Calling an FCC closure with named arguments silently bound them positionally: `$c = $o->m(...); $c(name: "Bob", greeting: "Hi")` gave "Bob, Hi" instead of PHP's "Hi, Bob". It affected every FCC whose closure unwraps to a [target,method] array callable ($o->m(...), C::m(...), value [obj,m]/[class,m], __invoke objects); direct calls already bound by name.

The OP_CALL dispatch was asymmetric: the object/__invoke branch forwarded the call's named-arg map (pInstr->p3) to VmCallObjectInvoke, but the array-callable branch called PH7_VmCallUserFunction, which dropped it (its hashmap branch called PH7_VmCallClassMethod, hardcoding the map to 0).

Mirror the existing PH7_VmCallClassMethod -> VmCallClassMethodWithMap thin-wrapper idiom: move the body to PH7_VmCallUserFunctionWithMap(..., VmCallArgMap *pArgMap), which forwards the map to VmCallClassMethodWithMap / VmCallObjectInvoke / the closure-unwrap recursion / the string-path synthetic OP_CALL. PH7_VmCallUserFunction becomes a pArgMap=0 wrapper, so all ~21 existing positional callers (call_user_func, array_map, usort, the C API) are unchanged. The OP_CALL array-callable site now passes pInstr->p3, symmetric with the object branch. Reuses VmResolveNamedArgs wholesale — no new logic.

Verified byte-for-byte vs php 8.5.7 (instance/static/value-array/__invoke FCC with out-of-order names, mixed positional+named, named arg skipping an optional param); positional callbacks unregressed; ASan-clean over a create+named-invoke stress. make test (2232 smoke + 767 integration) and test-compat green.
