### PR TITLE
Throw ValueError for string-builtin domain errors and convert arbitra…

### DIFF
--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -531,40 +531,47 @@ static int PH7_builtin_substr_count(ph7_context *pCtx,int nArg,ph7_value **apArg
 	zText = ph7_value_to_string(apArg[0],&nTextlen);
 	/* Point to the neddle */
 	zPattern = ph7_value_to_string(apArg[1],&nPatlen);
-	if( nTextlen < 1 || nPatlen < 1 || nPatlen > nTextlen ){
-		/* NOOP,return zero */
+	if( nPatlen < 1 ){
+		/* Empty needle: PHP 8 throws a catchable ValueError. */
+		return PH7_VmThrowException(pCtx,"ValueError",
+			"substr_count(): Argument #2 ($needle) must not be empty");
+	}
+	/* Apply the optional $offset/$length window before searching. PHP 8 validates
+	 * both against the haystack (a negative value counts from the end) and throws a
+	 * catchable ValueError when the result falls outside it — this happens before the
+	 * needle-fits check, so it fires even when the needle is longer than the haystack. */
+	if( nArg > 2 ){
+		ph7_int64 iOfft = ph7_value_to_int64(apArg[2]);
+		if( iOfft < 0 ){
+			iOfft += nTextlen;
+		}
+		if( iOfft < 0 || iOfft > nTextlen ){
+			return PH7_VmThrowException(pCtx,"ValueError",
+				"substr_count(): Argument #3 ($offset) must be contained in argument #1 ($haystack)");
+		}
+		/* Point to the desired offset and shrink the remaining region */
+		zText = &zText[iOfft];
+		nTextlen -= (int)iOfft;
+	}
+	if( nArg > 3 ){
+		ph7_int64 nLen = ph7_value_to_int64(apArg[3]);
+		if( nLen < 0 ){
+			/* Negative length is relative to the end of the (offset) haystack */
+			nLen += nTextlen;
+		}
+		if( nLen < 0 || nLen > nTextlen ){
+			return PH7_VmThrowException(pCtx,"ValueError",
+				"substr_count(): Argument #4 ($length) must be contained in argument #1 ($haystack)");
+		}
+		nTextlen = (int)nLen;
+	}
+	if( nTextlen < 1 || nPatlen > nTextlen ){
+		/* The windowed haystack can't contain the needle: zero matches */
 		ph7_result_int(pCtx,0);
 		return PH7_OK;
 	}
-	if( nArg > 2 ){
-		int iOfft;
-		/* Extract the offset */
-		iOfft = ph7_value_to_int(apArg[2]);
-		if( iOfft < 0 || iOfft > nTextlen ){
-			/* Invalid offset,return zero */
-			ph7_result_int(pCtx,0);
-			return PH7_OK;
-		}
-		/* Point to the desired offset */
-		zText = &zText[iOfft];
-		/* Adjust length */
-		nTextlen -= iOfft;
-	}
-	/* Point to the end of the string */
+	/* Point to the end of the windowed haystack */
 	zEnd = &zText[nTextlen];
-	if( nArg > 3 ){
-		int nLen;
-		/* Extract the length */
-		nLen = ph7_value_to_int(apArg[3]);
-		if( nLen < 0 || nLen > nTextlen ){
-			/* Invalid length,return 0 */
-			ph7_result_int(pCtx,0);
-			return PH7_OK;
-		}
-		/* Adjust pointer */
-		nTextlen = nLen;
-		zEnd = &zText[nTextlen];
-	}
 	/* Perform the search */
 	for(;;){
 		rc = SyBlobSearch((const void *)zText,(sxu32)(zEnd-zText),(const void *)zPattern,nPatlen,&nOfft);
@@ -614,8 +621,9 @@ static int PH7_builtin_chunk_split(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		/* Chunk length */
 		nChunkLen = ph7_value_to_int(apArg[1]);
 		if( nChunkLen < 1 ){
-			/* Switch back to the default length */
-			nChunkLen = 76;
+			/* PHP 8 throws a catchable ValueError for a non-positive length. */
+			return PH7_VmThrowException(pCtx,"ValueError",
+				"chunk_split(): Argument #2 ($length) must be greater than 0");
 		}
 		if( nArg > 2 ){
 			/* Separator */
@@ -1555,9 +1563,9 @@ static int PH7_builtin_explode(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	/* Extract the delimiter */
 	zDelim = ph7_value_to_string(apArg[0],&nDelim);
 	if( nDelim < 1 ){
-		/* Empty delimiter,return FALSE */
-		ph7_result_bool(pCtx,0);
-		return PH7_OK;
+		/* Empty delimiter: PHP 8 throws a catchable ValueError. */
+		return PH7_VmThrowException(pCtx,"ValueError",
+			"explode(): Argument #1 ($separator) must not be empty");
 	}
 	/* Extract the string */
 	zString = ph7_value_to_string(apArg[1],&nStrlen);
@@ -3052,7 +3060,8 @@ static int PH7_builtin_ucwords(ph7_context *pCtx,int nArg,ph7_value **apArg)
 static int PH7_builtin_str_repeat(ph7_context *pCtx,int nArg,ph7_value **apArg)
 {
 	const char *zIn;
-	int nLen,nMul;
+	int nLen;
+	ph7_int64 nMul;
 	int rc;
 	if( nArg < 2 ){
 		/* Missing arguments,return NULL */
@@ -3061,15 +3070,17 @@ static int PH7_builtin_str_repeat(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	}
 	/* Extract the target string */
 	zIn = ph7_value_to_string(apArg[0],&nLen);
-	if( nLen < 1 ){
-		/* Empty string.Return null */
-		ph7_result_null(pCtx);
-		return PH7_OK;
+	/* Extract the multiplier as a 64-bit value (a 32-bit read would wrap a large
+	 * positive $times into a negative one and trip a spurious ValueError). PHP
+	 * validates $times regardless of the string contents: a negative count throws
+	 * a catchable ValueError. */
+	nMul = ph7_value_to_int64(apArg[1]);
+	if( nMul < 0 ){
+		return PH7_VmThrowException(pCtx,"ValueError",
+			"str_repeat(): Argument #2 ($times) must be greater than or equal to 0");
 	}
-	/* Extract the multiplier */
-	nMul = ph7_value_to_int(apArg[1]);
-	if( nMul < 1 ){
-		/* Return the empty string */
+	if( nLen < 1 || nMul < 1 ){
+		/* Empty input or a zero multiplier yields the empty string (PHP). */
 		ph7_result_string(pCtx,"",0);
 		return PH7_OK;
 	}
@@ -6801,9 +6812,10 @@ static int PH7_builtin_str_pad(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		/* Padding string */
 		zPad = ph7_value_to_string(apArg[2],&iStrpad);
 		if( iStrpad < 1 ){
-			/* Empty string */
-			zPad = " "; /* Whitespace padding */
-			iStrpad = (int)sizeof(char);
+			/* An empty pad string throws a catchable ValueError in PHP 8
+			 * (only reached once padding is actually required). */
+			return PH7_VmThrowException(pCtx,"ValueError",
+				"str_pad(): Argument #3 ($pad_string) must not be empty");
 		}
 		if( nArg > 3 ){
 			/* Padd type */

--- a/src/ph7/builtin_math.c
+++ b/src/ph7/builtin_math.c
@@ -1256,64 +1256,73 @@ PH7_PRIVATE int PH7_builtin_srand(ph7_context *pCtx,int nArg,ph7_value **apArg)
  */
 PH7_PRIVATE int PH7_builtin_base_convert(ph7_context *pCtx,int nArg,ph7_value **apArg)
 {
-	int nLen,iFbase,iTobase;
+	static const char zDigits[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+	int nLen,iFbase,iTobase,i;
+	ph7_int64 iFbase64,iTobase64;
 	const char *zNum;
-	ph7_int64 iNum;
+	sxu64 uNum = 0;
 	if( nArg < 3 ){
 		/* Return the empty string*/
 		ph7_result_string(pCtx,"",0);
 		return PH7_OK;
 	}
-	/* Base numbers */
-	iFbase  = ph7_value_to_int(apArg[1]);
-	iTobase = ph7_value_to_int(apArg[2]);
-	if( ph7_value_is_string(apArg[0]) ){
-		/* Extract the target number */
-		zNum = ph7_value_to_string(apArg[0],&nLen);
-		if( nLen < 1 ){
-			/* Return the empty string*/
-			ph7_result_string(pCtx,"",0);
-			return PH7_OK;
-		}
-		/* Base conversion */
-		switch(iFbase){
-		case 16:
-			/* Hex */
-			SyHexStrToInt64(zNum,(sxu32)nLen,(void *)&iNum,0);
-			break;
-		case 8:
-			/* Octal */
-			SyOctalStrToInt64(zNum,(sxu32)nLen,(void *)&iNum,0);
-			break;
-		case 2:
-			/* Binary */
-			SyBinaryStrToInt64(zNum,(sxu32)nLen,(void *)&iNum,0);
-			break;
-		default:
-			/* Decimal */
-			SyStrToInt64(zNum,(sxu32)nLen,(void *)&iNum,0);
-			break;
-		}
-	}else{
-		iNum = ph7_value_to_int64(apArg[0]);
+	/* Base numbers. Read them as 64-bit so an out-of-range base can't wrap through
+	 * a 32-bit truncation back into the 2..36 window and bypass the check below. */
+	iFbase64 = ph7_value_to_int64(apArg[1]);
+	iTobase64 = ph7_value_to_int64(apArg[2]);
+	/* PHP 8 throws a catchable ValueError for a base outside 2..36; from_base
+	 * is validated before to_base, both before the string is even parsed. */
+	if( iFbase64 < 2 || iFbase64 > 36 ){
+		return PH7_VmThrowException(pCtx,"ValueError",
+			"base_convert(): Argument #2 ($from_base) must be between 2 and 36 (inclusive)");
 	}
-	switch(iTobase){
-	case 16:
-		/* Hex */
-		ph7_result_string_format(pCtx,"%qx",iNum); /* Quad hex */
-		break;
-	case 8:
-		/* Octal */
-		ph7_result_string_format(pCtx,"%qo",iNum); /* Quad octal */
-		break;
-	case 2:
-		/* Binary */
-		ph7_result_string_format(pCtx,"%qB",iNum); /* Quad binary */
-		break;
-	default:
-		/* Decimal */
-		ph7_result_string_format(pCtx,"%qd",iNum); /* Quad decimal */
-		break;
+	if( iTobase64 < 2 || iTobase64 > 36 ){
+		return PH7_VmThrowException(pCtx,"ValueError",
+			"base_convert(): Argument #3 ($to_base) must be between 2 and 36 (inclusive)");
+	}
+	/* Both bases are now known to fit in [2,36], so the int form is exact. */
+	iFbase  = (int)iFbase64;
+	iTobase = (int)iTobase64;
+	/* Parse the input number in from_base. Every base is handled the same way:
+	 * digits 0-9 then a-z/A-Z map to 0-35; a character that is not a valid digit
+	 * for from_base is ignored (PHP additionally raises an E_DEPRECATED for the
+	 * ignored characters — not yet emitted, see PLAN §3.1). */
+	zNum = ph7_value_to_string(apArg[0],&nLen);
+	for( i = 0 ; i < nLen ; ++i ){
+		int c = (unsigned char)zNum[i];
+		int d;
+		if( c >= '0' && c <= '9' ){
+			d = c - '0';
+		}else if( c >= 'a' && c <= 'z' ){
+			d = c - 'a' + 10;
+		}else if( c >= 'A' && c <= 'Z' ){
+			d = c - 'A' + 10;
+		}else{
+			d = 99;
+		}
+		if( d >= iFbase ){
+			/* Not a valid digit for this base: skip it (PHP). */
+			continue;
+		}
+		uNum = uNum * (sxu64)iFbase + (sxu64)d;
+	}
+	/* Format the result in to_base using lowercase digits. */
+	if( uNum == 0 ){
+		ph7_result_string(pCtx,"0",1);
+	}else{
+		char zOut[70]; /* base-2 of a 64-bit value fits in 64 digits */
+		int n = 0,j;
+		while( uNum > 0 ){
+			zOut[n++] = zDigits[uNum % (sxu64)iTobase];
+			uNum /= (sxu64)iTobase;
+		}
+		/* Digits were produced least-significant first: reverse in place. */
+		for( j = 0 ; j < n/2 ; ++j ){
+			char t = zOut[j];
+			zOut[j] = zOut[n - 1 - j];
+			zOut[n - 1 - j] = t;
+		}
+		ph7_result_string(pCtx,zOut,n);
 	}
 	return PH7_OK;
 }

--- a/tests/ph7/001-smoke/function/base_convert/base_convert_arbitrary_base.phpt
+++ b/tests/ph7/001-smoke/function/base_convert/base_convert_arbitrary_base.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+base_convert handles arbitrary bases (2..36), not just 2/8/10/16
+--FILE--
+<?php
+echo base_convert("z", 36, 10), "\n";
+echo base_convert("zz", 36, 16), "\n";
+echo base_convert("100", 10, 3), "\n";
+echo base_convert("777", 8, 20), "\n";
+echo base_convert("cafe", 16, 36), "\n";
+echo base_convert("11011", 2, 10), "\n";
+?>
+--EXPECT--
+35
+50f
+10201
+15b
+143i
+27
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/base_convert/base_convert_empty.phpt
+++ b/tests/ph7/001-smoke/function/base_convert/base_convert_empty.phpt
@@ -2,15 +2,12 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-base_convert with empty string
---SKIPIF--
-<?php 
-if (function_exists('zend_version')) echo 'skip';
+base_convert with empty string returns "0"
 --FILE--
 <?php
 echo base_convert("", 10, 16) . "\n";
 ?>
 --EXPECT--
+0
 --CLEAN--
 <?php
-

--- a/tests/ph7/001-smoke/function/base_convert/base_convert_invalid_base.phpt
+++ b/tests/ph7/001-smoke/function/base_convert/base_convert_invalid_base.phpt
@@ -1,0 +1,26 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+base_convert throws ValueError for a base outside 2..36
+--FILE--
+<?php
+// The last row (a base above 2^32) guards against a 32-bit truncation wrapping
+// it back into the valid 2..36 window.
+foreach ([[1, 10], [37, 10], [16, 1], [16, 99], [4294967298, 10]] as [$from, $to]) {
+    try {
+        base_convert("ff", $from, $to);
+        echo "NO_ERROR\n";
+    } catch (\ValueError $e) {
+        echo $e->getMessage(), "\n";
+    }
+}
+?>
+--EXPECT--
+base_convert(): Argument #2 ($from_base) must be between 2 and 36 (inclusive)
+base_convert(): Argument #2 ($from_base) must be between 2 and 36 (inclusive)
+base_convert(): Argument #3 ($to_base) must be between 2 and 36 (inclusive)
+base_convert(): Argument #3 ($to_base) must be between 2 and 36 (inclusive)
+base_convert(): Argument #2 ($from_base) must be between 2 and 36 (inclusive)
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/chunk_split/chunk_split_invalid_chunklen.phpt
+++ b/tests/ph7/001-smoke/function/chunk_split/chunk_split_invalid_chunklen.phpt
@@ -2,22 +2,17 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: chunk_split with invalid chunk length
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+chunk_split with a non-positive chunk length throws ValueError
 --FILE--
 <?php
-// Test chunk_split with zero chunk length (should reset to default 76)
-$result = chunk_split("hello", 0);
-$expected = "hello\r\n";
-if ($result === $expected) {
-    echo "PASS\n";
-} else {
-    echo "FAIL\n";
+try {
+    chunk_split("hello", 0);
+    echo "NO_ERROR\n";
+} catch (\ValueError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
-PASS
+chunk_split(): Argument #2 ($length) must be greater than 0
 --CLEAN--
 <?php
-unset($result, $expected);

--- a/tests/ph7/001-smoke/function/explode/explode_empty_delimiter.phpt
+++ b/tests/ph7/001-smoke/function/explode/explode_empty_delimiter.phpt
@@ -1,17 +1,18 @@
 --CREDITS--
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --TEST--
-explode with empty delimiter returns false
+explode with empty delimiter throws ValueError
 --FILE--
 <?php
-$result = explode("", "test");
-echo $result === false ? "EXPLODE_EMPTY_DELIM:FALSE\n" : "EXPLODE_EMPTY_DELIM:TRUE\n";
+try {
+    explode("", "test");
+    echo "NO_ERROR\n";
+} catch (\ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
 --EXPECT--
-EXPLODE_EMPTY_DELIM:FALSE
+explode(): Argument #1 ($separator) must not be empty
 --CLEAN--
 <?php
-unset($result);

--- a/tests/ph7/001-smoke/function/str_pad/str_pad_empty_pad.phpt
+++ b/tests/ph7/001-smoke/function/str_pad/str_pad_empty_pad.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+str_pad with an empty pad string throws ValueError only when padding is needed
+--FILE--
+<?php
+// No padding required: the empty pad string is not validated.
+echo str_pad("hello", 3, ""), "\n";
+try {
+    str_pad("x", 10, "");
+    echo "NO_ERROR\n";
+} catch (\ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+hello
+str_pad(): Argument #3 ($pad_string) must not be empty
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/str_repeat/str_repeat_negative.phpt
+++ b/tests/ph7/001-smoke/function/str_repeat/str_repeat_negative.phpt
@@ -2,16 +2,17 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PHL: str_repeat with negative multiplier returns empty string
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+str_repeat with negative multiplier throws ValueError
 --FILE--
 <?php
-$result = str_repeat("a", -1);
-var_dump($result);
+try {
+    str_repeat("a", -1);
+    echo "NO_ERROR\n";
+} catch (\ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
 --EXPECT--
-string(0) ""
+str_repeat(): Argument #2 ($times) must be greater than or equal to 0
 --CLEAN--
 <?php
-unset($result);

--- a/tests/ph7/001-smoke/function/substr_count/substr_count_empty_needle.phpt
+++ b/tests/ph7/001-smoke/function/substr_count/substr_count_empty_needle.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+substr_count with an empty needle throws ValueError
+--FILE--
+<?php
+try {
+    substr_count("abc", "");
+    echo "NO_ERROR\n";
+} catch (\ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+substr_count(): Argument #2 ($needle) must not be empty
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/substr_count/substr_count_invalid_length.phpt
+++ b/tests/ph7/001-smoke/function/substr_count/substr_count_invalid_length.phpt
@@ -2,21 +2,21 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: substr_count with invalid length returns 0
---SKIPIF--
-<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+substr_count length: out-of-range throws ValueError, negative counts from the end
 --FILE--
 <?php
-// Length greater than string length
-$result1 = substr_count('abc', 'b', 0, 10);
-echo "result1=" . $result1 . "\n";
-// Negative length
-$result2 = substr_count('abc', 'b', 0, -1);
-echo "result2=" . $result2 . "\n";
+// Length greater than the (offset) haystack throws.
+try {
+    substr_count('abc', 'b', 0, 10);
+    echo "NO_ERROR\n";
+} catch (\ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+// Negative length is relative to the end: "abc" with length -1 => "ab" => one 'b'.
+echo "result2=" . substr_count('abc', 'b', 0, -1) . "\n";
 ?>
 --EXPECT--
-result1=0
-result2=0
+substr_count(): Argument #4 ($length) must be contained in argument #1 ($haystack)
+result2=1
 --CLEAN--
 <?php
-unset($result1, $result2);

--- a/tests/ph7/001-smoke/function/substr_count/substr_count_invalid_offset.phpt
+++ b/tests/ph7/001-smoke/function/substr_count/substr_count_invalid_offset.phpt
@@ -2,15 +2,17 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-substr_count with invalid offset
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+substr_count with an out-of-range offset throws ValueError
 --FILE--
 <?php
-echo substr_count("hello", "l", 10) . "\n";
+try {
+    substr_count("hello", "l", 10);
+    echo "NO_ERROR\n";
+} catch (\ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
 ?>
 --EXPECT--
-0
+substr_count(): Argument #3 ($offset) must be contained in argument #1 ($haystack)
 --CLEAN--
 <?php
-

--- a/tests/ph7/001-smoke/function/substr_count/substr_count_length.phpt
+++ b/tests/ph7/001-smoke/function/substr_count/substr_count_length.phpt
@@ -2,30 +2,27 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: substr_count with offset and length parameters
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+substr_count with offset and length parameters
 --FILE--
 <?php
-// Test substr_count with 4 arguments (haystack, needle, offset, length)
 $haystack = "abababababa";
 $needle = "aba";
 
-// Test with offset and length
-$result1 = substr_count($haystack, $needle, 0, 6); // "ababab" -> 1 (at 0-2)
-echo "substr_count with offset 0, length 6: $result1\n";
+// Valid offset and length windows.
+echo "substr_count with offset 0, length 6: ", substr_count($haystack, $needle, 0, 6), "\n"; // "ababab" -> 1
+echo "substr_count with offset 2, length 8: ", substr_count($haystack, $needle, 2, 8), "\n"; // "abababab" -> 2
 
-$result2 = substr_count($haystack, $needle, 2, 8); // "abababab" -> 2 (at 2-4, 4-6)
-echo "substr_count with offset 2, length 8: $result2\n";
-
-// Test with invalid length (too large)
-$result3 = substr_count($haystack, $needle, 0, 100);
-echo "substr_count with large length: $result3\n";
+// A length past the end of the haystack throws.
+try {
+    substr_count($haystack, $needle, 0, 100);
+    echo "NO_ERROR\n";
+} catch (\ValueError $e) {
+    echo "substr_count with large length: ", $e->getMessage(), "\n";
+}
 ?>
 --EXPECT--
 substr_count with offset 0, length 6: 1
 substr_count with offset 2, length 8: 2
-substr_count with large length: 0
+substr_count with large length: substr_count(): Argument #4 ($length) must be contained in argument #1 ($haystack)
 --CLEAN--
 <?php
-unset($haystack, $needle, $result1, $result2, $result3);

--- a/tests/ph7/001-smoke/function/substr_count/substr_count_negative_offset.phpt
+++ b/tests/ph7/001-smoke/function/substr_count/substr_count_negative_offset.phpt
@@ -1,0 +1,17 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+substr_count with a negative offset counts from the end of the haystack
+--FILE--
+<?php
+// -5 => start at "world"; one 'o'.
+echo substr_count("hello world", "o", -5), "\n";
+// negative offset combined with a negative length window: window is "abcab" -> one "bc".
+echo substr_count("abcabcabc", "bc", -6, -1), "\n";
+?>
+--EXPECT--
+1
+1
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/substr_count/substr_count_valid_length.phpt
+++ b/tests/ph7/001-smoke/function/substr_count/substr_count_valid_length.phpt
@@ -2,9 +2,7 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: substr_count with valid length parameter
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+substr_count with valid length parameter
 --FILE--
 <?php
 // Test substr_count with valid length parameter (should not return 0)


### PR DESCRIPTION
…ry bases

explode (empty separator), str_repeat (negative times), str_pad (empty pad string), chunk_split (non-positive length), substr_count (empty needle), and base_convert (base outside 2..36) now throw the php-byte-exact catchable ValueError instead of silently returning a wrong value.

base_convert is also rewritten to convert arbitrary bases 2..36; it previously special-cased only 2/8/10/16 and mis-read every other in-range base as decimal.

substr_count now applies the $offset/$length window php-exactly (a negative value counts from the end, an out-of-range value throws ValueError) before the needle-fits check. base_convert and str_repeat read their base/times arguments as 64-bit so a huge value can't wrap through a 32-bit truncation into a spurious accept (base) or reject (times).

Oracle-blind zend-guarded tests that enshrined the old behavior are rewritten cross-engine; new cross-engine tests cover the arbitrary-base conversion, the domain ValueErrors, and the negative-offset / huge-base edges. Byte-verified vs php 8.5.7 (test-compat green) and docker ASan+UBSan clean.
