### PR TITLE
Add array_first and array_last

### DIFF
--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -7194,6 +7194,57 @@ static int ph7_hashmap_is_list(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	return PH7_OK;
 }
 /*
+ * mixed array_first(array $array)
+ * mixed array_last(array $array)
+ *  Return the value of the first (respectively last) element of the array,
+ *  or NULL when the array is empty. The internal array pointer is left
+ *  untouched (unlike reset()/end()).
+ */
+static int HashmapFirstLast(ph7_context *pCtx,int nArg,ph7_value **apArg,int bLast)
+{
+	ph7_hashmap *pMap;
+	ph7_hashmap_node *pNode;
+	ph7_value *pVal;
+	const char *zName = bLast ? "array_last" : "array_first";
+	if( nArg < 1 ){
+		return PH7_VmThrowException(pCtx,
+			"ArgumentCountError",
+			"%s() expects exactly 1 argument, 0 given",
+			zName
+			);
+	}
+	if( !ph7_value_is_array(apArg[0]) ){
+		return PH7_VmThrowException(pCtx,
+			"TypeError",
+			"%s(): Argument #1 ($array) must be of type array, %s given",
+			zName,
+			ph7_type_name(apArg[0])
+			);
+	}
+	pMap = (ph7_hashmap *)apArg[0]->x.pOther;
+	pNode = bLast ? pMap->pLast : pMap->pFirst;
+	if( pNode == 0 ){
+		/* Empty array: PHP returns NULL */
+		ph7_result_null(pCtx);
+		return PH7_OK;
+	}
+	pVal = HashmapExtractNodeValue(pNode);
+	if( pVal ){
+		ph7_result_value(pCtx,pVal);
+	}else{
+		ph7_result_null(pCtx);
+	}
+	return PH7_OK;
+}
+static int ph7_hashmap_first(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	return HashmapFirstLast(pCtx,nArg,apArg,0);
+}
+static int ph7_hashmap_last(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	return HashmapFirstLast(pCtx,nArg,apArg,1);
+}
+/*
  * Fetch the element identified by 'pKey' from 'pRow' which may be either an
  * array (hashmap lookup) or an object (public attribute lookup). Used by
  * array_column() for both the column value and the index key.
@@ -7629,6 +7680,8 @@ static const ph7_builtin_func aHashmapFunc[] = {
 	{"array_map",         ph7_hashmap_map     },
 	{"array_column",      ph7_hashmap_column  },
 	{"array_is_list",     ph7_hashmap_is_list },
+	{"array_first",       ph7_hashmap_first   },
+	{"array_last",        ph7_hashmap_last    },
 	{"array_find",        ph7_hashmap_find    },
 	{"array_find_key",    ph7_hashmap_find_key},
 	{"array_any",         ph7_hashmap_any     },

--- a/tests/ph7/001-smoke/array/array_first_last.phpt
+++ b/tests/ph7/001-smoke/array/array_first_last.phpt
@@ -1,0 +1,40 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+array_first/array_last return first/last value, NULL for empty, pointer untouched
+--FILE--
+<?php
+// value of the first / last element (keys ignored)
+echo array_first([3 => "a", 7 => "b"]), "\n";
+echo array_last([3 => "a", 7 => "b"]), "\n";
+// list form
+echo array_first([10, 20, 30]), "\n";
+echo array_last([10, 20, 30]), "\n";
+// empty array -> NULL
+var_export(array_first([]));
+echo "\n";
+var_export(array_last([]));
+echo "\n";
+// internal pointer is left untouched (unlike reset()/end())
+$a = [1, 2, 3];
+next($a);
+array_first($a);
+array_last($a);
+echo current($a), "\n";
+// argument validation matches php
+try { array_first(); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+try { array_last("x"); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+?>
+--EXPECT--
+a
+b
+10
+30
+NULL
+NULL
+2
+ArgumentCountError: array_first() expects exactly 1 argument, 0 given
+TypeError: array_last(): Argument #1 ($array) must be of type array, string given
+--CLEAN--
+<?php


### PR DESCRIPTION
Return the value of the first/last element of an array (keys ignored), NULL for an empty array, leaving the internal pointer untouched — unlike reset()/end(). Argument validation matches PHP: a missing argument throws ArgumentCountError, a non-array throws TypeError, both byte-exact with php 8.5.7. Cross-engine test.
