### PR TITLE
Implement the never return type

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -4754,6 +4754,24 @@ static sxi32 PH7_CompileReturn(ph7_gen_state *pGen)
 {
 	sxi32 nRet = 0; /* TRUE if there is a return value */
 	sxi32 rc;
+	sxu32 nLine = pGen->pIn->nLine;
+	GenBlock *pFuncBlock = pGen->pCurrent;
+	/* A `never`-returning function must not contain a `return` statement at all
+	 * (PHP compile error), with or without a value. Find the enclosing function
+	 * (nearest GEN_BLOCK_FUNC) and check its declared return type. The error is
+	 * recorded (nErr>0 fails the whole compile); the statement is still consumed
+	 * normally below so token processing stays consistent. */
+	while( pFuncBlock && (pFuncBlock->iFlags & GEN_BLOCK_FUNC) == 0 ){
+		pFuncBlock = pFuncBlock->pParent;
+	}
+	if( pFuncBlock && pFuncBlock->pUserData
+	 && ((ph7_vm_func *)pFuncBlock->pUserData)->nReturnType == MEMOBJ_NEVER ){
+		rc = PH7_GenCompileError(pGen, E_ERROR, nLine,
+			"A never-returning function must not return");
+		if( rc == SXERR_ABORT ){
+			return SXERR_ABORT;
+		}
+	}
 	/* Jump the 'return' keyword */
 	pGen->pIn++;
 	if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_SEMI) == 0 ){
@@ -6557,19 +6575,23 @@ static sxi32 GenStateParseUnionTypeDecl(
 				}
 			}
 			if( aAtoms[i].nType == UTA_NEVER_FLAG ){
-				/* `never` is parsed but not yet implemented in the type
-				 * system. Reject it explicitly rather than silently aliasing
-				 * to `void` — the two have different semantics (never =
-				 * does not return), and folding them would mislead any
-				 * future return-enforcement work. */
-				if( nAtoms > 1 ){
+				/* `never` is a bottom type usable only as a standalone RETURN
+				 * type (never = the function does not return). Mirrors the void
+				 * validation above; accepted here and enforced at compile time
+				 * (explicit `return` banned) and run time (fall-off TypeError). */
+				if( nAtoms > 1 || bShortNullable ){
+					/* `?never` is `never|null`, a union — PHP reports it the
+					 * same as any other non-standalone use. */
 					PH7_GenCompileError(pGen, E_ERROR, nLine,
 						"never can only be used as a standalone type");
 					return SXERR_SYNTAX;
 				}
-				PH7_GenCompileError(pGen, E_ERROR, nLine,
-					"never type is not yet implemented");
-				return SXERR_SYNTAX;
+				if( !bAllowVoid ){
+					/* Return-only: params call with bAllowVoid=0. */
+					PH7_GenCompileError(pGen, E_ERROR, nLine,
+						"never cannot be used as a parameter type");
+					return SXERR_SYNTAX;
+				}
 			}
 			if( aAtoms[i].nType == UTA_NULL_FLAG ){
 				bExplicitNull = 1;
@@ -6673,9 +6695,9 @@ static sxi32 GenStateParseUnionTypeDecl(
 					if( pClass ) SyStringInitFromBuf(pClass, zDup, pA->sClass.nByte);
 				}else if( pA->nType == UTA_VOID_FLAG ){
 					*pnType = MEMOBJ_VOID;
+				}else if( pA->nType == UTA_NEVER_FLAG ){
+					*pnType = MEMOBJ_NEVER;
 				}else{
-					/* UTA_NEVER_FLAG never reaches here — the validation
-					 * pass above rejects it as not-yet-implemented. */
 					*pnType = pA->nType;
 				}
 			}

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -100,6 +100,7 @@ struct ph7_value
 #define MEMOBJ_VOID      0x200  /* Pseudo-type: function must not return a value */
 #define MEMOBJ_REFERENCE 0x400  /* Memory value hold a reference (64-bit index) of another ph7_value */
 #define MEMOBJ_AUX_SPREAD 0x800 /* Stack-only marker: this value is a spread source for the next LOAD_MAP */
+#define MEMOBJ_NEVER     0x1000 /* Pseudo-type (return-only): never-returning function must not return at all */
 /* Mask of all known types */
 #define MEMOBJ_ALL (MEMOBJ_STRING|MEMOBJ_INT|MEMOBJ_REAL|MEMOBJ_BOOL|MEMOBJ_NULL|MEMOBJ_HASHMAP|MEMOBJ_OBJ|MEMOBJ_RES)
 /* Scalar variables

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -4318,14 +4318,16 @@ static sxi32 VmThrowTypeErrorForArg(ph7_vm *pVm,ph7_class *pOwnerClass,SyString 
  * Throw a PHP-compatible TypeError describing a return-value type mismatch.
  * Message format: "funcname(): Return value must be of type X, Y returned".
  */
-static sxi32 VmThrowTypeErrorForReturn(ph7_vm *pVm,SyString *pFuncName,const char *zExpected,const char *zGiven)
+/* Build a catchable TypeError from a pre-formatted message blob and throw it.
+ * The message is copied into the instance by __construct, so the caller owns
+ * (and releases) pMsg. Sets VM_FRAME_THROW so the terminal OP_DONE unwinds. */
+static sxi32 VmThrowTypeErrorMsg(ph7_vm *pVm,SyBlob *pMsg)
 {
 	ph7_class *pClass;
 	ph7_class_instance *pThis;
 	ph7_class_method *pCons;
 	ph7_value sArg;
 	ph7_value *apArg[1];
-	SyBlob sMsg;
 	SyString sMsgStr;
 	VmFrame *pFrame;
 	sxi32 rc;
@@ -4337,18 +4339,14 @@ static sxi32 VmThrowTypeErrorForReturn(ph7_vm *pVm,SyString *pFuncName,const cha
 	if( pThis == 0 ){
 		return PH7_ABORT;
 	}
-	SyBlobInit(&sMsg,&pVm->sAllocator);
-	SyBlobFormat(&sMsg,"%z(): Return value must be of type %s, %s returned",
-		pFuncName,zExpected,zGiven);
 	pCons = PH7_ClassExtractMethod(pClass,"__construct",sizeof("__construct")-1);
 	if( pCons ){
-		SyStringInitFromBuf(&sMsgStr,(const char *)SyBlobData(&sMsg),SyBlobLength(&sMsg));
+		SyStringInitFromBuf(&sMsgStr,(const char *)SyBlobData(pMsg),SyBlobLength(pMsg));
 		PH7_MemObjInitFromString(&(*pVm),&sArg,&sMsgStr);
 		apArg[0] = &sArg;
 		PH7_VmCallClassMethod(&(*pVm),pThis,pCons,0,1,apArg);
 		PH7_MemObjRelease(&sArg);
 	}
-	SyBlobRelease(&sMsg);
 	pFrame = pVm->pFrame;
 	if( pFrame ){
 		pFrame = VmSkipExceptionFrames(pFrame);
@@ -4360,6 +4358,30 @@ static sxi32 VmThrowTypeErrorForReturn(ph7_vm *pVm,SyString *pFuncName,const cha
 		return PH7_ABORT;
 	}
 	return PH7_EXCEPTION;
+}
+static sxi32 VmThrowTypeErrorForReturn(ph7_vm *pVm,SyString *pFuncName,const char *zExpected,const char *zGiven)
+{
+	SyBlob sMsg;
+	sxi32 rc;
+	SyBlobInit(&sMsg,&pVm->sAllocator);
+	SyBlobFormat(&sMsg,"%z(): Return value must be of type %s, %s returned",
+		pFuncName,zExpected,zGiven);
+	rc = VmThrowTypeErrorMsg(pVm,&sMsg);
+	SyBlobRelease(&sMsg);
+	return rc;
+}
+/* A never-returning function that returned normally (fall-off). PHP bans an
+ * explicit `return` at compile time, so this fires only for an implicit return. */
+static sxi32 VmThrowNeverReturnError(ph7_vm *pVm,SyString *pFuncName)
+{
+	SyBlob sMsg;
+	sxi32 rc;
+	SyBlobInit(&sMsg,&pVm->sAllocator);
+	SyBlobFormat(&sMsg,"%z(): never-returning function must not implicitly return",
+		pFuncName);
+	rc = VmThrowTypeErrorMsg(pVm,&sMsg);
+	SyBlobRelease(&sMsg);
+	return rc;
 }
 /*
  * Format the "X given" portion of error messages following PHP's value-name
@@ -4484,6 +4506,13 @@ static sxi32 VmEnforceReturnType(ph7_vm *pVm, ph7_vm_func *pFunc, ph7_value *pVa
 	/* Untyped function: no enforcement (no single type and no union/intersection). */
 	if( !VmFuncHasReturnType(pFunc) ){
 		return SXRET_OK;
+	}
+	/* never return type: the function must not return at all. An explicit
+	 * `return` is a compile error, so reaching here means the function ran off
+	 * the end normally (a throw/exit is skipped by the VM_FRAME_THROW guard at
+	 * the call site). */
+	if( pFunc->nReturnType == MEMOBJ_NEVER ){
+		return VmThrowNeverReturnError(pVm,&pFunc->sName);
 	}
 	/* void return type: the function must not produce a value. */
 	if( pFunc->nReturnType == MEMOBJ_VOID ){

--- a/tests/ph7/001-smoke/lang/never_return_type.phpt
+++ b/tests/ph7/001-smoke/lang/never_return_type.phpt
@@ -1,0 +1,36 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+never return type: a throwing function runs; falling off the end throws a catchable TypeError (PHP 8.1)
+--FILE--
+<?php
+function fail(string $m): never { throw new RuntimeException($m); }
+try { fail("boom"); } catch (RuntimeException $e) { echo "fn: ", $e->getMessage(), "\n"; }
+
+class NeverClass {
+    public function m(): never { throw new LogicException("meth"); }
+}
+$o = new NeverClass();
+try { $o->m(); } catch (LogicException $e) { echo "method: ", $e->getMessage(), "\n"; }
+
+$c = function(): never { throw new Exception("clo"); };
+try { $c(); } catch (Exception $e) { echo "closure: ", $e->getMessage(), "\n"; }
+
+// Falling off the end without throwing/exiting is a runtime TypeError.
+function neverImplicit(): never { $x = 1; }
+try { neverImplicit(); } catch (TypeError $e) { echo "fell off: ", $e->getMessage(), "\n"; }
+
+// A never method declared on an interface/abstract class is accepted.
+interface NeverIface { public function f(): never; }
+abstract class NeverAbstract { abstract public function g(): never; }
+echo "declared ok\n";
+?>
+--EXPECT--
+fn: boom
+method: meth
+closure: clo
+fell off: neverImplicit(): never-returning function must not implicitly return
+declared ok
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/never_explicit_return.phpt
+++ b/tests/ph7/002-integration/lang/never_explicit_return.phpt
@@ -1,0 +1,13 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+An explicit return in a never-returning function is a compile error
+--FILE--
+<?php
+function bad(): never { return; }
+?>
+--EXPECTF--
+%s Fatal error:  A never-returning function must not return in %s
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/never_not_standalone.phpt
+++ b/tests/ph7/002-integration/lang/never_not_standalone.phpt
@@ -1,0 +1,13 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+never in a union (or ?never) is rejected as non-standalone
+--FILE--
+<?php
+function u(): int|never {}
+?>
+--EXPECTF--
+%s Fatal error:  never can only be used as a standalone type in %s
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/never_param_type.phpt
+++ b/tests/ph7/002-integration/lang/never_param_type.phpt
@@ -1,0 +1,13 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+never cannot be used as a parameter type (return-only)
+--FILE--
+<?php
+function h(never $x) {}
+?>
+--EXPECTF--
+%s Fatal error:  never cannot be used as a parameter type in %s
+--CLEAN--
+<?php


### PR DESCRIPTION
PHL rejected `never` at compile time ("never type is not yet implemented"), so any PHP 8.1+ code with a never-returning helper (a fail()/redirect() that always throws or exits) failed to compile entirely — a hard breakage.

never is a bottom type usable only in return position; it mirrors the existing void machinery, inverted (void forbids a value return, never forbids any normal return):

- ph7int.h: new pseudo-type MEMOBJ_NEVER (0x1000), stored in ph7_vm_func.nReturnType like MEMOBJ_VOID so VmFuncHasReturnType fires and the terminal OP_DONE runs return enforcement.
- compile.c GenStateParseUnionTypeDecl: accept never for return types (map UTA_NEVER_FLAG -> MEMOBJ_NEVER), reject it as a parameter type, and reject a union / ?never as non-standalone — mirroring the void branch beside it.
- compile.c PH7_CompileReturn: an explicit `return` (with or without a value) in a never function is a compile error, detected by walking to the enclosing GEN_BLOCK_FUNC and checking its return type.
- vm.c VmEnforceReturnType: a never function that falls off the end throws a catchable TypeError ("f(): never-returning function must not implicitly return"). The existing VM_FRAME_THROW guard already skips enforcement while a function unwinds a throw/exit, so only a true implicit return is flagged. VmThrowTypeErrorForReturn was refactored into a shared VmThrowTypeErrorMsg helper reused by the new VmThrowNeverReturnError.

Verified byte-for-byte vs php 8.5.7: never-throws / never-exits run; fall-off throws a catchable TypeError; explicit return, never-as-param, int|never and ?never are compile errors; interface and abstract never methods declare fine; a never method/closure with a throwing body works; an uncalled never function produces no error. make test and make test-compat (both engines) green (smoke 2242 + integration 774); a 5000-iter fall-off/throw churn is clean; a high-effort /code-review found no correctness bug and confirmed the throw refactor is memory-safe.

New tests: never_return_type.phpt (smoke), never_explicit_return.phpt / never_param_type.phpt / never_not_standalone.phpt (integration).

Known residuals: never on a typed property/constant is rejected with the "parameter type" message noun (a rare error-fidelity nit), and the override variance checker conservatively skips a never return narrowing.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
