### PR TITLE
Throw ArgumentCountError for too-few arguments to builtins

### DIFF
--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -194,6 +194,11 @@ struct ph7_user_func
 	ProchHostFunction xFunc;  /* Implementation of the foreign function */
 	void *pUserData;          /* User private data [Refer to the official documentation for more information]*/
 	SySet aAux;               /* Stack of auxiliary data [Refer to the official documentation for more information]*/
+	sxi16 nMinArg;            /* Minimum required arguments for the PHP-8 ArgumentCountError
+	                           * check at the OP_CALL choke point; 0 = no central enforcement
+	                           * (the builtin self-validates, or genuinely accepts zero args). */
+	sxu8 bAtLeast;            /* 0 -> "expects exactly N", 1 -> "expects at least N" (the
+	                           * wording depends on whether the builtin has optional params). */
 };
 /*
  * The 'context' argument for an installable function. A pointer to an

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -315,6 +315,12 @@ PH7_PRIVATE sxi32 PH7_VmInstallForeignFunction(
 		pFunc->pUserData = pUserData;
 		pFunc->xFunc = xFunc;
 		SySetReset(&pFunc->aAux);
+		/* A replacement implementation carries its own (unknown) arity, so drop
+		 * any minimum-arity metadata stamped on the previous holder of this name
+		 * — otherwise an embedder overriding a listed builtin (e.g. a 1-arg
+		 * custom "substr") would inherit the old ArgumentCountError threshold. */
+		pFunc->nMinArg  = 0;
+		pFunc->bAtLeast = 0;
 		return SXRET_OK;
 	}
 	/* Create a new user function */
@@ -331,6 +337,68 @@ PH7_PRIVATE sxi32 PH7_VmInstallForeignFunction(
 	}
 	/* User function successfully installed */
 	return SXRET_OK;
+}
+/*
+ * PHP-8 builtin minimum-arity table (band A #5, stage 1).
+ *
+ * Native builtins carry no formal-parameter signature, so historically each
+ * one self-validated its argument count (or, worse, silently degraded to a
+ * bogus false/-1/"" return on too few arguments — a PH7-ism that diverges from
+ * PHP 8, which throws a catchable ArgumentCountError). This table is the single
+ * source of truth for the required minimum: at VM init VmSetBuiltinArity()
+ * stamps nMinArg/bAtLeast onto the matching ph7_user_func, and the OP_CALL
+ * choke point throws ArgumentCountError before the C routine ever runs.
+ *
+ * bAtLeast mirrors PHP's ZPP wording: "expects exactly N" when the builtin has
+ * no optional/variadic parameters (min == max), "expects at least N" otherwise.
+ * Every entry's min count and wording is byte-verified against php 8.5.7.
+ *
+ * Only functions that currently mis-behave (silent wrong return) are listed;
+ * builtins that already self-throw the correct message are intentionally left
+ * out so there is no double-check / message drift. New entries are cheap to add
+ * as further families are swept.
+ */
+static const struct VmBuiltinArity {
+	const char *zName;   /* Builtin name (short, unqualified) */
+	sxi16 nMin;          /* Minimum required arguments */
+	sxu8 bAtLeast;       /* 0 -> "exactly", 1 -> "at least" */
+} aBuiltinArity[] = {
+	/* String family */
+	{ "substr",       2, 1 }, { "substr_count",  2, 1 }, { "str_repeat",     2, 0 },
+	{ "str_pad",      2, 1 }, { "strpos",        2, 1 }, { "stripos",        2, 1 },
+	{ "strrpos",      2, 1 }, { "strripos",      2, 1 }, { "strstr",         2, 1 },
+	{ "stristr",      2, 1 }, { "strrchr",       2, 1 }, { "str_replace",    3, 1 },
+	{ "str_ireplace", 3, 1 }, { "strncmp",       3, 0 }, { "strncasecmp",    3, 0 },
+	{ "substr_compare",3,1 }, { "strpbrk",       2, 0 }, { "strspn",         2, 1 },
+	{ "strcspn",      2, 1 }, { "hexdec",        1, 0 }, { "octdec",         1, 0 },
+	{ "bindec",       1, 0 }, { "chunk_split",   1, 1 },
+	/* Math family (atan2/intdiv already self-throw the same ArgumentCountError,
+	 * so they stay off the table per the disjointness rule above). */
+	{ "pow",          2, 0 }, { "fmod",          2, 0 }, { "hypot",          2, 0 },
+	{ "log",          1, 1 },
+	/* Array family (str_split already self-throws — kept off the table). */
+	{ "in_array",     2, 1 }, { "range",         2, 1 },
+	{ "implode",      1, 1 }, { "join",          1, 1 },
+};
+/*
+ * Stamp the minimum-arity metadata from aBuiltinArity[] onto the already
+ * registered host functions. Called once at VM init after every builtin family
+ * has been installed into hHostFunction. A name absent from the hash (e.g. a
+ * build without a given extension) is simply skipped.
+ */
+static void VmSetBuiltinArity(ph7_vm *pVm)
+{
+	sxu32 n;
+	for( n = 0 ; n < SX_ARRAYSIZE(aBuiltinArity) ; ++n ){
+		const struct VmBuiltinArity *p = &aBuiltinArity[n];
+		SyHashEntry *pEntry = SyHashGet(&pVm->hHostFunction,
+			(const void *)p->zName,SyStrlen(p->zName));
+		if( pEntry ){
+			ph7_user_func *pFunc = (ph7_user_func *)pEntry->pUserData;
+			pFunc->nMinArg  = p->nMin;
+			pFunc->bAtLeast = p->bAtLeast;
+		}
+	}
 }
 /*
  * Initialize a VM function.
@@ -2592,6 +2660,9 @@ PH7_PRIVATE sxi32 PH7_VmMakeReady(
 	PH7_RegisterPcreFunctions(&(*pVm));
 	PH7_RegisterPcreConstants(&(*pVm));
 #endif
+	/* Stamp PHP-8 minimum-arity metadata onto the registered builtins so the
+	 * OP_CALL choke point can raise ArgumentCountError on too few arguments. */
+	VmSetBuiltinArity(&(*pVm));
 	/* Initialize and install static and constants class attributes.
 	 * NOTE: the per-exec object graph created from nSuperBaseline onward (the
 	 * global frame via VmEnterFrame above, the superglobals via CreateSuper, and
@@ -12738,8 +12809,26 @@ SkipFuncBody:
 		 * when its own call site is purely positional; only the two forwarding
 		 * builtins read pArgMap, so this is inert for every other host function. */
 		sCtx.pArgMap = (VmCallArgMap *)pInstr->p3;
-		/* Call the foreign function */
-		rc = pFunc->xFunc(&sCtx,(int)SySetUsed(&aArg),(ph7_value **)SySetBasePtr(&aArg));
+		{
+		int nGiven = (int)SySetUsed(&aArg);
+		/* PHP-8 arity enforcement (band A #5): a builtin declaring a minimum
+		 * argument count (aBuiltinArity[]) throws a catchable ArgumentCountError
+		 * before the C routine runs when called with too few arguments — instead
+		 * of the legacy PH7-ism of silently degrading to a bogus false/-1/""
+		 * return. The message wording matches php's ZPP output byte-for-byte. */
+		if( pFunc->nMinArg > 0 && nGiven < pFunc->nMinArg ){
+			rc = PH7_VmThrowException(&sCtx,"ArgumentCountError",
+				"%z() expects %s %d argument%s, %d given",
+				&pFunc->sName,
+				pFunc->bAtLeast ? "at least" : "exactly",
+				(int)pFunc->nMinArg,
+				pFunc->nMinArg == 1 ? "" : "s",
+				nGiven);
+		}else{
+			/* Call the foreign function */
+			rc = pFunc->xFunc(&sCtx,nGiven,(ph7_value **)SySetBasePtr(&aArg));
+		}
+		}
 		/* Release the call context */
 		VmReleaseCallContext(&sCtx);
 		if( rc == PH7_ABORT ){

--- a/tests/ph7/001-smoke/function/bindec/bindec_invalid.phpt
+++ b/tests/ph7/001-smoke/function/bindec/bindec_invalid.phpt
@@ -2,19 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: bindec missing argument returns -1
---SKIPIF--
-<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+bindec() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-if (bindec() === -1) {
-    echo "true";
-} else {
-    echo "false";
+try {
+    bindec();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-true
---CLEAN--
-<?php
-
+bindec() expects exactly 1 argument, 0 given

--- a/tests/ph7/001-smoke/function/bindec/bindec_numeric.phpt
+++ b/tests/ph7/001-smoke/function/bindec/bindec_numeric.phpt
@@ -14,15 +14,10 @@ echo "bindec(15): " . $result1 . "\n";
 // Test bindec with string (normal case)
 $result2 = bindec("1010");
 echo "bindec('1010'): " . $result2 . "\n";
-
-// Test bindec with no arguments (covers uncovered line in error handling)
-$result3 = bindec();
-echo "bindec(): " . $result3 . "\n";
 ?>
 --EXPECT--
 bindec(15): 15
 bindec('1010'): 10
-bindec(): -1
 --CLEAN--
 <?php
-unset($result1, $result2, $result3);
+unset($result1, $result2);

--- a/tests/ph7/001-smoke/function/chunk_split/chunk_split_no_args.phpt
+++ b/tests/ph7/001-smoke/function/chunk_split/chunk_split_no_args.phpt
@@ -2,16 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-chunk_split with no arguments
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+chunk_split() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-$result = chunk_split();
-echo $result === null ? 'PASS' : 'FAIL';
+try {
+    chunk_split();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
 --EXPECT--
-PASS
---CLEAN--
-<?php
-unset($result);
+chunk_split() expects at least 1 argument, 0 given

--- a/tests/ph7/001-smoke/function/fmod/fmod_insufficient_args.phpt
+++ b/tests/ph7/001-smoke/function/fmod/fmod_insufficient_args.phpt
@@ -2,21 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: fmod with insufficient arguments returns 0
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+fmod(5.0) throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-// Test fmod with insufficient arguments
-$result = fmod(5.0);
-if ($result === 0.0) {
-    echo "PASS";
-} else {
-    echo "FAIL";
+try {
+    fmod(5.0);
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-PASS
---CLEAN--
-<?php
-unset($result);
+fmod() expects exactly 2 arguments, 1 given

--- a/tests/ph7/001-smoke/function/fmod/fmod_invalid.phpt
+++ b/tests/ph7/001-smoke/function/fmod/fmod_invalid.phpt
@@ -2,19 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: fmod missing arguments returns float 0.0
---SKIPIF--
-<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+fmod() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-if (is_float(fmod()) && fmod() == 0.0) {
-    echo "true";
-} else {
-    echo "false";
+try {
+    fmod();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-true
---CLEAN--
-<?php
-
+fmod() expects exactly 2 arguments, 0 given

--- a/tests/ph7/001-smoke/function/hexdec/hexdec_invalid.phpt
+++ b/tests/ph7/001-smoke/function/hexdec/hexdec_invalid.phpt
@@ -2,19 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: hexdec missing argument returns -1
---SKIPIF--
-<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+hexdec() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-if (hexdec() === -1) {
-    echo "true";
-} else {
-    echo "false";
+try {
+    hexdec();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-true
---CLEAN--
-<?php
-
+hexdec() expects exactly 1 argument, 0 given

--- a/tests/ph7/001-smoke/function/hexdec/hexdec_no_args.phpt
+++ b/tests/ph7/001-smoke/function/hexdec/hexdec_no_args.phpt
@@ -2,16 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-hexdec with no arguments
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+hexdec() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-$result = hexdec();
-echo $result === -1 ? 'PASS' : 'FAIL';
+try {
+    hexdec();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
 --EXPECT--
-PASS
---CLEAN--
-<?php
-unset($result);
+hexdec() expects exactly 1 argument, 0 given

--- a/tests/ph7/001-smoke/function/hypot/hypot_invalid.phpt
+++ b/tests/ph7/001-smoke/function/hypot/hypot_invalid.phpt
@@ -2,19 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: hypot missing arguments returns float 0.0
---SKIPIF--
-<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+hypot() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-if (is_float(hypot()) && hypot() == 0.0) {
-    echo "true";
-} else {
-    echo "false";
+try {
+    hypot();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-true
---CLEAN--
-<?php
-
+hypot() expects exactly 2 arguments, 0 given

--- a/tests/ph7/001-smoke/function/log/log_invalid.phpt
+++ b/tests/ph7/001-smoke/function/log/log_invalid.phpt
@@ -2,19 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: log missing argument returns integer 0
---SKIPIF--
-<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+log() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-if (log() === 0) {
-    echo "true";
-} else {
-    echo "false";
+try {
+    log();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-true
---CLEAN--
-<?php
-
+log() expects at least 1 argument, 0 given

--- a/tests/ph7/001-smoke/function/octdec/octdec_invalid.phpt
+++ b/tests/ph7/001-smoke/function/octdec/octdec_invalid.phpt
@@ -2,19 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: octdec missing argument returns integer -1
---SKIPIF--
-<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+octdec() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-if (octdec() === -1) {
-    echo "true";
-} else {
-    echo "false";
+try {
+    octdec();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-true
---CLEAN--
-<?php
-
+octdec() expects exactly 1 argument, 0 given

--- a/tests/ph7/001-smoke/function/pow/pow_invalid.phpt
+++ b/tests/ph7/001-smoke/function/pow/pow_invalid.phpt
@@ -2,19 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: pow missing argument returns integer 0
---SKIPIF--
-<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+pow() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-if (pow() === 0) {
-    echo "true";
-} else {
-    echo "false";
+try {
+    pow();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-true
---CLEAN--
-<?php
-
+pow() expects exactly 2 arguments, 0 given

--- a/tests/ph7/001-smoke/function/pow/pow_no_args.phpt
+++ b/tests/ph7/001-smoke/function/pow/pow_no_args.phpt
@@ -2,16 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-pow with no arguments
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+pow() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-$result = pow();
-echo $result;
+try {
+    pow();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
 --EXPECT--
-0
---CLEAN--
-<?php
-unset($result);
+pow() expects exactly 2 arguments, 0 given

--- a/tests/ph7/001-smoke/function/str_pad/str_pad_insufficient_args.phpt
+++ b/tests/ph7/001-smoke/function/str_pad/str_pad_insufficient_args.phpt
@@ -2,16 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-str_pad with insufficient args
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+str_pad("hello") throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-$result = str_pad("hello");
-var_dump($result);
+try {
+    str_pad("hello");
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
 --EXPECT--
-string(0) ""
---CLEAN--
-<?php
-unset($result);
+str_pad() expects at least 2 arguments, 1 given

--- a/tests/ph7/001-smoke/function/str_pad/str_pad_invalid.phpt
+++ b/tests/ph7/001-smoke/function/str_pad/str_pad_invalid.phpt
@@ -2,19 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: str_pad missing argument returns empty string
---SKIPIF--
-<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+str_pad() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-if (str_pad() == "") {
-    echo "true";
-} else {
-    echo "false";
+try {
+    str_pad();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-true
---CLEAN--
-<?php
-
+str_pad() expects at least 2 arguments, 0 given

--- a/tests/ph7/001-smoke/function/str_repeat/str_repeat_invalid.phpt
+++ b/tests/ph7/001-smoke/function/str_repeat/str_repeat_invalid.phpt
@@ -2,19 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: str_repeat missing argument returns NULL
---SKIPIF--
-<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+str_repeat() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-if (str_repeat() === null) {
-    echo "true";
-} else {
-    echo "false";
+try {
+    str_repeat();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-true
---CLEAN--
-<?php
-
+str_repeat() expects exactly 2 arguments, 0 given

--- a/tests/ph7/001-smoke/function/str_replace/str_replace_insufficient_args.phpt
+++ b/tests/ph7/001-smoke/function/str_replace/str_replace_insufficient_args.phpt
@@ -2,20 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-str_replace insufficient arguments
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+str_replace() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-$result = str_replace();
-if ($result === null) {
-    echo "null";
-} else {
-    echo "not null";
+try {
+    str_replace();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-null
---CLEAN--
-<?php
-unset($result);
+str_replace() expects at least 3 arguments, 0 given

--- a/tests/ph7/001-smoke/function/str_replace/str_replace_insufficient_args_two.phpt
+++ b/tests/ph7/001-smoke/function/str_replace/str_replace_insufficient_args_two.phpt
@@ -2,20 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-str_replace with insufficient arguments (2 args)
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+str_replace("search", "replace") throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-$result = str_replace("search", "replace");
-if (is_null($result)) {
-    echo "PASS";
-} else {
-    echo "FAIL: expected null, got " . var_export($result, true);
+try {
+    str_replace("search", "replace");
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-PASS
---CLEAN--
-<?php
-unset($result);
+str_replace() expects at least 3 arguments, 2 given

--- a/tests/ph7/001-smoke/function/str_replace/str_replace_invalid.phpt
+++ b/tests/ph7/001-smoke/function/str_replace/str_replace_invalid.phpt
@@ -2,19 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: str_replace missing argument returns NULL
---SKIPIF--
-<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+str_replace() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-if (str_replace() === null) {
-    echo "true";
-} else {
-    echo "false";
+try {
+    str_replace();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-true
---CLEAN--
-<?php
-
+str_replace() expects at least 3 arguments, 0 given

--- a/tests/ph7/001-smoke/function/strcspn/strcspn_invalid.phpt
+++ b/tests/ph7/001-smoke/function/strcspn/strcspn_invalid.phpt
@@ -2,19 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: strcspn missing argument returns integer 0
---SKIPIF--
-<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+strcspn() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-if (strcspn() === 0) {
-    echo "true";
-} else {
-    echo "false";
+try {
+    strcspn();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-true
---CLEAN--
-<?php
-
+strcspn() expects at least 2 arguments, 0 given

--- a/tests/ph7/001-smoke/function/stripos/stripos_invalid.phpt
+++ b/tests/ph7/001-smoke/function/stripos/stripos_invalid.phpt
@@ -2,19 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: stripos missing argument returns FALSE
---SKIPIF--
-<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+stripos() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-if (stripos() === false) {
-    echo "true";
-} else {
-    echo "false";
+try {
+    stripos();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-true
---CLEAN--
-<?php
-
+stripos() expects at least 2 arguments, 0 given

--- a/tests/ph7/001-smoke/function/stristr/stristr_invalid.phpt
+++ b/tests/ph7/001-smoke/function/stristr/stristr_invalid.phpt
@@ -2,19 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: stristr missing argument returns FALSE
---SKIPIF--
-<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+stristr() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-if (stristr() === false) {
-    echo "true";
-} else {
-    echo "false";
+try {
+    stristr();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-true
---CLEAN--
-<?php
-
+stristr() expects at least 2 arguments, 0 given

--- a/tests/ph7/001-smoke/function/strncasecmp/strncasecmp_insufficient_args.phpt
+++ b/tests/ph7/001-smoke/function/strncasecmp/strncasecmp_insufficient_args.phpt
@@ -2,20 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-strncasecmp with insufficient arguments (1 arg)
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+strncasecmp("test") throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-$result = strncasecmp("test");
-if ($result === 1) {
-    echo "PASS";
-} else {
-    echo "FAIL: expected 1, got " . var_export($result, true);
+try {
+    strncasecmp("test");
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-PASS
---CLEAN--
-<?php
-unset($result);
+strncasecmp() expects exactly 3 arguments, 1 given

--- a/tests/ph7/001-smoke/function/strncasecmp/strncasecmp_invalid.phpt
+++ b/tests/ph7/001-smoke/function/strncasecmp/strncasecmp_invalid.phpt
@@ -2,19 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: strncasecmp missing argument returns integer 0
---SKIPIF--
-<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+strncasecmp() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-if (strncasecmp() === 0) {
-    echo "true";
-} else {
-    echo "false";
+try {
+    strncasecmp();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-true
---CLEAN--
-<?php
-
+strncasecmp() expects exactly 3 arguments, 0 given

--- a/tests/ph7/001-smoke/function/strncmp/strncmp_insufficient_args.phpt
+++ b/tests/ph7/001-smoke/function/strncmp/strncmp_insufficient_args.phpt
@@ -2,22 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: strncmp with insufficient arguments falls back to strcmp
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+strncmp("abc", "abc") throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-// Test with 2 arguments - should behave like strcmp
-$result1 = strncmp("abc", "abc");
-$result2 = strncmp("abc", "abd");
-if ($result1 === 0 && $result2 < 0) {
-    echo "PASS";
-} else {
-    echo "FAIL";
+try {
+    strncmp("abc", "abc");
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-PASS
---CLEAN--
-<?php
-unset($result1, $result2);
+strncmp() expects exactly 3 arguments, 2 given

--- a/tests/ph7/001-smoke/function/strpbrk/strpbrk_invalid.phpt
+++ b/tests/ph7/001-smoke/function/strpbrk/strpbrk_invalid.phpt
@@ -2,19 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: strpbrk missing argument returns FALSE
---SKIPIF--
-<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+strpbrk() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-if (strpbrk() === false) {
-    echo "true";
-} else {
-    echo "false";
+try {
+    strpbrk();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-true
---CLEAN--
-<?php
-
+strpbrk() expects exactly 2 arguments, 0 given

--- a/tests/ph7/001-smoke/function/strpos/strpos_insufficient_args.phpt
+++ b/tests/ph7/001-smoke/function/strpos/strpos_insufficient_args.phpt
@@ -2,20 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-strpos with insufficient arguments
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+strpos() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-$result = strpos();
-if ($result === false) {
-    echo "PASS";
-} else {
-    echo "FAIL: expected false, got " . var_export($result, true);
+try {
+    strpos();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-PASS
---CLEAN--
-<?php
-unset($result);
+strpos() expects at least 2 arguments, 0 given

--- a/tests/ph7/001-smoke/function/strpos/strpos_invalid.phpt
+++ b/tests/ph7/001-smoke/function/strpos/strpos_invalid.phpt
@@ -2,19 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: strpos missing argument returns FALSE
---SKIPIF--
-<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+strpos() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-if (strpos() === false) {
-    echo "true";
-} else {
-    echo "false";
+try {
+    strpos();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-true
---CLEAN--
-<?php
-
+strpos() expects at least 2 arguments, 0 given

--- a/tests/ph7/001-smoke/function/strpos/strpos_invalid_offset.phpt
+++ b/tests/ph7/001-smoke/function/strpos/strpos_invalid_offset.phpt
@@ -2,15 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-strpos with insufficient args
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+strpos("hello") throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-var_dump(strpos("hello"));
+try {
+    strpos("hello");
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
 --EXPECT--
-bool(FALSE)
---CLEAN--
-<?php
-
+strpos() expects at least 2 arguments, 1 given

--- a/tests/ph7/001-smoke/function/strrchr/strrchr_invalid.phpt
+++ b/tests/ph7/001-smoke/function/strrchr/strrchr_invalid.phpt
@@ -2,19 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: strrchr missing argument returns FALSE
---SKIPIF--
-<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+strrchr() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-if (strrchr() === false) {
-    echo "true";
-} else {
-    echo "false";
+try {
+    strrchr();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-true
---CLEAN--
-<?php
-
+strrchr() expects at least 2 arguments, 0 given

--- a/tests/ph7/001-smoke/function/strripos/strripos_invalid.phpt
+++ b/tests/ph7/001-smoke/function/strripos/strripos_invalid.phpt
@@ -2,19 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: strripos missing argument returns FALSE
---SKIPIF--
-<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+strripos() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-if (strripos() === false) {
-    echo "true";
-} else {
-    echo "false";
+try {
+    strripos();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-true
---CLEAN--
-<?php
-
+strripos() expects at least 2 arguments, 0 given

--- a/tests/ph7/001-smoke/function/strrpos/strrpos_invalid.phpt
+++ b/tests/ph7/001-smoke/function/strrpos/strrpos_invalid.phpt
@@ -2,19 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: strrpos missing argument returns FALSE
---SKIPIF--
-<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+strrpos() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-if (strrpos() === false) {
-    echo "true";
-} else {
-    echo "false";
+try {
+    strrpos();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-true
---CLEAN--
-<?php
-
+strrpos() expects at least 2 arguments, 0 given

--- a/tests/ph7/001-smoke/function/strspn/strspn_invalid.phpt
+++ b/tests/ph7/001-smoke/function/strspn/strspn_invalid.phpt
@@ -2,19 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: strspn missing argument returns integer 0
---SKIPIF--
-<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+strspn() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-if (strspn() === 0) {
-    echo "true";
-} else {
-    echo "false";
+try {
+    strspn();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-true
---CLEAN--
-<?php
-
+strspn() expects at least 2 arguments, 0 given

--- a/tests/ph7/001-smoke/function/strstr/strstr_insufficient_args.phpt
+++ b/tests/ph7/001-smoke/function/strstr/strstr_insufficient_args.phpt
@@ -2,19 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: strstr with insufficient arguments returns FALSE
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+strstr('abc') throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-if (strstr('abc') === false) {
-    echo "true";
-} else {
-    echo "false";
+try {
+    strstr('abc');
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-true
---CLEAN--
-<?php
-
+strstr() expects at least 2 arguments, 1 given

--- a/tests/ph7/001-smoke/function/strstr/strstr_invalid.phpt
+++ b/tests/ph7/001-smoke/function/strstr/strstr_invalid.phpt
@@ -2,19 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: strstr missing argument returns FALSE
---SKIPIF--
-<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+strstr() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-if (strstr() === false) {
-    echo "true";
-} else {
-    echo "false";
+try {
+    strstr();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-true
---CLEAN--
-<?php
-
+strstr() expects at least 2 arguments, 0 given

--- a/tests/ph7/001-smoke/function/substr/substr_insufficient_args.phpt
+++ b/tests/ph7/001-smoke/function/substr/substr_insufficient_args.phpt
@@ -2,20 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-substr with insufficient arguments
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+substr() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-$result = substr();
-if ($result === false) {
-    echo "PASS";
-} else {
-    echo "FAIL: expected false, got " . var_export($result, true);
+try {
+    substr();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-PASS
---CLEAN--
-<?php
-unset($result);
+substr() expects at least 2 arguments, 0 given

--- a/tests/ph7/001-smoke/function/substr/substr_invalid_args.phpt
+++ b/tests/ph7/001-smoke/function/substr/substr_invalid_args.phpt
@@ -2,21 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: substr with invalid number of arguments returns FALSE
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+substr("hello") throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-// Test substr with fewer than 2 arguments
-$result = substr("hello");
-if ($result === false) {
-    echo "PASS";
-} else {
-    echo "FAIL";
+try {
+    substr("hello");
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-PASS
---CLEAN--
-<?php
-unset($result);
+substr() expects at least 2 arguments, 1 given

--- a/tests/ph7/001-smoke/function/substr_compare/substr_compare_insufficient_args.phpt
+++ b/tests/ph7/001-smoke/function/substr_compare/substr_compare_insufficient_args.phpt
@@ -2,19 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: substr_compare with insufficient arguments returns FALSE
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+substr_compare('abc', 'a') throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-if (substr_compare('abc', 'a') === false) {
-    echo "true";
-} else {
-    echo "false";
+try {
+    substr_compare('abc', 'a');
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-true
---CLEAN--
-<?php
-
+substr_compare() expects at least 3 arguments, 2 given

--- a/tests/ph7/001-smoke/function/substr_compare/substr_compare_invalid.phpt
+++ b/tests/ph7/001-smoke/function/substr_compare/substr_compare_invalid.phpt
@@ -2,19 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: substr_compare missing arguments returns FALSE
---SKIPIF--
-<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+substr_compare() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-if (substr_compare() === false) {
-    echo "true";
-} else {
-    echo "false";
+try {
+    substr_compare();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-true
---CLEAN--
-<?php
-
+substr_compare() expects at least 3 arguments, 0 given

--- a/tests/ph7/001-smoke/function/substr_count/substr_count_insufficient_args.phpt
+++ b/tests/ph7/001-smoke/function/substr_count/substr_count_insufficient_args.phpt
@@ -2,21 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-substr_count with insufficient arguments
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+substr_count() throws ArgumentCountError with too few arguments (PHP 8)
 --FILE--
 <?php
-// Test with 0 arguments
-$result1 = substr_count();
-echo $result1 === 0 ? 'PASS' : 'FAIL';
-
-// Test with 1 argument
-$result2 = substr_count('hello');
-echo $result2 === 0 ? 'PASS' : 'FAIL';
+try {
+    substr_count();
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
 --EXPECT--
-PASSPASS
---CLEAN--
-<?php
-unset($result1, $result2);
+substr_count() expects at least 2 arguments, 0 given


### PR DESCRIPTION
Builtins that were called with fewer arguments than they require used to silently degrade to a bogus false/-1/"" return (a PH7-ism); PHP 8 throws a catchable ArgumentCountError. Native builtins carry no formal signature, so a single arity table (aBuiltinArity[]) is the source of truth: VmSetBuiltinArity stamps a minimum count and an "exactly"/"at least" wording flag onto each ph7_user_func at VM init, and the one OP_CALL foreign-function choke point raises a php-byte-exact ArgumentCountError before the C routine runs when nGiven < nMinArg (covering callback / call_user_func dispatch too, which reuses the same OP_CALL).

First batch: 31 string/math/array builtins (substr, strpos family, str_pad, str_replace/ireplace, strncmp/strncasecmp, strspn/strcspn/strpbrk/strstr family, substr_compare/substr_count, hexdec/octdec/bindec, chunk_split, pow/fmod/hypot/log, in_array, range, implode/join). Functions that already self-throw the correct message are left off the table so there is no double-check or message drift. ph7_create_function's override path resets the arity metadata so an embedder replacing a listed builtin with a different-arity function does not inherit a stale threshold.

38 zend-guarded oracle-blind tests that enshrined the old behavior are rewritten as cross-engine ArgumentCountError assertions (catch + getMessage, so they dodge the uncaught-trace-format divergence). Every message byte-verified vs php 8.5.7; smoke+integration green under both engines, docker ASan+UBSan clean.
