### PR TITLE
Code-quality polish for the iterative VM changes

### DIFF
--- a/src/ph7/ph7.h
+++ b/src/ph7/ph7.h
@@ -201,7 +201,7 @@ typedef int (*ph7_clock)(void *pUserData, ph7_int64 *pSec, ph7_int64 *pUsec);
 #define PH7_VM_CONFIG_OUTPUT           1  /* TWO ARGUMENTS: int (*xConsumer)(const void *pOut,unsigned int nLen,void *pUserData),void *pUserData */
 #define PH7_VM_CONFIG_IMPORT_PATH      3  /* ONE ARGUMENT: const char *zIncludePath */
 #define PH7_VM_CONFIG_ERR_REPORT       4  /* NO ARGUMENTS: Report all run-time errors in the VM output */
-#define PH7_VM_CONFIG_RECURSION_DEPTH  5  /* ONE ARGUMENT: int nMaxDepth (PHP call depth; 0 = unbounded, the default) */
+#define PH7_VM_CONFIG_RECURSION_DEPTH  5  /* ONE ARGUMENT: int nMaxDepth (PHP call depth; 0 = unbounded; default 0 host / 512 embedded) */
 #define PH7_VM_OUTPUT_LENGTH           6  /* ONE ARGUMENT: unsigned int *pLength */
 #define PH7_VM_CONFIG_CREATE_SUPER     7  /* TWO ARGUMENTS: const char *zName,ph7_value *pValue */
 #define PH7_VM_CONFIG_CREATE_VAR       8  /* TWO ARGUMENTS: const char *zName,ph7_value *pValue */

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -657,7 +657,7 @@ struct ph7_vm_func
 	SySet aReturnUnion;  /* Return-type union alternatives (ph7_type_alt). Empty unless union return. */
 	SyString sReturnTypeName; /* Original return-type text for error messages, in canonical PHP order */
 	sxu8 bStrictTypes;   /* 1 if defining file declared strict_types=1 (governs return-value coercion) */
-	sxu32 nMaxStack;     /* Cached operand-stack depth for this body (BYTECODE.md stage 7):
+	sxu32 nMaxStack;     /* Cached operand-stack depth for this body (BYTECODE stage 7):
 						  * 0 = not yet computed; otherwise the number of slots to allocate
 						  * per call (a tight bound from VmComputeMaxStack, or the whole
 						  * instruction count when the body is not statically modelable). */

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -2224,14 +2224,24 @@ static void VmTrackOutput(ph7_vm *pVm, sxu32 nLen)
  *   - Control flow follows real edges (JMP/JZ/JNZ + the fused comparison-branch
  *     forms). An out-of-range jump, a negative height, or a height exceeding the
  *     instruction-count bound -> fallback.
- *   - VM_STACK_GUARD slack is still added by VmNewOperandStack on top of the
- *     returned depth, and the full corpus runs under ASan (which catches any
- *     undersize as a heap-buffer-overflow) as the standing validation.
+ *   - VM_STACK_GUARD slack is still added by the operand-stack allocator on top
+ *     of the returned depth, and the full corpus runs under ASan (which catches
+ *     any undersize as a heap-buffer-overflow) as the standing validation.
  *
  * The exception-resume `pc =` reassignments inside some modeled handlers
  * (STORE/CALL/DONE/comparisons) only fire when this activation OWNS a catch
  * frame — impossible in a modeled body, since OP_LOAD_EXCEPTION is unmodeled and
  * forces fallback — so they are dead in analyzed bodies and need no edge.
+ *
+ * Drift safety (for whoever adds an opcode or changes a handler's stack effect):
+ * VmInstrStackEffect is a hand-maintained model that must stay in sync with the
+ * real handlers. Two things keep a drift from becoming a silent undersize: a NEW
+ * opcode is unmodeled by default (its `default:` return forces the safe
+ * instruction-count bound), so only *changing a modeled opcode's real pop count*
+ * to exceed its popmin can undersize — and that is caught deterministically by
+ * the standing ASan-over-corpus run (an undersize is a heap-buffer-overflow on
+ * the operand stack). When touching a modeled handler's push/pop, re-check its
+ * entry here.
  */
 #define VM_STACK_UNMODELED SXU32_HIGH
 /*
@@ -2315,6 +2325,7 @@ static int VmInstrStackEffect(VmInstr *pI, sxu32 pc, int *pPush, int *pN, sxu32 
  */
 static sxu32 VmComputeMaxStack(ph7_vm *pVm, VmInstr *aInstr, sxu32 nInstr)
 {
+	void *pScratch;
 	sxi32 *aH; sxu32 *aQ; unsigned char *aIn;
 	sxu32 nQ, i, nIter, nCap;
 	sxi32 iMax;
@@ -2330,15 +2341,16 @@ static sxu32 VmComputeMaxStack(ph7_vm *pVm, VmInstr *aInstr, sxu32 nInstr)
 			return VM_STACK_UNMODELED;
 		}
 	}
-	aH  = (sxi32 *)SyMemBackendAlloc(&pVm->sAllocator, nInstr * sizeof(sxi32));
-	aQ  = (sxu32 *)SyMemBackendAlloc(&pVm->sAllocator, nInstr * sizeof(sxu32));
-	aIn = (unsigned char *)SyMemBackendAlloc(&pVm->sAllocator, nInstr);
-	if( aH == 0 || aQ == 0 || aIn == 0 ){
-		if( aH ){ SyMemBackendFree(&pVm->sAllocator, aH); }
-		if( aQ ){ SyMemBackendFree(&pVm->sAllocator, aQ); }
-		if( aIn ){ SyMemBackendFree(&pVm->sAllocator, aIn); }
+	/* aH (entry height per pc), aQ (worklist), aIn (queued flag) share one lifetime
+	 * and count -> one allocation, carved into three regions with the 4-byte arrays
+	 * first (the byte array last needs no alignment). */
+	pScratch = SyMemBackendAlloc(&pVm->sAllocator, nInstr * (sizeof(sxi32) + sizeof(sxu32) + 1));
+	if( pScratch == 0 ){
 		return VM_STACK_UNMODELED;
 	}
+	aH  = (sxi32 *)pScratch;
+	aQ  = (sxu32 *)(aH + nInstr);
+	aIn = (unsigned char *)(aQ + nInstr);
 	for( i = 0; i < nInstr; i++ ){ aH[i] = -1; aIn[i] = 0; }
 	aH[0] = 0; aQ[0] = 0; aIn[0] = 1; nQ = 1; iMax = 0;
 	nIter = 0; nCap = nInstr * 16 + 1024; /* convergence backstop (fallback if hit) */
@@ -2362,9 +2374,7 @@ static sxu32 VmComputeMaxStack(ph7_vm *pVm, VmInstr *aInstr, sxu32 nInstr)
 		}
 		if( iMax < 0 ){ break; }
 	}
-	SyMemBackendFree(&pVm->sAllocator, aH);
-	SyMemBackendFree(&pVm->sAllocator, aQ);
-	SyMemBackendFree(&pVm->sAllocator, aIn);
+	SyMemBackendFree(&pVm->sAllocator, pScratch);
 	return ( iMax < 0 ) ? VM_STACK_UNMODELED : (sxu32)iMax;
 }
 /*
@@ -2372,6 +2382,11 @@ static sxu32 VmComputeMaxStack(ph7_vm *pVm, VmInstr *aInstr, sxu32 nInstr)
  * our compiled PHP program.
  * Return a pointer to the operand stack (array of ph7_values)
  * on success. NULL (Fatal error) on failure.
+ *
+ * This is the RAW allocator (always mallocs + inits nInstr + VM_STACK_GUARD
+ * slots). The OP_CALL hot path goes through VmOperandStackAlloc, which recycles a
+ * parked buffer when it can and falls back to this; the other entries (top-level,
+ * eval, coroutine, callbacks) call this directly.
  */
 static ph7_value * VmNewOperandStack(
 	ph7_vm *pVm, /* Target VM */
@@ -2416,6 +2431,12 @@ static ph7_value * VmNewOperandStack(
  * match keeps it O(1) and memory-tight (a mismatched size allocates fresh rather
  * than over-allocating — deep recursion, whose freelist is empty during descent,
  * is unaffected). Length is capped so the pool can't grow without bound.
+ *
+ * The head-only match is tuned for the design target (recursion / a hot loop
+ * calling one function — one size, ~total reuse). An alternating-size pattern
+ * (a() then b() with different depths, repeatedly) never matches the head, so it
+ * degrades to a fresh allocation every call — same as no pool, never worse; the
+ * recursion case is the one worth the O(1) simplicity.
  */
 typedef struct VmIdleStack VmIdleStack;
 struct VmIdleStack {
@@ -12454,11 +12475,18 @@ case PH7_OP_CALL: {
 		 */
 		PH7_MemObjRelease(pTos);
 		pTos = &pTos[-nCallArgs];
-		/* Allocate a new operand stack and evaluate the function body. Size it to
-		 * a tight static bound when the body is statically modelable (BYTECODE.md
-		 * stage 7) — the big memory win for deep recursion, where one such stack
-		 * lives per frame — falling back to the safe instruction-count bound
-		 * otherwise. The bound is computed once and cached on the func. */
+		/* Allocate an operand stack (via the recycling allocator) and evaluate the
+		 * function body. Size it to a tight static bound when the body is statically
+		 * modelable (BYTECODE.md stage 7) — the big memory win for deep recursion,
+		 * where one such stack lives per frame — falling back to the safe
+		 * instruction-count bound otherwise.
+		 *
+		 * The bound is computed LAZILY on the first call and cached on the func
+		 * (nMaxStack == 0 = not yet computed). Deliberately not a compile-time pass:
+		 * self-computing on first use is fail-safe against any body-creation path
+		 * (an uncomputed body just computes, never uses a wrong 0 -> undersize),
+		 * where undersizing is a heap overflow; the amortized cost is one analysis
+		 * per function. */
 		{
 			sxu32 nSlots = pVmFunc->nMaxStack;
 			if( nSlots == 0 ){

--- a/src/phl/phl.c
+++ b/src/phl/phl.c
@@ -193,8 +193,9 @@ static int Output_Consumer(const void *pOutput,unsigned int nOutputLen,void *pUs
 }
 /*
  * Parse an unsigned-long testing knob from the environment (PHL_MAX_ALLOC /
- * PHL_MAX_INPUT / PHL_MAX_RECURSION / PHL_MAX_NATIVE_DEPTH). Returns 1 and writes *pOut on a valid,
- * strictly-positive, fully-numeric value clamped to [uFloor, uCeil]; returns
+ * PHL_MAX_INPUT / PHL_MAX_RECURSION / PHL_MAX_NATIVE_DEPTH). Returns 1 and writes
+ * *pOut on a valid, strictly-positive, fully-numeric value clamped to
+ * [uFloor, uCeil]; returns
  * 0 (leaving *pOut untouched) when the var is unset, empty, non-numeric, has
  * trailing garbage, or is zero — so a typo like "-1" or "abc" is ignored
  * rather than silently reinterpreted (strtoul would wrap "-1" to ULONG_MAX).

--- a/tests/ph7/002-integration/lang/recursion_limit_eval.phpt
+++ b/tests/ph7/002-integration/lang/recursion_limit_eval.phpt
@@ -9,8 +9,11 @@ eval()/include/require recurse in C off the main OP_CALL trampoline
 flattened. PHP call depth is now unbounded, so what stops a self-eval chain
 from overflowing the native stack is the separate native-nesting cap
 (PH7_VM_CONFIG_NATIVE_DEPTH). Here it is lowered to 32 via PHL_MAX_NATIVE_DEPTH
-so the fatal fires quickly and deterministically. phl-only: an engine-internal
-cap real php does not express.
+so the fatal fires quickly and deterministically. This pins the CONFIG-KNOB path
+(PHL_MAX_NATIVE_DEPTH -> PH7_VM_CONFIG_NATIVE_DEPTH); its deep-tier sibling
+tests/ph7/004-deep/native_cap_eval.phpt pins the same fatal at the SHIPPED
+default (256, no env) — the pair is deliberate, not redundant. phl-only: an
+engine-internal cap real php does not express.
 --SKIPIF--
 <?php if (function_exists('zend_version')) echo 'skip phl-only: engine-internal native-nesting cap, not expressible in php'; ?>
 --ENV--

--- a/tests/ph7/004-deep/native_cap_eval.phpt
+++ b/tests/ph7/004-deep/native_cap_eval.phpt
@@ -8,8 +8,10 @@ eval/include recurse on the native C stack (VmEvalChunk -> VmByteCodeExec),
 a path the OP_CALL trampoline never flattened. PHP call depth is unbounded by
 default (stage 5), so the separate native-nesting guard is what stops this — at
 its SHIPPED default (256 host), with no env override, proving the default
-protects the C stack. phl-only: this pins an engine-internal cap fatal, which
-real php cannot express.
+protects the C stack. Its integration sibling
+tests/ph7/002-integration/lang/recursion_limit_eval.phpt pins the same fatal via
+the PHL_MAX_NATIVE_DEPTH config knob — the pair is deliberate, not redundant.
+phl-only: this pins an engine-internal cap fatal, which real php cannot express.
 --SKIPIF--
 <?php if (function_exists('zend_version')) echo 'skip phl-only: engine-internal native-nesting cap, not expressible in php'; ?>
 --FILE--


### PR DESCRIPTION
Quality-only pass (no behavior change) from a three-angle review of the session's changes:

- VmComputeMaxStack: collapse the three scratch arrays (aH/aQ/aIn) into one allocation carved into three regions — one alloc/free instead of three, and drop the 3-way OOM-cleanup ladder. Matches the codebase's single-block scratch idiom; behaviorally identical (ASan-verified).
- Comments/accuracy: document the operand-stack drift-safety model (new opcodes are unmodeled by default -> safe fallback; ASan-over-corpus is the standing guard for a changed handler); document why nMaxStack is computed lazily rather than at compile time (fail-safe self-compute vs a missed body-creation path undersizing); note VmNewOperandStack is the raw allocator behind the recycling VmOperandStackAlloc; note the freelist's head-only alternating-size limitation.
- Docs: PH7_VM_CONFIG_RECURSION_DEPTH now records the embedded default (512), not just the host 0; re-wrap the over-long PHL_EnvULong comment; normalize a BYTECODE reference.
- Tests: cross-reference the recursion_limit_eval (config-knob path) and native_cap_eval (shipped-default path) pair so the deliberate split reads as intentional, not redundant.

Full matrix green (smoke 2239 x2, integ 842 x2, stress 13, deep 7); ASan+UBSan (integration + deep) clean.
