### PR TITLE
filter_var(FILTER_VALIDATE_FLOAT): reject out-of-range magnitudes

### DIFF
--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "ph7int.h"
+/* filter_var(FILTER_VALIDATE_FLOAT) parses with libc strtod for overflow/underflow
+ * detection + a correctly-rounded value; SyStrToReal clamps the exponent and saturates,
+ * so it cannot reject out-of-range magnitudes. Same rationale as builtin_math.c's round(). */
+#include <stdlib.h>  /* strtod */
+#include <math.h>    /* HUGE_VAL */
+#include <errno.h>   /* ERANGE (strtod range-error signal) */
 /* This file implement built-in 'foreign' functions for the PH7 engine */
 /*
  * Section:
@@ -4820,7 +4826,7 @@ static int FvValidateInt(const char *z,int n,int flags,ph7_int64 *pOut){
 static int FvValidateFloat(const char *z,int n,int flags,double *pOut){
 	char zBuf[512];
 	int i, m = 0, seenDigit = 0;
-	const char *zv; int nv; double d = 0; const char *zRest = 0;
+	const char *zv; int nv; double d = 0;
 	FvTrim(&z,&n);
 	/* Bound the input: zBuf[512] holds the thousand-separator-stripped copy, and
 	 * the cap also rejects the pathological 500+ digit floats PHP refuses. */
@@ -4877,10 +4883,22 @@ static int FvValidateFloat(const char *z,int n,int flags,double *pOut){
 		while( i<nv && SyisDigit((unsigned char)zv[i]) ){ i++; }
 	}
 	if( i!=nv ){ return 0; } /* trailing junk */
-	/* Divergence: PHP rejects magnitudes beyond the double range ("1e400" ->
-	 * false), but SyStrToReal (the engine-wide float parser, also behind
-	 * floatval/(float)) saturates them to a finite value, so they validate here. */
-	SyStrToReal(zv,(sxu32)nv,(void *)&d,&zRest);
+	/* The grammar above guarantees zv[0..nv) is a clean ASCII decimal float (no hex /
+	 * inf / nan / trailing junk), so it is safe to hand to libc strtod, which — unlike
+	 * SyStrToReal (15 sig-digits + exponent clamped to 308, so it silently saturates
+	 * overflowing magnitudes to a finite value) — is overflow/underflow-aware and
+	 * correctly rounded. strtod needs a NUL-terminated string: the ALLOW_THOUSAND path
+	 * already built the span in zBuf (zv==zBuf); the plain path must copy it there (z is
+	 * const + not NUL-terminated). nv <= n <= 500 < sizeof(zBuf) by the cap above.
+	 * Matches PHP 8.5 byte-for-byte: reject overflow (-> +/-INF) and total underflow
+	 * (-> 0.0), keep subnormals (nonzero, errno==ERANGE) and a genuine "0" (errno==0). */
+	if( zv != zBuf ){ SyMemcpy(zv,zBuf,(sxu32)nv); }
+	zBuf[nv] = 0;
+	errno = 0;
+	d = strtod(zBuf,0);
+	if( errno == ERANGE && (d == HUGE_VAL || d == -HUGE_VAL || d == 0.0) ){
+		return 0;
+	}
 	*pOut = d;
 	return 1;
 }

--- a/tests/ph7/001-smoke/function/filter_var/float_magnitude.phpt
+++ b/tests/ph7/001-smoke/function/filter_var/float_magnitude.phpt
@@ -1,0 +1,51 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+filter_var FILTER_VALIDATE_FLOAT: reject out-of-range magnitudes (overflow + underflow-to-zero)
+--FILE--
+<?php
+/* PHP rejects a float whose magnitude overflows the double range (-> +/-INF) or
+ * totally underflows to zero, but accepts subnormals (nonzero) and a genuine 0. */
+
+/* Rejections: must all be === false. */
+foreach ([
+    "1e400", "-1e400", "1.8e308", "2e308", /* overflow */
+    "1e-400", "1e-330",                    /* underflow to zero */
+] as $x) {
+    echo (filter_var($x, FILTER_VALIDATE_FLOAT) === false) ? "reject\n" : "WRONG\n";
+}
+/* Overflow through the thousand-separator path too. */
+echo (filter_var("1,000e400", FILTER_VALIDATE_FLOAT, FILTER_FLAG_ALLOW_THOUSAND) === false) ? "reject\n" : "WRONG\n";
+
+/* Acceptances: a float in the expected ballpark. Ranges (not exact strings) keep
+ * the test cross-engine despite the extreme-magnitude float->string rendering gap. */
+$acc = [
+    ["1e308",   1e307,   1e309],
+    ["1.7e308", 1e308,   1.8e308],
+    ["1e-320",  0.0,     1e-319],   /* subnormal, nonzero */
+    ["5e-324",  0.0,     1e-323],   /* smallest subnormal */
+    ["1.5e300", 1e299,   1e301],
+    ["0",      -1.0,     1.0],      /* genuine zero, not an underflow */
+    ["1.5",     1.0,     2.0],
+];
+foreach ($acc as [$x, $lo, $hi]) {
+    $v = filter_var($x, FILTER_VALIDATE_FLOAT);
+    echo (is_float($v) && $v >= $lo && $v <= $hi) ? "ok\n" : "WRONG\n";
+}
+?>
+--EXPECT--
+reject
+reject
+reject
+reject
+reject
+reject
+reject
+ok
+ok
+ok
+ok
+ok
+ok
+ok


### PR DESCRIPTION
filter_var("1e400", FILTER_VALIDATE_FLOAT) returned a float (~1e308) where PHP returns false, and "1e-400" (total underflow) likewise wrongly validated. Root cause: after the grammar walk, FvValidateFloat computed the value with SyStrToReal, whose decimal exponent is clamped to 308 (SXDBL_MAX_EXP) -- so an overflowing literal saturates to a finite value and passes, and a naive isinf() on that result can never catch it.

Parse the already-grammar-validated ASCII span with libc strtod instead (NUL-terminated in the function's existing zBuf scratch), and reject errno==ERANGE && (d==+/-HUGE_VAL || d==0.0): drops overflow and total underflow, keeps subnormals (nonzero, ERANGE) and a genuine "0" (errno==0). strtod also returns the correctly-rounded double, so valid results are byte-exact too. Same libc-strtod rationale as builtin_math.c round(). SyStrToReal stays unchanged (float coercion wants leniency).

Verified byte-for-byte vs php 8.5.7 over a 17-case boundary matrix (overflow / underflow-to-zero / subnormal / valid / genuine-zero / ALLOW_THOUSAND-overflow). make test (2248 smoke + 802 integration) and make test-compat (both engines) green. New cross-engine float_magnitude.phpt (rejects asserted === false; accepted extremes via is_float + range to sidestep the float->string rendering gap).
