### PR TITLE
Auto-vivify a fresh object property via []=, ??=, ++, and compound-as…

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -94,6 +94,12 @@ struct LangConstruct
 #define EXPR_FLAG_LOAD_IDX_ISSET    0x008 /* LOAD_IDX argument is the LHS of isset() — emit iP2=4 (offsetExists) */
 #define EXPR_FLAG_LOAD_IDX_UNSET    0x010 /* LOAD_IDX argument is the LHS of unset() — emit iP2=5 (offsetUnset) */
 #define EXPR_FLAG_LOAD_IDX_EMPTY    0x020 /* LOAD_IDX argument is the LHS of empty() — emit iP2=6 (offsetExists+offsetGet) */
+#define EXPR_FLAG_MEMBER_WRITE      0x040 /* Sub-tree is the write lvalue of an assignment: tag a target
+                                           * OP_MEMBER iP2=PH7_MEMBER_WRITE so the VM auto-creates a missing
+                                           * property (e.g. `$o->arr[$k] = v`, `$o->p ??= v`). Propagated
+                                           * from the precedence-18 lvalue through SUBSCRIPT to the base
+                                           * member; stripped when descending into an intermediate `->`
+                                           * container (the container is read, not the write target). */
 /* Forward declaration */
 static sxi32 PH7_CompileExpr(ph7_gen_state *pGen,sxi32 iFlags,sxi32 (*xTreeValidator)(ph7_gen_state *,ph7_expr_node *));
 /*
@@ -10767,7 +10773,7 @@ static sxi32 GenStateEmitExprCode(
 		 * stack slot carries a writable nIdx. */
 		if( pNode->pRight ){
 			nNcNsBase = SySetUsed(&pGen->aNullsafeJmp);
-			rc = GenStateEmitExprCode(&(*pGen),pNode->pRight,iFlags|EXPR_FLAG_LOAD_IDX_STORE);
+			rc = GenStateEmitExprCode(&(*pGen),pNode->pRight,iFlags|EXPR_FLAG_LOAD_IDX_STORE|EXPR_FLAG_MEMBER_WRITE);
 			if( rc != SXRET_OK ){
 				return rc;
 			}
@@ -10936,7 +10942,7 @@ static sxi32 GenStateEmitExprCode(
 			}
 			for( n = 0 ; n < nArgs ; ++n ){
 				sxu32 nArgNsBase = SySetUsed(&pGen->aNullsafeJmp);
-				sxi32 iArgFlags = iFlags & ~EXPR_FLAG_LOAD_IDX_STORE;
+				sxi32 iArgFlags = iFlags & ~(EXPR_FLAG_LOAD_IDX_STORE|EXPR_FLAG_MEMBER_WRITE);
 				/* For a by-ref argument position, drop the read-only flag so the
 				 * variable is created if absent (PH7_OP_LOAD iP1=0 => bCreate), and
 				 * set write-context so a subscript target (preg_match($p,$s,$a['k']))
@@ -11014,6 +11020,19 @@ static sxi32 GenStateEmitExprCode(
 					|| pNode->pLeft->pOp->iOp == EXPR_OP_DC) ){
 				iLeftFlags &= ~EXPR_FLAG_LOAD_IDX_UNSET;
 			}
+			/* Write-lvalue propagation (mirrors the UNSET strip): EXPR_FLAG_MEMBER_WRITE marks the
+			 * write target of an assignment and flows through a SUBSCRIPT to its base member
+			 * ($o->arr[$k]=v → create arr). But when THIS node is itself a `->`/`::` member access, its
+			 * left operand is an intermediate container that is only READ ($o->a->b=v must not create
+			 * a; $o->arr[]=v reads $o), so strip MEMBER_WRITE there — PHP auto-vivifies arrays, never
+			 * objects. (The flag is ADDED to the lvalue at the precedence-18 site below / the `??=`
+			 * site, since `=` is right-associative and its lvalue is pNode->pRight.) */
+			if( pNode->pOp
+				&& (pNode->pOp->iOp == EXPR_OP_ARROW
+					|| pNode->pOp->iOp == EXPR_OP_NULLSAFE_ARROW
+					|| pNode->pOp->iOp == EXPR_OP_DC) ){
+				iLeftFlags &= ~EXPR_FLAG_MEMBER_WRITE;
+			}
 			rc = GenStateEmitExprCode(&(*pGen),pNode->pLeft,iLeftFlags);
 		}
 		if( rc != SXRET_OK ){
@@ -11077,7 +11096,7 @@ static sxi32 GenStateEmitExprCode(
 			sxi32 n;
 			sxi32 iChildMask = ~(EXPR_FLAG_LOAD_IDX_STORE
 				|EXPR_FLAG_LOAD_IDX_ISSET|EXPR_FLAG_LOAD_IDX_UNSET
-				|EXPR_FLAG_LOAD_IDX_EMPTY);
+				|EXPR_FLAG_LOAD_IDX_EMPTY|EXPR_FLAG_MEMBER_WRITE);
 			/* Recurse and generate bytecodes for array index */
 			apNode = (ph7_expr_node **)SySetBasePtr(&pNode->aNodeArgs);
 			for( n = 0 ; n < (sxi32)SySetUsed(&pNode->aNodeArgs) ; ++n ){
@@ -11170,7 +11189,10 @@ static sxi32 GenStateEmitExprCode(
 			PH7_VmEmitInstr(pGen->pVm,PH7_OP_NULLSAFE_JMP,0,0,0,&nNsJmp);
 			SySetPut(&pGen->aNullsafeJmp,(const void *)&nNsJmp);
 		}else if( pNode->pOp->iPrec == 18 /* Combined binary operators [i.e: =,'.=','+=',*=' ...] precedence */ ){
-			iFlags |= EXPR_FLAG_LOAD_IDX_STORE;
+			/* The lvalue is the RIGHT operand (these ops are right-associative). Mark it a write
+			 * target so a missing member (the base of a subscript-write, or a bare `$o->p`) is
+			 * auto-created — PHP auto-vivifies on write. */
+			iFlags |= EXPR_FLAG_LOAD_IDX_STORE | EXPR_FLAG_MEMBER_WRITE;
 		}
 		nRhsNsBase = SySetUsed(&pGen->aNullsafeJmp);
 		rc = GenStateEmitExprCode(&(*pGen),pNode->pRight,iFlags);
@@ -11324,6 +11346,9 @@ static sxi32 GenStateEmitExprCode(
 					iP2 = PH7_MEMBER_ISSET;
 				}else if( iFlags & EXPR_FLAG_LOAD_IDX_EMPTY ){
 					iP2 = PH7_MEMBER_EMPTY;
+				}else if( iFlags & EXPR_FLAG_MEMBER_WRITE ){
+					/* Write-lvalue base ($o->arr[$k]=v, $o->p ??= v): auto-create a missing prop. */
+					iP2 = PH7_MEMBER_WRITE;
 				}
 			}
 		}

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1175,6 +1175,7 @@ enum ph7_vm_op {
 #define PH7_MEMBER_UNSET  2 /* unset($o->p): remove the property */
 #define PH7_MEMBER_ISSET  3 /* isset($o->p): silent on a read-miss */
 #define PH7_MEMBER_EMPTY  4 /* empty($o->p): silent on a read-miss */
+#define PH7_MEMBER_WRITE  5 /* write-lvalue base ($o->arr[..]=, $o->p??=): auto-create a missing prop */
 /* -- END-OF INSTRUCTIONS -- */
 /*
  * Expression Operators ID.

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -1256,10 +1256,12 @@ static void VmRecreateDeclaredAttr(ph7_vm *pVm,ph7_class_instance *pThis,ph7_cla
 	pVmAttr->nIdx = pMemObj->nIdx;
 	pVmAttr->iState = 0;
 	pVmAttr->pOwner = pThis->pClass;
-	if( SySetUsed(&pAttr->aByteCode) > 0 ){
-		/* Re-run the declared default; the assignment that triggered this overwrites it. */
-		VmLocalExec(&(*pVm),&pAttr->aByteCode,pMemObj,FALSE);
-	}else if( pAttr->iFlags & PH7_CLASS_ATTR_TYPED ){
+	/* Do NOT re-run the declared default initializer. A property recreated after unset() is a fresh
+	 * UNDEFINED property — PHP applies the class default only at construction, not on re-creation. The
+	 * reserved slot stays NULL, so a read-modify-write that triggered this (`$o->p += 1`, `.=`, `??=`)
+	 * sees null/0/"" as PHP does; a plain `$o->p = v` overwrites it either way. For a typed property,
+	 * mark it uninitialized so a read before the (re)assignment is an Error, matching PHP. */
+	if( pAttr->iFlags & PH7_CLASS_ATTR_TYPED ){
 		pVmAttr->iState |= VM_CLASS_ATTR_UNINIT;
 	}
 	/* Tail-insert: a re-created property appends (creation order), consistent with a dynamic prop.
@@ -5074,6 +5076,32 @@ static void VmWarnCannotUseAsArray(ph7_vm *pVm, sxi32 iFlags)
 static int VmMemberCtxIsLookup(sxi32 iP2)
 {
 	return iP2 == PH7_MEMBER_ISSET || iP2 == PH7_MEMBER_EMPTY;
+}
+/*
+ * Whether the instruction immediately following an OP_MEMBER that missed (property absent) is a
+ * write/modify of the member slot that lands DIRECTLY on it — so a fresh property should be
+ * auto-created (PHP-style auto-vivification) for the op to work. Covers the read-modify-write forms
+ * whose op immediately follows OP_MEMBER: increment/decrement and the compound-assign family
+ * (`$o->n++`, `$o->s .= "x"`, `$o->c += 1`), plus a plain member store. Subscript-writes
+ * (`$o->arr[] = x`, `$o->m[$k] = x`, `??=`) are NOT detectable here — the key sits between OP_MEMBER
+ * and OP_STORE_IDX — so those are marked by the compiler instead (OP_MEMBER iP2 == PH7_MEMBER_WRITE).
+ * One-token lookahead only.
+ */
+static int VmMemberNextIsWrite(const VmInstr *pNext)
+{
+	switch( pNext->iOp ){
+		case PH7_OP_STORE:
+			return pNext->iP2 != 0;                          /* member store ($o->p = v) */
+		case PH7_OP_INCR: case PH7_OP_DECR:
+		case PH7_OP_ADD_STORE: case PH7_OP_SUB_STORE: case PH7_OP_MUL_STORE:
+		case PH7_OP_DIV_STORE: case PH7_OP_MOD_STORE: case PH7_OP_POW_STORE:
+		case PH7_OP_CAT_STORE:
+		case PH7_OP_SHL_STORE: case PH7_OP_SHR_STORE:
+		case PH7_OP_BAND_STORE: case PH7_OP_BOR_STORE: case PH7_OP_BXOR_STORE:
+			return 1;
+		default:
+			return 0;
+	}
 }
 /*
  * Execute as much of a PH7 bytecode program as we can then return.
@@ -9147,14 +9175,22 @@ case PH7_OP_MEMBER: {
 					break;
 				}
 				if( pObjAttr == 0 && sName.nByte > 0 ){
-					/* Member not present on the instance and this is the LHS of an assignment
-					 * (next instr is a member store; the compiler always emits a terminating
-					 * PH7_OP_DONE so pInstr+1 is in-bounds). Create the property so the store lands:
+					/* Member not present on the instance and the next instruction writes/modifies it
+					 * (store, array-append/keyed-write, `??=`, ++/--, or a compound-assign — see
+					 * VmMemberNextIsWrite; the compiler always emits a terminating PH7_OP_DONE so
+					 * pInstr+1 is in-bounds). Create the property so the operation lands on a real slot
+					 * (PHP auto-vivifies a fresh property for all these forms, not just `=`):
 					 *   - a DECLARED prop that was unset() and is re-assigned → recreate it
 					 *     (PHP re-appends it at the end), OR
-					 *   - a dynamic prop on a dynamic-allowing class (stdClass). */
+					 *   - a dynamic prop on a dynamic-allowing class (stdClass).
+					 * The created slot is NULL with a real nIdx, which the modify-op then vivifies
+					 * (NULL→array for [], NULL→0/"" for ++/.=) and writes back in place.
+					 * Two signals: the compiler tags the member itself iP2=PH7_MEMBER_WRITE when it is
+					 * the base of a write-subscript / `??=` (the modify-op is not the immediately-next
+					 * instruction there), and for ++/--/compound-assign/store the next opcode is the
+					 * modify-op directly (VmMemberNextIsWrite). */
 					VmInstr *pNext = pInstr + 1;
-					if( pNext->iOp == PH7_OP_STORE && pNext->iP2 ){
+					if( pInstr->iP2 == PH7_MEMBER_WRITE || VmMemberNextIsWrite(pNext) ){
 						ph7_class_attr *pDecl = PH7_ClassExtractAttribute(pThis->pClass,sName.zString,sName.nByte);
 						if( pDecl && (pDecl->iFlags & (PH7_CLASS_ATTR_STATIC|PH7_CLASS_ATTR_CONSTANT)) == 0 ){
 							VmRecreateDeclaredAttr(&(*pVm),pThis,pDecl,&pObjAttr);

--- a/tests/ph7/001-smoke/lang/dynamic_prop_vivify.phpt
+++ b/tests/ph7/001-smoke/lang/dynamic_prop_vivify.phpt
@@ -1,0 +1,65 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A fresh object property is auto-created by array-append / keyed-write / ??= (not just plain =)
+--FILE--
+<?php
+/* Only pure-write forms are asserted here: PHP emits an "Undefined property"
+ * warning for the read-modify-write forms ($o->n++, $o->s .= "x", $o->c += 1) on
+ * a fresh property that PHL does not, so those are covered by spot-checks instead.
+ * The value/auto-creation behaviour is identical across all forms. */
+
+/* stdClass: array-append, keyed write, nested write, ??= (subscript and plain member) */
+$o = new stdClass;
+$o->arr[] = 5; $o->arr[] = 6;
+echo json_encode($o), "\n";                         // {"arr":[5,6]}
+
+$o = new stdClass;
+$o->map["k"] = 7;
+$k = "x"; $o->kv[$k] = 9;
+echo json_encode($o), "\n";                         // {"map":{"k":7},"kv":{"x":9}}
+
+$o = new stdClass;
+$o->grid[1][2] = 9;                                 // nested auto-vivify
+echo json_encode($o), "\n";                         // {"grid":{"1":{"2":9}}}
+
+$o = new stdClass;
+$o->box["a"] ??= 1;                                 // ??= on a missing subscript prop
+$o->flag ??= true;                                  // ??= on a missing plain prop
+echo json_encode($o), "\n";                         // {"box":{"a":1},"flag":true}
+
+/* a DECLARED property that was unset() is recreated by the same forms */
+class DpvC { public $p; public $q; }
+$c = new DpvC();
+unset($c->p, $c->q);
+$c->p[] = 5;
+$c->q["k"] = 7;
+echo json_encode($c), "\n";                         // {"p":[5],"q":{"k":7}}
+
+/* a declared property recreated after unset() is UNDEFINED, not its class default:
+ * ??= must see null and assign (it must not keep the old default value) */
+class DpvDef { public $n = 10; }
+$d = new DpvDef();
+unset($d->n);
+$d->n ??= 99;
+echo json_encode($d), "\n";                         // {"n":99}  (not {"n":10})
+
+/* negatives: a lookup must NOT create the property */
+$o = new stdClass;
+echo var_export(isset($o->missing), true), "\n";    // false
+echo var_export(empty($o->missing), true), "\n";    // true
+echo json_encode($o), "\n";                         // {}  (still empty)
+?>
+--EXPECT--
+{"arr":[5,6]}
+{"map":{"k":7},"kv":{"x":9}}
+{"grid":{"1":{"2":9}}}
+{"box":{"a":1},"flag":true}
+{"p":[5],"q":{"k":7}}
+{"n":99}
+false
+true
+{}
+--CLEAN--
+<?php


### PR DESCRIPTION
…sign

A property was auto-created only for a plain `$o->p = v` write. Every other write form on a FRESH dynamic (stdClass) or declared-but-unset property errored or lost the write, where PHP auto-vivifies:

  $o = new stdClass;
  $o->arr[] = 5;   // PHP: [5];   was: "Undefined class attribute"
  $o->c += 1;      // PHP: 1;     was: "Cannot perform assignment on a constant class attribute"
  $o->map[$k] = v; // PHP: {k:v}; was: error

The OP_MEMBER write-miss hook keyed on a one-token `next == OP_STORE` lookahead, which subscript-writes defeat (the key sits between OP_MEMBER and OP_STORE_IDX). Two signals now fire it:

1. The compiler tags the write-target member OP_MEMBER iP2 = PH7_MEMBER_WRITE via a new EXPR_FLAG_MEMBER_WRITE, propagated from the precedence-18 assignment lvalue (the right operand — these ops are right-associative) through a SUBSCRIPT to its base member, STRIPPED when descending into an intermediate ->/:: container (so `$o->a->b = v` does not create `a` — PHP auto-vivifies arrays, never objects) and stripped from subscript-index / call args.
2. VmMemberNextIsWrite one-token lookahead for the forms whose modify-op immediately follows the member: ++/--, the compound-store family, plain store.

The created slot is NULL with a real nIdx, which the modify-op vivifies (NULL->array for [], NULL->0/"" for ++/.=) and writes back in place. This also makes keyed-subscript-write and plain-member `$o->p ??= v` work.

VmRecreateDeclaredAttr no longer re-runs the declared default initializer: a property recreated after unset() is a fresh UNDEFINED property (PHP applies the default only at construction), so `unset($p->v); $p->v += 4` now reads null->0 (=4) and `$p->v ??= 99` assigns 99, instead of reading the stale default. (Found by code-review — the default-reinit was latent, masked by the plain-store overwrite until this change let read-modify-write forms reach the recreate.)

Scoped out (documented): unset($o->missing[0]) (LOAD_IDX iP2=5) stays a no-op; PHL doesn't emit PHP's "Undefined property" warning for a read-modify-write create (value correct, warning suppressed, consistent with the silent `=` create).

Verified byte-for-byte vs php 8.5.7 across all forms + negatives (plain read, isset/empty, object-chain, member-valued index do not create); make test (2240 + 768) and test-compat (both engines) green; plain create/destroy churn clean. ASan unavailable this session (env startup hang). New dynamic_prop_vivify.phpt.
