### PR TITLE
Implement clone() with property updates (PHP 8.5)

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -1686,6 +1686,96 @@ PH7_PRIVATE sxi32 PH7_CompileArray(ph7_gen_state *pGen,sxi32 iCompileFlag)
 	return GenStateCompileArrayBody(pGen);
 }
 /*
+ * Compile the PHP 8.5 clone(...) call form:
+ *   clone($object)                          -> identical to the `clone $object` operator
+ *   clone($object, ['prop' => value, ...])  -> clone, run __clone(), then apply the
+ *                                              property updates as scope-aware writes
+ *   clone(object: $o, withProperties: [..]) -> the named-argument spelling
+ * Codegen: compile the object argument and emit OP_CLONE (which clones and runs
+ * __clone()); if a withProperties argument is present, compile it and emit
+ * OP_CLONE_APPLY, which applies each update to the fresh clone AFTER __clone(),
+ * honouring visibility / readonly-set-scope / typed-property enforcement in the
+ * calling scope. The parser (ExprExtractNode) delimited this node's tokens as
+ * `clone ( ... )`; pGen->pIn/pEnd point at the first/one-past-last of that range.
+ */
+PH7_PRIVATE sxi32 PH7_CompileCloneCall(ph7_gen_state *pGen,sxi32 iCompileFlag)
+{
+	SyToken *pIn,*pEnd,*pNext;
+	SyToken *pObjStart = 0,*pObjEnd = 0;
+	SyToken *pUpdStart = 0,*pUpdEnd = 0;
+	int nArg = 0;
+	sxi32 rc;
+	SXUNUSED(iCompileFlag);
+	/* pGen->pIn -> 'clone', pGen->pIn[1] -> '(', pGen->pEnd -> one past ')'. */
+	pIn  = pGen->pIn + 2;   /* skip 'clone' and the opening '(' */
+	pEnd = pGen->pEnd - 1;  /* exclude the closing ')' */
+	/* clone(...) first-class-callable form: a lone ellipsis is the whole list. */
+	if( pIn < pEnd && (pIn->nType & PH7_TK_ELLIPSIS) ){
+		return PH7_GenCompileError(pGen,E_ERROR,pIn->nLine,
+			"clone(...) first-class callable form is not yet supported");
+	}
+	/* Split the (at most two) comma-separated arguments, tolerating named labels. */
+	while( pIn < pEnd ){
+		SyToken *pArgStart,*pArgEnd,*pName = 0;
+		if( PH7_GetNextExpr(pIn,pEnd,&pNext) != SXRET_OK ){
+			break;
+		}
+		pArgStart = pIn;
+		pArgEnd   = pNext;
+		/* Named-argument label: <ID|keyword> ':' expr. A single ':' is PH7_TK_COLON;
+		 * '::' is a distinct operator token, so this never mis-fires on `A::B`. */
+		if( (pArgEnd - pArgStart) >= 2
+			&& (pArgStart[0].nType & (PH7_TK_ID|PH7_TK_KEYWORD))
+			&& (pArgStart[1].nType & PH7_TK_COLON) ){
+			pName = pArgStart;
+			pArgStart += 2;
+		}
+		if( pName ){
+			if( pName->sData.nByte == sizeof("object")-1
+				&& SyStrnicmp(pName->sData.zString,"object",sizeof("object")-1) == 0 ){
+				pObjStart = pArgStart; pObjEnd = pArgEnd;
+			}else if( pName->sData.nByte == sizeof("withProperties")-1
+				&& SyStrnicmp(pName->sData.zString,"withProperties",sizeof("withProperties")-1) == 0 ){
+				pUpdStart = pArgStart; pUpdEnd = pArgEnd;
+			}else{
+				return PH7_GenCompileError(pGen,E_ERROR,pName->nLine,
+					"Unknown named parameter $%z for clone()",&pName->sData);
+			}
+		}else if( nArg == 0 ){
+			pObjStart = pArgStart; pObjEnd = pArgEnd;
+		}else if( nArg == 1 ){
+			pUpdStart = pArgStart; pUpdEnd = pArgEnd;
+		}else{
+			return PH7_GenCompileError(pGen,E_ERROR,pArgStart->nLine,
+				"clone() expects at most 2 arguments");
+		}
+		nArg++;
+		pIn = pNext;
+		if( pIn < pEnd && (pIn->nType & PH7_TK_COMMA) ){
+			pIn++; /* step over the argument separator */
+		}
+	}
+	if( pObjStart == 0 || pObjStart >= pObjEnd ){
+		return PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,
+			"clone() expects at least 1 argument, 0 given");
+	}
+	/* Object argument -> clone (+ __clone()). */
+	rc = GenStateCompileArrayEntry(pGen,pObjStart,pObjEnd,EXPR_FLAG_RDONLY_LOAD,0);
+	if( rc == SXERR_ABORT ){
+		return SXERR_ABORT;
+	}
+	PH7_VmEmitInstr(pGen->pVm,PH7_OP_CLONE,0,0,0,0);
+	/* Property updates (evaluated after __clone runs). */
+	if( pUpdStart && pUpdStart < pUpdEnd ){
+		rc = GenStateCompileArrayEntry(pGen,pUpdStart,pUpdEnd,EXPR_FLAG_RDONLY_LOAD,0);
+		if( rc == SXERR_ABORT ){
+			return SXERR_ABORT;
+		}
+		PH7_VmEmitInstr(pGen->pVm,PH7_OP_CLONE_APPLY,0,0,0,0);
+	}
+	return SXRET_OK;
+}
+/*
  * Compile a short array literal using the PHP 5.4 bracket syntax.
  * [1, 2, 3] is equivalent to array(1, 2, 3).
  * ['key' => 'value'] is equivalent to array('key' => 'value').

--- a/src/ph7/parse.c
+++ b/src/ph7/parse.c
@@ -963,6 +963,45 @@ static sxi32 ExprExtractNode(ph7_gen_state *pGen,ph7_expr_node **ppNode,int iLas
 		}else{
 			pNode->xCode = PH7_CompileShortArray;
 		}
+	}else if( bAfterMemberOp && (pCur->nType & PH7_TK_OP) && (pCur->nType & PH7_TK_ID) ){
+		/* An alpha-stream operator-keyword (clone/new/and/or/xor/instanceof) used
+		 * as a member NAME right after -> / ?-> / :: — e.g. $o->clone(), C::new(),
+		 * $o->and() — is a plain identifier, exactly like the TK_KEYWORD member-name
+		 * case below (PHP allows any keyword there). Clear PH7_TK_OP so ExprVerifyNodes
+		 * / ExprMakeTree treat this as a term, not an operator with a NULL pOp. This
+		 * must precede the clone(...) call-form branch so `$o->clone(...)` is a method
+		 * call, not the clone() intrinsic. */
+		pNode->pStart->nType &= ~PH7_TK_OP;
+		ExprAssembleLiteral(&pCur,pGen->pEnd);
+		pNode->xCode = PH7_CompileLiteral;
+	}else if( (pCur->nType & PH7_TK_OP) && pCur->pUserData
+		&& ((const ph7_expr_op *)pCur->pUserData)->iOp == EXPR_OP_CLONE
+		&& &pCur[1] < pGen->pEnd && (pCur[1].nType & PH7_TK_LPAREN) ){
+		/* PHP 8.5 clone(...) call form: clone($object [, $withProperties]).
+		 * `clone` is an alpha-stream operator, so `clone(` is NOT auto-marked
+		 * as a function call the way `foo(` is — collect the parenthesised
+		 * argument list here and let PH7_CompileCloneCall reparse it (mirrors
+		 * how array(...)/list(...) are handled). The bare operator/statement
+		 * form `clone $obj` (no immediately-following '(') keeps the
+		 * precedence-1 operator path below. Clear PH7_TK_OP on the 'clone'
+		 * token: this node is now a self-evaluating term (xCode set, pOp NULL),
+		 * so ExprVerifyNodes / ExprMakeTree must not treat its start token as an
+		 * operator (which would dereference the NULL pOp). */
+		pNode->pStart->nType &= ~PH7_TK_OP;
+		pCur += 2; /* skip 'clone' and the opening '(' */
+		PH7_DelimitNestedTokens(pCur,pGen->pEnd,PH7_TK_LPAREN,PH7_TK_RPAREN,&pCur);
+		if( pCur < pGen->pEnd ){
+			pCur++; /* skip the closing ')' */
+		}else{
+			rc = PH7_GenCompileError(pGen,E_ERROR,pNode->pStart->nLine,
+				"clone: Missing closing parenthesis ')'");
+			if( rc != SXERR_ABORT ){
+				rc = SXERR_SYNTAX;
+			}
+			SyMemBackendPoolFree(&pGen->pVm->sAllocator,pNode);
+			return rc;
+		}
+		pNode->xCode = PH7_CompileCloneCall;
 	}else if( pCur->nType & PH7_TK_OP ){
 		/* Point to the instance that describe this operator */
 		pNode->pOp = (const ph7_expr_op *)pCur->pUserData;

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1266,6 +1266,7 @@ enum ph7_vm_op {
   PH7_OP_DECR,         /* Decrement -- */
   PH7_OP_NEW,          /* new */
   PH7_OP_CLONE,        /* clone */
+  PH7_OP_CLONE_APPLY,  /* apply clone() property updates (PHP 8.5) */
   PH7_OP_ADD_STORE,    /* Add and store '+=' */
   PH7_OP_SUB_STORE,    /* Sub and store '-=' */
   PH7_OP_MUL_STORE,    /* Mul and store '*=' */
@@ -1937,6 +1938,7 @@ PH7_PRIVATE sxi32 PH7_CompileString(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileHereDoc(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileNowDoc(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileArray(ph7_gen_state *pGen,sxi32 iCompileFlag);
+PH7_PRIVATE sxi32 PH7_CompileCloneCall(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileShortArray(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileList(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileShortList(ph7_gen_state *pGen,sxi32 iCompileFlag);

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -4847,7 +4847,7 @@ static const char *VmFormatValueClassName(ph7_value *pValue,char *zBuf,sxu32 nBu
 	return zBuf;
 }
 
-static sxi32 VmEnforcePropertyTypeOnStore(ph7_vm *pVm,sxu32 nIdx,ph7_value *pValue)
+static sxi32 VmEnforcePropertyTypeOnStore(ph7_vm *pVm,sxu32 nIdx,ph7_value *pValue,int bCloneInit)
 {
 	SyHashEntry *pSlot;
 	VmClassAttr *pVmAttr;
@@ -4869,13 +4869,16 @@ static sxi32 VmEnforcePropertyTypeOnStore(ph7_vm *pVm,sxu32 nIdx,ph7_value *pVal
 		 * VM_CLASS_ATTR_UNINIT and that flag is cleared only by a *successful*
 		 * write below — making it the write-once latch (a type-rejected write
 		 * leaves it set, so a later valid initialization still works). */
-		if( (pVmAttr->iState & VM_CLASS_ATTR_UNINIT) == 0 ){
-			/* Already initialized: any further write is forbidden, any scope. */
+		if( !bCloneInit && (pVmAttr->iState & VM_CLASS_ATTR_UNINIT) == 0 ){
+			/* Already initialized: any further write is forbidden, any scope.
+			 * (PHP 8.5 clone($o,[...]) is the sole exception — bCloneInit — which
+			 * re-initializes a readonly property from an allowed scope, so it
+			 * falls through to the set-scope check below.) */
 			return VmThrowReadonlyError(pVm,pVmAttr->pOwner,pAttr,1);
 		}
 		{
-			/* First write must come from within the declaring class scope
-			 * (readonly's set-scope is protected — a subclass may initialize). */
+			/* First write (or a clone re-init) must come from within the declaring
+			 * class scope (readonly's set-scope is protected — a subclass may set). */
 			ph7_class *pDecl = pAttr->pDeclClass ? pAttr->pDeclClass : pVmAttr->pOwner;
 			ph7_class *pActive = VmCurrentSelf(pVm);
 			if( pActive == 0 || pDecl == 0 || !PH7_VmInstanceOf(pActive,pDecl) ){
@@ -4991,6 +4994,72 @@ static sxi32 VmEnforcePropertyTypeOnStore(ph7_vm *pVm,sxu32 nIdx,ph7_value *pVal
 		}
 	}
 	pVmAttr->iState &= ~VM_CLASS_ATTR_UNINIT;
+	return SXRET_OK;
+}
+/*
+ * Apply ONE property update from a PHP 8.5 clone($obj, [ 'name' => value, ... ])
+ * to the freshly-produced clone. The write happens in the caller's scope, so:
+ *   - visibility is enforced (a private/protected property is only writable from
+ *     a scope that could normally reach it — else a catchable Error),
+ *   - a readonly property may be RE-initialized here (bCloneInit) provided the
+ *     caller's scope could set it (else the readonly set-scope Error),
+ *   - typed properties are coerced/validated exactly as a normal store, and
+ *   - an unknown name creates a dynamic property (PHP still creates it; the 8.2
+ *     deprecation notice is not emitted yet — PLAN §3.9 / band A #8).
+ * Returns SXRET_OK, or PH7_EXCEPTION/PH7_ABORT (already thrown) on failure.
+ */
+static sxi32 VmCloneApplyUpdate(ph7_vm *pVm,ph7_class_instance *pClone,
+	const char *zName,sxu32 nName,ph7_value *pValue)
+{
+	ph7_class *pClass = pClone->pClass;
+	SyHashEntry *pEntry;
+	VmClassAttr *pVmAttr;
+	ph7_class_attr *pAttr;
+	ph7_value *pSlot;
+	sxi32 rc;
+	pEntry = (nName > 0) ? SyHashGet(&pClone->hAttr,(const void *)zName,nName) : 0;
+	if( pEntry == 0 ){
+		/* Unknown property: PHP creates a dynamic property (deprecated on a class
+		 * without #[AllowDynamicProperties], but still created — the notice is a
+		 * deferred residual). */
+		pSlot = PH7_VmCreateDynamicAttr(pVm,pClone,zName,nName,0);
+		if( pSlot == 0 ){
+			return PH7_VmMemoryError(pVm);
+		}
+		PH7_MemObjStore(pValue,pSlot);
+		return SXRET_OK;
+	}
+	pVmAttr = (VmClassAttr *)pEntry->pUserData;
+	pAttr = pVmAttr->pAttr;
+	/* Static / class-constant "properties" are not per-instance state. */
+	if( pAttr->iFlags & (PH7_CLASS_ATTR_STATIC|PH7_CLASS_ATTR_CONSTANT) ){
+		SyBlob sMsg;
+		SyBlobInit(&sMsg,&pVm->sAllocator);
+		SyBlobFormat(&sMsg,"Cannot update static property %z::$%z via clone()",
+			&pClass->sName,&pAttr->sName);
+		return VmThrowBuiltinError(pVm,"Error",sizeof("Error")-1,&sMsg);
+	}
+	/* Visibility: enforced against the current (calling) frame's scope. A public
+	 * readonly property passes here and is handled by the readonly set-scope check
+	 * inside VmEnforcePropertyTypeOnStore below. */
+	if( !PH7_VmClassMemberAccess(pVm,pClass,&pAttr->sName,pAttr->iProtection,FALSE) ){
+		const char *zProt = (pAttr->iProtection == PH7_CLASS_PROT_PRIVATE) ? "private" : "protected";
+		ph7_class *pOwner = pAttr->pDeclClass ? pAttr->pDeclClass : pVmAttr->pOwner;
+		SyBlob sMsg;
+		SyBlobInit(&sMsg,&pVm->sAllocator);
+		SyBlobFormat(&sMsg,"Cannot access %s property %z::$%z",zProt,&pOwner->sName,&pAttr->sName);
+		return VmThrowBuiltinError(pVm,"Error",sizeof("Error")-1,&sMsg);
+	}
+	/* Typed + readonly (clone re-init) enforcement — may coerce pValue in place. */
+	rc = VmEnforcePropertyTypeOnStore(pVm,pVmAttr->nIdx,pValue,1 /* bCloneInit */);
+	if( rc != SXRET_OK ){
+		return rc;
+	}
+	/* Commit the (possibly coerced) value into the property slot. */
+	pSlot = (ph7_value *)SySetAt(&pVm->aMemObj,pVmAttr->nIdx);
+	if( pSlot ){
+		PH7_MemObjStore(pValue,pSlot);
+	}
 	return SXRET_OK;
 }
 /*
@@ -6652,7 +6721,7 @@ static sxi32 VmByteCodeExecBody(
  */
 #define PH7_ENFORCE_TYPED_STORE(nIdxArg, pSrcArg) \
 	{ \
-		sxi32 _rcT = VmEnforcePropertyTypeOnStore(&(*pVm),(nIdxArg),(pSrcArg)); \
+		sxi32 _rcT = VmEnforcePropertyTypeOnStore(&(*pVm),(nIdxArg),(pSrcArg),0); \
 		PH7_DISPATCH_ENFORCE_RC(_rcT) \
 	}
 /*
@@ -8068,7 +8137,7 @@ case PH7_OP_STORE: {
 		}else{
 			/* Enforce typed property declaration if any. May coerce the
 			 * incoming value in place (weak mode) or throw TypeError. */
-			rcT = VmEnforcePropertyTypeOnStore(&(*pVm),nIdx,pTos);
+			rcT = VmEnforcePropertyTypeOnStore(&(*pVm),nIdx,pTos,0);
 			if( rcT == PH7_ABORT ){
 				goto Abort;
 			}
@@ -11429,12 +11498,27 @@ case PH7_OP_CLONE: {
 		goto Abort;
 	}
 #endif
-	/* Make sure we are dealing with a class instance */
+	/* Make sure we are dealing with a class instance. PHP 8 throws a catchable
+	 * TypeError for a non-object operand — for both `clone $x` and clone($x). */
 	if( (pTos->iFlags & MEMOBJ_OBJ) == 0 ){
-		PH7_VmThrowError(&(*pVm),0,PH7_CTX_ERR,
-			"Clone: Expecting a class instance as left operand,PH7 is loading NULL");
+		SyBlob sMsg;
+		SyBlobInit(&sMsg,&pVm->sAllocator);
+		SyBlobFormat(&sMsg,"clone(): Argument #1 ($object) must be of type object, %s given",
+			ph7_type_name(pTos));
+		rc = VmThrowBuiltinError(pVm,"TypeError",sizeof("TypeError")-1,&sMsg);
 		PH7_MemObjRelease(pTos);
-		break;
+		pTos->nIdx = SXU32_HIGH;
+		if( rc == PH7_ABORT ){
+			goto Abort;
+		}
+		{
+			sxi32 iRp;
+			if( VmRecordedResume(pVm,&iRp,sState.pEntryFrame,aInstr) ){
+				pc = iRp;
+				break;
+			}
+		}
+		goto Exception;
 	}
 	/* Point to the source */
 	pSrc = (ph7_class_instance *)pTos->x.pOther;
@@ -11457,6 +11541,109 @@ case PH7_OP_CLONE: {
 		pTos->x.pOther = pClone;
 		MemObjSetType(pTos,MEMOBJ_OBJ);
 	}
+	break;
+				   }
+/*
+ * OP_CLONE_APPLY * * *
+ *  Apply the PHP 8.5 clone($obj, $withProperties) property updates. The updates
+ *  array is on the stack top and the freshly-cloned object (from OP_CLONE) is
+ *  directly below it. Each entry is applied as a scope-aware property write
+ *  (AFTER __clone() has already run); the array is then popped, leaving the
+ *  clone as the result.
+ */
+case PH7_OP_CLONE_APPLY: {
+	ph7_value *pUpdates,*pObj;
+	ph7_class_instance *pClone;
+	ph7_hashmap *pMap;
+	ph7_hashmap_node *pNode;
+	sxi32 rcApply = SXRET_OK;
+	sxu32 n;
+#ifdef UNTRUST
+	if( pTos < &pStack[1] ){
+		goto Abort;
+	}
+#endif
+	pUpdates = pTos;
+	pObj = &pTos[-1];
+	/* $withProperties must be an array (PHP: TypeError otherwise). */
+	if( (pUpdates->iFlags & MEMOBJ_HASHMAP) == 0 ){
+		SyBlob sMsg;
+		SyBlobInit(&sMsg,&pVm->sAllocator);
+		SyBlobFormat(&sMsg,"clone(): Argument #2 ($withProperties) must be of type array, %s given",
+			ph7_type_name(pUpdates));
+		rc = VmThrowBuiltinError(pVm,"TypeError",sizeof("TypeError")-1,&sMsg);
+		if( rc == PH7_ABORT ){
+			goto Abort;
+		}
+		/* Pop the (bad) updates argument and dispatch to the nearest catch. */
+		VmPopOperand(&pTos,1);
+		{
+			sxi32 iRp;
+			if( VmRecordedResume(pVm,&iRp,sState.pEntryFrame,aInstr) ){
+				pc = iRp;
+				break;
+			}
+		}
+		goto Exception;
+	}
+	/* The clone must be an object; OP_CLONE leaves NULL only on a prior failure
+	 * (already reported) — in that case just drop the updates and carry the NULL. */
+	if( (pObj->iFlags & MEMOBJ_OBJ) == 0 ){
+		VmPopOperand(&pTos,1);
+		break;
+	}
+	pClone = (ph7_class_instance *)pObj->x.pOther;
+	pMap = (ph7_hashmap *)pUpdates->x.pOther;
+	/* Apply each update in insertion order (pFirst -> pPrev is the forward link). */
+	pNode = pMap->pFirst;
+	for( n = pMap->nEntry ; n > 0 && rcApply == SXRET_OK ; --n ){
+		ph7_value *pVal;
+		ph7_value sVal;
+		const char *zName;
+		sxu32 nName;
+		char zKeyBuf[64];
+		if( pNode == 0 ){
+			break;
+		}
+		pVal = (ph7_value *)SySetAt(&pVm->aMemObj,pNode->nValIdx);
+		if( pNode->iType == HASHMAP_INT_NODE ){
+			/* An int key becomes the property name (PHP: `$5`). */
+			nName = SyBufferFormat(zKeyBuf,sizeof(zKeyBuf),"%qd",pNode->xKey.iKey);
+			zName = zKeyBuf;
+		}else{
+			zName = (const char *)SyBlobData(&pNode->xKey.sKey);
+			nName = SyBlobLength(&pNode->xKey.sKey);
+		}
+		if( pVal ){
+			/* Snapshot the update value into a stack local FIRST: applying it may
+			 * create a dynamic property, whose slot reservation can reallocate
+			 * pVm->aMemObj and dangle pVal (a pointer into it). The name is safe
+			 * (it lives in the node's key blob / zKeyBuf, not in aMemObj). */
+			PH7_MemObjInit(pVm,&sVal);
+			PH7_MemObjLoad(pVal,&sVal);
+			rcApply = VmCloneApplyUpdate(pVm,pClone,zName,nName,&sVal);
+			PH7_MemObjRelease(&sVal);
+		}
+		pNode = pNode->pPrev;
+	}
+	if( rcApply == PH7_ABORT ){
+		goto Abort;
+	}
+	if( rcApply == PH7_EXCEPTION ){
+		/* An update threw (visibility / readonly / type). Pop the updates array
+		 * and hand control to the nearest catch, else propagate out of the loop. */
+		VmPopOperand(&pTos,1);
+		{
+			sxi32 iRp;
+			if( VmRecordedResume(pVm,&iRp,sState.pEntryFrame,aInstr) ){
+				pc = iRp;
+				break;
+			}
+		}
+		goto Exception;
+	}
+	/* Success: drop the updates array, leaving the clone on the stack. */
+	VmPopOperand(&pTos,1);
 	break;
 				   }
 /*
@@ -15510,6 +15697,7 @@ static const char * VmInstrToString(sxi32 nOp)
 	case PH7_OP_DECR:       zOp = "DECR       "; break;
 	case PH7_OP_NEW:        zOp = "NEW        "; break;
 	case PH7_OP_CLONE:      zOp = "CLONE      "; break;
+	case PH7_OP_CLONE_APPLY: zOp = "CLONE_APPLY"; break;
 	case PH7_OP_ADD_STORE:  zOp = "ADD_STORE  "; break;
 	case PH7_OP_SUB_STORE:  zOp = "SUB_STORE  "; break;
 	case PH7_OP_MUL_STORE:  zOp = "MUL_STORE  "; break;

--- a/tests/ph7/001-smoke/oo/clone_with_properties.phpt
+++ b/tests/ph7/001-smoke/oo/clone_with_properties.phpt
@@ -1,0 +1,70 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PHP 8.5 clone($obj, [updates]) with property updates
+--FILE--
+<?php
+class Point {
+    public function __construct(public int $x = 0, public int $y = 0) {}
+    public function __clone() { echo "clone sees x={$this->x}\n"; }
+}
+$p = new Point(1, 2);
+// property updates apply AFTER __clone(); the original is untouched
+$q = clone($p, ['x' => 10]);
+echo "$q->x,$q->y / $p->x,$p->y\n";       // 10,2 / 1,2
+// multiple updates
+$r = clone($p, ['x' => 5, 'y' => 6]);
+echo "$r->x,$r->y\n";                     // 5,6
+// no-updates call form equals the statement form
+$s = clone($p);
+echo "$s->x,$s->y\n";                     // 1,2
+$t = clone $p;
+echo "$t->x,$t->y\n";                     // 1,2
+// named arguments
+$u = clone(object: $p, withProperties: ['y' => 99]);
+echo "$u->x,$u->y\n";                     // 1,99
+// typed property: a numeric string coerces like a normal store
+$v = clone($p, ['x' => "42"]);
+echo "$v->x\n";                           // 42
+
+// readonly: re-initialized in-scope, rejected from outside
+final class Temp {
+    public function __construct(public readonly float $c) {}
+    public function withC(float $c): static { return clone($this, ['c' => $c]); }
+}
+$a = new Temp(20.0);
+$b = $a->withC(100.0);
+echo "$a->c $b->c\n";                     // 20 100
+try {
+    clone($a, ['c' => 0.0]);              // from global scope: not allowed
+} catch (\Error $e) {
+    echo $e->getMessage(), "\n";
+}
+
+// visibility: private property update from outside is an Error
+class Secret { private $s = 'a'; }
+try {
+    clone(new Secret(), ['s' => 'b']);
+} catch (\Error $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+clone sees x=1
+10,2 / 1,2
+clone sees x=1
+5,6
+clone sees x=1
+1,2
+clone sees x=1
+1,2
+clone sees x=1
+1,99
+clone sees x=1
+42
+20 100
+Cannot modify protected(set) readonly property Temp::$c from global scope
+Cannot access private property Secret::$s
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/oo/operator_keyword_member_names.phpt
+++ b/tests/ph7/001-smoke/oo/operator_keyword_member_names.phpt
@@ -1,0 +1,39 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Alpha operator-keywords (clone/new/and/or/xor/instanceof) as member names
+--FILE--
+<?php
+// PHP lets any keyword — including the alpha-stream operators — be a method or
+// property name reached through -> / ?-> / :: .
+class OkmC {
+    public $and = "prop";
+    function clone() { return "m:clone"; }
+    function and() { return "m:and"; }
+    function or() { return "m:or"; }
+    function xor() { return "m:xor"; }
+    function instanceof() { return "m:instanceof"; }
+    static function new() { return "s:new"; }
+}
+$o = new OkmC();
+echo $o->clone(), "\n";
+echo $o->and(), "\n";
+echo $o->or(), "\n";
+echo $o->xor(), "\n";
+echo $o->instanceof(), "\n";
+echo OkmC::new(), "\n";
+echo $o?->clone(), "\n";
+echo $o->and, "\n";           // property named 'and'
+?>
+--EXPECT--
+m:clone
+m:and
+m:or
+m:xor
+m:instanceof
+s:new
+m:clone
+prop
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/clone_invalid.phpt
+++ b/tests/ph7/002-integration/oo/clone_invalid.phpt
@@ -2,34 +2,34 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-Clone on invalid type should produce error
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+Cloning a non-object throws a catchable TypeError (PHP 8)
 --FILE--
 <?php
-// Test cloning a scalar value (should return null)
+// Cloning a scalar / null throws TypeError in PHP 8 (was a warning-and-null
+// PH7-ism). Catch + getMessage() to stay cross-engine (dodges the uncaught
+// trace-format divergence). Both the `clone $x` and clone($x) forms apply.
 $scalar = 42;
-$cloned = clone $scalar;
-if ($cloned === null) {
-    echo "Clone scalar returned null\n";
-} else {
-    echo "Unexpected result\n";
+try {
+    $cloned = clone $scalar;
+} catch (\TypeError $e) {
+    echo $e->getMessage(), "\n";
 }
-
-// Test cloning null
 $null = null;
-$cloned2 = clone $null;
-if ($cloned2 === null) {
-    echo "Clone null returned null\n";
-} else {
-    echo "Unexpected result for null\n";
+try {
+    $cloned2 = clone $null;
+} catch (\TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+// call form
+try {
+    $cloned3 = clone("string");
+} catch (\TypeError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
---EXPECTF--
-%s Error:  Clone: Expecting a class instance as left operand,PH7 is loading NULL
-Clone scalar returned null
-%s Error:  Clone: Expecting a class instance as left operand,PH7 is loading NULL
-Clone null returned null
+--EXPECT--
+clone(): Argument #1 ($object) must be of type object, int given
+clone(): Argument #1 ($object) must be of type object, null given
+clone(): Argument #1 ($object) must be of type object, string given
 --CLEAN--
 <?php
-unset($scalar, $cloned, $null, $cloned2);


### PR DESCRIPTION
The clone($object, $withProperties) call form now parses (a dedicated PH7_CompileCloneCall, since `clone` is an alpha-stream operator that the generic function-call marking skips) and accepts positional or named (object:/withProperties:) arguments; the `clone $o` statement form is unchanged. A new OP_CLONE_APPLY applies each update to the fresh clone AFTER __clone() runs, as a scope-aware write in the calling frame: visibility is enforced (private/protected from the wrong scope throws a catchable Error), a readonly property may be re-initialized from a scope that could set it (a new bCloneInit path in VmEnforcePropertyTypeOnStore, else the readonly set-scope Error), typed properties coerce as a normal store, and an unknown key creates a dynamic property. OP_CLONE now throws a catchable TypeError for a non-object operand (both forms).

Also lets an alpha operator-keyword (clone/new/and/or/xor/instanceof) be a member name after ->/?->/:: (e.g. $o->clone(), C::new()), which the clone( call-form detection would otherwise capture.

Byte-verified vs php 8.5.7 across updates/__clone-ordering/named-args/ readonly-in-and-out-of-scope/visibility/typed/non-object. Deferred: the clone(...) FCC form and the 8.2 dynamic-property deprecation notice.
