### PR TITLE
Split recursion cap into PHP-depth + native-nesting guards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,11 +100,11 @@ TEST_STRESS_CMD = PHL_MAX_ALLOC=1048576 PHL_MAX_INPUT=32768 "$(PHL_BIN)" "tests/
 	--target-dir tests/ph7/003-stress \
 	--output-format dot
 
-# Deep-recursion tier (BYTECODE.md stage 3): PHP call depth is heap-bound, so
-# these run with the cap raised via PHL_MAX_RECURSION and WITHOUT the small
-# per-allocation cap (deep frames legitimately grow single slot-table
-# allocations past 1 MB).
-TEST_DEEP_CMD = PHL_MAX_RECURSION=131072 "$(PHL_BIN)" "tests/phpt.php" \
+# Deep-recursion tier (BYTECODE.md stage 3+5): PHP call depth is heap-bound and
+# UNBOUNDED by default since stage 5, so these run at the stock host defaults —
+# no PHL_MAX_RECURSION needed. Still WITHOUT the small per-allocation cap (deep
+# frames legitimately grow single slot-table allocations past 1 MB).
+TEST_DEEP_CMD = "$(PHL_BIN)" "tests/phpt.php" \
 	--target-executable "$(PHL_BIN)" \
 	--target-dir tests/ph7/004-deep \
 	--output-format dot

--- a/src/ph7/ph7.h
+++ b/src/ph7/ph7.h
@@ -201,7 +201,7 @@ typedef int (*ph7_clock)(void *pUserData, ph7_int64 *pSec, ph7_int64 *pUsec);
 #define PH7_VM_CONFIG_OUTPUT           1  /* TWO ARGUMENTS: int (*xConsumer)(const void *pOut,unsigned int nLen,void *pUserData),void *pUserData */
 #define PH7_VM_CONFIG_IMPORT_PATH      3  /* ONE ARGUMENT: const char *zIncludePath */
 #define PH7_VM_CONFIG_ERR_REPORT       4  /* NO ARGUMENTS: Report all run-time errors in the VM output */
-#define PH7_VM_CONFIG_RECURSION_DEPTH  5  /* ONE ARGUMENT: int nMaxDepth */
+#define PH7_VM_CONFIG_RECURSION_DEPTH  5  /* ONE ARGUMENT: int nMaxDepth (PHP call depth; 0 = unbounded, the default) */
 #define PH7_VM_OUTPUT_LENGTH           6  /* ONE ARGUMENT: unsigned int *pLength */
 #define PH7_VM_CONFIG_CREATE_SUPER     7  /* TWO ARGUMENTS: const char *zName,ph7_value *pValue */
 #define PH7_VM_CONFIG_CREATE_VAR       8  /* TWO ARGUMENTS: const char *zName,ph7_value *pValue */
@@ -220,6 +220,7 @@ typedef int (*ph7_clock)(void *pUserData, ph7_int64 *pSec, ph7_int64 *pUsec);
 #define PH7_VM_CONFIG_ERR_LOG_HANDLER 21  /* ONE ARGUMENT: void (*xErrLog)(const char *,int,const char *,const char *) */
 #define PH7_VM_CONFIG_RESPONSE_STATUS  22  /* ONE ARGUMENT: int *pStatusCode */
 #define PH7_VM_CONFIG_RESPONSE_HEADERS 23  /* TWO ARGUMENTS: int (*xCallback)(const char *zName,unsigned int nName,const char *zValue,unsigned int nValue,void *pUserData), void *pUserData */
+#define PH7_VM_CONFIG_NATIVE_DEPTH    24  /* ONE ARGUMENT: int nMaxNativeDepth (native VmByteCodeExec nesting: eval/include, callbacks, coroutine resume; default 256 host / 16 embedded) */
 /*
  * Global Library Configuration Commands.
  *

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1030,10 +1030,19 @@ struct ph7_vm
 	void *pStdout;             /* STDOUT IO stream */
 	void *pStderr;             /* STDERR IO stream */
 	int bErrReport;            /* TRUE to report all runtime Error/Warning/Notice */
-	int nRecursionDepth;       /* Current recursion depth */
-	int nMaxDepth;             /* Maximum allowed recusion depth */
+	int nRecursionDepth;       /* Current PHP call depth (OP_CALL frames only) */
+	int nMaxDepth;             /* Maximum PHP call depth; 0 == unbounded (the host
+	                            * default: PHP frames are heap-bound since the
+	                            * iterative executor, so recursion is limited by
+	                            * memory like the main PHP engine). Embedders opt in
+	                            * via PH7_VM_CONFIG_RECURSION_DEPTH. */
 	int nVmExecDepth;          /* Live native VmByteCodeExec activations (C-stack guard;
 	                            * see the VmByteCodeExec wrapper in vm.c) */
+	int nMaxNativeDepth;       /* Maximum native VmByteCodeExec nesting (mini-programs,
+	                            * C->PHP callbacks, ctx start/resume, eval/include) —
+	                            * what actually protects the C stack now that PHP
+	                            * recursion is iterative. Platform-sized default,
+	                            * PH7_VM_CONFIG_NATIVE_DEPTH overrides. */
 	void *pIdleCallFrames;     /* Freelist of VmCallFrame nodes (BYTECODE stage 2):
 	                            * fixed-size, strictly LIFO per invocation — reusing
 	                            * them skips a pool alloc/free round-trip per PHP

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -2028,11 +2028,23 @@ PH7_PRIVATE sxi32 PH7_VmInit(
 	PH7_MemObjInit(&(*pVm),&pVm->aErrCB[0]);
 	PH7_MemObjInit(&(*pVm),&pVm->aErrCB[1]);
 	PH7_MemObjInit(&(*pVm),&pVm->sAssertCallback);
-	/* Set a default recursion limit */
+	/* Recursion policy (BYTECODE.md stage 5). PHP call depth is heap-bound since
+	 * the iterative executor, so the host default is UNBOUNDED (0) — real PHP runs
+	 * deep userland recursion until memory_limit, and so must PHL; an embedder opts
+	 * back into a cap via PH7_VM_CONFIG_RECURSION_DEPTH. What still needs guarding
+	 * is NATIVE VmByteCodeExec nesting (eval/include towers, coroutine-resume
+	 * chains, self-recursive C->PHP callbacks) — sized to the platform stack. */
 #if defined(__WINNT__) || defined(__UNIXES__)
-	pVm->nMaxDepth = 32;
+	pVm->nMaxDepth = 0;         /* host: unbounded PHP call depth (memory-bound) */
+	pVm->nMaxNativeDepth = 256; /* host: proven the safe ceiling under ASan (the
+	                             * usort-in-comparator path overflows at 1024) */
 #else
-	pVm->nMaxDepth = 16;
+	/* Small-stack embedders (e.g. ESP32 16 KB task, 8 MB PSRAM): PHP recursion is
+	 * iterative/heap-bound, but a tiny device still wants a runaway-recursion
+	 * bound, so keep a PHP-depth default here (~3.5 KB/frame × 512 ≈ 1.8 MB PSRAM
+	 * at max depth — BYTECODE.md §6). The embedder tunes both via config verbs. */
+	pVm->nMaxDepth = 512;
+	pVm->nMaxNativeDepth = 16;
 #endif
 	/* Default assertion flags */
 	pVm->iAssertFlags = 0; /* PHP 8: no warning flag by default, AssertionError is thrown */
@@ -2994,14 +3006,30 @@ PH7_PRIVATE sxi32 PH7_VmConfigure(
 		pVm->bErrReport = 1;
 		break;
 	case PH7_VM_CONFIG_RECURSION_DEPTH:{
-		/* Recursion depth. PHP frames are heap-bound since the iterative
-		 * executor (BYTECODE.md stage 2), so no upper clamp: the embedder's
-		 * value is policy, bounded by memory like the main PHP engine. (The
-		 * old <1024 clamp guarded the native stack the recursion no longer
-		 * grows; stage 5 finalizes the defaults.) */
+		/* PHP call-depth cap (OP_CALL frames). The host default is UNBOUNDED
+		 * (nMaxDepth == 0) — PHP frames are heap-bound since the iterative
+		 * executor, so recursion is limited by memory like the main PHP engine.
+		 * This is an embedder opt-in: any non-negative value installs a cap of that
+		 * many frames; 0 restores the unbounded default. No upper clamp (the old
+		 * <1024 clamp guarded the native stack the recursion no longer grows — that
+		 * role is now PH7_VM_CONFIG_NATIVE_DEPTH). A negative value is ignored (it
+		 * would otherwise read as an enormous positive cap). */
 		int nDepth = va_arg(ap,int);
-		if( nDepth > 2 ){
+		if( nDepth >= 0 ){
 			pVm->nMaxDepth = nDepth;
+		}
+		break;
+									   }
+	case PH7_VM_CONFIG_NATIVE_DEPTH:{
+		/* Native VmByteCodeExec nesting cap: the C-stack guard for the re-entry
+		 * classes the trampoline does not flatten (eval/include towers, nested
+		 * coroutine resume, self-recursive C->PHP callbacks). Sized to the
+		 * platform stack; the default (256 host / 16 small-stack embedders) is
+		 * set in VmInit. A value > 1 overrides it (1 would forbid any re-entry,
+		 * so it is rejected as a footgun). */
+		int nDepth = va_arg(ap,int);
+		if( nDepth > 1 ){
+			pVm->nMaxNativeDepth = nDepth;
 		}
 		break;
 									   }
@@ -3467,14 +3495,29 @@ PH7_PRIVATE sxi32 PH7_ContextMemoryError(ph7_context *pCtx)
 	return PH7_VmMemoryError(pCtx->pVm);
 }
 /*
- * Single source of truth for the call-recursion cap policy. Each recursion
- * entry point (OP_CALL, eval/include, fibers/generators) tests this before
- * descending another native C frame; the control flow on a hit differs per
- * site, but the rule itself lives here.
+ * Single source of truth for the PHP call-depth cap policy (BYTECODE.md stage
+ * 5). Only OP_CALL tests this — a PHP->PHP call is the sole thing that grows
+ * nRecursionDepth. Native re-entries (eval/include, coroutine start/resume,
+ * C->PHP callbacks) are bounded separately by nMaxNativeDepth in the
+ * VmByteCodeExec wrapper, since PHP recursion no longer grows the C stack.
  */
 static int VmRecursionExceeded(ph7_vm *pVm)
 {
-	return pVm->nRecursionDepth > pVm->nMaxDepth;
+	/* nMaxDepth == 0 means unbounded (the host default): PHP call depth is
+	 * heap-bound, so only an embedder-configured cap can trip. */
+	return pVm->nMaxDepth > 0 && pVm->nRecursionDepth > pVm->nMaxDepth;
+}
+/*
+ * Single source of truth for the NATIVE VmByteCodeExec nesting cap (the C-stack
+ * guard) — the twin of VmRecursionExceeded for the other axis. Tested by the
+ * VmByteCodeExec wrapper and, before mutating VM state, by the coroutine
+ * start/resume entries (which splice frames in before that wrapper runs). Always
+ * bounded (unlike the PHP cap there is no unbounded mode — the whole point is to
+ * keep native re-entries off a finite C stack).
+ */
+static int VmNativeNestingExceeded(ph7_vm *pVm)
+{
+	return pVm->nVmExecDepth >= pVm->nMaxNativeDepth;
 }
 /*
  * Raise the recursion-limit fatal and request a clean VM halt. Mirrors
@@ -3485,9 +3528,9 @@ static int VmRecursionExceeded(ph7_vm *pVm)
  * would re-trip the limit and recurse forever. A clean fatal removes the old
  * silent "return NULL and continue" hazard while keeping the promise that deep
  * recursion never panics: it unwinds via the abort path and still runs
- * register_shutdown_function() callbacks. Used by every recursion path —
- * OP_CALL, eval()/include/require (VmEvalChunk) and fibers/generators
- * (VmStartCtx/VmResumeCtx).
+ * register_shutdown_function() callbacks. Raised by OP_CALL only (the sole
+ * site testing the PHP call-depth cap); native nesting has its own fatal
+ * (VmNativeNestingFatal).
  *
  * Halt is requested BEFORE emitting the diagnostic, and a re-entry guard makes
  * this idempotent, so an error handler that itself recurses past the cap can't
@@ -5715,16 +5758,16 @@ static sxi32 VmByteCodeExecBody(ph7_vm *pVm,VmInstr *aInstr,ph7_value *pStack,in
  * PHP call depth, raisable to memory-bound values since the clamp removal),
  * so this counter is what actually protects the C stack: recursive
  * eval/include towers, nested coroutine-resume chains and self-recursive
- * C-callback compositions hit a clean fatal instead of overflowing. This is a
- * coarse frame-count net, not php's stack-byte measurement (stage 5 turns it
- * into a per-platform config knob measuring real usage, BYTECODE.md §3 stage
- * 5, nNativeDepth); the value is therefore conservative — well below the old
- * config clamp's <1024 ceiling so it also holds on the fattest frames (the
- * callback path drags in usort/mergesort/trampoline C frames per re-entry,
- * and instrumented builds inflate every frame), while still 8x the default
- * PHP-depth cap and far beyond any realistic eval/include/callback nesting.
+ * C-callback compositions hit a clean fatal instead of overflowing. The limit
+ * lives in pVm->nMaxNativeDepth — a per-platform default (256 host / 16 small-
+ * stack embedders, VmInit) overridable via PH7_VM_CONFIG_NATIVE_DEPTH. This is
+ * still a coarse frame-count net rather than php's stack-byte measurement, so
+ * the host default is conservative — well below the old config clamp's <1024
+ * ceiling so it holds on the fattest frames (the callback path drags in
+ * usort/mergesort/trampoline C frames per re-entry, and instrumented builds
+ * inflate every frame), while far beyond any realistic eval/include/callback
+ * nesting.
  */
-#define PH7_VM_NATIVE_NESTING_MAX 256
 static sxi32 VmByteCodeExec(
 	ph7_vm *pVm,         /* Target VM */
 	VmInstr *aInstr,     /* PH7 bytecode program */
@@ -5739,8 +5782,8 @@ static sxi32 VmByteCodeExec(
 	)
 {
 	sxi32 rc;
-	if( pVm->nVmExecDepth >= PH7_VM_NATIVE_NESTING_MAX ){
-		return VmNativeNestingFatal(&(*pVm));
+	if( VmNativeNestingExceeded(pVm) ){
+		return VmNativeNestingFatal(pVm);
 	}
 	pVm->nVmExecDepth++;
 	rc = VmByteCodeExecBody(&(*pVm),aInstr,pStack,nTos,pResult,pLastRef,is_callback,nPc,
@@ -11304,10 +11347,12 @@ case PH7_OP_CALL: {
 				}
 			}
 		}
-		/* Check The recursion limit. Hitting it raises a clean, non-catchable
-		 * fatal (was: silently set NULL and continue) and halts. The check is
-		 * before VmEnterFrame/the recursive VmByteCodeExec below, so a
-		 * correctly-set cap also keeps deep recursion off the native stack. */
+		/* Check the PHP call-depth cap (the sole site — BYTECODE.md stage 5).
+		 * Default is unbounded (heap-bound recursion, decoupled from the C stack
+		 * by the stage-2 trampoline); the C stack is guarded separately by
+		 * nMaxNativeDepth. This fires only when an embedder configures a cap, and
+		 * then raises a clean non-catchable fatal (was: silently set NULL and
+		 * continue) and halts. */
 		if( VmRecursionExceeded(pVm) ){
 			/* Args and the function-name slot are released by the Abort label,
 			 * which walks the whole operand stack — don't release them here. */
@@ -12795,10 +12840,14 @@ static sxi32 VmStartCtx(ph7_vm *pVm, ph7_exec_ctx *pCtx, ph7_value *pResult)
 	if( pCtx->iState != PH7_CTX_STATE_CREATED ){
 		return SXERR_INVALID;
 	}
-	/* Bound fiber/generator nesting under the same cap (each start adds a C
-	 * frame); reject before mutating VM state so the abort is clean. */
-	if( VmRecursionExceeded(pVm) ){
-		return VmRecursionFatal(pVm);
+	/* A fiber/generator start is a native VmByteCodeExec re-entry, bounded by
+	 * nMaxNativeDepth. Reject HERE, before attaching the frame / mutating VM
+	 * state, so the abort is clean — the wrapper's own check fires only after
+	 * this function has spliced the coroutine into the frame chain, which its
+	 * post-exec detach cannot fully unwind. The PHP call-depth cap belongs to
+	 * OP_CALL only (BYTECODE.md stage 5). */
+	if( VmNativeNestingExceeded(pVm) ){
+		return VmNativeNestingFatal(pVm);
 	}
 	/* Attach the fiber's frame to the VM frame chain */
 	pCtx->pFrame->pParent = pVm->pFrame;
@@ -12814,7 +12863,6 @@ static sxi32 VmStartCtx(ph7_vm *pVm, ph7_exec_ctx *pCtx, ph7_value *pResult)
 	 * Fiber::suspend() at a deeper depth is inside a C->PHP callback and gets a
 	 * FiberError instead of parking across the native frame (stage 4). */
 	pCtx->nBodyExecDepth = pVm->nVmExecDepth + 1;
-	pVm->nRecursionDepth++;
 	/* Execute from the beginning. A GENERATOR FUNCTION's declared return type
 	 * belongs to the call site (always a Generator object, validated at compile
 	 * time — "must be a supertype of Generator"); the body's own return value
@@ -12826,7 +12874,6 @@ static sxi32 VmStartCtx(ph7_vm *pVm, ph7_exec_ctx *pCtx, ph7_value *pResult)
 	rc = VmByteCodeExec(pVm, (VmInstr *)SySetBasePtr(&pCtx->pFunc->aByteCode),
 		pCtx->pStack, -1, &pCtx->sRetValue, 0, FALSE, 0,
 		((pCtx->pFunc->iFlags & VM_FUNC_GENERATOR) == 0 && VmFuncHasReturnType(pCtx->pFunc)) ? pCtx->pFunc : 0, FALSE);
-	pVm->nRecursionDepth--;
 	/* Restore the previous context */
 	pVm->pActiveCtx = pOldCtx;
 	if( rc == PH7_SUSPEND ){
@@ -12864,10 +12911,14 @@ static sxi32 VmResumeCtx(ph7_vm *pVm, ph7_exec_ctx *pCtx, ph7_value *pResumeValu
 	if( pCtx->iState != PH7_CTX_STATE_SUSPENDED ){
 		return SXERR_INVALID;
 	}
-	/* Bound fiber/generator nesting under the same cap; reject before mutating
-	 * VM state so the abort is clean. */
-	if( VmRecursionExceeded(pVm) ){
-		return VmRecursionFatal(pVm);
+	/* A resume is a native VmByteCodeExec re-entry, bounded by nMaxNativeDepth.
+	 * Reject HERE, before re-attaching the (possibly deep) parked segment to the
+	 * frame chain and re-adding its nRecords to nRecursionDepth — a wrapper-level
+	 * abort past those mutations would leave pVm->pFrame pointing into the parked
+	 * callee and the depth accounting un-reverted. The PHP call-depth cap is
+	 * OP_CALL-only (BYTECODE.md stage 5). */
+	if( VmNativeNestingExceeded(pVm) ){
+		return VmNativeNestingFatal(pVm);
 	}
 	/* Push the resume value onto the SUSPENDED activation's operand stack so it
 	 * appears as Fiber::suspend()'s return value. For a deep suspend (stage 4)
@@ -12923,13 +12974,11 @@ static sxi32 VmResumeCtx(ph7_vm *pVm, ph7_exec_ctx *pCtx, ph7_value *pResumeValu
 	pVm->pActiveCtx = pCtx;
 	pCtx->iState = PH7_CTX_STATE_RUNNING;
 	pCtx->nBodyExecDepth = pVm->nVmExecDepth + 1; /* see VmStartCtx */
-	pVm->nRecursionDepth++;
 	/* Resume execution from saved PC. Generator-function bodies skip
 	 * return-type enforcement — see the block comment in VmStartCtx. */
 	rc = VmByteCodeExec(pVm, (VmInstr *)SySetBasePtr(&pCtx->pFunc->aByteCode),
 		pCtx->pStack, pCtx->nTos, &pCtx->sRetValue, 0, FALSE, pCtx->pc,
 		((pCtx->pFunc->iFlags & VM_FUNC_GENERATOR) == 0 && VmFuncHasReturnType(pCtx->pFunc)) ? pCtx->pFunc : 0, FALSE);
-	pVm->nRecursionDepth--;
 	/* Restore the previous context */
 	pVm->pActiveCtx = pOldCtx;
 	if( rc == PH7_SUSPEND ){
@@ -18942,17 +18991,12 @@ static sxi32 VmEvalChunk(
 			/* Assume a null return value */
 			PH7_MemObjInit(pVm,&sResult);
 		}
-		/* Execute the compiled chunk. eval()/include/require recurse in C here,
-		 * a path the OP_CALL cap check can't see; bound it under the same limit
-		 * so a recursive include/eval can't overflow the native stack. */
-		if( VmRecursionExceeded(pVm) ){
-			PH7_MemObjRelease(&sResult);
-			VmRecursionFatal(pVm);
-			goto Cleanup;
-		}
-		pVm->nRecursionDepth++;
+		/* Execute the compiled chunk. eval()/include/require recurse in C here
+		 * (VmLocalExec -> VmByteCodeExec) — a native re-entry bounded by
+		 * nMaxNativeDepth in the wrapper, so a recursive include/eval hits the
+		 * native-nesting fatal instead of overflowing the C stack. The PHP
+		 * call-depth cap is OP_CALL-only (BYTECODE.md stage 5). */
 		VmLocalExec(pVm,&aByteCode,&sResult,FALSE);
-		pVm->nRecursionDepth--;
 		if( pCtx ){
 			/* Set the execution result */
 			ph7_result_value(pCtx,&sResult);

--- a/src/phl/phl.c
+++ b/src/phl/phl.c
@@ -193,7 +193,7 @@ static int Output_Consumer(const void *pOutput,unsigned int nOutputLen,void *pUs
 }
 /*
  * Parse an unsigned-long testing knob from the environment (PHL_MAX_ALLOC /
- * PHL_MAX_INPUT / PHL_MAX_RECURSION). Returns 1 and writes *pOut on a valid,
+ * PHL_MAX_INPUT / PHL_MAX_RECURSION / PHL_MAX_NATIVE_DEPTH). Returns 1 and writes *pOut on a valid,
  * strictly-positive, fully-numeric value clamped to [uFloor, uCeil]; returns
  * 0 (leaving *pOut untouched) when the var is unset, empty, non-numeric, has
  * trailing garbage, or is zero — so a typo like "-1" or "abc" is ignored
@@ -456,15 +456,21 @@ int main(int argc,char **argv)
 	if( rc != PH7_OK ){
 		Fatal("Error while installing the VM output consumer callback");
 	}
-	/* Optional PHP-recursion-depth cap override (PHL_MAX_RECURSION=frames).
-	 * Testing hatch like PHL_MAX_ALLOC: lets the deep-recursion tests
-	 * (tests/ph7/004-deep) run past the conservative host default until the
-	 * BYTECODE.md stage-5 config rework makes the host default unbounded.
-	 * Floor of 3 because PH7_VM_CONFIG_RECURSION_DEPTH ignores nDepth<=2. */
+	/* Optional recursion caps via the environment (like PHL_MAX_ALLOC). The host
+	 * defaults are PHP-parity — PHP call depth is UNBOUNDED (heap-bound) and only
+	 * the native VmByteCodeExec nesting is capped — so these knobs are for tests
+	 * and embedders that want a tighter bound, not to raise a low default.
+	 *   PHL_MAX_RECURSION   -> PH7_VM_CONFIG_RECURSION_DEPTH (PHP call depth; any
+	 *                          positive value is a cap, PHL_EnvULong rejects 0)
+	 *   PHL_MAX_NATIVE_DEPTH -> PH7_VM_CONFIG_NATIVE_DEPTH   (native nesting;
+	 *                          floor 2) */
 	{
 		unsigned long uMax;
-		if( PHL_EnvULong("PHL_MAX_RECURSION",3UL,0x7FFFFFFFUL,&uMax) ){
+		if( PHL_EnvULong("PHL_MAX_RECURSION",1UL,0x7FFFFFFFUL,&uMax) ){
 			ph7_vm_config(pVm,PH7_VM_CONFIG_RECURSION_DEPTH,(int)uMax);
+		}
+		if( PHL_EnvULong("PHL_MAX_NATIVE_DEPTH",2UL,0x7FFFFFFFUL,&uMax) ){
+			ph7_vm_config(pVm,PH7_VM_CONFIG_NATIVE_DEPTH,(int)uMax);
 		}
 	}
 	/* Define PHP_BINARY: absolute path of this interpreter */

--- a/tests/ph7/002-integration/lang/recursion_limit_eval.phpt
+++ b/tests/ph7/002-integration/lang/recursion_limit_eval.phpt
@@ -2,17 +2,24 @@
 SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-Recursion through eval() is bounded by the depth cap (no native-stack overflow)
+Recursion through eval() is bounded by the NATIVE-nesting cap (no native-stack overflow)
+--DESCRIPTION--
+eval()/include/require recurse in C off the main OP_CALL trampoline
+(VmEvalChunk -> VmByteCodeExec), a path the iterative executor never
+flattened. PHP call depth is now unbounded, so what stops a self-eval chain
+from overflowing the native stack is the separate native-nesting cap
+(PH7_VM_CONFIG_NATIVE_DEPTH). Here it is lowered to 32 via PHL_MAX_NATIVE_DEPTH
+so the fatal fires quickly and deterministically. phl-only: an engine-internal
+cap real php does not express.
 --SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+<?php if (function_exists('zend_version')) echo 'skip phl-only: engine-internal native-nesting cap, not expressible in php'; ?>
+--ENV--
+PHL_MAX_NATIVE_DEPTH=32
 --FILE--
 <?php
-// eval()/include/require recurse in C off the main OP_CALL path; without the
-// VmEvalChunk guard a self-eval chain would overflow the native stack and
-// reboot a small-stack embedder. It must instead hit the same cap and halt.
 function r() { eval("r();"); }
 r();
 echo "AFTER\n";
 ?>
 --EXPECTF--
-%s Error:  Maximum recursion depth of %d reached
+%s Error:  Maximum native nesting depth reached

--- a/tests/ph7/002-integration/lang/recursion_limit_fatal.phpt
+++ b/tests/ph7/002-integration/lang/recursion_limit_fatal.phpt
@@ -2,20 +2,28 @@
 SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-Recursion limit raises a clean fatal and halts (not a silent NULL, not a panic)
+A configured PHP call-depth cap raises a clean fatal and halts (not a silent NULL, not a panic)
+--DESCRIPTION--
+The host default is UNBOUNDED (PHP frames are heap-bound since the iterative
+executor — BYTECODE.md stage 5), so this test installs a cap via the
+PHL_MAX_RECURSION knob (-> PH7_VM_CONFIG_RECURSION_DEPTH) and checks that
+exceeding it is a clean, non-catchable fatal that still runs shutdown handlers.
+phl-only: the cap is engine policy real php does not expose the same way.
 --SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+<?php if (function_exists('zend_version')) echo 'skip phl-only: exercises an engine-internal configured PHP-depth cap, not expressible in php'; ?>
+--ENV--
+PHL_MAX_RECURSION=64
 --FILE--
 <?php
-// Unconditional self-recursion trips the depth cap regardless of its value.
-// The old engine silently returned NULL and kept running; it must now raise a
-// fatal and halt — the statement after the call must NOT execute, and a
-// shutdown callback must still run (clean unwind, never a native-stack panic).
+// Unconditional self-recursion trips the configured depth cap. The old engine
+// silently returned NULL and kept running; it must raise a fatal and halt —
+// the statement after the call must NOT execute, and a shutdown callback must
+// still run (clean unwind, never a native-stack panic).
 register_shutdown_function(function () { echo "SHUTDOWN\n"; });
 function g() { g(); }
 g();
 echo "AFTER\n";
 ?>
 --EXPECTF--
-%s Error:  Maximum recursion depth of %d reached
+%s Error:  Maximum recursion depth of 64 reached
 SHUTDOWN

--- a/tests/ph7/002-integration/oo/magic/tostring_recurse.phpt
+++ b/tests/ph7/002-integration/oo/magic/tostring_recurse.phpt
@@ -2,9 +2,17 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-Object __toString recursion limit
+Object __toString infinite recursion hits the native-nesting cap
+--DESCRIPTION--
+A magic method is invoked through a C->PHP callback trampoline (a native
+VmByteCodeExec re-entry), not the OP_CALL trampoline — so unbounded __toString
+recursion is bounded by the native-nesting cap (PH7_VM_CONFIG_NATIVE_DEPTH),
+lowered here to 32 for a fast, deterministic fatal (BYTECODE.md stage 5).
+phl-only: an engine-internal cap real php does not express.
 --SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+<?php if (function_exists('zend_version')) echo 'skip phl-only: engine-internal native-nesting cap, not expressible in php'; ?>
+--ENV--
+PHL_MAX_NATIVE_DEPTH=32
 --FILE--
 <?php
 class A {
@@ -17,7 +25,7 @@ $a = new A();
 echo $a;
 ?>
 --EXPECTF--
-%s Error:  Maximum recursion depth of %d reached
+%s Error:  Maximum native nesting depth reached
 Object
 --CLEAN--
 <?php

--- a/tests/ph7/004-deep/generator_at_10k_depth.phpt
+++ b/tests/ph7/004-deep/generator_at_10k_depth.phpt
@@ -8,7 +8,7 @@ The ctx start/resume native re-entries must be indifferent to PHP call depth:
 the generator body runs as the bottom record of its own dispatch invocation
 while the surrounding 10k frames are heap records.
 --SKIPIF--
-<?php if (!getenv('PHL_MAX_RECURSION')) { echo "skip needs PHL_MAX_RECURSION (run: make test-stress)"; } ?>
+<?php if (function_exists('zend_version')) echo 'skip phl-only deep-recursion probe: depth exceeds the php oracle stack / xdebug nesting limit'; ?>
 --FILE--
 <?php
 function counter(int $from): Generator {

--- a/tests/ph7/004-deep/native_cap_callback.phpt
+++ b/tests/ph7/004-deep/native_cap_callback.phpt
@@ -2,14 +2,15 @@
 SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-Self-recursive C->PHP callback (usort in its own comparator) hits the native-nesting fatal (BYTECODE.md stage 3)
+Self-recursive C->PHP callback (usort in its own comparator) hits the native-nesting fatal at the shipped default (BYTECODE.md stage 5)
 --DESCRIPTION--
 Each C->PHP callback dispatch runs a fresh native VmByteCodeExec; a comparator
 that re-enters the same builtin nests native frames the trampoline does not
-flatten. The native guard must fire cleanly instead of overflowing the C
-stack. phl-only: engine-internal cap fatal.
+flatten. PHP call depth is unbounded by default (stage 5), so the native guard
+is what fires — at its shipped default (256 host, the value proven safe on this
+fattest re-entry path under ASan). phl-only: engine-internal cap fatal.
 --SKIPIF--
-<?php if (!getenv('PHL_MAX_RECURSION')) { echo "skip needs PHL_MAX_RECURSION (run: make test-stress)"; } ?>
+<?php if (function_exists('zend_version')) echo 'skip phl-only: engine-internal native-nesting cap, not expressible in php'; ?>
 --FILE--
 <?php
 function f(int $n): void {

--- a/tests/ph7/004-deep/native_cap_eval.phpt
+++ b/tests/ph7/004-deep/native_cap_eval.phpt
@@ -2,14 +2,16 @@
 SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-Recursive eval() hits the native-nesting fatal, not a C-stack overflow (BYTECODE.md stage 3)
+Recursive eval() hits the native-nesting fatal at the shipped default, not a C-stack overflow (BYTECODE.md stage 5)
 --DESCRIPTION--
 eval/include recurse on the native C stack (VmEvalChunk -> VmByteCodeExec),
-a path the OP_CALL trampoline never flattened. With the PHP-depth cap raised,
-the separate native-nesting guard must stop it cleanly. phl-only: this pins an
-engine-internal cap fatal, which real php cannot express.
+a path the OP_CALL trampoline never flattened. PHP call depth is unbounded by
+default (stage 5), so the separate native-nesting guard is what stops this — at
+its SHIPPED default (256 host), with no env override, proving the default
+protects the C stack. phl-only: this pins an engine-internal cap fatal, which
+real php cannot express.
 --SKIPIF--
-<?php if (!getenv('PHL_MAX_RECURSION')) { echo "skip needs PHL_MAX_RECURSION (run: make test-stress)"; } ?>
+<?php if (function_exists('zend_version')) echo 'skip phl-only: engine-internal native-nesting cap, not expressible in php'; ?>
 --FILE--
 <?php
 function r(int $n): int { return $n === 0 ? 0 : 1 + eval("return r(" . ($n - 1) . ");"); }

--- a/tests/ph7/004-deep/recursion_10k_include.phpt
+++ b/tests/ph7/004-deep/recursion_10k_include.phpt
@@ -9,7 +9,7 @@ PHP recursion inside it must still be heap-bound, and a second 10k descent
 that calls include at the bottom exercises depth accounting across the
 include boundary.
 --SKIPIF--
-<?php if (!getenv('PHL_MAX_RECURSION')) { echo "skip needs PHL_MAX_RECURSION (run: make test-stress)"; } ?>
+<?php if (function_exists('zend_version')) echo 'skip phl-only deep-recursion probe: depth exceeds the php oracle stack / xdebug nesting limit'; ?>
 --FILE--
 <?php
 $inc = __DIR__ . '/recursion_10k_include.inc.tmp.php';

--- a/tests/ph7/004-deep/recursion_20k_mutual.phpt
+++ b/tests/ph7/004-deep/recursion_20k_mutual.phpt
@@ -4,7 +4,7 @@ SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 20k-deep mutual recursion (function <-> method <-> closure) completes (BYTECODE.md stage 3)
 --SKIPIF--
-<?php if (!getenv('PHL_MAX_RECURSION')) { echo "skip needs PHL_MAX_RECURSION (run: make test-stress)"; } ?>
+<?php if (function_exists('zend_version')) echo 'skip phl-only deep-recursion probe: depth exceeds the php oracle stack / xdebug nesting limit'; ?>
 --FILE--
 <?php
 class Hop {

--- a/tests/ph7/004-deep/recursion_50k_plain.phpt
+++ b/tests/ph7/004-deep/recursion_50k_plain.phpt
@@ -4,11 +4,13 @@ SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 50k-deep linear recursion completes on the heap (iterative executor; BYTECODE.md stage 3)
 --DESCRIPTION--
-Runs under PHL_MAX_RECURSION (set by `make test-stress` for this directory).
-Before the trampoline this depth overflowed the native stack at ~7.7k frames;
-now PHP call frames are heap records and depth is a policy knob.
+Runs at the stock uncapped host default (BYTECODE.md stage 5; the deep tier no
+longer needs PHL_MAX_RECURSION). Before the trampoline this depth overflowed the
+native stack at ~7.7k frames; now PHP call frames are heap records and depth is
+memory-bound. phl-only: this depth trips the php oracle's stack / xdebug
+max_nesting_level (256), so it cannot be asserted cross-engine.
 --SKIPIF--
-<?php if (!getenv('PHL_MAX_RECURSION')) { echo "skip needs PHL_MAX_RECURSION (run: make test-stress)"; } ?>
+<?php if (function_exists('zend_version')) echo 'skip phl-only deep-recursion probe: depth exceeds the php oracle stack / xdebug nesting limit'; ?>
 --FILE--
 <?php
 function down(int $n, int $acc): int {

--- a/tests/ph7/004-deep/throw_50k_finally_tower.phpt
+++ b/tests/ph7/004-deep/throw_50k_finally_tower.phpt
@@ -8,7 +8,7 @@ Every level opens its own try/finally (per-activation exception state, stage
 2b); the throw at the bottom must run each level's finally exactly once on
 the way out and reach the catch with the counter intact.
 --SKIPIF--
-<?php if (!getenv('PHL_MAX_RECURSION')) { echo "skip needs PHL_MAX_RECURSION (run: make test-stress)"; } ?>
+<?php if (function_exists('zend_version')) echo 'skip phl-only deep-recursion probe: depth exceeds the php oracle stack / xdebug nesting limit'; ?>
 --FILE--
 <?php
 $finallys = 0;

--- a/tests/phpt.php
+++ b/tests/phpt.php
@@ -11,7 +11,7 @@
 $phpt_valid_sections = array('test', 'description', 'credits', 'skipif', 'file', 'expect', 'expectf', 'expectregex', 'clean', 'post', 'post_raw', 'get', 'cookie', 'stdin', 'ini', 'args', 'env');
 
 // Unimplemented section types
-$phpt_not_implemented = array('post', 'post_raw', 'get', 'cookie', 'stdin', 'ini', 'args', 'env', 'expectregex');
+$phpt_not_implemented = array('post', 'post_raw', 'get', 'cookie', 'stdin', 'ini', 'args', 'expectregex');
 
 // Default values
 $phpt_target_executable = "";
@@ -334,14 +334,51 @@ function match_expectf_pattern($phpt_pattern, $phpt_output) {
     return true;
 }
 
+// Parse an --ENV-- section into an ordered map of KEY => VALUE. Each non-empty
+// line is "KEY=VALUE" (VALUE may be empty); blank lines are ignored.
+function parse_env_section($phpt_env_text) {
+    $phpt_env = array();
+    foreach (explode("\n", $phpt_env_text) as $phpt_env_line) {
+        $phpt_env_line = trim($phpt_env_line);
+        if ($phpt_env_line === '' || strpos($phpt_env_line, '=') === false) {
+            continue;
+        }
+        list($phpt_env_key, $phpt_env_val) = explode('=', $phpt_env_line, 2);
+        // Trim both sides: `KEY = 32` is a common way to write the section, and a
+        // stray space would otherwise reach the child as a value like " 32".
+        $phpt_env[trim($phpt_env_key)] = trim($phpt_env_val);
+    }
+    return $phpt_env;
+}
+
+// Build the platform-appropriate command prefix that exports $env for a child
+// process (used for --ENV-- support). Values are quoted; keys are assumed sane.
+function build_env_prefix($phpt_env) {
+    // The runner is self-hosted under phl, so avoid escapeshellarg() (not a phl
+    // builtin) and quote POSIX values by hand: wrap in single quotes, closing +
+    // escaping any embedded quote.
+    $phpt_prefix = '';
+    foreach ($phpt_env as $phpt_env_key => $phpt_env_val) {
+        if (PHP_OS === 'WINNT') {
+            // set "KEY=VAL"&& — the quotes bound the value so a trailing space
+            // before && is NOT captured into it (cmd.exe would otherwise keep it).
+            $phpt_prefix .= 'set "' . $phpt_env_key . '=' . $phpt_env_val . '"&& ';
+        } else {
+            $phpt_quoted = "'" . str_replace("'", "'\\''", $phpt_env_val) . "'";
+            $phpt_prefix .= $phpt_env_key . '=' . $phpt_quoted . ' ';
+        }
+    }
+    return $phpt_prefix;
+}
+
 // Run a PHPT section file through an external target executable
 // Returns the combined stdout/stderr output as string, or false if popen() failed
-function run_file_with_target($phpt_target_executable, $phpt_file) {
-    if (PHP_OS === 'WINNT') {
-        $cmd = "set PHPT_TARGET_EXECUTABLE=" . $phpt_target_executable . " && ";
-    } else {
-        $cmd = 'PHPT_TARGET_EXECUTABLE=' . $phpt_target_executable . ' ';
-    }
+function run_file_with_target($phpt_target_executable, $phpt_file, $phpt_env = array()) {
+    // Export PHPT_TARGET_EXECUTABLE through the same per-OS, value-quoting path as
+    // the --ENV-- vars (build_env_prefix) so a target path containing a space is
+    // quoted too. The '+' keeps PHPT_TARGET_EXECUTABLE ahead of any --ENV-- vars.
+    $phpt_full_env = array('PHPT_TARGET_EXECUTABLE' => $phpt_target_executable) + $phpt_env;
+    $cmd = build_env_prefix($phpt_full_env);
     $cmd .= '"' . $phpt_target_executable . '" "' . $phpt_file . '" 2>&1';
     $fp = popen($cmd, 'r');
     if ($fp === false) {
@@ -388,6 +425,16 @@ $phpt_failures = array();
 foreach ($phpt_files as $phpt_file) {
     $phpt_sections = parse_phpt_sections($phpt_file, $phpt_valid_sections);
 
+    // Optional --ENV-- section: extra environment for the target CHILD process.
+    // Only meaningful with --target-executable: it is exported via the command
+    // prefix so a fresh child reads it at startup. In-process (@include) runs
+    // share the runner's own already-started VM, so env cannot be applied there
+    // (phl's putenv can't unset for a clean restore, and startup-read knobs like
+    // PHL_MAX_* would not re-read) — such tests are skipped below rather than
+    // run with the env silently dropped.
+    $phpt_env = isset($phpt_sections['env']) ? parse_env_section($phpt_sections['env']) : array();
+    $phpt_env_unsupported = (!empty($phpt_env) && empty($phpt_target_executable));
+
     // Write sections to disk
     if (isset($phpt_sections['file'])) {
         $phpt_file_path = $phpt_file . '.file';
@@ -407,10 +454,14 @@ foreach ($phpt_files as $phpt_file) {
 
     // SKIPIF check
     $phpt_skip = false;
-    if (isset($phpt_sections['skipif'])) {
+    if ($phpt_env_unsupported) {
+        // --ENV-- is only honored for a fresh child process (see the parse note);
+        // skip rather than run in-process with the env silently dropped.
+        $phpt_skip = true;
+    } elseif (isset($phpt_sections['skipif'])) {
         $phpt_skipif_path = $phpt_file . '.skipif';
         if (!empty($phpt_target_executable)) {
-            $phpt_skip_output = run_file_with_target($phpt_target_executable, $phpt_skipif_path);
+            $phpt_skip_output = run_file_with_target($phpt_target_executable, $phpt_skipif_path, $phpt_env);
             if ($phpt_skip_output === false) {
                 echo "# ERROR: Failed to spawn skipif for $phpt_skipif_path\n";
                 $phpt_skip_output = '';
@@ -464,7 +515,7 @@ foreach ($phpt_files as $phpt_file) {
             // Test execution
             $phpt_file_path = $phpt_file . '.file';
             if (!empty($phpt_target_executable)) {
-                $phpt_output = run_file_with_target($phpt_target_executable, $phpt_file_path);
+                $phpt_output = run_file_with_target($phpt_target_executable, $phpt_file_path, $phpt_env);
                 if ($phpt_output === false) {
                     echo "# ERROR: Failed to spawn test for $phpt_file_path\n";
                     $phpt_output = "";
@@ -528,7 +579,7 @@ foreach ($phpt_files as $phpt_file) {
     if (isset($phpt_sections['clean']) && $phpt_skip === false) {
         $phpt_clean_path = $phpt_file . '.clean';
         if (!empty($phpt_target_executable)) {
-            $phpt_clean_output = run_file_with_target($phpt_target_executable, $phpt_clean_path);
+            $phpt_clean_output = run_file_with_target($phpt_target_executable, $phpt_clean_path, $phpt_env);
             if ($phpt_clean_output === false) {
                 echo "# ERROR: Failed to spawn clean for $phpt_clean_path\n";
             }


### PR DESCRIPTION
The single recursion counter becomes two independent guards with PHP-parity defaults, now that PHP->PHP calls run iteratively (stage 2 trampoline):

- PHP call depth (nRecursionDepth/nMaxDepth) is checked at OP_CALL push only. Host default is UNBOUNDED (0) — recursion is heap/memory-bound like the main PHP engine; small-stack embedders keep a bounded 512 default. The redundant checks + body-level increments in VmStartCtx/VmResumeCtx/eval are removed (those are native re-entries; the parked-segment nRecords accounting stays). PH7_VM_CONFIG_RECURSION_DEPTH accepts any nDepth >= 0 (0 = unbounded).
- Native VmByteCodeExec nesting (nVmExecDepth/new nMaxNativeDepth, default 256 host / 16 embedded) is now the sole C-stack guard for the re-entries the trampoline does not flatten (eval/include, C->PHP callbacks, coroutine start/resume), configurable via the new PH7_VM_CONFIG_NATIVE_DEPTH verb. A shared VmNativeNestingExceeded() predicate mirrors VmRecursionExceeded.

phl.c keeps PHL_MAX_RECURSION (now lowers rather than raises) and adds PHL_MAX_NATIVE_DEPTH. tests/phpt.php gains child-process --ENV-- support (external-only: in-process is skipped, since phl's putenv can't unset and startup-read knobs can't be reconfigured mid-run). Recursion tests reworked to exercise the configured PHP cap and the native cap; deep-tier SKIPIFs made reasoned; Makefile deep tier runs at the stock uncapped default.

Includes two adversarial-review rounds: restored a clean abort-before-mutation guard on the deep fiber-resume path (native cap firing inside the wrapper after frame-chain splice was a UAF), bounded the embedded PHP-depth default, honored small configured caps, and corrected the --ENV-- runner handling.

Full compat matrix green (smoke 2239 x2, integration 842 x2, stress 13, deep 7); docker ASan+UBSan over deep + integration + stress clean.
