### PR TITLE
deep-recursion stress tier; iterative exception unwind; recursion-cap…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,15 @@ TEST_STRESS_CMD = PHL_MAX_ALLOC=1048576 PHL_MAX_INPUT=32768 "$(PHL_BIN)" "tests/
 	--target-dir tests/ph7/003-stress \
 	--output-format dot
 
+# Deep-recursion tier (BYTECODE.md stage 3): PHP call depth is heap-bound, so
+# these run with the cap raised via PHL_MAX_RECURSION and WITHOUT the small
+# per-allocation cap (deep frames legitimately grow single slot-table
+# allocations past 1 MB).
+TEST_DEEP_CMD = PHL_MAX_RECURSION=131072 "$(PHL_BIN)" "tests/phpt.php" \
+	--target-executable "$(PHL_BIN)" \
+	--target-dir tests/ph7/004-deep \
+	--output-format dot
+
 default: build
 
 # --- POLYGLOT MAGIC BEGINS
@@ -151,6 +160,7 @@ $(BUILD_DIR)-test-integration: $(PHL_BIN)
 $(BUILD_DIR)-test-stress: $(PHL_BIN)
 	"$(PHL_BIN)" --version
 	$(TEST_STRESS_CMD)
+	$(TEST_DEEP_CMD)
 
 $(BUILD_DIR)-test-integration-compat: $(PHL_BIN)
 	"$(PHP_BIN)" --version

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -2994,9 +2994,13 @@ PH7_PRIVATE sxi32 PH7_VmConfigure(
 		pVm->bErrReport = 1;
 		break;
 	case PH7_VM_CONFIG_RECURSION_DEPTH:{
-		/* Recursion depth */
+		/* Recursion depth. PHP frames are heap-bound since the iterative
+		 * executor (BYTECODE.md stage 2), so no upper clamp: the embedder's
+		 * value is policy, bounded by memory like the main PHP engine. (The
+		 * old <1024 clamp guarded the native stack the recursion no longer
+		 * grows; stage 5 finalizes the defaults.) */
 		int nDepth = va_arg(ap,int);
-		if( nDepth > 2 && nDepth < 1024 ){
+		if( nDepth > 2 ){
 			pVm->nMaxDepth = nDepth;
 		}
 		break;
@@ -17304,12 +17308,14 @@ static sxi32 VmThrowInline(ph7_vm *pVm, ph7_class_instance *pThis,
 		VmExcRelease(&(*pVm),pException); /* not re-pushed: activation ends here */
 		return SXRET_OK;
 	}
-	/* No catch, no finally: drop this try's frame and continue unwinding. */
+	/* No catch, no finally: drop this try's frame and continue unwinding.
+	 * SXERR_RETRY tells the (sole) caller, VmThrowException, to loop back to
+	 * its Rethrow label — flat native stack instead of mutual recursion. */
 	if( pVm->pFrame->iFlags & VM_FRAME_EXCEPTION ){
 		VmLeaveFrame(&(*pVm));
 	}
 	VmExcRelease(&(*pVm),pException); /* not re-pushed: activation ends here */
-	return VmThrowException(&(*pVm),pThis);
+	return SXERR_RETRY;
 }
 static sxi32 VmThrowException(
 	ph7_vm *pVm,              /* Target VM */
@@ -17319,6 +17325,12 @@ static sxi32 VmThrowException(
 	ph7_exception_block *pCatch; /* Catch block to execute */
 	ph7_exception **apException;
 	ph7_exception *pException;
+Rethrow:
+	/* Unwinding to the next outer handler loops back here instead of the old
+	 * self tail-call: a throw from N frames deep runs N finallys at constant
+	 * native depth (the ASan deep-tier stress overflowed the C stack on the
+	 * recursive form; the dispatch-loop trampoline made PHP depth heap-bound,
+	 * so the throw path must be too). */
 	/* An in-flight throw abandons any pending null-coalesce-assign store:
 	 * disarm so the RHS-evaluation throw can't leave the slot live for a
 	 * later unrelated NULLC_STORE (stale offsetSet) or leak the instance ref. */
@@ -17394,7 +17406,12 @@ static sxi32 VmThrowException(
 	 * only classifies the throw and sets a pc-redirect (pInlineInstr/iInlinePc) that the
 	 * throw site jumps to, so catch/finally run in the generator's own dispatch loop. */
 	if( pException && pException->iInlined ){
-		return VmThrowInline(&(*pVm),pThis,pException,pCatch);
+		sxi32 rcInline = VmThrowInline(&(*pVm),pThis,pException,pCatch);
+		if( rcInline == SXERR_RETRY ){
+			/* No catch/finally in that inline try: keep unwinding outward. */
+			goto Rethrow;
+		}
+		return rcInline;
 	}
 	/* Execute the cached block if available */
 	if( pCatch == 0 ){
@@ -17458,9 +17475,10 @@ static sxi32 VmThrowException(
 		}
 		/* Check if there is an outer exception handler on the stack */
 		if( SySetUsed(&pVm->aException) > 0 ){
-			/* Re-throw to the outer handler */
+			/* Re-throw to the outer handler — flat loop (see Rethrow), one
+			 * iteration per unwound level instead of one native frame. */
 			VmExcRelease(&(*pVm),pException);
-			return VmThrowException(&(*pVm),pThis);
+			goto Rethrow;
 		}
 		/* No outer handler. If the handlers were temporarily hidden
 		 * (catch body re-throw with finally pending), defer the
@@ -17665,7 +17683,9 @@ static sxi32 VmThrowException(
 				ph7_class_instance *pReThrow = pVm->pPendingException;
 				pVm->pPendingException = 0;
 				VmExcRelease(&(*pVm),pException);
-				return VmThrowException(&(*pVm),pReThrow);
+				/* Continue unwinding with the re-thrown exception (flat loop) */
+				pThis = pReThrow;
+				goto Rethrow;
 			}
 			/* Swallowed by the catch/finally's return: drop the deferred exception. */
 			PH7_ClassInstanceUnref(pVm->pPendingException);

--- a/src/phl/phl.c
+++ b/src/phl/phl.c
@@ -434,6 +434,22 @@ int main(int argc,char **argv)
 	if( rc != PH7_OK ){
 		Fatal("Error while installing the VM output consumer callback");
 	}
+	/* Optional PHP-recursion-depth cap override (PHL_MAX_RECURSION=frames).
+	 * Testing hatch like PHL_MAX_ALLOC: lets the deep-recursion stress tests
+	 * (tests/ph7/003-stress) run past the conservative host default until the
+	 * BYTECODE.md stage-5 config rework makes the host default unbounded. */
+	{
+		const char *zMaxRec = getenv("PHL_MAX_RECURSION");
+		if( zMaxRec ){
+			unsigned long uMax = strtoul(zMaxRec,0,10);
+			if( uMax > 0 ){
+				if( uMax > 0x7FFFFFFFUL ){
+					uMax = 0x7FFFFFFFUL;
+				}
+				ph7_vm_config(pVm,PH7_VM_CONFIG_RECURSION_DEPTH,(int)uMax);
+			}
+		}
+	}
 	/* Define PHP_BINARY: absolute path of this interpreter */
 	ph7_create_constant(pVm,"PHP_BINARY",PHL_PhpBinaryConst,
 		(void *)PHL_ResolveBinaryPath(argv[0]));

--- a/tests/ph7/004-deep/generator_at_10k_depth.phpt
+++ b/tests/ph7/004-deep/generator_at_10k_depth.phpt
@@ -1,0 +1,45 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Generator created at 10k call depth, and resumed from a fresh 10k-deep chain (BYTECODE.md stage 3)
+--DESCRIPTION--
+The ctx start/resume native re-entries must be indifferent to PHP call depth:
+the generator body runs as the bottom record of its own dispatch invocation
+while the surrounding 10k frames are heap records.
+--SKIPIF--
+<?php if (!getenv('PHL_MAX_RECURSION')) { echo "skip needs PHL_MAX_RECURSION (run: make test-stress)"; } ?>
+--FILE--
+<?php
+function counter(int $from): Generator {
+    while (true) {
+        yield $from++;
+    }
+}
+function makeAtDepth(int $n): Generator {
+    if ($n === 0) {
+        $g = counter(100);
+        $g->current(); // prime at depth
+        return $g;
+    }
+    return makeAtDepth($n - 1);
+}
+function resumeAtDepth(int $n, Generator $g): int {
+    if ($n === 0) {
+        $g->next();
+        return $g->current();
+    }
+    return resumeAtDepth($n - 1, $g);
+}
+$g = makeAtDepth(10000);
+echo "primed=", $g->current(), "\n";
+echo "resumed=", resumeAtDepth(10000, $g), "\n";
+echo "again=", resumeAtDepth(10000, $g), "\n";
+?>
+--EXPECT--
+primed=100
+resumed=101
+again=102
+--CLEAN--
+<?php
+unset($g);

--- a/tests/ph7/004-deep/recursion_10k_include.phpt
+++ b/tests/ph7/004-deep/recursion_10k_include.phpt
@@ -1,0 +1,35 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+10k-deep recursion running inside an include'd file (BYTECODE.md stage 3)
+--DESCRIPTION--
+include executes via VmEvalChunk/VmLocalExec (a native re-entry); the deep
+PHP recursion inside it must still be heap-bound, and a second 10k descent
+that calls include at the bottom exercises depth accounting across the
+include boundary.
+--SKIPIF--
+<?php if (!getenv('PHL_MAX_RECURSION')) { echo "skip needs PHL_MAX_RECURSION (run: make test-stress)"; } ?>
+--FILE--
+<?php
+$inc = __DIR__ . '/recursion_10k_include.inc.tmp.php';
+file_put_contents($inc,
+    '<?php function deepInc(int $n): int { return $n === 0 ? 0 : 1 + deepInc($n - 1); } return deepInc(10000);');
+echo "in-include=", include($inc), "\n";
+function descendThenInclude(int $n, string $inc): int {
+    if ($n === 0) {
+        return include($inc); // include at the bottom of a 10k chain
+    }
+    return descendThenInclude($n - 1, $inc);
+}
+// deepInc is already defined by the first include; make the second chunk reuse it
+file_put_contents($inc, '<?php return deepInc(10000);');
+echo "include-at-depth=", descendThenInclude(10000, $inc), "\n";
+unlink($inc);
+?>
+--EXPECT--
+in-include=10000
+include-at-depth=10000
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/recursion_10k_include.inc.tmp.php');

--- a/tests/ph7/004-deep/recursion_20k_mutual.phpt
+++ b/tests/ph7/004-deep/recursion_20k_mutual.phpt
@@ -1,0 +1,33 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+20k-deep mutual recursion (function <-> method <-> closure) completes (BYTECODE.md stage 3)
+--SKIPIF--
+<?php if (!getenv('PHL_MAX_RECURSION')) { echo "skip needs PHL_MAX_RECURSION (run: make test-stress)"; } ?>
+--FILE--
+<?php
+class Hop {
+    public function viaMethod(int $n): int {
+        return viaFunction($n - 1);
+    }
+}
+function viaFunction(int $n): int {
+    global $viaClosure;
+    if ($n <= 0) {
+        return 0;
+    }
+    return 1 + $viaClosure($n);
+}
+$hop = new Hop();
+$viaClosure = function (int $n) use ($hop): int {
+    return 1 + $hop->viaMethod($n);
+};
+// each round trips function -> closure -> method: 3 frames per unit
+echo "units=", viaFunction(20000), "\n";
+?>
+--EXPECT--
+units=40000
+--CLEAN--
+<?php
+unset($hop, $viaClosure);

--- a/tests/ph7/004-deep/recursion_50k_plain.phpt
+++ b/tests/ph7/004-deep/recursion_50k_plain.phpt
@@ -1,0 +1,31 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+50k-deep linear recursion completes on the heap (iterative executor; BYTECODE.md stage 3)
+--DESCRIPTION--
+Runs under PHL_MAX_RECURSION (set by `make test-stress` for this directory).
+Before the trampoline this depth overflowed the native stack at ~7.7k frames;
+now PHP call frames are heap records and depth is a policy knob.
+--SKIPIF--
+<?php if (!getenv('PHL_MAX_RECURSION')) { echo "skip needs PHL_MAX_RECURSION (run: make test-stress)"; } ?>
+--FILE--
+<?php
+function down(int $n, int $acc): int {
+    if ($n === 0) {
+        return $acc;
+    }
+    return down($n - 1, $acc + 1);
+}
+echo "depth=", down(50000, 0), "\n";
+// fib-shaped (tree) recursion for call-shape variety: depth 20, 2^21-ish calls
+function fib(int $n): int {
+    return $n < 2 ? $n : fib($n - 1) + fib($n - 2);
+}
+echo "fib(20)=", fib(20), "\n";
+?>
+--EXPECT--
+depth=50000
+fib(20)=6765
+--CLEAN--
+<?php

--- a/tests/ph7/004-deep/throw_50k_finally_tower.phpt
+++ b/tests/ph7/004-deep/throw_50k_finally_tower.phpt
@@ -1,0 +1,39 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Throw from 50k deep unwinds 50k per-frame finallys to a top-level catch (BYTECODE.md stage 3)
+--DESCRIPTION--
+Every level opens its own try/finally (per-activation exception state, stage
+2b); the throw at the bottom must run each level's finally exactly once on
+the way out and reach the catch with the counter intact.
+--SKIPIF--
+<?php if (!getenv('PHL_MAX_RECURSION')) { echo "skip needs PHL_MAX_RECURSION (run: make test-stress)"; } ?>
+--FILE--
+<?php
+$finallys = 0;
+function diveAndThrow(int $n): void {
+    global $finallys;
+    try {
+        if ($n === 0) {
+            throw new RuntimeException("from the bottom");
+        }
+        diveAndThrow($n - 1);
+    } finally {
+        $finallys++;
+    }
+}
+try {
+    diveAndThrow(50000);
+    echo "UNREACHABLE\n";
+} catch (RuntimeException $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
+echo "finallys=", $finallys, "\n";
+?>
+--EXPECT--
+caught: from the bottom
+finallys=50001
+--CLEAN--
+<?php
+unset($finallys);


### PR DESCRIPTION
… plumbing

BYTECODE.md stage 3: with PHP call frames heap-bound, validate the trampoline at depth and make the remaining O(depth) native path iterative.

- New tests/ph7/004-deep tier (run by make test-stress via TEST_DEEP_CMD, outside the OOM tier's 1 MB per-allocation cap): 50k-deep linear + fib-tree recursion, 20k-deep function/closure/method mutual recursion, generator created at 10k depth and resumed from a fresh 10k chain, 10k recursion inside an include plus include at the bottom of a 10k chain, and a throw from 50k deep through 50,001 per-frame finallys.
- VmThrowException unwound to each outer handler by native tail-recursion (plus a mutual tail through VmThrowInline), so a deep throw still consumed O(depth) C stack -- the ASan deep-tier run overflowed on the finally tower the host's 8 MB stack had been absorbing. The four tail sites are now a single Rethrow: loop; VmThrowInline signals continue-unwinding with SXERR_RETRY to its sole caller.
- PHL_MAX_RECURSION env hatch in phl.c (PHL_MAX_ALLOC-style testing knob until the stage-5 config rework lands) and the <1024 clamp on PH7_VM_CONFIG_RECURSION_DEPTH removed: PHP depth is a memory-bound policy knob now; the host default stays 32 until stage 5.

Heap cost measured at ~3.5 KB per frame for a 1-arg linear function (7.9 MB @ depth 1k to 357.9 MB @ depth 101k, 0.27 s wall for 100k calls).

Suites: host smoke 2239 x2 + integration 835 x2 + stress 13 + deep 5 green; docker ASan+UBSan sweep over all tiers clean.
