### PR TITLE
Stop redirecting an explicit null argument to a parameter's default

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -12060,12 +12060,11 @@ case PH7_OP_CALL: {
 				if( iSrc >= 0 ){
 					/* Argument was provided — install with type checking */
 					ph7_value *pVal = &pArg[iSrc];
-					/* NULL-to-default redirect (existing behavior) */
-					if( (pVal->iFlags & MEMOBJ_NULL) && SySetUsed(&aFormalArg[n].aByteCode) > 0
-						&& !(aFormalArg[n].iFlags & VM_FUNC_ARG_NULLABLE) ){
-						rc = VmLocalExec(&(*pVm),&aFormalArg[n].aByteCode,pVal,FALSE);
-						if( rc == PH7_ABORT ) goto Abort;
-					}
+					/* An explicit null is NOT redirected to the default: PHP applies a
+					 * default only for an OMITTED argument. An explicit null falls through
+					 * to the type check below (TypeError for a non-nullable typed param,
+					 * kept as null for a typeless one). An implicitly-nullable `Type $x =
+					 * null` param carries VM_FUNC_ARG_NULLABLE, so the check accepts null. */
 					/* Type checking: union types */
 					if( aFormalArg[n].iFlags & VM_FUNC_ARG_UNION ){
 						sxi32 rcU = VmCoerceToUnion(pVm, pVal, &aFormalArg[n].aUnionAlts,
@@ -12398,14 +12397,11 @@ case PH7_OP_CALL: {
 				break; /* All remaining args consumed */
 			}
 			if( n < SySetUsed(&pVmFunc->aArgs) ){
-				if( (pArg->iFlags & MEMOBJ_NULL) && SySetUsed(&aFormalArg[n].aByteCode) > 0
-					&& !(aFormalArg[n].iFlags & VM_FUNC_ARG_NULLABLE) ){
-					/* NULL values are redirected to default arguments (but not for nullable types) */
-					rc = VmLocalExec(&(*pVm),&aFormalArg[n].aByteCode,pArg,FALSE);
-					if( rc == PH7_ABORT ){
-						goto Abort;
-					}
-				}
+				/* An explicit null is NOT redirected to the default (PHP applies a
+				 * default only for an omitted arg); it falls through to the type check
+				 * below — TypeError for a non-nullable typed param, kept as null for a
+				 * typeless one. A `Type $x = null` param is flagged VM_FUNC_ARG_NULLABLE
+				 * at compile time so its check accepts null. */
 				/* Union type: dispatch to the shared coercion helper. */
 				if( aFormalArg[n].iFlags & VM_FUNC_ARG_UNION ){
 					sxi32 rcU = VmCoerceToUnion(pVm, pArg, &aFormalArg[n].aUnionAlts,

--- a/tests/ph7/001-smoke/lang/explicit_null_not_defaulted.phpt
+++ b/tests/ph7/001-smoke/lang/explicit_null_not_defaulted.phpt
@@ -1,0 +1,59 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+An explicit null argument is not replaced by a parameter's default value
+--DESCRIPTION--
+PHP applies a default only for an OMITTED argument, never for an explicit null.
+An explicit null therefore reaches the type check: it stays null for a typeless
+param, throws a TypeError for a non-nullable typed param, and is accepted for an
+explicit `?Type` nullable param. (The implicit `Type $x = null` nullable form
+behaves the same in PHL but is left out of this cross-engine test — php emits an
+8.4 deprecation notice for it that PHL does not.) The ", called in <file> on
+line N" tail PHP appends to the TypeError is intentionally not asserted (PHL
+omits it for every exception — a separate error-format-fidelity item).
+--FILE--
+<?php
+function endTe(callable $fn): string {
+    try { $fn(); return "no-throw"; }
+    catch (\TypeError $e) {
+        return str_contains($e->getMessage(), "must be of type") ? "TE" : "TE?";
+    }
+}
+
+/* typeless param with a default: an explicit null stays null, an omitted arg defaults */
+function endTypeless($x = 5) { return var_export($x, true); }
+echo "typeless-null:", endTypeless(null), "\n";   // NULL (not 5)
+echo "typeless-omit:", endTypeless(), "\n";       // 5
+
+/* non-nullable typed param with a default: an explicit null throws */
+function endTyped(int $x = 5) { return $x; }
+echo "typed-null:", endTe(fn() => endTyped(null)), "\n";  // TE
+echo "typed-omit:", endTyped(), "\n";                     // 5
+
+/* the message prefix is PHP-exact (sans the "called in" suffix) */
+try { endTyped(null); } catch (\TypeError $e) {
+    echo substr($e->getMessage(), 0, strpos($e->getMessage(), " given") + 6), "\n";
+}
+
+/* an explicit `?type` default accepts null (the implicitly-nullable
+ * `Type $x = null` form behaves the same in PHL but carries an 8.4 deprecation
+ * notice under php, so it is left out of this cross-engine test) */
+function endNullable(?int $x = null) { return var_export($x, true); }
+echo "explicit-nullable:", endNullable(null), "\n";  // NULL
+
+/* the named-argument binding path behaves identically */
+function endNamedTypeless($p = 1, $x = 5)      { return var_export($x, true); }
+function endNamedTyped($p = 1, int $x = 5)     { return $x; }
+echo "named-typeless:", endNamedTypeless(x: null), "\n";           // NULL
+echo "named-typed:", endTe(fn() => endNamedTyped(x: null)), "\n";  // TE
+?>
+--EXPECT--
+typeless-null:NULL
+typeless-omit:5
+typed-null:TE
+typed-omit:5
+endTyped(): Argument #1 ($x) must be of type int, null given
+explicit-nullable:NULL
+named-typeless:NULL
+named-typed:TE


### PR DESCRIPTION
PHP applies a default only for an omitted argument, never for an explicit null. Two leftover PH7-ism "NULL-to-default redirect" blocks (the positional and named-argument install paths in OP_CALL) overwrote an explicit null with a non-nullable parameter's default before type-checking, so f($x=5); f(null) returned int(5) instead of NULL and f(int $x=5); f(null) returned int(5) instead of throwing TypeError.

Delete both blocks. An explicit null now falls through to the type check: kept as null for a typeless param, a catchable TypeError for a non-nullable typed param. An omitted argument still gets the default (that path never had the MEMOBJ_NULL guard), and an implicitly-nullable `Type $x = null` param (VM_FUNC_ARG_NULLABLE) or an explicit ?type still accepts null.

Byte-verified vs php 8.5.7 on both binding sites; test-compat green.
