### PR TITLE
Parse new C()->m() without wrapping parens (PHP 8.4)

### DIFF
--- a/src/ph7/parse.c
+++ b/src/ph7/parse.c
@@ -1541,6 +1541,30 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 				 for( iPtr = 1; iPtr <= nFuncTok ; iPtr++ ){
 					 apNode[iCur+iPtr] = 0;
 				 }
+				 /* PHP 8.4: `new ClassName(args)` may be the left operand of a
+				  * postfix operator without wrapping parens — `new C()->m()`
+				  * means `(new C())->m()`, not `new (C()->m())`. If this call's
+				  * callee is immediately preceded by a `new` operator, fold the
+				  * constructor call into that new-node NOW, before the postfix
+				  * operators bind, and relocate the completed new-node onto this
+				  * call slot so a trailing ->/::/[]/call picks it up as its left
+				  * operand. `new C` without a constructor-arg '(' never reaches
+				  * this branch, so it keeps the legacy precedence-1 path (and
+				  * `new C->m()` stays a parse error, like PHP). */
+				 {
+					 sxi32 iNew = iLeft - 1;
+					 while( iNew >= 0 && apNode[iNew] == 0 ){
+						 iNew--;
+					 }
+					 if( iNew >= 0 && apNode[iNew]->pOp
+						 && apNode[iNew]->pOp->iOp == EXPR_OP_NEW
+						 && apNode[iNew]->pLeft == 0 ){
+						 apNode[iNew]->pLeft = pNode; /* new -> ClassName(args) */
+						 apNode[iCur] = apNode[iNew]; /* relocate onto the call slot */
+						 apNode[iNew] = 0;
+						 pNode = apNode[iCur];
+					 }
+				 }
 			 }else if (pNode->pOp->iOp == EXPR_OP_SUBSCRIPT ){
 				 /* Subscripting */
 				 sxi32 iArrTok = iCur + 1;
@@ -1549,7 +1573,10 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 					 apNode[iLeft]->xCode != PH7_CompileSimpleString && apNode[iLeft]->xCode != PH7_CompileString &&
 					 apNode[iLeft]->xCode != PH7_CompileHereDoc && apNode[iLeft]->xCode != PH7_CompileNowDoc &&
 					 apNode[iLeft]->xCode != PH7_CompileArray && apNode[iLeft]->xCode != PH7_CompileShortArray ) ) ||
-					 ( apNode[iLeft]->pOp && apNode[iLeft]->pOp->iPrec != 2 /* postfix */) ){
+					 ( apNode[iLeft]->pOp && apNode[iLeft]->pOp->iPrec != 2 /* postfix */
+						 /* PHP 8.4: a folded `new C()` (precedence-1 op) is a valid
+						  * subscript base — `new C()[0]` means `(new C())[0]`. */
+						 && apNode[iLeft]->pOp->iOp != EXPR_OP_NEW ) ){
 						 /* Syntax error */
 						 rc = PH7_GenCompileError(pGen,E_ERROR,pNode->pStart->nLine,"Invalid array name");
 						 if( rc != SXERR_ABORT ){
@@ -1669,6 +1696,23 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 				 }
 			 }else{
 				 /* New */
+				 if( apNode[iLeft]->pOp && apNode[iLeft]->pOp->iOp == EXPR_OP_NEW
+					 && (apNode[iLeft]->iFlags & EXPR_NODE_PARENS) == 0 ){
+					 /* `new new C()` — the operand of `new` is a class-name
+					  * reference and cannot itself be an unparenthesized `new`
+					  * expression (PHP parse error). The postfix pass folds
+					  * `new C()` into a completed term, so guard against the
+					  * outer `new` accepting it here. `new (new C())` is allowed
+					  * (the inner is a parenthesized group). */
+					 pToken = apNode[iLeft]->pStart;
+					 rc = PH7_GenCompileError(pGen,E_ERROR,pNode->pStart->nLine,
+						 "'%z': Unexpected token '%z', expecting literal, variable or constructor call",
+						 &pNode->pOp->sOp,&pToken->sData);
+					 if( rc != SXERR_ABORT ){
+						 rc = SXERR_SYNTAX;
+					 }
+					 return rc;
+				 }
 				 if( apNode[iLeft]->pOp == 0 ){
 					 ProcNodeConstruct xCons = apNode[iLeft]->xCode;
 					 if( xCons != PH7_CompileVariable && xCons != PH7_CompileLiteral && xCons != PH7_CompileSimpleString

--- a/tests/ph7/001-smoke/oo/new_without_parens.phpt
+++ b/tests/ph7/001-smoke/oo/new_without_parens.phpt
@@ -1,0 +1,48 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PHP 8.4 new NwpC()->member without wrapping parens: (new NwpC())->...
+--FILE--
+<?php
+class NwpC {
+    const X = 9;
+    public static $s = 5;
+    public $p = 42;
+    function m() { return [10, 20]; }
+    function self() { return $this; }
+}
+class NwpD implements ArrayAccess {
+    function offsetExists($o): bool { return true; }
+    function offsetGet($o): mixed { return "g$o"; }
+    function offsetSet($o, $v): void {}
+    function offsetUnset($o): void {}
+}
+// method call directly on a new expression
+echo new NwpC()->m()[1], "\n";
+// property access
+echo new NwpC()->p, "\n";
+// static const / static prop via an instance
+echo new NwpC()::X, "\n";
+echo new NwpC()::$s, "\n";
+// chained calls
+echo new NwpC()->self()->p, "\n";
+// subscript directly on a new expression
+echo new NwpD()[5], "\n";
+// dynamic class name
+$c = "NwpC";
+echo new $c()->m()[0], "\n";
+// still binds tighter than instanceof
+echo (new NwpC() instanceof NwpC) ? "yes" : "no", "\n";
+?>
+--EXPECT--
+20
+42
+9
+5
+42
+g5
+10
+yes
+--CLEAN--
+<?php


### PR DESCRIPTION
A member access, static access, subscript, or call directly on a `new` expression now binds to the constructed object — `new C()->m()` means `(new C())->m()`, not `new (C()->m())`. The postfix pass folds `new ClassName(args)` into a completed node before the postfix operators bind, and the SUBSCRIPT base check accepts that folded node so `new C()[0]` works. `new C` without a constructor-arg group keeps the legacy path (and `new C->m()` stays a parse error, like PHP), and the precedence-1 `new` still rejects an unparenthesized `new` operand so `new new C()` remains an error while `new (new C())` parses.

Byte-verified vs php 8.5.7 across method/property/static/subscript/ chained/nested/named-arg/ternary/multiple-new forms.
