### PR TITLE
Fix two clone() call-form parity gaps

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -1731,15 +1731,17 @@ PH7_PRIVATE sxi32 PH7_CompileCloneCall(ph7_gen_state *pGen,sxi32 iCompileFlag)
 			pArgStart += 2;
 		}
 		if( pName ){
+			/* PHP named parameters are case-SENSITIVE, so `Object:`/`WITHPROPERTIES:`
+			 * must be rejected as unknown (SyMemcmp, not SyStrnicmp). */
 			if( pName->sData.nByte == sizeof("object")-1
-				&& SyStrnicmp(pName->sData.zString,"object",sizeof("object")-1) == 0 ){
+				&& SyMemcmp(pName->sData.zString,"object",sizeof("object")-1) == 0 ){
 				pObjStart = pArgStart; pObjEnd = pArgEnd;
 			}else if( pName->sData.nByte == sizeof("withProperties")-1
-				&& SyStrnicmp(pName->sData.zString,"withProperties",sizeof("withProperties")-1) == 0 ){
+				&& SyMemcmp(pName->sData.zString,"withProperties",sizeof("withProperties")-1) == 0 ){
 				pUpdStart = pArgStart; pUpdEnd = pArgEnd;
 			}else{
 				return PH7_GenCompileError(pGen,E_ERROR,pName->nLine,
-					"Unknown named parameter $%z for clone()",&pName->sData);
+					"Unknown named parameter $%z",&pName->sData);
 			}
 		}else if( nArg == 0 ){
 			pObjStart = pArgStart; pObjEnd = pArgEnd;

--- a/src/ph7/parse.c
+++ b/src/ph7/parse.c
@@ -1680,7 +1680,12 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 				 pNode->pLeft = apNode[iLeft];
 				 if( (pNode->pOp->iOp == EXPR_OP_ARROW /*'->'*/ || pNode->pOp->iOp == EXPR_OP_NULLSAFE_ARROW /*'?->'*/)
 					 && pNode->pLeft->pOp == 0 &&
-					 pNode->pLeft->xCode != PH7_CompileVariable ){
+					 pNode->pLeft->xCode != PH7_CompileVariable &&
+					 /* A clone(...) call term (pOp==0, xCode set) produces an object,
+					  * so `(clone($o))->x` is a valid arrow left operand — like the
+					  * `clone $o` operator form (pOp!=0), which this guard already
+					  * accepts. */
+					 pNode->pLeft->xCode != PH7_CompileCloneCall ){
 						 /* Syntax error */
 						 rc = PH7_GenCompileError(pGen,E_ERROR,pNode->pStart->nLine,
 							 "'%z': Expecting a variable as left operand",&pNode->pOp->sOp);

--- a/tests/ph7/001-smoke/oo/clone_with_properties.phpt
+++ b/tests/ph7/001-smoke/oo/clone_with_properties.phpt
@@ -27,6 +27,9 @@ echo "$u->x,$u->y\n";                     // 1,99
 // typed property: a numeric string coerces like a normal store
 $v = clone($p, ['x' => "42"]);
 echo "$v->x\n";                           // 42
+// a parenthesized clone() call is a valid arrow/method left operand
+echo (clone($p, ['x' => 8]))->x, "\n";    // 8
+echo (clone($p))->x, "\n";                // 1
 
 // readonly: re-initialized in-scope, rejected from outside
 final class Temp {
@@ -63,6 +66,10 @@ clone sees x=1
 1,99
 clone sees x=1
 42
+clone sees x=1
+8
+clone sees x=1
+1
 20 100
 Cannot modify protected(set) readonly property Temp::$c from global scope
 Cannot access private property Secret::$s


### PR DESCRIPTION
- clone() named-argument labels are now matched case-sensitively (SyMemcmp, not SyStrnicmp), so `clone(Object: $o)` / `WITHPROPERTIES:` are rejected as unknown parameters like PHP, and the message drops the non-PHP " for clone()" suffix.
- A parenthesized clone() call is now a valid arrow/nullsafe-arrow left operand: `(clone($o))->x` and `(clone(new C()))->m()` compile and run, matching PHP (the clone-call term has pOp==0, so the member-access guard wrongly rejected it; the `clone $o` operator form already worked). A scalar left operand like `5->x` still errors, unchanged.

Byte-verified vs php 8.5.7; cross-engine test extended.
