### PR TITLE
Register Random\RandomException for CSPRNG builtins

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -1868,6 +1868,7 @@ PH7_PRIVATE sxi32 PH7_VmInit(
 	 )
 {
 	SyString sBuiltin;
+	SyString sRandom;
 	ph7_value *pObj;
 	sxi32 rc;
 	/* Zero the structure */
@@ -1985,6 +1986,20 @@ PH7_PRIVATE sxi32 PH7_VmInit(
 	SyStringInitFromBuf(&sBuiltin,PH7_BUILTIN_LIB,sizeof(PH7_BUILTIN_LIB)-1);
 	/* Compile the built-in library */
 	VmEvalChunk(&(*pVm),0,&sBuiltin,PH7_PHP_ONLY,FALSE);
+	/* Register the Random\RandomException namespaced class (PHP 8.2+).
+	 * Kept in its own VmEvalChunk (not appended to PH7_BUILTIN_LIB): a namespace
+	 * declaration is NOT reset at the block's closing brace in this engine, so
+	 * anything following it in the same chunk would leak into the Random
+	 * namespace. Isolation instead comes from VmEvalChunk saving/restoring
+	 * pVm->sNamespace (and PH7_ResetCodeGenerator clearing the compiler
+	 * namespace) per chunk, so this lands as Random\RandomException while later
+	 * user code still compiles in the global namespace. */
+	{
+		static const char zRandomLib[] =
+			"namespace Random { class RandomException extends \\Exception { } }";
+		SyStringInitFromBuf(&sRandom,zRandomLib,sizeof(zRandomLib)-1);
+		VmEvalChunk(&(*pVm),0,&sRandom,PH7_PHP_ONLY,FALSE);
+	}
 	/* Cache the Fiber class pointer for fast dispatch */
 	pVm->pFiberClass = PH7_VmExtractClass(pVm,"Fiber",5,0,0);
 	/* Cache built-in interface pointers used on hot dispatch paths */
@@ -15282,10 +15297,8 @@ static int vm_builtin_random_int(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		 * and the low-half mask would always read 0). */
 		sxu64 uDraw;
 		if( SyOSCSPRNG(&uDraw,sizeof(uDraw)) != SXRET_OK ){
-			/* PHP 8.2+ would throw Random\RandomException here; that class
-			 * is not yet registered in PHL (see PLAN.md item 6.13). */
 			return PH7_VmThrowException(pCtx,
-				"Exception",
+				"Random\\RandomException",
 				"Cannot gather sufficient random data"
 				);
 		}
@@ -15297,7 +15310,7 @@ static int vm_builtin_random_int(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	}
 	if( nAttempt >= 50 ){
 		return PH7_VmThrowException(pCtx,
-			"Exception",
+			"Random\\RandomException",
 			"Cannot gather sufficient random data"
 			);
 	}
@@ -15359,7 +15372,7 @@ static int vm_builtin_random_bytes(ph7_context *pCtx,int nArg,ph7_value **apArg)
 			SyMemBackendFree(&pCtx->pVm->sAllocator,pBuf);
 		}
 		return PH7_VmThrowException(pCtx,
-			"Exception",
+			"Random\\RandomException",
 			"Cannot gather sufficient random data"
 			);
 	}

--- a/tests/ph7/002-integration/function/random_exception_catch.phpt
+++ b/tests/ph7/002-integration/function/random_exception_catch.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Random\RandomException is catchable as \Exception and by FQN
+--SKIPIF--
+<?php if (function_exists('xdebug_info')) echo "skip xdebug annotates thrown exceptions with a dynamic \$xdebug_message property that Random\\RandomException forbids"; ?>
+--FILE--
+<?php
+try { throw new \Random\RandomException('boom'); }
+catch (\Exception $x) { echo "caught-as-exception: ", $x->getMessage(), "\n"; }
+try { throw new \Random\RandomException('boom2'); }
+catch (\Random\RandomException $x) { echo "caught-as-fqn: ", $x->getMessage(), "\n"; }
+--EXPECT--
+caught-as-exception: boom
+caught-as-fqn: boom2

--- a/tests/ph7/002-integration/function/random_exception_class.phpt
+++ b/tests/ph7/002-integration/function/random_exception_class.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Random\RandomException is registered (PHP 8.2+)
+--FILE--
+<?php
+echo class_exists('Random\\RandomException') ? "exists\n" : "missing\n";
+echo get_parent_class('Random\\RandomException'), "\n";      // Exception
+$e = new \Random\RandomException('x');
+echo ($e instanceof \Exception) ? "is-exception\n" : "no\n";
+--EXPECT--
+exists
+Exception
+is-exception


### PR DESCRIPTION
PHP 8.2+ throws Random\RandomException (extends \Exception) when the OS CSPRNG cannot produce data; random_int()/random_bytes() were throwing a generic Exception at those failure sites.

Register the namespaced class in its own VmEvalChunk after PH7_BUILTIN_LIB (a namespace declaration does not reset at the block's closing brace in this engine, so isolation comes from VmEvalChunk's per-chunk sNamespace save/restore, not the braces). Switch the three CSPRNG-source-failure throw sites to "Random\\RandomException" (looked up by exact FQN string); the class extends \Exception so existing catch(Exception) still catches it.

Message text left as PHL's original: php 8.5's real messages are platform-specific (macOS: "...CCRandomGenerateBytes") and untestable through PHL's portable SyOSCSPRNG abstraction, so only the exception class changed. The random_bytes allocation-failure site stays a generic Exception (an OOM, not a RandomException in PHP).

New cross-engine test asserts existence/parent/instanceof/catchability (the throw path itself is not runtime-triggerable). make test (2248 smoke + 805 integration) and make test-compat (both engines) green.
