### PR TITLE
ASan/UBSan sweep fixes: fiber-drain UAF, allocator alignment, etc

### DIFF
--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -17,7 +17,8 @@
  */
 static sxu32 IntHash(sxi64 iKey)
 {
-	return (sxu32)(iKey ^ (iKey << 8) ^ (iKey >> 8));
+	sxu64 uKey = (sxu64)iKey; /* unsigned mixing: shifting a negative key is UB */
+	return (sxu32)(uKey ^ (uKey << 8) ^ (uKey >> 8));
 }
 /*
  * Default hash function for string/BLOB keys.
@@ -610,10 +611,12 @@ IntKey:
 		rc = HashmapInsertIntKey(&(*pMap),pKey->x.iVal,&(*pVal),0,FALSE);
 		if( rc == SXRET_OK ){
 			if( pKey->x.iVal >= pMap->iNextIdx ){
-				/* Increment the automatic index */
-				pMap->iNextIdx = pKey->x.iVal + 1;
+				/* Increment the automatic index. Like Zend's nNextFreeElement, the
+				 * index saturates at PHP_INT_MAX (incrementing past it is signed
+				 * overflow); the occupied-slot case errors at append time below. */
+				pMap->iNextIdx = pKey->x.iVal < SXI64_HIGH ? pKey->x.iVal + 1 : SXI64_HIGH;
 				/* Make sure the automatic index is not reserved */
-				while( SXRET_OK == HashmapLookupIntKey(&(*pMap),pMap->iNextIdx,0) ){
+				while( pMap->iNextIdx < SXI64_HIGH && SXRET_OK == HashmapLookupIntKey(&(*pMap),pMap->iNextIdx,0) ){
 					pMap->iNextIdx++;
 				}
 			}
@@ -624,9 +627,18 @@ IntKey:
 			PH7_VmThrowError(pMap->pVm,0,PH7_CTX_NOTICE,"$GLOBALS is a read-only array,insertion is forbidden");
 			return SXRET_OK;
 		}
+		if( pMap->iNextIdx == SXI64_HIGH && SXRET_OK == HashmapLookupIntKey(&(*pMap),SXI64_HIGH,0) ){
+			/* The saturated automatic index is taken: php throws a catchable Error
+			 * here; PHL reports it as a runtime error (divergence recorded in
+			 * PLAN.md §3 — catchability needs exception plumbing in the store
+			 * opcodes). */
+			PH7_VmThrowError(pMap->pVm,0,PH7_CTX_ERR,
+				"Cannot add element to the array as the next element is already occupied");
+			return SXRET_OK;
+		}
 		/* Assign an automatic index */
 		rc = HashmapInsertIntKey(&(*pMap),pMap->iNextIdx,&(*pVal),0,FALSE);
-		if( rc == SXRET_OK ){
+		if( rc == SXRET_OK && pMap->iNextIdx < SXI64_HIGH ){
 			++pMap->iNextIdx;
 		}
 	}
@@ -711,18 +723,24 @@ IntKey:
 		rc = HashmapInsertIntKey(&(*pMap),pKey->x.iVal,0,nRefIdx,TRUE);
 		if( rc == SXRET_OK ){
 			if( pKey->x.iVal >= pMap->iNextIdx ){
-				/* Increment the automatic index */
-				pMap->iNextIdx = pKey->x.iVal + 1;
+				/* Increment the automatic index (saturating — see PH7_HashmapInsert) */
+				pMap->iNextIdx = pKey->x.iVal < SXI64_HIGH ? pKey->x.iVal + 1 : SXI64_HIGH;
 				/* Make sure the automatic index is not reserved */
-				while( SXRET_OK == HashmapLookupIntKey(&(*pMap),pMap->iNextIdx,0) ){
+				while( pMap->iNextIdx < SXI64_HIGH && SXRET_OK == HashmapLookupIntKey(&(*pMap),pMap->iNextIdx,0) ){
 					pMap->iNextIdx++;
 				}
 			}
 		}
 	}else{
+		if( pMap->iNextIdx == SXI64_HIGH && SXRET_OK == HashmapLookupIntKey(&(*pMap),SXI64_HIGH,0) ){
+			/* Saturated automatic index taken (see PH7_HashmapInsert) */
+			PH7_VmThrowError(pMap->pVm,0,PH7_CTX_ERR,
+				"Cannot add element to the array as the next element is already occupied");
+			return SXRET_OK;
+		}
 		/* Assign an automatic index */
 		rc = HashmapInsertIntKey(&(*pMap),pMap->iNextIdx,0,nRefIdx,TRUE);
-		if( rc == SXRET_OK ){
+		if( rc == SXRET_OK && pMap->iNextIdx < SXI64_HIGH ){
 			++pMap->iNextIdx;
 		}
 	}

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -862,7 +862,14 @@ static sxi32 VmDrainFinally(ph7_vm *pVm, sxu32 nExceptionBase)
 		ph7_exception *pExc = apExc[nUsed - 1];
 		(void)SySetPop(&pVm->aException);
 		pExc->pFrame = 0;
-		VmLeaveFrame(&(*pVm));
+		/* Leave the try's exception frame — but only a genuine one. For a RESUMED
+		 * generator/fiber body the handler was restored from the parked ctx and its
+		 * exception frame was discarded at suspend, so pVm->pFrame is the coroutine
+		 * body itself; popping it would free the entry frame OP_DONE still reads
+		 * (same guard as OP_POP_EXCEPTION's). */
+		if( pVm->pFrame->iFlags & VM_FRAME_EXCEPTION ){
+			VmLeaveFrame(&(*pVm));
+		}
 		if( pExc->iHasFinally && !pExc->iFinallyDone ){
 			sxi32 rcF;
 			pExc->iFinallyDone = 1;

--- a/src/sx/sxmem.c
+++ b/src/sx/sxmem.c
@@ -87,42 +87,51 @@ PH7_PRIVATE sxu32 SyMemcpy(const void *pSrc,void *pDest,sxu32 nLen)
 	SX_MACRO_FAST_MEMCPY(pSrc,pDest,nLen);
 	return nLen;
 }
+/* Size prefix stored ahead of every OS allocation. Padded to pointer size so
+ * the returned payload (and the SyMemBlock/SyMemHeader the backend lays on
+ * top of it) keeps the allocator's natural alignment — a bare sxu32 prefix
+ * left every chunk 4-misaligned on 64-bit platforms. */
+typedef union MemOSHeader MemOSHeader;
+union MemOSHeader {
+	sxu32 nBytes;
+	void *pAlign;
+};
 static void * MemOSAlloc(sxu32 nBytes)
 {
-	sxu32 *pChunk;
-	pChunk = (sxu32 *)SyOSHeapAlloc(nBytes + sizeof(sxu32));
+	MemOSHeader *pChunk;
+	pChunk = (MemOSHeader *)SyOSHeapAlloc(nBytes + sizeof(MemOSHeader));
 	if( pChunk == 0 ){
 		return 0;
 	}
-	pChunk[0] = nBytes;
+	pChunk->nBytes = nBytes;
 	return (void *)&pChunk[1];
 }
 static void * MemOSRealloc(void *pOld,sxu32 nBytes)
 {
-	sxu32 *pOldChunk;
-	sxu32 *pChunk;
-	pOldChunk = (sxu32 *)(((char *)pOld)-sizeof(sxu32));
-	if( pOldChunk[0] >= nBytes ){
+	MemOSHeader *pOldChunk;
+	MemOSHeader *pChunk;
+	pOldChunk = (MemOSHeader *)(((char *)pOld)-sizeof(MemOSHeader));
+	if( pOldChunk->nBytes >= nBytes ){
 		return pOld;
 	}
-	pChunk = (sxu32 *)SyOSHeapRealloc(pOldChunk,nBytes + sizeof(sxu32));
+	pChunk = (MemOSHeader *)SyOSHeapRealloc(pOldChunk,nBytes + sizeof(MemOSHeader));
 	if( pChunk == 0 ){
 		return 0;
 	}
-	pChunk[0] = nBytes;
+	pChunk->nBytes = nBytes;
 	return (void *)&pChunk[1];
 }
 static void MemOSFree(void *pBlock)
 {
 	void *pChunk;
-	pChunk = (void *)(((char *)pBlock)-sizeof(sxu32));
+	pChunk = (void *)(((char *)pBlock)-sizeof(MemOSHeader));
 	SyOSHeapFree(pChunk);
 }
 static sxu32 MemOSChunkSize(void *pBlock)
 {
-	sxu32 *pChunk;
-	pChunk = (sxu32 *)(((char *)pBlock)-sizeof(sxu32));
-	return pChunk[0];
+	MemOSHeader *pChunk;
+	pChunk = (MemOSHeader *)(((char *)pBlock)-sizeof(MemOSHeader));
+	return pChunk->nBytes;
 }
 /* Export OS allocation methods */
 static const SyMemMethods sOSAllocMethods = {
@@ -333,6 +342,7 @@ PH7_PRIVATE sxi32 SyMemBackendDisbaleMutexing(SyMemBackend *pBackend)
 #define SXMEM_POOL_MAGIC		0xDEAD
 #define SXMEM_POOL_MAXALLOC		(1<<(SXMEM_POOL_NBUCKETS+SXMEM_POOL_INCR))
 #define SXMEM_POOL_MINALLOC		(1<<(SXMEM_POOL_INCR))
+#if !defined(SXMEM_POOL_BYPASS)
 static sxi32 MemPoolBucketAlloc(SyMemBackend *pBackend,sxu32 nBucket)
 {
 	char *zBucket,*zBucketEnd;
@@ -361,8 +371,21 @@ static sxi32 MemPoolBucketAlloc(SyMemBackend *pBackend,sxu32 nBucket)
 
 	return SXRET_OK;
 }
+#endif /* !SXMEM_POOL_BYPASS */
 static void * MemBackendPoolAlloc(SyMemBackend *pBackend,sxu32 nByte)
 {
+#if defined(SXMEM_POOL_BYPASS)
+	/* Sanitizer builds: no bucket recycling — every request is a real
+	 * backend allocation so ASan tracks each object's lifetime. Freed via
+	 * the big-block path in MemBackendPoolFree. */
+	SyMemHeader *pBucket;
+	pBucket = (SyMemHeader *)MemBackendAlloc(&(*pBackend),nByte+sizeof(SyMemHeader));
+	if( pBucket == 0 ){
+		return 0;
+	}
+	pBucket->nBucket = ((sxu32)SXMEM_POOL_MAGIC << 16) | SXU16_HIGH;
+	return (void *)(pBucket+1);
+#else
 	SyMemHeader *pBucket,*pNext;
 	sxu32 nBucketSize;
 	sxu32 nBucket;
@@ -374,7 +397,7 @@ static void * MemBackendPoolAlloc(SyMemBackend *pBackend,sxu32 nByte)
 			return 0;
 		}
 		/* Record as big block */
-		pBucket->nBucket = (sxu32)(SXMEM_POOL_MAGIC << 16) | SXU16_HIGH;
+		pBucket->nBucket = ((sxu32)SXMEM_POOL_MAGIC << 16) | SXU16_HIGH;
 		return (void *)(pBucket+1);
 	}
 	/* Locate the appropriate bucket */
@@ -397,8 +420,9 @@ static void * MemBackendPoolAlloc(SyMemBackend *pBackend,sxu32 nByte)
 	pNext = pBucket->pNext;
 	pBackend->apPool[nBucket] = pNext;
 	/* Record bucket&magic number */
-	pBucket->nBucket = (SXMEM_POOL_MAGIC << 16) | nBucket;
+	pBucket->nBucket = (((sxu32)SXMEM_POOL_MAGIC << 16) | nBucket);
 	return (void *)&pBucket[1];
+#endif /* SXMEM_POOL_BYPASS */
 }
 PH7_PRIVATE void * SyMemBackendPoolAlloc(SyMemBackend *pBackend,sxu32 nByte)
 {

--- a/src/sx/sxzip.c
+++ b/src/sx/sxzip.c
@@ -362,7 +362,8 @@ static sxi32 ZipExtract(SyArchive *pArch,const unsigned char *zCentral,sxu32 nLe
 	zEnd = &zCentral[nLen];
 
 	for(;;){
-		if( &zCentral[nOfft] >= zEnd ){
+		if( &zCentral[nOfft] >= zEnd || (sxu32)(zEnd - &zCentral[nOfft]) < SXZIP_CENTRAL_HDRSZ ){
+			/* No room left for a full central directory record */
 			break;
 		}
 		/* Add a new entry */
@@ -374,6 +375,10 @@ static sxi32 ZipExtract(SyArchive *pArch,const unsigned char *zCentral,sxu32 nLe
 		pEntry->nMagic = SXARCH_MAGIC;
 		nIncr = 0;
 		rc = GetCentralDirectoryEntry(&(*pArch),pEntry,&zCentral[nOfft],&nIncr);
+		if( rc == SXRET_OK && nIncr > (sxu32)(zEnd - &zCentral[nOfft]) ){
+			/* Name/extra/comment lengths run past the central directory end */
+			rc = SXERR_CORRUPT;
+		}
 		if( rc == SXRET_OK ){
 			/* Fix the starting record offset so we can access entry contents correctly */
 			rc = ZipFixOffset(pEntry,pSrc);
@@ -381,8 +386,11 @@ static sxi32 ZipExtract(SyArchive *pArch,const unsigned char *zCentral,sxu32 nLe
 		if(rc != SXRET_OK ){
 			sxu32 nJmp = 0;
 			SyMemBackendPoolFree(pArch->pAllocator,pEntry);
-			/* Try to recover by brute-forcing for a valid central directory record */
-			if( SXRET_OK == SyBlobSearch((const void *)&zCentral[nOfft + nIncr],(sxu32)(zEnd - &zCentral[nOfft + nIncr]),
+			/* Try to recover by brute-forcing for a valid central directory record.
+			 * Guard the window: a corrupted record can claim lengths that put
+			 * nOfft + nIncr past zEnd, and the unsigned size would underflow. */
+			if( nOfft + nIncr < (sxu32)(zEnd - zCentral) &&
+				SXRET_OK == SyBlobSearch((const void *)&zCentral[nOfft + nIncr],(sxu32)(zEnd - &zCentral[nOfft + nIncr]),
 				(const void *)"PK\001\002",sizeof(sxu32),&nJmp)){
 					nOfft += nIncr + nJmp; /* Check next entry */
 					continue;

--- a/tests/ph7/002-integration/lang/array_append_intmax.phpt
+++ b/tests/ph7/002-integration/lang/array_append_intmax.phpt
@@ -1,0 +1,33 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Appending past an occupied PHP_INT_MAX key: PHL reports php's message as a non-catchable runtime error and skips the insert (php throws a catchable Error — see array_append_intmax_zend.phpt; divergence recorded in PLAN.md §3)
+--SKIPIF--
+<?php
+if (function_exists('zend_version')) {
+    echo "skip";
+}
+--FILE--
+<?php
+$a = [PHP_INT_MAX - 1 => 'x'];
+$a[] = 'y'; // lands on PHP_INT_MAX, like php
+var_export(array_keys($a));
+echo "\n";
+try {
+    $a[] = 'z';
+    echo "appended, count=", count($a), "\n";
+} catch (Error $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+?>
+--EXPECTF--
+array (
+  0 => 9223372036854775806,
+  1 => 9223372036854775807,
+)
+%s Error:  Cannot add element to the array as the next element is already occupied
+appended, count=2
+--CLEAN--
+<?php
+unset($a);

--- a/tests/ph7/002-integration/lang/array_append_intmax_zend.phpt
+++ b/tests/ph7/002-integration/lang/array_append_intmax_zend.phpt
@@ -1,0 +1,32 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Appending past an occupied PHP_INT_MAX key throws a catchable Error (php semantics; PHL reports the same message as a non-catchable runtime error — divergence recorded in PLAN.md §3)
+--SKIPIF--
+<?php
+if (!function_exists('zend_version')) {
+    echo "skip";
+}
+--FILE--
+<?php
+$a = [PHP_INT_MAX - 1 => 'x'];
+$a[] = 'y'; // lands on PHP_INT_MAX, like php
+var_export(array_keys($a));
+echo "\n";
+try {
+    $a[] = 'z';
+    echo "appended\n";
+} catch (Error $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+array (
+  0 => 9223372036854775806,
+  1 => 9223372036854775807,
+)
+caught: Cannot add element to the array as the next element is already occupied
+--CLEAN--
+<?php
+unset($a);


### PR DESCRIPTION
Full smoke+integration+stress under -fsanitize=address,undefined in docker (pool bypassed via the new SXMEM_POOL_BYPASS switch so ASan sees real object lifetimes) now runs clean. Fixed along the way:

- VmDrainFinally freed the coroutine body frame when draining FIBER-RESTORED handlers (their exception frames died at the lossy suspend), then OP_DONE's epilogue read the freed VmFrame. Guarded with VM_FRAME_EXCEPTION, the same guard OP_POP_EXCEPTION already uses.
- MemOSAlloc's bare sxu32 size prefix left every backend allocation 4-byte misaligned on 64-bit platforms (UB on each SyMemBlock/pointer store, and a genuine fault hazard for the xtensa port). The prefix is now a pointer- aligned union.
- ZipExtract overread the central directory three ways on corrupted archives: parsing a truncated 46-byte record at the tail, entry name/extra/comment lengths running past the directory end, and the recovery scan's unsigned underflow producing a huge search window past the mapping.
- Array auto-index arithmetic overflowed at PHP_INT_MAX keys (UB; the old wrap silently appended at PHP_INT_MIN where php throws). iNextIdx now saturates like Zend's nNextFreeElement and an append onto the occupied saturated slot reports php's exact "Cannot add element to the array as the next element is already occupied" message (catchability gap recorded; array_append_intmax twin pair pins both engines).
- IntHash shifted negative keys (unsigned mixing now) and the pool magic tag computed 0xDEAD << 16 in int.

Suites: host smoke 2239 + integration 835 + stress 13 green on both engines; docker ASan+UBSan smoke/integration/stress clean, no reports.
