### PR TITLE
Implement Closure::bind/bindTo/call/fromCallable

### DIFF
--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -422,6 +422,7 @@ struct VmFrame
 	VmFrame *pParent; /* Parent frame or NULL if global scope */
 	void *pUserData;  /* Upper layer private data associated with this frame */
 	ph7_class_instance *pThis; /* Current class instance [i.e: the '$this' variable].NULL otherwise */
+	ph7_class *pBoundScope; /* Closure::bindTo/call scope override for private/protected access (Increment 2) */
 	SySet sLocal;     /* Local variables container (VmSlot instance) */
 	ph7_vm *pVm;      /* VM that own this frame */
 	SyHash hVar;      /* Variable hashtable for fast lookup */
@@ -988,6 +989,11 @@ struct ph7_vm
 	ph7_class *pFiberClass;    /* Cached Fiber class pointer for fast dispatch */
 	ph7_class *pGeneratorClass; /* Cached Generator class pointer */
 	ph7_class *pClosureClass;  /* Cached Closure class pointer (closures are instances of it) */
+	ph7_class_instance *pClosureThis; /* Transient: bound $this for a bound PLAIN closure about to be
+	                                   * invoked, set by VmClosureUnwrap, consumed (ref transferred) at
+	                                   * the OP_CALL user-function frame setup. Owns one reference. */
+	ph7_class *pClosureScope; /* Transient: bound $__scope class for the same bound PLAIN closure
+	                           * (private/protected visibility override); consumed alongside pClosureThis. */
 	ph7_class *pStdClass;      /* Cached stdClass pointer (target of (object) cast + dynamic props) */
 	ph7_class *pArrayAccessClass; /* Cached ArrayAccess interface pointer */
 	ph7_class *pCountableClass;   /* Cached Countable interface pointer */

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -1329,6 +1329,8 @@ static int vm_builtin_Generator_send(ph7_context *pCtx, int nArg, ph7_value **ap
 static int vm_builtin_Generator_throw(ph7_context *pCtx, int nArg, ph7_value **apArg);
 static int vm_builtin_Generator_getReturn(ph7_context *pCtx, int nArg, ph7_value **apArg);
 static int vm_builtin_Generator_destruct(ph7_context *pCtx, int nArg, ph7_value **apArg);
+static int vm_builtin_Closure_bindTo(ph7_context *pCtx, int nArg, ph7_value **apArg);
+static int vm_builtin_Closure_fromCallable(ph7_context *pCtx, int nArg, ph7_value **apArg);
 /*
  * Built-in classes/interfaces and some functions that cannot be implemented
  * directly as foreign functions.
@@ -1572,6 +1574,10 @@ static int vm_builtin_Generator_destruct(ph7_context *pCtx, int nArg, ph7_value 
 	"  private $__this;"\
 	"  private $__scope;"\
 	"  public function __construct(){ throw new \\Error('Instantiation of class Closure is not allowed'); }"\
+	"  public function bindTo($newThis, $scope = 'static'){ return __closure_bindTo($this, $newThis, $scope); }"\
+	"  public function call($newThis, ...$args){ $bound = __closure_bindTo($this, $newThis, get_class($newThis)); return $bound(...$args); }"\
+	"  public static function bind($closure, $newThis, $scope = 'static'){ return __closure_bindTo($closure, $newThis, $scope); }"\
+	"  public static function fromCallable($callable){ return __closure_fromCallable($callable); }"\
 	"}"\
 	/* stdClass is empty (PHP-exact): holds only dynamic (runtime-added) properties. */\
 	"class stdClass{"\
@@ -1941,6 +1947,11 @@ PH7_PRIVATE sxi32 PH7_VmInit(
 	ph7_create_function(pVm,"__fiber_destruct",vm_builtin_Fiber_destruct,0);
 	/* Cache the Closure class pointer (closures are instances of it) */
 	pVm->pClosureClass = PH7_VmExtractClass(pVm,"Closure",7,0,0);
+	pVm->pClosureThis = 0; /* transient bound-$this slot, consumed per call */
+	pVm->pClosureScope = 0; /* transient bound-scope slot, consumed per call */
+	/* Closure::bind/bindTo/call/fromCallable native delegates (Increment 2) */
+	ph7_create_function(pVm,"__closure_bindTo",vm_builtin_Closure_bindTo,0);
+	ph7_create_function(pVm,"__closure_fromCallable",vm_builtin_Closure_fromCallable,0);
 	/* Cache the stdClass pointer ((object) cast target + dynamic-property owner) */
 	pVm->pStdClass = PH7_VmExtractClass(pVm,"stdClass",sizeof("stdClass")-1,0,0);
 	/* Cache the Generator class pointer and register generator functions */
@@ -2269,6 +2280,13 @@ PH7_PRIVATE sxi32 PH7_VmReset(ph7_vm *pVm)
 	/* The $GLOBALS array is normally protected from deletion; drop the guard so
 	 * its hashmap is actually released below, then rebuilt by CreateSuper. */
 	pVm->pGlobal = 0;
+	/* Defensive: a bound-closure $this transient is consumed within the same OP_CALL it is set,
+	 * so it is normally 0 here. But if a prior request aborted (e.g. OOM) between set and consume,
+	 * a stale pointer must not survive into the next reused (-S server) request — the object pool
+	 * is about to be truncated, which would dangle it. Just null it (the pool free reclaims the
+	 * object); unref'ing here would race the teardown below. */
+	pVm->pClosureThis = 0;
+	pVm->pClosureScope = 0;
 	/* Suppress user __destruct while we tear down the per-exec object pool: the
 	 * reference table is gone and $GLOBALS is nulled, so running arbitrary PHP
 	 * here is unsafe (and could realloc aMemObj mid-release). Engine memory is
@@ -10057,10 +10075,23 @@ case PH7_OP_CALL: {
 		ph7_value *pObj;
 		VmSlot sArg;
 		sxu32 n;
+		int bClosureThis = 0;
+		ph7_class *pClosureScope = 0;
 		/* initialize fields */
 		pVmFunc = (ph7_vm_func *)pEntry->pUserData;
 		pThis = 0;
 		pSelf = 0;
+		/* A bound PLAIN closure stashed its $this in pVm->pClosureThis (VmClosureUnwrap); consume it
+		 * here — transferring the owned reference to this frame's $this (teardown unrefs). Only ever
+		 * set for a bound plain closure, which dispatches as a function, so the method branch below
+		 * is skipped for it. The matching $__scope (private/protected visibility) rides alongside. */
+		if( pVm->pClosureThis ){
+			pThis = pVm->pClosureThis;
+			pVm->pClosureThis = 0;
+			bClosureThis = 1;
+			pClosureScope = pVm->pClosureScope;
+			pVm->pClosureScope = 0;
+		}
 		if( pVmFunc->iFlags & VM_FUNC_CLASS_METHOD ){
 			ph7_class_method *pMeth;
 			/* Class method call */
@@ -10289,6 +10320,12 @@ case PH7_OP_CALL: {
 			VmErrorFormat(&(*pVm),PH7_CTX_ERR,
 				"PH7 is running out of memory while calling function '%z',NULL will be returned",
 				&pVmFunc->sName);
+			/* The frame that would own (and later release) $this never got created; for a bound
+			 * plain closure the consumed transient is the object's ONLY ref, so release it here
+			 * to avoid a leak (a method call's pThis stays owned by the receiver on the stack). */
+			if( bClosureThis && pThis ){
+				PH7_ClassInstanceUnref(pThis);
+			}
 			/* Pop given arguments */
 			if( nCallArgs > 0 ){
 				VmPopOperand(&pTos,nCallArgs);
@@ -10297,8 +10334,13 @@ case PH7_OP_CALL: {
 			PH7_MemObjRelease(pTos);
 			break;
 		}
-		if( (pVmFunc->iFlags & VM_FUNC_CLASS_METHOD) && pThis ){
-			/* Install the '$this' variable */
+		if( bClosureThis && pClosureScope ){
+			/* Bound plain closure with an explicit scope: private/protected access inside the body
+			 * resolves against it (Closure::bindTo($o, Scope::class) / call($o)). */
+			pFrame->pBoundScope = pClosureScope;
+		}
+		if( pThis && ((pVmFunc->iFlags & VM_FUNC_CLASS_METHOD) || bClosureThis) ){
+			/* Install the '$this' variable (a method call, or a bound plain closure — Increment 2). */
 			static const SyString sThis = { "this" , sizeof("this") - 1 };
 			pObj = VmExtractMemObj(&(*pVm),&sThis,FALSE,TRUE);
 			if( pObj ){
@@ -10621,8 +10663,14 @@ case PH7_OP_CALL: {
 				/* Variadic parameter: collect all remaining args into an array */
 				pObj = VmExtractMemObj(&(*pVm),&aFormalArg[n].sName,FALSE,TRUE);
 				if( pObj ){
+					/* Capture the slot index now: PH7_HashmapInsert below can PH7_ReserveMemObj,
+					 * reallocating pVm->aMemObj and dangling pObj — so don't read pObj->nIdx after
+					 * the packing loop (pre-existing UAF, masked by the pool allocator). pMap is a
+					 * separately-allocated hashmap and stays valid across the realloc. */
+					sxu32 nVariadicIdx;
 					/* Initialize as empty array */
 					PH7_MemObjToHashmap(pObj);
+					nVariadicIdx = pObj->nIdx;
 					{
 						ph7_hashmap *pMap = (ph7_hashmap *)pObj->x.pOther;
 						while( pArg < pTos ){
@@ -10706,7 +10754,7 @@ case PH7_OP_CALL: {
 							pArg++;
 						}
 					}
-					sArg.nIdx = pObj->nIdx;
+					sArg.nIdx = nVariadicIdx; /* pObj may be stale here (aMemObj realloc) — use the saved index */
 					sArg.pUserData = 0;
 					SySetPut(&pFrame->sArg,(const void *)&sArg);
 				}
@@ -11701,9 +11749,39 @@ static sxi32 VmClosureUnwrap(ph7_vm *pVm, ph7_value *pVal, ph7_value *pOut)
 		bScope = pScope && (pScope->iFlags & MEMOBJ_STRING) && SyBlobLength(&pScope->sBlob) > 0;
 		if( bBoundObj || bScope ){
 			/* Method/static first-class callable -> [ target, "method" ] array callable. */
-			ph7_hashmap *pMap = PH7_NewHashmap(&(*pVm), 0, 0);
+			ph7_hashmap *pMap;
 			ph7_value sTarget, sMeth;
 			sxi32 rc;
+			if( bBoundObj ){
+				ph7_class_instance *pBoundObj = (ph7_class_instance *)pBound->x.pOther;
+				/* A bound PLAIN closure (`function(){…}->bindTo($o)`): $__fn names a function, not a
+				 * method of the bound object's class, so a [obj,method] array callable would fail
+				 * method resolution. Stash the bound object (own a ref) so the OP_CALL user-function
+				 * frame setup injects it as $this, and return the plain $__fn string for a normal
+				 * function dispatch. */
+				if( PH7_ClassExtractMethod(pBoundObj->pClass,
+						(const char *)SyBlobData(&pFn->sBlob), SyBlobLength(&pFn->sBlob)) == 0 ){
+					/* Only a USER function (anonymous closure / named fn in hFunction) reads $this and
+					 * reaches the OP_CALL user-function frame-setup that consumes pClosureThis. A HOST
+					 * function (e.g. Closure::fromCallable('strlen')->bindTo($o)) ignores $this and
+					 * dispatches via the host path which never consumes the transient — setting it
+					 * there would leak the ref and inject a stale $this into the next call. */
+					if( SyHashGet(&pVm->hFunction, (const void *)SyBlobData(&pFn->sBlob),
+							SyBlobLength(&pFn->sBlob)) != 0 ){
+						pBoundObj->iRef++;
+						pVm->pClosureThis = pBoundObj;
+						/* Carry the bound scope (if set) so private/protected member access inside
+						 * the closure body resolves against it — bindTo($o, Scope::class) / call($o). */
+						if( bScope ){
+							pVm->pClosureScope = PH7_VmExtractClass(pVm,
+								(const char *)SyBlobData(&pScope->sBlob), SyBlobLength(&pScope->sBlob), FALSE, 0);
+						}
+					}
+					PH7_MemObjStringAppend(pOut, SyBlobData(&pFn->sBlob), SyBlobLength(&pFn->sBlob));
+					return SXRET_OK;
+				}
+			}
+			pMap = PH7_NewHashmap(&(*pVm), 0, 0);
 			if( pMap == 0 ){
 				return SXERR_NOTFOUND;
 			}
@@ -11876,6 +11954,161 @@ static ph7_class_instance * VmFccWrapValue(ph7_vm *pVm, ph7_value *pValue)
 	/* Unreachable in practice — the PH7_VmIsCallable gate admits only string/array/object, all
 	 * handled above; kept to satisfy the non-void return path. */
 	return 0;
+}
+/*
+ * Return a fresh Closure instance (iRef==0 from create/clone) as a builtin result, taking the
+ * one reference into pCtx->pRet — mirrors the OP_LOAD_FCC store convention.
+ */
+static int VmClosureResult(ph7_context *pCtx, ph7_class_instance *pClosure)
+{
+	if( pClosure == 0 ){
+		ph7_result_null(pCtx);
+		return PH7_OK;
+	}
+	PH7_MemObjRelease(pCtx->pRet);
+	pClosure->iRef++;
+	pCtx->pRet->x.pOther = pClosure;
+	MemObjSetType(pCtx->pRet, MEMOBJ_OBJ);
+	return PH7_OK;
+}
+/*
+ * Overwrite a Closure clone's $__this (bound object, or 0 to unbind) and, when pScope != 0, its
+ * $__scope (the class-name string; pScope->nByte==0 clears it). pScope==0 leaves $__scope as the
+ * clone inherited it (PHP's "static" = keep-scope). Refreshes VM_INSTANCE_FCC_BOUND from the result.
+ * The clone inherited a ref on the original $__this (PH7_CloneClassInstance copies via MemObjStore);
+ * this drops that and takes one on pNewThis.
+ */
+static void VmClosureRebind(ph7_class_instance *pClone,
+	ph7_class_instance *pNewThis, const SyString *pScope)
+{
+	SyString sAttr;
+	ph7_value *pThisAttr, *pScopeAttr;
+	int bBound = 0;
+	SyStringInitFromBuf(&sAttr, "__this", 6);
+	pThisAttr = PH7_ClassInstanceFetchAttr(pClone, &sAttr);
+	if( pThisAttr ){
+		/* PH7_MemObjRelease already drops the cloned-in object's refcount for an OBJ value —
+		 * do NOT also decrement by hand (that double-frees the original bound object). */
+		PH7_MemObjRelease(pThisAttr);
+		if( pNewThis ){
+			pThisAttr->x.pOther = pNewThis;
+			MemObjSetType(pThisAttr, MEMOBJ_OBJ);
+			pNewThis->iRef++;
+		}
+	}
+	if( pScope ){
+		SyStringInitFromBuf(&sAttr, "__scope", 7);
+		pScopeAttr = PH7_ClassInstanceFetchAttr(pClone, &sAttr);
+		if( pScopeAttr ){
+			PH7_MemObjRelease(pScopeAttr);
+			if( pScope->nByte ){
+				PH7_MemObjStringAppend(pScopeAttr, pScope->zString, pScope->nByte);
+			}
+		}
+	}
+	/* Refresh the FCC_BOUND fast-path flag from the resulting $__this/$__scope. pThisAttr already
+	 * points at the final $__this slot; only $__scope needs a (re)fetch — the top half fetched it
+	 * just for pScope != 0. */
+	SyStringInitFromBuf(&sAttr, "__scope", 7);
+	pScopeAttr = PH7_ClassInstanceFetchAttr(pClone, &sAttr);
+	if( (pThisAttr && (pThisAttr->iFlags & MEMOBJ_OBJ))
+		|| (pScopeAttr && (pScopeAttr->iFlags & MEMOBJ_STRING) && SyBlobLength(&pScopeAttr->sBlob) > 0) ){
+		bBound = 1;
+	}
+	if( bBound ){
+		pClone->iFlags |= VM_INSTANCE_FCC_BOUND;
+	}else{
+		pClone->iFlags &= ~VM_INSTANCE_FCC_BOUND;
+	}
+}
+/*
+ * Resolve the bindTo/bind/call $scope argument to a class-name SyString.
+ * Returns 1 and fills *pOut if $__scope should be replaced (pOut->nByte==0 means "clear");
+ * returns 0 to leave the scope unchanged (the PHP "static" sentinel / scope omitted).
+ */
+static int VmClosureResolveScope(ph7_value *pScopeArg, SyString *pOut)
+{
+	if( pScopeArg == 0 ){
+		return 0; /* keep */
+	}
+	if( (pScopeArg->iFlags & MEMOBJ_STRING) && SyBlobLength(&pScopeArg->sBlob) == 6
+		&& SyMemcmp((const void *)SyBlobData(&pScopeArg->sBlob), (const void *)"static", 6) == 0 ){
+		return 0; /* "static" -> keep current scope */
+	}
+	if( pScopeArg->iFlags & MEMOBJ_NULL ){
+		SyStringInitFromBuf(pOut, 0, 0); /* unscoped */
+		return 1;
+	}
+	if( pScopeArg->iFlags & MEMOBJ_OBJ ){
+		ph7_class_instance *pScopeObj = (ph7_class_instance *)pScopeArg->x.pOther;
+		*pOut = pScopeObj->pClass->sName;
+		return 1;
+	}
+	if( pScopeArg->iFlags & MEMOBJ_STRING ){
+		SyStringInitFromBuf(pOut, (const char *)SyBlobData(&pScopeArg->sBlob), SyBlobLength(&pScopeArg->sBlob));
+		return 1;
+	}
+	return 0;
+}
+/*
+ * Closure::bindTo($newThis, $scope='static') / Closure::bind($closure, $newThis, $scope='static').
+ * Clone the receiver and rebind $this/$scope; returns the new Closure (NULL on a non-Closure
+ * receiver, matching PHP's failure mode).
+ */
+static int vm_builtin_Closure_bindTo(ph7_context *pCtx, int nArg, ph7_value **apArg)
+{
+	ph7_vm *pVm = pCtx->pVm;
+	ph7_class_instance *pClosure, *pNewThis, *pClone;
+	ph7_value *pNewThisArg;
+	SyString sScope;
+	const SyString *pScopePtr = 0;
+	if( nArg < 2 || !VmValueIsClosure(pVm, apArg[0]) ){
+		ph7_result_null(pCtx);
+		return PH7_OK;
+	}
+	pClosure = (ph7_class_instance *)apArg[0]->x.pOther;
+	pNewThisArg = apArg[1];
+	if( pNewThisArg->iFlags & MEMOBJ_NULL ){
+		pNewThis = 0;
+	}else if( pNewThisArg->iFlags & MEMOBJ_OBJ ){
+		pNewThis = (ph7_class_instance *)pNewThisArg->x.pOther;
+	}else{
+		return PH7_VmThrowException(pCtx, "TypeError",
+			"Closure::bindTo(): Argument #1 ($newThis) must be of type ?object");
+	}
+	if( VmClosureResolveScope((nArg > 2) ? apArg[2] : 0, &sScope) ){
+		pScopePtr = &sScope;
+	}
+	pClone = PH7_CloneClassInstance(pClosure);
+	if( pClone == 0 ){
+		ph7_result_null(pCtx);
+		return PH7_OK;
+	}
+	VmClosureRebind(pClone, pNewThis, pScopePtr);
+	return VmClosureResult(pCtx, pClone);
+}
+/*
+ * Closure::fromCallable($callable) — normalize any callable value to a Closure (reuses the
+ * VmFccWrapValue primitive); idempotent on a Closure; TypeError on a non-callable.
+ */
+static int vm_builtin_Closure_fromCallable(ph7_context *pCtx, int nArg, ph7_value **apArg)
+{
+	ph7_vm *pVm = pCtx->pVm;
+	ph7_class_instance *pClosure;
+	if( nArg < 1 ){
+		return PH7_VmThrowException(pCtx, "TypeError",
+			"Closure::fromCallable() expects exactly 1 argument, 0 given");
+	}
+	if( VmValueIsClosure(pVm, apArg[0]) ){
+		ph7_result_value(pCtx, apArg[0]); /* already a Closure: idempotent */
+		return PH7_OK;
+	}
+	pClosure = VmFccWrapValue(pVm, apArg[0]);
+	if( pClosure == 0 ){
+		return PH7_VmThrowException(pCtx, "TypeError",
+			"Closure::fromCallable(): Argument #1 ($callback) is not a valid callback");
+	}
+	return VmClosureResult(pCtx, pClosure);
 }
 /*
  * Fiber::suspend($value = null) — static method.
@@ -13709,6 +13942,15 @@ PH7_PRIVATE sxi32 PH7_VmCallUserFunctionWithMap(
 		PH7_MemObjInit(pVm,&sCallable);
 		if( VmClosureUnwrap(pVm,pFunc,&sCallable) == SXRET_OK ){
 			rcClo = PH7_VmCallUserFunctionWithMap(pVm,&sCallable,nArg,apArg,pResult,pArgMap);
+			/* A bound PLAIN closure parks its $this in pVm->pClosureThis for the (synthetic) OP_CALL
+			 * frame setup to consume. If that dispatch failed before the consume (e.g. operand-stack
+			 * OOM), the transient is still set — release its owned ref and clear it so it neither
+			 * leaks nor poisons the next call's frame with a stale $this. */
+			if( pVm->pClosureThis ){
+				PH7_ClassInstanceUnref(pVm->pClosureThis);
+				pVm->pClosureThis = 0;
+				pVm->pClosureScope = 0;
+			}
 			PH7_MemObjRelease(&sCallable);
 			return rcClo;
 		}

--- a/src/ph7/vm_builtin_class.c
+++ b/src/ph7/vm_builtin_class.c
@@ -516,17 +516,24 @@ PH7_PRIVATE int PH7_VmClassMemberAccess(
 	if( iProtection != PH7_CLASS_PROT_PUBLIC ){
 		VmFrame *pFrame = pVm->pFrame;
 		ph7_vm_func *pVmFunc;
+		ph7_class *pCallerScope;
 		while( pFrame->pParent && (pFrame->iFlags & (VM_FRAME_EXCEPTION|VM_FRAME_CATCH) ) ){
 			/* Safely ignore the exception frame */
 			pFrame = pFrame->pParent;
 		}
 		pVmFunc = (ph7_vm_func *)pFrame->pUserData;
-		if( pVmFunc == 0 || (pVmFunc->iFlags & VM_FUNC_CLASS_METHOD) == 0 ){
-			goto dis; /* Access is forbidden */
+		/* The calling scope is the executing method's declaring class — OR, for a bound closure
+		 * (Closure::bindTo/call), the explicit scope override carried on the frame (Increment 2). */
+		if( pFrame->pBoundScope ){
+			pCallerScope = pFrame->pBoundScope;
+		}else if( pVmFunc && (pVmFunc->iFlags & VM_FUNC_CLASS_METHOD) ){
+			pCallerScope = (ph7_class *)pVmFunc->pUserData;
+		}else{
+			goto dis; /* Not in a class scope: access is forbidden */
 		}
 		if( iProtection == PH7_CLASS_PROT_PRIVATE ){
 			/* Must be the same instance or a trait used by the class */
-			ph7_class *pCaller = (ph7_class *)pVmFunc->pUserData;
+			ph7_class *pCaller = pCallerScope;
 			if( pCaller != pClass ){
 				/* Check if the caller is a trait used by pClass */
 				ph7_class **apTrait;
@@ -546,7 +553,7 @@ PH7_PRIVATE int PH7_VmClassMemberAccess(
 			}
 		}else{
 			/* Protected */
-			ph7_class *pBase = (ph7_class *)pVmFunc->pUserData;
+			ph7_class *pBase = pCallerScope;
 			/* Must be in the same class hierarchy */
 			if( !PH7_VmInstanceOf(pClass,pBase) && !PH7_VmInstanceOf(pBase,pClass) ){
 				goto dis; /* Access is forbidden */

--- a/tests/ph7/001-smoke/lang/closure_bind_scope.phpt
+++ b/tests/ph7/001-smoke/lang/closure_bind_scope.phpt
@@ -1,0 +1,32 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Closure::bindTo scope grants private/protected access to the bound object
+--FILE--
+<?php
+class Inc2Scope {
+  private $secret = "hidden";
+  protected $prot = "guarded";
+}
+
+/* explicit class-name scope -> private + protected accessible */
+$reader = function (){ return $this->secret . "/" . $this->prot; };
+$bound = $reader->bindTo(new Inc2Scope(), Inc2Scope::class);
+echo $bound(), "\n";                              // hidden/guarded
+
+/* scope given as an object also works */
+$r2 = function (){ return $this->secret; };
+$b2 = $r2->bindTo(new Inc2Scope(), new Inc2Scope());
+echo $b2(), "\n";                                 // hidden
+
+/* Closure::call() rescopes to the bound object's class -> private accessible */
+$r3 = function (){ return $this->secret; };
+echo $r3->call(new Inc2Scope()), "\n";            // hidden
+?>
+--EXPECT--
+hidden/guarded
+hidden
+hidden
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/closure_bindto.phpt
+++ b/tests/ph7/001-smoke/lang/closure_bindto.phpt
@@ -1,0 +1,46 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Closure::bindTo / Closure::bind rebind $this on plain and method-FCC closures
+--FILE--
+<?php
+class Inc2Bind {
+  public $v;
+  function __construct($v){ $this->v = $v; }
+  function m(){ return $this->v; }
+}
+
+/* plain closure: bindTo injects $this into the body */
+$f = function (){ return $this->v; };
+$b = $f->bindTo(new Inc2Bind(7));
+echo $b(), "\n";                                  // 7
+
+/* with arguments */
+$g = function ($x){ return $this->v + $x; };
+$bg = $g->bindTo(new Inc2Bind(10));
+echo $bg(5), "\n";                                // 15
+
+/* Closure::bind() static form */
+$h = Closure::bind($f, new Inc2Bind(99));
+echo $h(), "\n";                                  // 99
+
+/* rebinding a method-FCC closure to another instance */
+$a = new Inc2Bind(1); $cb = $a->m(...);
+echo $cb(), "\n";                                 // 1
+$reb = $cb->bindTo(new Inc2Bind(2));
+echo $reb(), "\n";                                // 2
+
+/* independent: original binding survives rebinding to a new closure */
+$b2 = $b->bindTo(new Inc2Bind(8));
+echo $b2(), " ", $b(), "\n";                      // 8 7
+?>
+--EXPECT--
+7
+15
+99
+1
+2
+8 7
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/closure_call.phpt
+++ b/tests/ph7/001-smoke/lang/closure_call.phpt
@@ -1,0 +1,36 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Closure::call binds $this+scope and invokes (zero, one and many args)
+--FILE--
+<?php
+class Inc2Call {
+  public $v;
+  private $secret;
+  function __construct($v){ $this->v = $v; $this->secret = "s$v"; }
+}
+
+/* zero extra args */
+$f = function (){ return $this->v; };
+echo $f->call(new Inc2Call(9)), "\n";             // 9
+
+/* one arg */
+$g = function ($x){ return $this->v + $x; };
+echo $g->call(new Inc2Call(10), 5), "\n";         // 15
+
+/* many args */
+$h = function ($a, $b, $c){ return "$this->v:$a:$b:$c"; };
+echo $h->call(new Inc2Call(1), "x", "y", "z"), "\n";  // 1:x:y:z
+
+/* call() rescopes to $newThis's class -> private access works */
+$p = function (){ return $this->secret; };
+echo $p->call(new Inc2Call(4)), "\n";             // s4
+?>
+--EXPECT--
+9
+15
+1:x:y:z
+s4
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/closure_fromcallable.phpt
+++ b/tests/ph7/001-smoke/lang/closure_fromcallable.phpt
@@ -1,0 +1,47 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Closure::fromCallable normalizes any callable to a Closure (idempotent on a Closure)
+--FILE--
+<?php
+class Inc2FC {
+  public $tag = "obj";
+  function m($x){ return $this->tag . ":" . $x; }
+  static function sm($x){ return "static:" . $x; }
+}
+class Inc2FCInv { function __invoke($x){ return "inv:" . $x; } }
+
+$c1 = Closure::fromCallable("strlen");
+echo var_export($c1 instanceof Closure, true), "\n";
+echo $c1("hello"), "\n";
+
+$o = new Inc2FC();
+$c2 = Closure::fromCallable([$o, "m"]);
+echo var_export($c2 instanceof Closure, true), "\n";
+echo $c2("a"), "\n";
+
+$c3 = Closure::fromCallable(["Inc2FC", "sm"]);
+echo $c3("b"), "\n";
+
+$iv = new Inc2FCInv();
+$c4 = Closure::fromCallable($iv);
+echo $c4("z"), "\n";
+
+/* idempotent: passing a Closure returns a Closure (same callable) */
+$cl = function ($x) { return "cl:" . $x; };
+$c5 = Closure::fromCallable($cl);
+echo var_export($c5 instanceof Closure, true), "\n";
+echo $c5("q"), "\n";
+?>
+--EXPECT--
+true
+5
+true
+obj:a
+static:b
+inv:z
+true
+cl:q
+--CLEAN--
+<?php


### PR DESCRIPTION
Closures were real Closure objects but had none of the bind family. Add all four via the embedded-stub -> C-delegate pattern (like Fiber/Generator):

  - fromCallable($c): reuse VmFccWrapValue (the callable-value -> Closure primitive); idempotent on a Closure, TypeError on a non-callable.
  - bindTo($newThis, $scope='static') / bind(...): clone the closure (PH7_CloneClassInstance) and rebind $__this / $__scope; 'static' keeps the current scope, null unscopes, a string/object sets it.
  - call($newThis, ...$args): a PHP stub = bindTo($newThis, get_class($newThis)) then $bound(...$args) — invoking via the normal OP_CALL path (avoids a fragile direct-dispatch path that mis-handled the zero-extra-args case).

The headline work is binding $this into a PLAIN closure's frame. A plain function(){} closure dispatches as a function with pThis=NULL; the [obj,method] array-callable trick only works for method-FCC closures (where $__fn is a real method). So VmClosureUnwrap, for a bound plain closure whose $__fn is a USER function, stashes the bound object (and resolved scope) in a transient pVm->pClosureThis/pClosureScope (owning a ref); the OP_CALL user-function frame setup consumes it — transferring the ref to the frame's $this (teardown unrefs) and installing the $this variable. A host-function $__fn (e.g. fromCallable('strlen')->bindTo($o)) ignores $this and never reaches that consume site, so the transient is deliberately not set there (else it would leak + inject a stale $this into the next call).

Private/protected visibility honors the bound scope: a new VmFrame.pBoundScope (set from $__scope) is consulted by PH7_VmClassMemberAccess before the executing method's declaring class. When pBoundScope==0 (every normal access) the logic is byte-identical to before.

Also fixes a pre-existing UAF surfaced by the variadic call() stub: the variadic arg collector's slot pointer (pObj) was read after the PH7_HashmapInsert packing loop, which can PH7_ReserveMemObj -> realloc aMemObj and dangle it; capture the stable slot index before the loop instead.

Verified byte-for-byte vs php 8.5.7 (fromCallable / bindTo plain+method-FCC / call 0/1/many args / private+protected via scope / independent rebinds); two independent /code-review passes (refcounts, the visibility refactor's pBoundScope==0 equivalence, the variadic fix — all confirmed; the host-fn transient-leak found and fixed). make test (2236 smoke + 768 integration), test-compat (both engines), ASan-clean (malloc-passthrough) over a bind/call/ fromCallable + host-fn-bound stress.

Deferred (documented): a private-access Error from a NO-scope bound closure is thrown but not always catchable by an enclosing try/catch (pre-existing exception-from-deep-frame propagation limitation); ($expr)->method() on a parenthesized closure literal still mis-parses.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
