### PR TITLE
Reject a bare float literal in an int typed class constant

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -7108,6 +7108,29 @@ static int GenStateClassConstHasType(ph7_gen_state *pGen)
 	return 0;
 }
 /*
+ * TRUE when the class-constant initializer starting at pGen->pIn is a bare real
+ * literal (e.g. `1.0`, `-1.0`, `2.0e3`), optionally preceded by unary sign(s).
+ * Used to reject `const int X = 1.0` at compile time: PHL's number model tags a
+ * whole-valued real MEMOBJ_REAL|MEMOBJ_INT, so the runtime flag test would wrongly
+ * accept it as an int. The literal shape is the only reliable signal that separates
+ * the invalid `1.0` from the valid `4/2` (a computed whole-real PHP accepts as int).
+ * Peek only; never consumes tokens.
+ */
+static int GenStateConstInitIsRealLiteral(ph7_gen_state *pGen)
+{
+	SyToken *p = pGen->pIn;
+	while( p < pGen->pEnd && (p->nType & PH7_TK_OP) && p->sData.nByte == 1
+		&& (p->sData.zString[0] == '-' || p->sData.zString[0] == '+') ){
+		p++; /* skip leading unary sign(s) */
+	}
+	if( p >= pGen->pEnd || (p->nType & PH7_TK_REAL) == 0 ){
+		return 0; /* not a real literal (int literal, cast, call, ...) */
+	}
+	p++;
+	/* Must be the WHOLE initializer: the next token ends this constant. */
+	return ( p >= pGen->pEnd || (p->nType & (PH7_TK_SEMI|PH7_TK_COMMA)) ) ? 1 : 0;
+}
+/*
  * Copy a parsed declared type onto a freshly created class attribute (property,
  * promoted property or class constant). nType/pClass/pTypeName/iTypeFlags come
  * straight from GenStateParseUnionTypeDecl; for a union the alternatives are
@@ -7218,6 +7241,20 @@ loop:
 		goto Synchronize;
 	}
 	pGen->pIn++; /* Jump the equal sign */
+	/* PHP 8.3: a bare float literal cannot initialize an `int` typed constant
+	 * (`const int X = 1.0`). Runtime flag-testing can't distinguish it from the valid
+	 * `const int X = 4/2` (both whole-reals in PHL's number model), so reject the
+	 * literal shape here, at definition time, matching PHP's eager fatal. */
+	if( (iTypeFlags & PH7_CLASS_ATTR_TYPED) && !(iTypeFlags & PH7_CLASS_ATTR_UNION)
+		&& nType == MEMOBJ_INT && GenStateConstInitIsRealLiteral(pGen) ){
+		rc = PH7_GenCompileError(pGen,E_ERROR,nLine,
+			"Cannot use float as value for class constant %z::%z of type %z",
+			&pClass->sName,pName,&sTypeText);
+		if( rc == SXERR_ABORT ){
+			return SXERR_ABORT;
+		}
+		goto Synchronize;
+	}
 	/* Allocate a new class attribute */
 	pCons = PH7_NewClassAttr(pGen->pVm,pName,nLine,iProtection,iFlags|iTypeFlags);
 	if( pCons == 0 ){

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -4225,14 +4225,16 @@ static sxi32 VmEnforceConstantType(ph7_vm *pVm,ph7_class *pClass,ph7_class_attr 
 	 * implicit widening. Everything else is a type error.
 	 *
 	 * Known lenient divergence: PHL's number model leaves a whole-valued real
-	 * flagged MEMOBJ_REAL|MEMOBJ_INT (a `1.0` literal, and — because `/` always
-	 * yields a real — an evenly-dividing `4/2`), so such a value satisfies a
-	 * `: int` constant here. PHP accepts `const int X = 4/2` (its `/` yields a
-	 * genuine int) but rejects `const int X = 1.0`; PHL cannot tell the two
-	 * apart by flag, so it accepts both rather than rejecting the valid `4/2`.
-	 * A fractional real (`1.5`, MEMOBJ_REAL only) carries no MEMOBJ_INT and is
-	 * correctly rejected. Tightening this needs PHL's float-identity/division
-	 * model, which is out of scope here. */
+	 * flagged MEMOBJ_REAL|MEMOBJ_INT, so a computed whole-real (e.g. `1.0 + 0.0`,
+	 * or the evenly-dividing `4/2` — `/` always yields a real) satisfies a `: int`
+	 * constant here. PHP accepts `const int X = 4/2` (its `/` yields a genuine int)
+	 * but rejects `const int X = 1.0 + 0.0`; PHL cannot tell them apart by flag, so
+	 * it accepts both rather than rejecting the valid `4/2`. The common bare-literal
+	 * case `const int X = 1.0` is caught earlier, at definition time, by the
+	 * syntactic check in GenStateCompileClassConstant (compile.c) — the literal
+	 * shape is the only reliable signal. A fractional real (`1.5`, MEMOBJ_REAL only)
+	 * carries no MEMOBJ_INT and is correctly rejected here. Tightening the computed
+	 * residual needs PHL's float-identity/division model, which is out of scope. */
 	if( pValue->iFlags & pAttr->nType ){
 		return SXRET_OK;
 	}

--- a/tests/ph7/001-smoke/oo/class_const_typed.phpt
+++ b/tests/ph7/001-smoke/oo/class_const_typed.phpt
@@ -3,6 +3,8 @@ SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Typed class constants (PHP 8.3): scalar, array and int->float widening
+--SKIPIF--
+<?php if (function_exists('zend_version') && version_compare(PHP_VERSION, '8.5.0', '<')) echo 'skip Requires PHP 8.5+'; ?>
 --FILE--
 <?php
 class TypedConstScalar {
@@ -11,6 +13,9 @@ class TypedConstScalar {
     const string D = "x";
     const bool E = true;
     const array F = [10, 20];
+    const int G = 1024 / 4;   // computed int-valued expression stays accepted
+    const int H = 4 / 2;      // evenly-dividing division stays accepted
+    const int I = (int) 1.5;  // explicit int cast stays accepted
 }
 echo TypedConstScalar::A, "\n";
 echo TypedConstScalar::B, "\n";
@@ -18,6 +23,9 @@ echo gettype(TypedConstScalar::B), "\n";     // double (the value was widened)
 echo TypedConstScalar::D, "\n";
 echo TypedConstScalar::E ? "true" : "false", "\n";
 echo TypedConstScalar::F[0] + TypedConstScalar::F[1], "\n";
+echo TypedConstScalar::G, "\n";              // 256 (echo renders whole values the same on both engines)
+echo TypedConstScalar::H, "\n";              // 2
+echo TypedConstScalar::I, "\n";              // 1
 ?>
 --EXPECT--
 1
@@ -26,5 +34,8 @@ double
 x
 true
 30
+256
+2
+1
 --CLEAN--
 <?php

--- a/tests/ph7/002-integration/oo/class_const_float_literal_int.phpt
+++ b/tests/ph7/002-integration/oo/class_const_float_literal_int.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A bare float literal cannot initialize an int typed class constant (PHP 8.3)
+--FILE--
+<?php
+class C {
+    const int X = 1.0;
+}
+echo C::X;
+?>
+--EXPECTF--
+%s Fatal error:  Cannot use float as value for class constant C::X of type int %s
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/class_const_float_literal_int_signed.phpt
+++ b/tests/ph7/002-integration/oo/class_const_float_literal_int_signed.phpt
@@ -1,0 +1,16 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A signed bare float literal (-1.0) cannot initialize an int typed class constant
+--FILE--
+<?php
+class C {
+    const int X = -1.0;
+}
+echo C::X;
+?>
+--EXPECTF--
+%s Fatal error:  Cannot use float as value for class constant C::X of type int %s
+--CLEAN--
+<?php


### PR DESCRIPTION
`const int X = 1.0;` ran in PHL where PHP 8.3+ rejects it at definition time (`Cannot use float as value for class constant C::X of type int`) — the last open P0 correctness gap (silent accept-invalid).

Root cause: PHL's number model tags a whole-valued real MEMOBJ_REAL|MEMOBJ_INT, so the definition-time enforcer `VmEnforceConstantType` passes `(REAL|INT) & INT` for `1.0`. A naive runtime strict check (`INT && !REAL`) would regress the valid `const int X = 4/2` (PHP yields int; PHL's `/` always yields a whole-real), so the two are indistinguishable by runtime value. The only reliable signal is syntactic.

Fix: a compile-time pre-check in `GenStateCompileClassConstant`. A new peek helper `GenStateConstInitIsRealLiteral` (skips optional leading unary sign, requires one PH7_TK_REAL token spanning the whole initializer) fires only for a plain non-union `: int`/`?int` target, rejecting via the existing `PH7_GenCompileError` with the PHP-exact message; nothing is allocated on the reject path. Computed int-valued expressions (`4/2`, `1024/4`, `(int)1.5`) stay accepted.

Verified byte-for-byte vs php 8.5.7 across the matrix (bare/signed literal reject, division/cast/union/nullable/widening/multi-decl/ interface). `make test` (2242 smoke + 776 integration) and `make test-compat` (both engines) green; the new tests pass under both engines. Residual (float-model-blocked, documented): a computed or parenthesized whole-real (`1.0 + 0.0`, `(1.0)`) is still accepted — not a regression, both engines accept `4/2`.
