### PR TITLE
Recycle operand stacks across same-size calls

### DIFF
--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1052,6 +1052,14 @@ struct ph7_vm
 	                            * them skips a pool alloc/free round-trip per PHP
 	                            * call (the measured trampoline overhead). Backing
 	                            * memory is allocator-owned; freed wholesale. */
+	void *pIdleOperandStacks;  /* Freelist of recycled operand-stack buffers (BYTECODE
+	                            * stage 7): a returning PHP call recycles its (tight-sized)
+	                            * operand stack here instead of freeing it, so a same-size
+	                            * call (recursion / a hot call loop) reuses it — skipping
+	                            * the buffer alloc AND the per-slot init. LIFO, exact-size
+	                            * head match, capped length; buffers are plain allocator
+	                            * blocks so cold/suspend/abort paths can still raw-free them. */
+	int nIdleOperandStacks;    /* Length of pIdleOperandStacks (cap: VM_STACK_POOL_MAX) */
 	int nObDepth;              /* OB depth */
 	int nExceptDepth;          /* Exception depth */
 	int closure_cnt;           /* Loaded closures counter */

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -2004,6 +2004,8 @@ PH7_PRIVATE sxi32 PH7_VmInit(
 	SyHashInit(&pVm->hTypedSlot,&pVm->sAllocator,0,0);
 	SySetInit(&pVm->aException,&pVm->sAllocator,sizeof(ph7_exception *));
 	pVm->pIdleCallFrames = 0;
+	pVm->pIdleOperandStacks = 0;
+	pVm->nIdleOperandStacks = 0;
 	SySetInit(&pVm->aFinallyAction,&pVm->sAllocator,sizeof(VmFinallyAction));
 	pVm->bInlineTryCatch = 1; /* ROOT C: enable inline generator try/catch/finally */
 	pVm->pPendingException = 0;
@@ -2396,6 +2398,85 @@ static ph7_value * VmNewOperandStack(
 	}
 	/* Ready for bytecode execution */
 	return pStack;
+}
+/*
+ * Operand-stack recycling (BYTECODE.md stage 7).
+ *
+ * After tight sizing, a PHP call still allocates + inits an operand stack on the
+ * way in and frees it on the way out. For recursion and hot call loops the freed
+ * stack is exactly the size the next call needs, so instead of freeing it at the
+ * normal OP_CALL return (VmCallFinish) we park it on a small per-VM freelist and
+ * hand it back to the next same-size call — skipping the buffer allocation and
+ * the per-slot PH7_MemObjInit.
+ *
+ * The freelist holds plain allocator blocks (no header): a parked buffer is just
+ * a ph7_value array whose slots were all released at recycle time, so it is
+ * clean to reuse, cannot leak a stale value, and can still be raw-freed by the
+ * cold/suspend/abort paths that never route through here. Head-only exact-size
+ * match keeps it O(1) and memory-tight (a mismatched size allocates fresh rather
+ * than over-allocating — deep recursion, whose freelist is empty during descent,
+ * is unaffected). Length is capped so the pool can't grow without bound.
+ */
+typedef struct VmIdleStack VmIdleStack;
+struct VmIdleStack {
+	ph7_value *pStack;   /* Parked buffer (nCap slots, all released) */
+	sxu32 nCap;          /* Its allocated slot count (VmNewOperandStack size) */
+	VmIdleStack *pNext;  /* LIFO link */
+};
+#define VM_STACK_POOL_MAX 64      /* max buffers parked at once */
+#define VM_STACK_POOL_MAXSLOTS 512 /* only pool buffers this small — bounds pool memory
+                                    * (a large fallback-sized stack recursing would
+                                    * otherwise park up to VM_STACK_POOL_MAX huge buffers;
+                                    * the tight-sized hot case is far below this) */
+/*
+ * Allocate an operand stack of nSlots (+ VM_STACK_GUARD) usable slots, reusing a
+ * parked same-size buffer when one is available (its slots are already clean).
+ */
+static ph7_value * VmOperandStackAlloc(ph7_vm *pVm, sxu32 nSlots)
+{
+	VmIdleStack *pIdle = (VmIdleStack *)pVm->pIdleOperandStacks;
+	sxu32 nCap = nSlots + VM_STACK_GUARD;
+	if( pIdle && pIdle->nCap == nCap ){
+		ph7_value *pStack = pIdle->pStack;
+		pVm->pIdleOperandStacks = pIdle->pNext;
+		pVm->nIdleOperandStacks--;
+		SyMemBackendPoolFree(&pVm->sAllocator,pIdle);
+		return pStack; /* slots already released -> reusable without re-init */
+	}
+	return VmNewOperandStack(&(*pVm),nSlots);
+}
+/*
+ * Return an operand stack to the freelist (or free it if the pool is full).
+ * nCap is its full allocated slot count (== the VmNewOperandStack size). Every
+ * slot is released so the parked buffer is clean for reuse and never retains a
+ * live value.
+ */
+static void VmOperandStackRecycle(ph7_vm *pVm, ph7_value *pStack, sxu32 nCap)
+{
+	VmIdleStack *pIdle;
+	sxu32 i;
+	if( pStack == 0 ){
+		return;
+	}
+	if( pVm->nIdleOperandStacks >= VM_STACK_POOL_MAX || nCap > VM_STACK_POOL_MAXSLOTS
+	 || (pIdle = (VmIdleStack *)SyMemBackendPoolAlloc(&pVm->sAllocator,sizeof(VmIdleStack))) == 0 ){
+		SyMemBackendFree(&pVm->sAllocator,pStack);
+		return;
+	}
+	for( i = 0; i < nCap; i++ ){
+		PH7_MemObjRelease(&pStack[i]);
+		/* Reset the global-slot index to the "temporary / not a variable" marker.
+		 * A released slot is already reusable (the dispatch reuses released slots
+		 * mid-call, and every push sets nIdx before the slot is read), but marking
+		 * it here means a stale index can never masquerade as a live variable slot
+		 * across invocations — cheap defense in depth. */
+		pStack[i].nIdx = SXU32_HIGH;
+	}
+	pIdle->pStack = pStack;
+	pIdle->nCap = nCap;
+	pIdle->pNext = (VmIdleStack *)pVm->pIdleOperandStacks;
+	pVm->pIdleOperandStacks = pIdle;
+	pVm->nIdleOperandStacks++;
 }
 /* Forward declaration */
 static sxi32 VmRegisterSpecialFunction(ph7_vm *pVm);
@@ -5878,9 +5959,13 @@ static sxi32 VmCallFinish(ph7_vm *pVm,VmExecState *pCaller,VmCallRecord *pCallee
 			}
 		}
 	}
-	/* Free the operand stack (NULL when function body was skipped) */
+	/* Recycle the operand stack for the next same-size call (BYTECODE stage 7),
+	 * or free it if the pool is full. Its allocated size is the callee's cached
+	 * nMaxStack + VM_STACK_GUARD — exactly what VmOperandStackAlloc handed out.
+	 * (NULL when the function body was skipped.) */
 	if( pCallee->pFrameStack ){
-		SyMemBackendFree(&pVm->sAllocator,pCallee->pFrameStack);
+		VmOperandStackRecycle(pVm,pCallee->pFrameStack,
+			pCallee->pVmFunc->nMaxStack + VM_STACK_GUARD);
 	}
 	/* Leave the frame */
 	VmLeaveFrame(&(*pVm));
@@ -12384,7 +12469,7 @@ case PH7_OP_CALL: {
 				if( nSlots == 0 ){ nSlots = 1; } /* a 0-depth body still needs a valid, nonzero cache marker */
 				pVmFunc->nMaxStack = nSlots;
 			}
-			pFrameStack = VmNewOperandStack(&(*pVm),nSlots);
+			pFrameStack = VmOperandStackAlloc(&(*pVm),nSlots);
 		}
 		if( pFrameStack == 0 ){
 			/* Raise exception: Out of memory */


### PR DESCRIPTION
Follow-on to sizing work. Even tight-sized, a call's operand stack is big enough (~1.5 KB) that its per-call alloc/free falls through the pool allocator to a real malloc/free — the dominant remaining call-path cost.

Add a small per-VM freelist (pVm->pIdleOperandStacks): the normal OP_CALL return (VmCallFinish) recycles its operand stack instead of freeing it, and the next same-size call reuses it, skipping the malloc and the per-slot init. LIFO, exact-size head match, capped at 64 buffers of <=512 slots. Recursion and hot call loops reuse ~every time; deep recursion is unaffected (nothing frees during descent, so the pool is empty at peak depth — the sizing memory win is preserved); mismatched sizes allocate fresh (never worse than baseline).

Safety (pooling changes operand-stack lifetime): a recycled buffer is a plain allocator block (no header), so cold/suspend/abort/callback paths still raw-free it; at recycle every slot is PH7_MemObjRelease'd (idempotent - slots are already drained on normal and unwind paths) and nIdx is reset to the temp marker, so a reused buffer is byte-equivalent to a fresh one and can never retain a live value or a stale variable index. nMaxStack is write-once, so the recycle nCap always equals the buffer's true capacity. Parked (suspended-fiber) stacks are never recycled.

fib(28) 1.61 s -> 0.94 s (best-of-5), 2.33x faster than pre-stage-7. Full matrix byte-identical (smoke 2239 x2, integ 842 x2, stress 13, deep 7); all tiers ASan+UBSan clean; a dedicated adversarial lifetime review found no defect.
