### PR TITLE
Forward send() and throw() through yield from into the delegate

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -621,6 +621,7 @@ static VmFrame * VmNewFrame(
 }
 /* Forward declaration */
 static VmFrame * VmSkipExceptionFrames(VmFrame *pFrame);
+static sxi32 VmResumeCtx(ph7_vm *pVm, ph7_exec_ctx *pCtx, ph7_value *pResumeValue, ph7_value *pResult);
 /*
  * Enter a VM frame.
  */
@@ -6419,9 +6420,15 @@ static sxi32 VmByteCodeExecBody(
 	 * the caller's handler) and the ctx closes. pInjected is one-shot and only meaningful at
 	 * the resume pc, so this is checked once at entry — NOT per-instruction — keeping the hot
 	 * dispatch loop untouched for all normal code. The pFrame gate keeps a nested call / catch
-	 * mini-program sharing the ctx (a separate VmByteCodeExec entry) from re-firing. */
+	 * mini-program sharing the ctx (a separate VmByteCodeExec entry) from re-firing.
+	 *
+	 * Exception: when this body is suspended mid `yield from` over an inner Generator
+	 * (iDelegateState==3), a Generator::throw() on the OUTER generator must be forwarded
+	 * INTO the delegate (PHP yield-from transparency), not raised here. Leave pInjected
+	 * set and skip; the resume pc is that OP_YIELD_FROM, which consumes and forwards it. */
 	if( pVm->pActiveCtx && pVm->pActiveCtx->pInjected
-	 && pVm->pActiveCtx->pFrame == sState.pEntryFrame ){
+	 && pVm->pActiveCtx->pFrame == sState.pEntryFrame
+	 && pVm->pActiveCtx->iDelegateState != 3 ){
 		ph7_class_instance *pInj = pVm->pActiveCtx->pInjected;
 		VmFrame *pThrowFrame;
 		sxi32 iResumePc;
@@ -11474,18 +11481,52 @@ case PH7_OP_YIELD_FROM: {
 			if( rcm == PH7_ABORT || rcm == PH7_EXCEPTION ){ goto yf_propagate; }
 		}
 	}else{
-		/* Resume entry: discard the value VmResumeCtx pushed. Forwarding send()
-		 * into the delegated generator is deferred (see the Generator::throw TODO);
-		 * arrays/Traversables ignore send() anyway. */
+		/* Resume entry: the value VmResumeCtx pushed is the send() value (null for a
+		 * plain next()). For a Generator delegate (state 3) PHP forwards send()/throw()
+		 * transparently INTO the inner generator; arrays/plain Iterators (state 1/2)
+		 * ignore send() and just advance with next(). */
 #ifdef UNTRUST
 		if( pTos < pStack ){ goto Abort; }
 #endif
-		PH7_MemObjRelease(pTos);
-		pTos--;
-		if( pCtxFrom->iDelegateState >= 2 ){
-			rcm = VmIterCallMethod(pVm,(ph7_class_instance *)pCtxFrom->sDelegate.x.pOther,
-				"next",sizeof("next")-1,0);
+		if( pCtxFrom->iDelegateState == 3 ){
+			ph7_generator *pInner = VmGeneratorExtractCtx(&(*pVm),&pCtxFrom->sDelegate);
+			/* A pending Generator::throw() on the outer was parked on pInjected by the
+			 * body-entry gate (which skips its own raise for state 3); forward it as a
+			 * throw into the delegate, else forward the sent value. */
+			ph7_class_instance *pInjFwd = pCtxFrom->pInjected;
+			ph7_value sSent;
+			PH7_MemObjInit(pVm,&sSent);
+			PH7_MemObjStore(pTos,&sSent); /* take the sent value off the stack */
+			PH7_MemObjRelease(pTos);
+			pTos--;
+			pCtxFrom->pInjected = 0;
+			if( pInner && pInner->pCtx && pInner->pCtx->iState == PH7_CTX_STATE_SUSPENDED ){
+				if( pInjFwd ){
+					/* Borrowed ref: the outer's Generator::throw() holds it across this
+					 * whole resume, so the inner inject path must not unref it. */
+					pInner->pCtx->pInjected = pInjFwd;
+					rcm = VmResumeCtx(&(*pVm),pInner->pCtx,0,0);
+					pInner->pCtx->pInjected = 0;
+				}else{
+					rcm = VmResumeCtx(&(*pVm),pInner->pCtx,&sSent,0);
+				}
+			}else if( pInjFwd ){
+				/* No live delegate to receive the throw (inner already finished/closed):
+				 * raise it at the yield-from in the outer generator's own frame. */
+				VmFrame *pTF = VmSkipExceptionFrames(pVm->pFrame);
+				pTF->iFlags |= VM_FRAME_THROW;
+				rcm = (VmThrowException(&(*pVm),pInjFwd) == SXERR_ABORT) ? PH7_ABORT : PH7_EXCEPTION;
+			}
+			PH7_MemObjRelease(&sSent);
 			if( rcm == PH7_ABORT || rcm == PH7_EXCEPTION ){ goto yf_propagate; }
+		}else{
+			PH7_MemObjRelease(pTos);
+			pTos--;
+			if( pCtxFrom->iDelegateState >= 2 ){
+				rcm = VmIterCallMethod(pVm,(ph7_class_instance *)pCtxFrom->sDelegate.x.pOther,
+					"next",sizeof("next")-1,0);
+				if( rcm == PH7_ABORT || rcm == PH7_EXCEPTION ){ goto yf_propagate; }
+			}
 		}
 	}
 	/* Fetch the current (key,value) of the delegate, or mark exhausted. */

--- a/tests/ph7/002-integration/lang/yield_from_send_throw_forward.phpt
+++ b/tests/ph7/002-integration/lang/yield_from_send_throw_forward.phpt
@@ -1,0 +1,61 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Generator: yield from forwards send() and throw() into the delegated generator (PHP transparency)
+--SKIPIF--
+<?php if (function_exists('zend_version') && version_compare(PHP_VERSION, '7.0.0', '<')) echo 'skip Requires PHP 7.0+'; ?>
+--FILE--
+<?php
+// send() reaches the delegate's own yield expression, not the outer generator.
+function innerSend(){ $x = yield 1; echo "inner received: ", var_export($x, true), "\n"; yield 2; }
+function outerSend(){ yield from innerSend(); }
+$g = outerSend();
+echo "start: ", $g->current(), "\n";
+echo "send ret: ", $g->send("HELLO"), "\n";
+echo "cur: ", $g->current(), "\n";
+
+// throw() is injected at the delegate's suspended yield; the delegate's own catch handles it.
+function innerThrow(){ try { yield 1; } catch (Exception $e) { echo "inner caught: ", $e->getMessage(), "\n"; yield 99; } }
+function outerThrow(){ yield from innerThrow(); }
+$h = outerThrow();
+$h->current();
+echo "throw ret: ", $h->throw(new Exception("boom")), "\n";
+echo "cur: ", $h->current(), "\n";
+
+// Nested delegation top -> mid -> leaf: send/throw thread to the innermost, return values bubble up.
+function leaf(){ $a = yield 1; echo "leaf got: $a\n"; $b = yield 2; echo "leaf got: $b\n"; return "leaf-ret"; }
+function mid(){ $r = yield from leaf(); echo "mid saw return: $r\n"; yield 3; }
+function top(){ yield from mid(); }
+$t = top();
+echo "cur=", $t->current(), "\n";
+echo "send1=", $t->send("A"), "\n";
+echo "send2=", $t->send("B"), "\n";
+echo "cur=", $t->current(), "\n";
+
+// An uncaught throw in the delegate propagates through the yield from to the throw() caller.
+function innerBare(){ yield 1; yield 2; }
+function outerBare(){ yield from innerBare(); echo "NOT REACHED\n"; }
+$u = outerBare();
+$u->current();
+try { $u->throw(new RuntimeException("kaboom")); }
+catch (RuntimeException $e) { echo "caught at top: ", $e->getMessage(), "\n"; }
+?>
+--EXPECT--
+start: 1
+send ret: inner received: 'HELLO'
+2
+cur: 2
+throw ret: inner caught: boom
+99
+cur: 99
+cur=1
+send1=leaf got: A
+2
+send2=leaf got: B
+mid saw return: leaf-ret
+3
+cur=3
+caught at top: kaboom
+--CLEAN--
+<?php


### PR DESCRIPTION
A send()/throw() on a generator suspended mid `yield from` over an inner Generator is now forwarded transparently into the delegate, matching PHP: send($v) reaches the delegate's own yield expression and throw($e) is injected at the delegate's suspended yield so its own catch handles it. The delegate's return value still bubbles up and an uncaught throw propagates through the yield-from to the throw() caller; nested delegation threads to the innermost generator. Arrays, plain Iterators, and an IteratorAggregate whose getIterator() returns a Generator (delegate state 1/2) keep ignoring send() and raise throw() at the outer yield-from point -- byte-exact with php, which only forwards into a directly-delegated Generator.

The body-entry inject-raise now skips when the resumed body is delegating to a Generator (iDelegateState==3), leaving pInjected on the ctx for the resume pc; the OP_YIELD_FROM resume branch forwards the sent value or the pending injection into the inner ctx via VmResumeCtx instead of discarding it and calling next().
