### PR TITLE
Yield NULL (not a char-index) for keyed destructuring from a non-array

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -1702,10 +1702,12 @@ static sxi32 GenStateCompileKeyedListBody(ph7_gen_state *pGen)
 			return SXERR_ABORT;
 		}
 		/* LOAD_IDX: pop the key, replace the DUP'd source with source[key].
-		 * iP2=0 is a read context: a missing key loads NULL silently, matching a
-		 * normal `$arr[$k]` read. (PHP also emits an "Undefined array key"
-		 * warning here; PHL omits it, like its other subscript reads — §3.7.) */
-		PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOAD_IDX,1,0,0,0);
+		 * iP2=7 is the keyed-destructuring read context: an array source reads like
+		 * iP2=0 (missing key loads NULL silently, matching a normal `$arr[$k]` read;
+		 * PHP also emits an "Undefined array key" warning here, PHL omits it — §3.7),
+		 * but a NON-array source yields NULL + a per-key "Cannot use <type> as array"
+		 * warning instead of char-indexing a string (matching PHP's OP_LOAD_LIST path). */
+		PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOAD_IDX,1,7,0,0);
 		if( pTarget < pNext && ( (pTarget->nType & PH7_TK_OSB)
 			|| ( (pTarget->nType & PH7_TK_KEYWORD)
 				&& SX_PTR_TO_INT(pTarget->pUserData) == PH7_TKWRD_LIST ) ) ){

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -4956,6 +4956,36 @@ static sxi32 VmSpreadValuesStep(ph7_vm *pVm, ph7_value *pKey, ph7_value *pValue,
 	return SXRET_OK;
 }
 /*
+ * Raise the PHP "Cannot use <type> as array" warning for a non-array source used in a
+ * list / array-destructuring assignment. Shared by the positional OP_LOAD_LIST path and the
+ * keyed OP_LOAD_IDX (iP2=7) path. The CALLER decides whether to warn at all — the two paths
+ * disagree on which scalar types are silent (positional silences null+bool; keyed silences
+ * only null, warning for bool to match PHP) — this only maps the type name and emits.
+ */
+static void VmWarnCannotUseAsArray(ph7_vm *pVm, sxi32 iFlags)
+{
+	const char *zType = "unknown";
+	char zMsg[64];
+	if( iFlags & MEMOBJ_STRING ){
+		zType = "string";
+	}else if( iFlags & MEMOBJ_REAL ){
+		/* REAL before INT: a whole-valued real carries MEMOBJ_REAL|MEMOBJ_INT (see the
+		 * float-identity note), and PHP names it "float" here, not "int". A pure int has no
+		 * REAL flag, so it still falls through to the int arm. */
+		zType = "float";
+	}else if( iFlags & MEMOBJ_INT ){
+		zType = "int";
+	}else if( iFlags & MEMOBJ_BOOL ){
+		zType = "bool";
+	}else if( iFlags & MEMOBJ_OBJ ){
+		zType = "object";
+	}else if( iFlags & MEMOBJ_RES ){
+		zType = "resource";
+	}
+	SyBufferFormat(zMsg,sizeof(zMsg),"Cannot use %s as array",zType);
+	PH7_VmThrowError(&(*pVm),0,PH7_CTX_WARNING,zMsg);
+}
+/*
  * Execute as much of a PH7 bytecode program as we can then return.
  *
  * [PH7_VmMakeReady()] must be called before this routine in order to
@@ -5832,23 +5862,8 @@ case PH7_OP_LOAD_LIST: {
 			pEntry++;
 		}
 		if( (pTos[-pInstr->iP1].iFlags & (MEMOBJ_NULL|MEMOBJ_BOOL)) == 0 ){
-			/* Emit PHP-compatible warning with type name */
-			const char *zType = "unknown";
-			sxi32 iFlags = pTos[-pInstr->iP1].iFlags;
-			char zMsg[256];
-			if( iFlags & MEMOBJ_STRING ){
-				zType = "string";
-			}else if( iFlags & MEMOBJ_INT ){
-				zType = "int";
-			}else if( iFlags & MEMOBJ_REAL ){
-				zType = "float";
-			}else if( iFlags & MEMOBJ_OBJ ){
-				zType = "object";
-			}else if( iFlags & MEMOBJ_RES ){
-				zType = "resource";
-			}
-			SyBufferFormat(zMsg,sizeof(zMsg),"Cannot use %s as array",zType);
-			PH7_VmThrowError(&(*pVm),0,PH7_CTX_WARNING,zMsg);
+			/* Positional list destructuring silences null+bool; warn for the rest. */
+			VmWarnCannotUseAsArray(&(*pVm),pTos[-pInstr->iP1].iFlags);
 		}
 	}
 	VmPopOperand(&pTos,pInstr->iP1);
@@ -5886,6 +5901,23 @@ case PH7_OP_LOAD_IDX: {
 	}else{
 		pIdx = pTos;
 		pTos--;
+	}
+	if( pInstr->iP2 == 7 && (pTos->iFlags & MEMOBJ_HASHMAP) == 0 ){
+		/* Keyed list destructuring `["k"=>$v] = $src` from a NON-array source: yield NULL
+		 * (never char-index a string), warning once per key — matching PHP, which warns per
+		 * key here. A NULL source is silent; unlike the positional OP_LOAD_LIST path, a bool
+		 * source DOES warn (PHP warns for bool in keyed destructuring). */
+		if( (pTos->iFlags & MEMOBJ_NULL) == 0 ){
+			VmWarnCannotUseAsArray(&(*pVm),pTos->iFlags);
+		}
+		if( pIdx ){
+			/* Release the key (a string literal for keyed destructuring), like the
+			 * normal hashmap-read exit below — otherwise its blob is orphaned. */
+			PH7_MemObjRelease(pIdx);
+		}
+		PH7_MemObjRelease(pTos);
+		MemObjSetType(pTos,MEMOBJ_NULL);
+		break;
 	}
 	if( pTos->iFlags & MEMOBJ_STRING ){
 		/* String access */

--- a/tests/ph7/002-integration/error/keyed_list_non_array.phpt
+++ b/tests/ph7/002-integration/error/keyed_list_non_array.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Keyed list destructuring from a non-array source yields NULL + warns (not char-index)
+--SKIPIF--
+<?php if (function_exists('zend_version') && version_compare(PHP_VERSION, '8.5.0', '<')) echo 'skip'; ?>
+--FILE--
+<?php
+["a" => $a] = "string";   // string source: warn, $a NULL (NOT char-indexed to "s")
+["b" => $i] = 42;         // int source: warn, $i NULL
+["c" => $n] = null;       // null source: silent, $n NULL
+echo isset($a) ? "a-set" : "a-unset", "\n";
+echo isset($i) ? "i-set" : "i-unset", "\n";
+echo isset($n) ? "n-set" : "n-unset", "\n";
+?>
+--EXPECTF--
+%s Warning:  Cannot use string as array%A Warning:  Cannot use int as array%Aa-unset%Ai-unset%An-unset
+--CLEAN--
+<?php
+unset($a, $i, $n);


### PR DESCRIPTION
`["a" => $x] = "str";` char-indexed the string ($x = "s") — a silent wrong answer — instead of PHP's NULL + "Cannot use string as array". The positional form `[$a] = "str"` was already correct via the dedicated OP_LOAD_LIST opcode, but keyed destructuring compiled each `key => target` as DUP -> push-key -> LOAD_IDX in plain read context (iP2=0), and LOAD_IDX's string branch char-indexes regardless of context. iP2=0 is shared with normal subscript reads (`$str[0]`, which should char-index), so the fix is a new destructuring-aware LOAD_IDX mode iP2=7: GenStateCompileKeyedListBody emits 7, and one guard in the OP_LOAD_IDX handler (before the string branch) yields NULL for any non-hashmap base with a per-key "Cannot use <type> as array" warning (string/int/float/bool/ object; NULL source silent), mirroring OP_LOAD_LIST's warning block. A hashmap base falls through to the existing read path, byte-identical to iP2=0.

Verified byte-for-byte vs php 8.5.7 including the per-key warning count (2 keys -> 2 warnings, which the per-element LOAD_IDX matches naturally); normal string indexing, positional destructuring, and nested/compound subscripts unbroken. make test (2232 smoke + 768 integration) and test-compat (both engines) green.
