### PR TITLE
Forward named arguments through call_user_func / call_user_func_array

### DIFF
--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -5,9 +5,8 @@
  */
 #include "ph7int.h"
 /* This file implement generic hashmaps known as 'array' in the PHP world */
-/* Allowed node types */
-#define HASHMAP_INT_NODE   1  /* Node with an int [i.e: 64-bit integer] key */
-#define HASHMAP_BLOB_NODE  2  /* Node with a string/BLOB key */
+/* HASHMAP_INT_NODE / HASHMAP_BLOB_NODE (node key types) are declared in ph7int.h
+ * alongside ph7_hashmap_node so name-forwarding builtins can classify keys. */
 /* Node control flags */
 #define HASHMAP_NODE_FOREIGN_OBJ 0x001 /* Node hold a reference to a foreign ph7_value
                                         * [i.e: array(&var)/$a[] =& $var ]

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -200,6 +200,7 @@ struct ph7_user_func
  * instance of this structure is the first argument to the routines used
  * implement the foreign functions.
  */
+typedef struct VmCallArgMap VmCallArgMap; /* Forward decl; full definition below. */
 struct ph7_context
 {
 	ph7_user_func *pFunc;   /* Function information. */
@@ -212,11 +213,17 @@ struct ph7_context
 							 */
 	ph7_vm *pVm;            /* Virtual machine that own this context */
 	sxi32 iFlags;           /* Call flags */
+	VmCallArgMap *pArgMap;  /* Call-site named-argument map (or 0). Lets a builtin
+	                         * such as call_user_func forward its callers' name:
+	                         * arguments to the inner callback. */
 };
 /*
  * Each hashmap entry [i.e: array(4,5,6)] is recorded in an instance
  * of the following structure.
  */
+/* Allowed hashmap node key types (iType below) */
+#define HASHMAP_INT_NODE   1  /* Node with an int [i.e: 64-bit integer] key */
+#define HASHMAP_BLOB_NODE  2  /* Node with a string/BLOB key */
 struct ph7_hashmap_node
 {
 	ph7_hashmap *pMap;     /* Hashmap that own this instance */
@@ -804,7 +811,6 @@ struct VmInstr
  * Named-argument metadata attached to PH7_OP_CALL instructions via p3.
  * Also carries the namespace-qualification flag formerly stored as p3=(void*)1.
  */
-typedef struct VmCallArgMap VmCallArgMap;
 struct VmCallArgMap
 {
 	sxu8 bHasNamed;      /* 1 if any argument uses name: syntax */

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -2943,6 +2943,7 @@ static sxi32 VmInitCallContext(
 	MemObjSetType(pRet,MEMOBJ_NULL);
 	pOut->pRet = pRet;
 	pOut->iFlags = iFlags;
+	pOut->pArgMap = 0; /* Set by the OP_CALL dispatcher for named-arg-aware builtins */
 	return SXRET_OK;
 }
 /*
@@ -5628,6 +5629,7 @@ static sxi32 VmResolveNamedArgs(
 {
 	sxi32 posIdx = 0;
 	sxu32 i;
+	int bSeenNamed = 0;
 	char zErrMsg[256];
 	SyZero(aUsed, nNonVariadic * sizeof(sxu8));
 	for( i = 0; i < nActual; i++ ){
@@ -5637,6 +5639,7 @@ static sxi32 VmResolveNamedArgs(
 		if( i < pMap->nTotal && pMap->aNames[i].nByte > 0 ){
 			/* Named argument — find formal by name */
 			int found = 0;
+			bSeenNamed = 1;
 			sxu32 k;
 			for( k = 0; k < nNonVariadic; k++ ){
 				if( aFormalArg[k].sName.nByte == pMap->aNames[i].nByte
@@ -5668,7 +5671,16 @@ static sxi32 VmResolveNamedArgs(
 				}
 			}
 		}else{
-			/* Positional argument */
+			/* Positional argument. Source-syntax calls can't reach here after a
+			 * named arg (the parser rejects it at compile time), but a call
+			 * reconstructed from an array — call_user_func_array(['b'=>9, 'x']) —
+			 * can, so enforce PHP's rule at this shared choke point. */
+			if( bSeenNamed ){
+				VmThrowNamedArgError(&(*pVm),
+					"Cannot use positional argument after named argument",
+					sizeof("Cannot use positional argument after named argument") - 1);
+				return PH7_ABORT;
+			}
 			if( (sxu32)posIdx < nNonVariadic ){
 				if( aUsed[posIdx] ){
 					SyBufferFormat(zErrMsg,sizeof(zErrMsg),
@@ -12662,6 +12674,13 @@ SkipFuncBody:
 		PH7_MemObjInit(&(*pVm),&sRet);
 		/* Init the call context */
 		VmInitCallContext(&sCtx,&(*pVm),pFunc,&sRet,0);
+		/* Hand the call-site named-argument map to the builtin so name-forwarding
+		 * helpers (call_user_func & friends) can relay name: arguments — and the
+		 * caller's strict_types mode — to the inner callback. Forwarded whole (not
+		 * gated on bHasNamed) because call_user_func_array reads bStrict from it even
+		 * when its own call site is purely positional; only the two forwarding
+		 * builtins read pArgMap, so this is inert for every other host function. */
+		sCtx.pArgMap = (VmCallArgMap *)pInstr->p3;
 		/* Call the foreign function */
 		rc = pFunc->xFunc(&sCtx,(int)SySetUsed(&aArg),(ph7_value **)SySetBasePtr(&aArg));
 		/* Release the call context */

--- a/src/ph7/vm_builtin_class.c
+++ b/src/ph7/vm_builtin_class.c
@@ -910,8 +910,28 @@ PH7_PRIVATE int vm_builtin_call_user_func(ph7_context *pCtx,int nArg,ph7_value *
 	}
 	PH7_MemObjInit(pCtx->pVm,&sResult);
 	sResult.nIdx = SXU32_HIGH; /* Mark as constant */
-	/* Try to invoke the callback */
-	rc = PH7_VmCallUserFunction(pCtx->pVm,apArg[0],nArg - 1,&apArg[1],&sResult);
+	/* Try to invoke the callback. If the call_user_func() call site used
+	 * name: arguments (e.g. call_user_func('f', b: 9)), forward them to the
+	 * callback. The inner call's argument i is the outer argument i+1 (outer
+	 * argument 0 is the callback), so the inner name array is simply the outer
+	 * names shifted by one — no copy needed: VmResolveNamedArgs treats any index
+	 * >= nTotal as positional, so a shorter map covers the callback's args. */
+	if( pCtx->pArgMap && pCtx->pArgMap->bHasNamed && nArg > 1 ){
+		VmCallArgMap *pOuter = pCtx->pArgMap;
+		VmCallArgMap sInner;
+		sInner.bHasNamed = 1;
+		sInner.bIsNamespaced = 0;
+		/* Named args to call_user_func coerce in WEAK mode even from a
+		 * strict_types=1 caller (verified vs php 8.5.7): a name: argument
+		 * collected into the variadic and re-spread loses the strict context.
+		 * call_user_func_array does NOT share this quirk (it stays strict). */
+		sInner.bStrict = 0;
+		sInner.nTotal = pOuter->nTotal > 1 ? pOuter->nTotal - 1 : 0;
+		sInner.aNames = sInner.nTotal > 0 ? &pOuter->aNames[1] : 0;
+		rc = PH7_VmCallUserFunctionWithMap(pCtx->pVm,apArg[0],nArg - 1,&apArg[1],&sResult,&sInner);
+	}else{
+		rc = PH7_VmCallUserFunction(pCtx->pVm,apArg[0],nArg - 1,&apArg[1],&sResult);
+	}
 	if( rc == PH7_EXCEPTION ){
 		/* The callback raised: propagate so the OP_CALL dispatcher unwinds
 		 * through the nearest try/catch instead of returning FALSE. */
@@ -944,7 +964,9 @@ PH7_PRIVATE int vm_builtin_call_user_func_array(ph7_context *pCtx,int nArg,ph7_v
 	ph7_hashmap_node *pEntry; /* Current hashmap entry */
 	ph7_value *pValue,sResult;/* Store callback return value here */
 	ph7_hashmap *pMap;        /* Target hashmap */
-	SySet aArg;               /* Arguments containers */
+	SySet aArg;               /* Argument value pointers */
+	SyString *aNames = 0;     /* Name map, lazily allocated when a string key appears */
+	sxu32 nSlot = 0;          /* Number of collected arguments */
 	sxi32 rc;
 	sxu32 n;
 	if( nArg < 2 || !ph7_value_is_array(apArg[1]) ){
@@ -956,19 +978,54 @@ PH7_PRIVATE int vm_builtin_call_user_func_array(ph7_context *pCtx,int nArg,ph7_v
 	sResult.nIdx = SXU32_HIGH; /* Mark as constant */
 	/* Initialize the arguments container */
 	SySetInit(&aArg,&pCtx->pVm->sAllocator,sizeof(ph7_value *));
-	/* Turn hashmap entries into callback arguments */
+	/* Turn hashmap entries into callback arguments. A string key becomes a
+	 * named argument (PHP 8: call_user_func_array($cb, ['b' => 9])), an integer
+	 * key stays positional. The name map points straight at each node's key
+	 * blob: the source array stays pinned on the operand stack for the whole
+	 * call, so the blobs outlive argument binding. A pure list array (no string
+	 * keys) never allocates aNames and takes the plain positional path. */
 	pMap = (ph7_hashmap *)apArg[1]->x.pOther;
 	pEntry = pMap->pFirst; /* First inserted entry */
 	for( n = 0 ; n < pMap->nEntry ; n++ ){
 		/* Extract node value */
 		if( (pValue = (ph7_value *)SySetAt(&pCtx->pVm->aMemObj,pEntry->nValIdx)) != 0 ){
+			if( pEntry->iType == HASHMAP_BLOB_NODE ){
+				if( aNames == 0 ){
+					/* First string key: allocate the whole map, zeroed so every
+					 * not-yet-seen slot defaults to positional. */
+					aNames = (SyString *)SyMemBackendAlloc(&pCtx->pVm->sAllocator,pMap->nEntry * sizeof(SyString));
+					if( aNames == 0 ){
+						SySetRelease(&aArg);
+						PH7_MemObjRelease(&sResult);
+						return PH7_ContextMemoryError(pCtx);
+					}
+					SyZero(aNames,pMap->nEntry * sizeof(SyString));
+				}
+				SyStringInitFromBuf(&aNames[nSlot],SyBlobData(&pEntry->xKey.sKey),SyBlobLength(&pEntry->xKey.sKey));
+			}
 			SySetPut(&aArg,(const void *)&pValue);
+			nSlot++;
 		}
 		/* Point to the next entry */
 		pEntry = pEntry->pPrev; /* Reverse link */
 	}
 	/* Try to invoke the callback */
-	rc = PH7_VmCallUserFunction(pCtx->pVm,apArg[0],(int)SySetUsed(&aArg),(ph7_value **)SySetBasePtr(&aArg),&sResult);
+	if( aNames ){
+		VmCallArgMap sMap;
+		sMap.bHasNamed = 1;
+		sMap.bIsNamespaced = 0;
+		/* Coercion strictness follows the caller's file; the OP_CALL dispatcher
+		 * forwards the call site's map on pArgMap (0 only at non-OP_CALL sites). */
+		sMap.bStrict = (pCtx->pArgMap ? pCtx->pArgMap->bStrict : 0);
+		sMap.nTotal = nSlot;
+		sMap.aNames = aNames;
+		rc = PH7_VmCallUserFunctionWithMap(pCtx->pVm,apArg[0],(int)nSlot,
+			(ph7_value **)SySetBasePtr(&aArg),&sResult,&sMap);
+		SyMemBackendFree(&pCtx->pVm->sAllocator,aNames);
+	}else{
+		rc = PH7_VmCallUserFunction(pCtx->pVm,apArg[0],(int)nSlot,
+			(ph7_value **)SySetBasePtr(&aArg),&sResult);
+	}
 	if( rc == PH7_EXCEPTION ){
 		/* The callback raised: propagate so the OP_CALL dispatcher unwinds. */
 		PH7_MemObjRelease(&sResult);

--- a/tests/ph7/001-smoke/function/call_user_func/call_user_func_array_named_keys.phpt
+++ b/tests/ph7/001-smoke/function/call_user_func/call_user_func_array_named_keys.phpt
@@ -1,0 +1,29 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+call_user_func_array maps string array keys to named arguments
+--FILE--
+<?php
+function cufaKeysF($a, $b) { echo "$a/$b\n"; }
+call_user_func_array('cufaKeysF', ['b' => 9, 'a' => 1]);  // both named
+call_user_func_array('cufaKeysF', [1, 'b' => 9]);         // positional + named
+call_user_func_array('cufaKeysF', [1, 2]);                // plain positional still works
+
+$cufaKeysClo = function ($x, $y, $z) { echo "$x-$y-$z\n"; };
+call_user_func_array($cufaKeysClo, ['z' => 3, 'x' => 1, 'y' => 2]);
+
+function cufaKeysCollect($first, ...$rest) {
+    echo $first . ':' . implode(',', array_keys($rest)) . "\n";
+}
+call_user_func_array('cufaKeysCollect', ['first' => 'F', 'k' => 'v', 'm' => 'w']);
+?>
+--EXPECT--
+1/9
+1/9
+1/2
+1-2-3
+F:k,m
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/call_user_func/call_user_func_array_named_strict.phpt
+++ b/tests/ph7/001-smoke/function/call_user_func/call_user_func_array_named_strict.phpt
@@ -1,0 +1,30 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+call_user_func_array named forwarding honors the caller's strict_types
+--FILE--
+<?php
+declare(strict_types=1);
+function cufaStrictF(int $x) { echo "x=$x\n"; }
+// call_user_func_array binds a name:'d string to a typed param under the
+// caller's strict_types, so a string->int mismatch throws (verified vs php).
+try {
+    call_user_func_array('cufaStrictF', ['x' => '5']);
+    echo "cufa: no throw\n";
+} catch (\TypeError $e) {
+    echo "cufa: TypeError\n";
+}
+// call_user_func with a NAMED arg is the documented php quirk: it coerces in
+// weak mode even here, so '5' becomes 5 rather than throwing.
+call_user_func('cufaStrictF', x: '5');
+// An exactly-typed value still passes through by name.
+call_user_func_array('cufaStrictF', ['x' => 7]);
+?>
+--EXPECT--
+cufa: TypeError
+x=5
+x=7
+--CLEAN--
+<?php
+

--- a/tests/ph7/001-smoke/function/call_user_func/call_user_func_named_args.phpt
+++ b/tests/ph7/001-smoke/function/call_user_func/call_user_func_named_args.phpt
@@ -1,0 +1,39 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+call_user_func forwards name: arguments to the callback
+--FILE--
+<?php
+function cufNamedF($a, $b) { echo "$a/$b\n"; }
+call_user_func('cufNamedF', 1, b: 9);       // positional + named
+call_user_func('cufNamedF', b: 9, a: 1);    // both named, out of order
+call_user_func('cufNamedF', a: 1, b: 2);    // both named, in order
+call_user_func('cufNamedF', 5, 6);          // plain positional still works
+
+$cufNamedClo = function ($x, $y, $z) { echo "$x-$y-$z\n"; };
+call_user_func($cufNamedClo, z: 3, x: 1, y: 2);
+
+class CufNamedC {
+    public function m($a, $b) { echo "m:$a/$b\n"; }
+    public static function s($a, $b) { echo "s:$a/$b\n"; }
+}
+$cufNamedObj = new CufNamedC();
+call_user_func([$cufNamedObj, 'm'], b: 9, a: 1);
+call_user_func(['CufNamedC', 's'], b: 9, a: 1);
+
+function cufNamedCollect(...$args) { echo implode(',', array_keys($args)) . "\n"; }
+call_user_func('cufNamedCollect', x: 1, y: 2);
+?>
+--EXPECT--
+1/9
+1/9
+1/2
+5/6
+1-2-3
+m:1/9
+s:1/9
+x,y
+--CLEAN--
+<?php
+


### PR DESCRIPTION
call_user_func("f", b: 9) bound 9 positionally instead of by name because the call-site VmCallArgMap was dropped at the foreign-function boundary. Stash it on ph7_context.pArgMap so the two forwarding builtins can relay name: arguments to the inner callback: call_user_func shifts the outer name map by one (arg 0 is the callback), call_user_func_array synthesizes a map from the argument array's string keys (PHP 8), both dispatching through PH7_VmCallUserFunctionWithMap.

The name map for the array form points straight at the live hashmap node key blobs (stable while the array is pinned for the call), so a plain list array allocates nothing; HASHMAP_INT/BLOB_NODE move to ph7int.h for that. The call_user_func inner map is pure pointer arithmetic on the outer names.

strict_types: call_user_func_array named forwarding honors the caller's mode (the dispatcher now forwards the whole call-site map, not just when it has named args), while call_user_func named matches php's weak-coercion quirk. A positional argument after a named one in a reconstructed array is rejected at the shared VmResolveNamedArgs choke point, matching php.

Byte-verified vs php 8.5.7; docker ASan+UBSan clean.
