### PR TITLE
deep re-suspend accounting, abandon body-stack, OOM fatal

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -5830,7 +5830,8 @@ static sxi32 VmByteCodeExecBody(
 		sState = pSeg->sState;
 		aInstr = sState.aInstr;
 		pStack = sState.pStack;
-		pc = nPc;               /* pCtx->pc — the innermost's post-suspend pc */
+		/* pc is already nPc (== pCtx->pc, the innermost's post-suspend pc) from the
+		 * init above; only the stack/top move to the innermost activation. */
 		pTos = &pStack[nTos];   /* nTos == pCtx->nTos — innermost, resume value pushed */
 		SyMemBackendFree(&pVm->sAllocator,pSeg); /* holder only; its contents are now live */
 	}
@@ -12413,12 +12414,15 @@ Suspend:
 		 * FiberError before it could arrive here. */
 		VmParkedSegment *pSeg = (VmParkedSegment *)SyMemBackendAlloc(&pVm->sAllocator,sizeof(VmParkedSegment));
 		if( pSeg == 0 ){
-			/* OOM on the park allocation: fall back to the lossy unwind rather
-			 * than losing the suspension (non-silent — the fiber still suspends,
-			 * just at the body level as before stage 4). */
+			/* OOM on the park allocation. VmSuspendCtx already wrote the INNERMOST
+			 * pc/nTos into the ctx, so the lossy body-level fallback would resume
+			 * the callee's pc against the body stack — silent corruption, exactly
+			 * what stage 4 removed. Take the non-catchable OOM fatal instead (the
+			 * §3.1 convention shared with the stage-2 record-alloc OOM site). */
+			PH7_VmMemoryError(&(*pVm));
+			rc = PH7_ABORT;
 			goto Unwind;
 		}
-		sState.pc = pc;
 		sState.pTos = pTos; /* innermost live top (args already popped at the CALL) */
 		pSeg->sState = sState;
 		pSeg->pCallTop = pCallTop;
@@ -12905,16 +12909,14 @@ static sxi32 VmResumeCtx(ph7_vm *pVm, ph7_exec_ctx *pCtx, ph7_value *pResumeValu
 						(sxu32)((sxi32)pRec->sCaller.nExceptionBase + iDelta);
 				}
 			}
-			/* Re-attach the WHOLE segment: body frame onto the live chain, then
-			 * make the suspend-time top frame current so the dispatch loop's
-			 * adopt (VmByteCodeExec entry) resumes inside the innermost callee. */
-			pCtx->pFrame->pParent = pVm->pFrame;
-			pVm->pFrame = pSeg->pTopFrame;
-		}else{
-			/* Re-attach the fiber's body frame to the VM frame chain */
-			pCtx->pFrame->pParent = pVm->pFrame;
-			pVm->pFrame = pCtx->pFrame;
 		}
+		/* Re-attach the coroutine to the live VM frame chain: the body frame's
+		 * parent becomes the resumer's current frame. For a deep segment the
+		 * suspend-time top frame (the innermost callee / open-try wrapper) then
+		 * becomes current so the adopt at VmByteCodeExec entry resumes inside the
+		 * callee; body-level resumes make the body frame current. */
+		pCtx->pFrame->pParent = pVm->pFrame;
+		pVm->pFrame = pSeg ? pSeg->pTopFrame : pCtx->pFrame;
 	}
 	/* Save and set the active context */
 	pOldCtx = pVm->pActiveCtx;
@@ -12931,15 +12933,12 @@ static sxi32 VmResumeCtx(ph7_vm *pVm, ph7_exec_ctx *pCtx, ph7_value *pResumeValu
 	/* Restore the previous context */
 	pVm->pActiveCtx = pOldCtx;
 	if( rc == PH7_SUSPEND ){
-		/* Fiber suspended again. Free the try wrappers the yield was nested in, then
-		 * detach the fiber's body frame. */
-		VmFreeSuspendedExceptionFrames(pVm, pCtx);
-		pVm->pFrame = pCtx->pFrame->pParent;
-		pCtx->pFrame->pParent = 0;
-		VmParkCtxExceptionHandlers(pVm, pCtx);
-		if( pResult ){
-			PH7_MemObjStore(&pCtx->sSuspendValue, pResult);
-		}
+		/* Suspended again — same detach as VmStartCtx. Crucially this handles a
+		 * deep RE-suspend (a resumed segment that parks a fresh segment): the
+		 * shared helper deactivates the new segment's recursion accounting, parks
+		 * its aSelf, and (for a segment) skips VmFreeSuspendedExceptionFrames so
+		 * it can't free the still-live parked try wrappers. */
+		VmSuspendCtxDetach(pVm, pCtx, pResult);
 		return SXRET_OK;
 	}
 	/* Detach frame */
@@ -13003,7 +13002,7 @@ static void VmFreeDetachedFrame(ph7_vm *pVm, VmFrame *pFrame)
  * The body frame/stack are NOT here — they are freed by the caller
  * (VmReleaseExecCtx) as pCtx->pFrame / pCtx->pStack.
  */
-static void VmFreeParkedSegment(ph7_vm *pVm, VmParkedSegment *pSeg)
+static void VmFreeParkedSegment(ph7_vm *pVm, ph7_exec_ctx *pCtx, VmParkedSegment *pSeg)
 {
 	/* Live top-of-stack of the activation running on the current record's callee
 	 * stack: the innermost (sState) for the topmost record, then each caller. */
@@ -13027,6 +13026,11 @@ static void VmFreeParkedSegment(ph7_vm *pVm, VmParkedSegment *pSeg)
 		SyMemBackendPoolFree(&pVm->sAllocator, pRec);
 		pRec = pNext;
 	}
+	/* pTosAbove now points at the BODY activation's live top (the bottom record's
+	 * sCaller, which runs on pCtx->pStack). pCtx->nTos still holds the INNERMOST
+	 * index (VmSuspendCtx saved it), which would over-index the body stack in
+	 * VmReleaseExecCtx's release loop — correct it to the body's real top. */
+	pCtx->nTos = (sxi32)(pTosAbove - pCtx->pStack);
 	SyMemBackendFree(&pVm->sAllocator, pSeg);
 }
 /*
@@ -13075,7 +13079,7 @@ static void VmReleaseExecCtx(ph7_vm *pVm, ph7_exec_ctx *pCtx)
 	 * stacks are still alive and only this holder references them. Must run
 	 * before the body frame/stack below (they are the segment's floor). */
 	if( pCtx->pParkedSegment ){
-		VmFreeParkedSegment(pVm, (VmParkedSegment *)pCtx->pParkedSegment);
+		VmFreeParkedSegment(pVm, pCtx, (VmParkedSegment *)pCtx->pParkedSegment);
 		pCtx->pParkedSegment = 0;
 	}
 	/* Release the frame if it's detached (not in the VM chain) */
@@ -13561,16 +13565,22 @@ static int vm_builtin_Fiber_suspend(ph7_context *pCtx, int nArg, ph7_value **apA
 		return PH7_VmThrowException(pCtx, "FiberError",
 			"Cannot suspend outside of a fiber");
 	}
-	/* Stage 4 scoped divergence: PHL runs C->PHP callbacks (usort comparators,
-	 * array_map, preg_replace_callback, …) on a fresh native VmByteCodeExec
-	 * activation. A suspend from there would have to unwind PH7_SUSPEND across
-	 * that native C frame — which php does via full stack switching but PHL
-	 * cannot without real coroutine stacks (BYTECODE.md §2.4). Raising a
-	 * catchable FiberError here is the loud, documented failure instead of the
-	 * old silent frame-discard that corrupted the callback's caller. */
+	/* Stage 4 scoped divergence: the trampoline only makes PHP->PHP CALLs
+	 * iterative. Every OTHER re-entry runs on a fresh native VmByteCodeExec
+	 * activation (nVmExecDepth bumped) that PH7_SUSPEND cannot unwind across
+	 * without real coroutine stacks (BYTECODE.md §2.4): a C->PHP callback
+	 * (usort/array_map/preg_replace_callback comparator), and — because fibers
+	 * use the LEGACY (non-inline) try/catch machinery — a suspend inside a
+	 * fiber's catch/finally body, a match/switch arm, or eval()/include()'d
+	 * code, all of which run via VmLocalExec. php does all of these via full
+	 * native-stack switching; PHL raises a catchable FiberError instead of the
+	 * old silent corruption. A suspend in a fiber's try BODY (not catch/finally)
+	 * runs in the main dispatch loop and parks normally. Recorded in PLAN.md
+	 * §3.9; making the catch/finally case work needs fibers on the inline
+	 * try machinery (the generator ROOT C path), a follow-up. */
 	if( pVm->nVmExecDepth != pVm->pActiveCtx->nBodyExecDepth ){
 		return PH7_VmThrowException(pCtx, "FiberError",
-			"Cannot suspend across an internal (C) call boundary");
+			"Cannot suspend across an internal call boundary");
 	}
 	if( nArg > 0 ){
 		PH7_MemObjStore(apArg[0], &pVm->pActiveCtx->sSuspendValue);

--- a/tests/ph7/002-integration/lang/fiber_suspend_in_callback.phpt
+++ b/tests/ph7/002-integration/lang/fiber_suspend_in_callback.phpt
@@ -31,6 +31,6 @@ try {
 }
 ?>
 --EXPECT--
-FiberError: Cannot suspend across an internal (C) call boundary
+FiberError: Cannot suspend across an internal call boundary
 --CLEAN--
 <?php

--- a/tests/ph7/002-integration/lang/fiber_suspend_in_finally.phpt
+++ b/tests/ph7/002-integration/lang/fiber_suspend_in_finally.phpt
@@ -1,0 +1,34 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+SCOPED DIVERGENCE (BYTECODE.md stage 4, PLAN.md §3.9): Fiber::suspend() inside a fiber's catch/finally raises a catchable FiberError — fibers use the legacy (non-inline) try machinery, so catch/finally run on a nested native activation PH7_SUSPEND cannot cross. php suspends fine (permanent _zend twin).
+--SKIPIF--
+<?php
+if (function_exists('zend_version')) {
+    echo "skip";
+}
+--FILE--
+<?php
+$f = new Fiber(function () {
+    try {
+        echo "try\n";
+    } finally {
+        Fiber::suspend("in-finally");
+    }
+    return "done";
+});
+try {
+    $v = $f->start();
+    echo "suspended:", var_export($v, true), "\n";
+    $f->resume();
+    echo "ret=", $f->getReturn(), "\n";
+} catch (FiberError $e) {
+    echo "FiberError: ", $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+try
+FiberError: Cannot suspend across an internal call boundary
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/fiber_suspend_in_finally_zend.phpt
+++ b/tests/ph7/002-integration/lang/fiber_suspend_in_finally_zend.phpt
@@ -1,0 +1,32 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Fiber::suspend() inside a finally suspends and resumes fine on php (full native-stack switch); PHL's scoped divergence (see fiber_suspend_in_finally.phpt) makes this twin permanent
+--SKIPIF--
+<?php
+if (!function_exists('zend_version')) {
+    echo "skip";
+}
+?>
+--FILE--
+<?php
+$f = new Fiber(function () {
+    try {
+        echo "try\n";
+    } finally {
+        Fiber::suspend("in-finally");
+    }
+    return "done";
+});
+$v = $f->start();
+echo "suspended:", var_export($v, true), "\n";
+$f->resume();
+echo "ret=", $f->getReturn(), "\n";
+?>
+--EXPECT--
+try
+suspended:'in-finally'
+ret=done
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/fiber_suspend_resuspend_many.phpt
+++ b/tests/ph7/002-integration/lang/fiber_suspend_resuspend_many.phpt
@@ -1,0 +1,25 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Many deep re-suspend cycles from a nested call complete without leaking recursion depth (php-exact; BYTECODE.md stage 4 re-suspend accounting)
+--FILE--
+<?php
+function worker() {
+    $sum = 0;
+    for ($i = 0; $i < 40; $i++) {
+        $sum += (int) Fiber::suspend($i);
+    }
+    return $sum;
+}
+function driver() { return worker(); }
+$f = new Fiber('driver');
+$v = $f->start();
+$cycles = 0;
+while ($f->isSuspended()) { $v = $f->resume(1); $cycles++; }
+echo "cycles=$cycles ret=", $f->getReturn(), "\n";
+?>
+--EXPECT--
+cycles=40 ret=40
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/fiber_suspend_resuspend_try.phpt
+++ b/tests/ph7/002-integration/lang/fiber_suspend_resuspend_try.phpt
@@ -1,0 +1,28 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Repeated deep re-suspend from inside a nested try runs the finally once and completes (php-exact; BYTECODE.md stage 4 — the parked try wrapper is not freed on re-suspend)
+--FILE--
+<?php
+function worker() {
+    try {
+        for ($i = 0; $i < 5; $i++) {
+            Fiber::suspend("y$i");
+        }
+    } finally {
+        echo "worker-finally\n";
+    }
+    return "wdone";
+}
+function driver() { return worker(); }
+$f = new Fiber('driver');
+$v = $f->start();
+while ($f->isSuspended()) { $v = $f->resume(); }
+echo "ret=", $f->getReturn(), "\n";
+?>
+--EXPECT--
+worker-finally
+ret=wdone
+--CLEAN--
+<?php


### PR DESCRIPTION
- VmResumeCtx's PH7_SUSPEND branch was never converted to VmSuspendCtxDetach (only VmStartCtx was), so a deep RE-suspend -- a resumed segment that parks a fresh segment -- skipped all the stage-4 bookkeeping every cycle: it leaked nRecursionDepth by nRecords per cycle (40 cycles hit the spurious "Maximum recursion depth of 32"), leaked the segment's aSelf, and ran VmFreeSuspendedExceptionFrames unconditionally, freeing the still-live parked try wrapper (UAF on the next resume). The 3-cycle no-try multicycle test masked it. Now routed through the shared helper; pinned by fiber_suspend_resuspend_{many,try}.
- VmReleaseExecCtx released the BODY operand stack using pCtx->nTos, which VmSuspendCtx had set to the INNERMOST index -- an over-index / wrong-count release when a deep-suspended fiber is abandoned. VmFreeParkedSegment now corrects pCtx->nTos to the body activation's real top.
- OOM at the park allocation did `goto Unwind` (lossy body-level fallback), but VmSuspendCtx had already written the innermost pc/nTos into the ctx, so resume ran the callee's pc against the body stack -- silent corruption, plus it reintroduced the removed stage-2b freed-frame-handler UAF. Now a non-catchable PH7_VmMemoryError fatal, so no successful suspend degrades to a lossy discard.
- The FiberError scoped divergence is broader than first documented: the depth guard correctly rejects every suspend that would cross a native re-entry -- not only C->PHP callbacks but also a fiber's catch/finally, match/switch arms, and eval/include (fibers use the legacy non-inline try machinery). This is the safe behavior; message generalized (dropped "(C)"), PLAN.md widened, and the fiber_suspend_in_finally twin pair added.

Cleanups: removed the dead `pc = nPc` in the adopt, the unread sState.pc park store, and collapsed the duplicated frame-reattach line.

Suites: host smoke 2239 x2 + integration 842 x2 + stress 13 + deep 7 green on both engines; docker ASan+UBSan sweep clean.
