### PR TITLE
Throw TypeError for null / non-numeric-string to non-nullable params

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -5997,6 +5997,19 @@ static sxi32 GenStateCollectFuncArgs(ph7_vm_func *pFunc,ph7_gen_state *pGen,SyTo
 				if( rc != SXRET_OK ){
 					return rc;
 				}
+				/* PHP rule: a typed parameter whose default is the literal `null`
+				 * (`C $c = null`, `int $x = null`, `A|B $x = null`) is implicitly
+				 * nullable — an explicit null is accepted even though the type isn't
+				 * written `?T`. Detect the single-token `null` default here so the VM
+				 * arg-type check lets null through. */
+				if( (sArg.nType > 0 || (sArg.iFlags & VM_FUNC_ARG_UNION))
+					&& (sArg.iFlags & VM_FUNC_ARG_NULLABLE) == 0
+					&& &pIn[1] == pDefend
+					&& pIn->nType & (PH7_TK_ID|PH7_TK_KEYWORD)
+					&& pIn->sData.nByte == sizeof("null")-1
+					&& SyStrnicmp(SyStringData(&pIn->sData),"null",sizeof("null")-1) == 0 ){
+					sArg.iFlags |= VM_FUNC_ARG_NULLABLE;
+				}
 				/* Point beyond the default value */
 				pIn = pDefend;
 			}

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -4087,29 +4087,60 @@ static sxi32 VmCheckReadonlyMutate(ph7_vm *pVm,sxu32 nIdx)
  */
 static int VmStringIsStrictNumeric(ph7_value *pValue)
 {
-	const char *z, *zEnd, *zTail;
+	const char *z, *zEnd;
 	sxu32 n;
-	sxu8 bReal;
-	sxi32 rc;
+	int bDigit = 0;
 	if( (pValue->iFlags & MEMOBJ_STRING) == 0 ){
 		return 0;
 	}
 	z = (const char *)SyBlobData(&pValue->sBlob);
 	n = SyBlobLength(&pValue->sBlob);
-	zEnd = z + n;
 	if( n == 0 ){
 		return 0;
 	}
-	zTail = 0;
-	rc = SyStrIsNumeric(z,n,&bReal,&zTail);
-	if( rc != SXRET_OK || zTail == 0 ){
+	zEnd = z + n;
+	/* PHP's numeric-string grammar (used for int/float coercion), implemented
+	 * directly rather than via SyStrIsNumeric — which requires a leading digit
+	 * (so it rejects ".5"/"-.5", valid in PHP) and accepts a dangling exponent
+	 * ("1e", invalid in PHP). Grammar: [ws] [sign] ( D+ [.D*] | .D+ ) [ (e|E)
+	 * [sign] D+ ] [ws], entire string consumed. */
+	while( z < zEnd && (unsigned char)z[0] < 0xc0 && SyisSpace(z[0]) ){
+		z++;
+	}
+	if( z < zEnd && (z[0] == '+' || z[0] == '-') ){
+		z++;
+	}
+	while( z < zEnd && (unsigned char)z[0] < 0xc0 && SyisDigit(z[0]) ){
+		z++; bDigit = 1;
+	}
+	if( z < zEnd && z[0] == '.' ){
+		z++;
+		while( z < zEnd && (unsigned char)z[0] < 0xc0 && SyisDigit(z[0]) ){
+			z++; bDigit = 1;
+		}
+	}
+	/* At least one mantissa digit required (rejects "", ".", "+", "e5"). */
+	if( !bDigit ){
 		return 0;
 	}
-	/* Trailing whitespace is allowed by PHP, trailing anything else is not. */
-	while( zTail < zEnd && SyisSpace(zTail[0]) ){
-		zTail++;
+	/* Optional exponent — must carry at least one digit (rejects "1e", "1e+"). */
+	if( z < zEnd && (z[0] == 'e' || z[0] == 'E') ){
+		z++;
+		if( z < zEnd && (z[0] == '+' || z[0] == '-') ){
+			z++;
+		}
+		if( z >= zEnd || (unsigned char)z[0] >= 0xc0 || !SyisDigit(z[0]) ){
+			return 0;
+		}
+		while( z < zEnd && (unsigned char)z[0] < 0xc0 && SyisDigit(z[0]) ){
+			z++;
+		}
 	}
-	return zTail == zEnd ? 1 : 0;
+	/* Trailing whitespace allowed; anything else means not a numeric string. */
+	while( z < zEnd && (unsigned char)z[0] < 0xc0 && SyisSpace(z[0]) ){
+		z++;
+	}
+	return z == zEnd ? 1 : 0;
 }
 
 /*
@@ -4404,6 +4435,21 @@ static sxi32 VmEnforceScalarType(ph7_value *pVal, sxu32 nType, int bStrict)
 			PH7_MemObjToReal(pVal);
 			return SXRET_OK;
 		}
+		return SXERR_INVALID;
+	}
+	/* Weak mode, but PHP still rejects some coercions with a TypeError rather
+	 * than silently fabricating a value (mirroring the return-type path above):
+	 *   - null to a non-nullable scalar (a null reaching here is always
+	 *     non-nullable — the caller's guards skip nullable+null, and a
+	 *     `Type $x = null` default is flagged implicitly nullable at compile time).
+	 *   - a non-numeric string to int/float ("abc"/"12abc"). Only a strictly
+	 *     numeric string (optional surrounding whitespace) coerces. */
+	if( pVal->iFlags & MEMOBJ_NULL ){
+		return SXERR_INVALID;
+	}
+	if( (nType == MEMOBJ_INT || nType == MEMOBJ_REAL)
+		&& (pVal->iFlags & MEMOBJ_STRING)
+		&& !VmStringIsStrictNumeric(pVal) ){
 		return SXERR_INVALID;
 	}
 	{
@@ -12008,12 +12054,14 @@ case PH7_OP_CALL: {
 							 * warn + NULL-coerce (which silently ran the body with a corrupted arg). */
 							pClass = (rcPseudo == 1) ? 0 : VmResolveTypeClass(&(*pVm),pName,pSelfHint);
 							if( pClass ){
-								/* An explicit null to a non-nullable class param stays a lenient
-								 * pass-through (PHP throws; that needs the param nullable/default
-								 * model — out of scope here). */
-								int bBad = (pVal->iFlags & MEMOBJ_OBJ) == 0
-									? ((pVal->iFlags & MEMOBJ_NULL) == 0)
-									: !PH7_VmInstanceOf(((ph7_class_instance *)pVal->x.pOther)->pClass,pClass);
+								/* Reaching here means the param is non-nullable (the guard
+								 * above skips nullable+null; a `Type $x = null` default is
+								 * marked implicitly nullable at compile time). So ANY
+								 * non-object — including an explicit null — is a TypeError,
+								 * matching PHP (&& below short-circuits so instanceof only
+								 * derefs a real object). */
+								int bBad = !((pVal->iFlags & MEMOBJ_OBJ)
+									&& PH7_VmInstanceOf(((ph7_class_instance *)pVal->x.pOther)->pClass,pClass));
 								if( bBad ){
 									char zTypeBuf[128],zGivenBuf[128];
 									rc = VmThrowTypeErrorForArg(&(*pVm),pSelfHint,&pVmFunc->sName,n+1,
@@ -12098,8 +12146,11 @@ case PH7_OP_CALL: {
 							sArg.nIdx = pObj->nIdx;
 							sArg.pUserData = 0;
 							SySetPut(&pFrame->sArg,(const void *)&sArg);
+							/* A null default on an implicitly-nullable param must stay null
+							 * (see the positional-path note above). */
 							if( aFormalArg[n].nType > 0 && aFormalArg[n].nType != MEMOBJ_OBJ
-								&& (pObj->iFlags & aFormalArg[n].nType) == 0 ){
+								&& (pObj->iFlags & aFormalArg[n].nType) == 0
+								&& !((aFormalArg[n].iFlags & VM_FUNC_ARG_NULLABLE) && (pObj->iFlags & MEMOBJ_NULL)) ){
 								ProcMemObjCast xCast = PH7_MemObjCastMethod(aFormalArg[n].nType);
 								if( xCast ) xCast(pObj);
 							}
@@ -12345,11 +12396,13 @@ case PH7_OP_CALL: {
 						 * the legacy warn + NULL-coerce. (Symmetric with the positional path.) */
 						pClass = (rcPseudo == 1) ? 0 : VmResolveTypeClass(&(*pVm),pName,pSelfHint);
 						if( pClass ){
-							/* An explicit null to a non-nullable class param stays a lenient
-							 * pass-through (PHP throws; needs the param nullable/default model). */
-							int bBad = (pArg->iFlags & MEMOBJ_OBJ) == 0
-								? ((pArg->iFlags & MEMOBJ_NULL) == 0)
-								: !PH7_VmInstanceOf(((ph7_class_instance *)pArg->x.pOther)->pClass,pClass);
+							/* Reaching here means the param is non-nullable (the guard above
+							 * skips nullable+null; a `Type $x = null` default is marked
+							 * implicitly nullable at compile time). So ANY non-object —
+							 * including an explicit null — is a TypeError, matching PHP
+							 * (&& below short-circuits so instanceof only derefs an object). */
+							int bBad = !((pArg->iFlags & MEMOBJ_OBJ)
+								&& PH7_VmInstanceOf(((ph7_class_instance *)pArg->x.pOther)->pClass,pClass));
 							if( bBad ){
 								char zTypeBuf[128],zGivenBuf[128];
 								rc = VmThrowTypeErrorForArg(&(*pVm),pSelfHint,&pVmFunc->sName,n+1,
@@ -12492,9 +12545,13 @@ case PH7_OP_CALL: {
 					sArg.nIdx = pObj->nIdx;
 					sArg.pUserData = 0;
 					SySetPut(&pFrame->sArg,(const void *)&sArg);
-					/* Make sure the default argument is of the correct type */
+					/* Make sure the default argument is of the correct type.
+					 * A null default on an implicitly-nullable param (`int $x = null`)
+					 * must stay null — casting it to 0/""/false would diverge from PHP
+					 * and contradict the explicit-null path, which now keeps it null. */
 					if( aFormalArg[n].nType > 0 && aFormalArg[n].nType != MEMOBJ_OBJ
-						&& ((pObj->iFlags & aFormalArg[n].nType) == 0) ){
+						&& ((pObj->iFlags & aFormalArg[n].nType) == 0)
+						&& !((aFormalArg[n].iFlags & VM_FUNC_ARG_NULLABLE) && (pObj->iFlags & MEMOBJ_NULL)) ){
 						ProcMemObjCast xCast = PH7_MemObjCastMethod(aFormalArg[n].nType);
 						/* Cast to the desired type */
 						xCast(pObj);

--- a/tests/ph7/002-integration/lang/param_implicit_nullable_default.phpt
+++ b/tests/ph7/002-integration/lang/param_implicit_nullable_default.phpt
@@ -1,0 +1,43 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A `Type $x = null` default makes the param implicitly nullable (accepts null)
+--FILE--
+<?php
+// PHP treats a literal `null` default as making the type implicitly nullable,
+// so an explicit null is accepted for class, scalar and union types alike.
+// (PHP 8.4 also emits a deprecation at declaration time; PHL does not — the %A
+// below swallows it so this stays a cross-engine test.)
+class C {}
+class A {}
+class B {}
+
+function fClass(C $c = null)   { echo 'class:',  ($c === null ? 'null' : 'obj'),  "\n"; }
+function fInt(int $x = null)   { echo 'int:',    ($x === null ? 'null' : $x),     "\n"; }
+function fUnion(A|B $x = null) { echo 'union:',  ($x === null ? 'null' : 'obj'),  "\n"; }
+
+// Explicit null and the OMITTED case must both yield null — a null default must
+// not be cast to 0/""/false when the arg is left out.
+fClass(null);
+fClass();
+fClass(new C());
+fInt(null);
+fInt();
+fInt(7);
+fUnion(null);
+fUnion();
+fUnion(new A());
+?>
+--EXPECTF--
+%Aclass:null
+class:null
+class:obj
+int:null
+int:null
+int:7
+union:null
+union:null
+union:obj
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/param_type_null_and_string_rejection.phpt
+++ b/tests/ph7/002-integration/lang/param_type_null_and_string_rejection.phpt
@@ -1,0 +1,64 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Non-nullable param rejects explicit null and non-numeric string (TypeError)
+--FILE--
+<?php
+class C {}
+class D {}
+
+function needsC(C $c) { echo "C ok\n"; }
+function needsInt(int $x) { echo "int:$x\n"; }
+function needsFloat(float $x) { echo "float:$x\n"; }
+
+// Explicit null to a non-nullable class param -> TypeError
+try { needsC(null); } catch (TypeError $e) { echo "null->C TypeError\n"; }
+// Wrong class -> TypeError
+try { needsC(new D()); } catch (TypeError $e) { echo "D->C TypeError\n"; }
+// Valid instance passes
+needsC(new C());
+
+// Explicit null to a non-nullable scalar param -> TypeError
+try { needsInt(null); } catch (TypeError $e) { echo "null->int TypeError\n"; }
+// Fully non-numeric string -> TypeError
+try { needsInt("abc"); } catch (TypeError $e) { echo "abc->int TypeError\n"; }
+// Leading-numeric-with-garbage string is NOT accepted (PHP 8) -> TypeError
+try { needsInt("12abc"); } catch (TypeError $e) { echo "12abc->int TypeError\n"; }
+// Empty string -> TypeError
+try { needsInt(""); } catch (TypeError $e) { echo "empty->int TypeError\n"; }
+try { needsFloat("xyz"); } catch (TypeError $e) { echo "xyz->float TypeError\n"; }
+// Dangling exponent is not a numeric string -> TypeError
+try { needsInt("1e"); } catch (TypeError $e) { echo "1e->int TypeError\n"; }
+// A lone dot is not numeric -> TypeError
+try { needsFloat("."); } catch (TypeError $e) { echo ".->float TypeError\n"; }
+
+// Valid weak-mode coercions still work
+needsInt("42");     // numeric string
+needsInt("  42  "); // surrounding whitespace allowed
+needsInt(true);     // bool -> int
+needsFloat("1e3");  // numeric float-string
+needsFloat(".5");   // leading-decimal numeric string
+needsFloat("-.5");  // signed leading-decimal
+needsFloat("5.");   // trailing-dot numeric string
+?>
+--EXPECT--
+null->C TypeError
+D->C TypeError
+C ok
+null->int TypeError
+abc->int TypeError
+12abc->int TypeError
+empty->int TypeError
+xyz->float TypeError
+1e->int TypeError
+.->float TypeError
+int:42
+int:42
+int:1
+float:1000
+float:0.5
+float:-0.5
+float:5
+--CLEAN--
+<?php


### PR DESCRIPTION
A non-nullable class/scalar/union parameter now rejects an explicit null with a catchable TypeError instead of silently coercing it to null/0, and a non-numeric string passed to an int/float parameter (e.g. "abc", "12abc", "", "1e", ".") is rejected too — matching PHP 8. Valid weak-mode coercions ("42", "1e3", ".5", "-.5", "5.", surrounding whitespace, bool->int) work.

Both the named- and positional-argument install paths' bBad check now treat any non-object as incompatible with a class hint (the guard already excludes nullable+null), and VmEnforceScalarType rejects null and non-strictly-numeric strings for int/float via VmStringIsStrictNumeric.

PHP's implicit-nullable rule (`Type $x = null` accepts null) is preserved by flagging a parameter with a literal-null default VM_FUNC_ARG_NULLABLE at compile time — which also spares the omitted-arg default from being cast to 0/""/false (so f() and f(null) both yield null for `Type $x = null`).

VmStringIsStrictNumeric was rewritten to PHP's exact numeric-string grammar: it previously rejected leading-decimal ".5"/"-.5" (SyStrIsNumeric requires a leading digit) and accepted a dangling exponent "1e"; the fix also corrects the shared property/return-type coercion sites.

Byte-verified vs php 8.5.7; docker ASan+UBSan clean.
