### PR TITLE
Make float<->string conversions byte-exact with php

### DIFF
--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -4,12 +4,14 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "ph7int.h"
-/* filter_var(FILTER_VALIDATE_FLOAT) parses with libc strtod for overflow/underflow
- * detection + a correctly-rounded value; SyStrToReal clamps the exponent and saturates,
- * so it cannot reject out-of-range magnitudes. Same rationale as builtin_math.c's round(). */
+/* filter_var(FILTER_VALIDATE_FLOAT) parses with libc strtod directly because it
+ * needs errno==ERANGE to reject out-of-range magnitudes; SyStrToReal (also
+ * strtod-backed nowadays) exposes no range-error signal. */
 #include <stdlib.h>  /* strtod */
 #include <math.h>    /* HUGE_VAL */
 #include <errno.h>   /* ERANGE (strtod range-error signal) */
+#include <stdio.h>   /* snprintf (printf-family float conversions — correctly
+                      * rounded digits like php's zend_dtoa; see PH7_InputFormat) */
 /* This file implement built-in 'foreign' functions for the PH7 engine */
 /*
  * Section:
@@ -3244,34 +3246,9 @@ struct ph7_fmt_info
   char *charset; /* The character set for conversion */
   char *prefix;  /* Prefix on non-zero values in alt format */
 };
-#ifndef PH7_OMIT_FLOATING_POINT
-/*
-** "*val" is a double such that 0.1 <= *val < 10.0
-** Return the ascii code for the leading digit of *val, then
-** multiply "*val" by 10.0 to renormalize.
-**
-** Example:
-**     input:     *val = 3.14159
-**     output:    *val = 1.4159    function return = '3'
-**
-** The counter *cnt is incremented each time.  After counter exceeds
-** 16 (the number of significant digits in a 64-bit float) '0' is
-** always returned.
-*/
-static int vxGetdigit(sxlongreal *val,int *cnt)
-{
-  sxlongreal d;
-  int digit;
-
-  if( (*cnt)++ >= 16 ){
-	  return '0';
-  }
-  digit = (int)*val;
-  d = digit;
-   *val = (*val - d)*10.0;
-  return digit + '0' ;
-}
-#endif /* PH7_OMIT_FLOATING_POINT */
+/* PH7_PhpFloatShape (php's float-shape post-processing) lives in memobj.c —
+ * the default float->string cast needs it even when this whole formatting
+ * region is compiled out by PH7_DISABLE_DISK_IO. */
 /*
  * The following table is searched linearly, so it is good to put the most frequently
  * used conversion types first.
@@ -3573,28 +3550,24 @@ PH7_PRIVATE sxi32 PH7_InputFormat(
 		case PH7_FMT_EXP:
 		case PH7_FMT_GENERIC:{
 #ifndef PH7_OMIT_FLOATING_POINT
-		long double realvalue;
-		int  exp;                /* exponent of real numbers */
-		double rounder;          /* Used for rounding floating point values */
-		int flag_dp;            /* True if decimal point should be shown */
-		int flag_rtz;           /* True if trailing zeros should be removed */
-		int flag_exp;           /* True to force display of the exponent */
-		int nsd;                 /* Number of significant digits returned */
+		double realvalue;
+		char zFmt[8];
+		int nOut, nFmt;
 		pArg = NEXT_ARG;
 		if( pArg == 0 ){
 			realvalue = 0;
 		}else{
 			realvalue = ph7_value_to_double(pArg);
 		}
-		/* Special-case NaN and infinities since the normal formatting logic
-		 * below assumes a finite positive realvalue. */
+		/* php prints the IEEE specials bare — NaN / INF / -INF with no width
+		 * padding, precision, or sign flags (php_sprintf_appenddouble). */
 		if( PH7_IS_NAN(realvalue) ){
-			zBuf = "NAN";
+			zBuf = "NaN";
 			length = 3;
+			width = 0;
 			break;
 		}
 		if( PH7_IS_INF(realvalue) ){
-			/* Infinity prints as INF or -INF depending on sign. */
 			if( realvalue < 0.0 ){
 				zBuf = "-INF";
 				length = 4;
@@ -3602,112 +3575,55 @@ PH7_PRIVATE sxi32 PH7_InputFormat(
 				zBuf = "INF";
 				length = 3;
 			}
+			width = 0;
 			break;
 		}
 		if( precision<0 ) precision = 6;         /* Set default precision */
-		if( precision>PH7_FMT_BUFSIZ-40) precision = PH7_FMT_BUFSIZ-40;
-        if( realvalue<0.0 ){
-          realvalue = -realvalue;
-          prefix = '-';
-        }else{
-          if( flag_plussign )          prefix = '+';
-          else if( flag_blanksign )    prefix = ' ';
-          else                         prefix = 0;
-        }
-        if( pInfo->type==PH7_FMT_GENERIC && precision>0 ) precision--;
-        rounder = 0.0;
-#if 0
-        /* Rounding works like BSD when the constant 0.4999 is used.Wierd! */
-        for(idx=precision, rounder=0.4999; idx>0; idx--, rounder*=0.1);
-#else
-        /* It makes more sense to use 0.5 */
-        for(idx=precision, rounder=0.5; idx>0; idx--, rounder*=0.1);
-#endif
-        if( pInfo->type==PH7_FMT_FLOAT ) realvalue += rounder;
-        /* Normalize realvalue to within 10.0 > realvalue >= 1.0 */
-        exp = 0;
-        if( realvalue>0.0 ){
-          while( realvalue>=1e8 && exp<=350 ){ realvalue *= 1e-8; exp+=8; }
-          while( realvalue>=10.0 && exp<=350 ){ realvalue *= 0.1; exp++; }
-          while( realvalue<1e-8 && exp>=-350 ){ realvalue *= 1e8; exp-=8; }
-          while( realvalue<1.0 && exp>=-350 ){ realvalue *= 10.0; exp--; }
-          if( exp>350 || exp<-350 ){
-            zBuf = "NaN";
-            length = 3;
-            break;
-          }
-        }
-        zBuf = zWorker;
-        /*
-        ** If the field type is etGENERIC, then convert to either etEXP
-        ** or etFLOAT, as appropriate.
-        */
-        flag_exp = xtype==PH7_FMT_EXP;
-        if( xtype!=PH7_FMT_FLOAT ){
-          realvalue += rounder;
-          if( realvalue>=10.0 ){ realvalue *= 0.1; exp++; }
-        }
-        if( xtype==PH7_FMT_GENERIC ){
-          flag_rtz = !flag_alternateform;
-          if( exp<-4 || exp>precision ){
-            xtype = PH7_FMT_EXP;
-          }else{
-            precision = precision - exp;
-            xtype = PH7_FMT_FLOAT;
-          }
-        }else{
-          flag_rtz = 0;
-        }
-        /*
-        ** The "exp+precision" test causes output to be of type etEXP if
-        ** the precision is too large to fit in buf[].
-        */
-        nsd = 0;
-        if( xtype==PH7_FMT_FLOAT && exp+precision<PH7_FMT_BUFSIZ-30 ){
-          flag_dp = (precision>0 || flag_alternateform);
-          if( prefix ) *(zBuf++) = (char)prefix;         /* Sign */
-          if( exp<0 )  *(zBuf++) = '0';            /* Digits before "." */
-          else for(; exp>=0; exp--) *(zBuf++) = (char)vxGetdigit(&realvalue,&nsd);
-          if( flag_dp ) *(zBuf++) = '.';           /* The decimal point */
-          for(exp++; exp<0 && precision>0; precision--, exp++){
-            *(zBuf++) = '0';
-          }
-          while( (precision--)>0 ) *(zBuf++) = (char)vxGetdigit(&realvalue,&nsd);
-          *(zBuf--) = 0;                           /* Null terminate */
-          if( flag_rtz && flag_dp ){     /* Remove trailing zeros and "." */
-            while( zBuf>=zWorker && *zBuf=='0' ) *(zBuf--) = 0;
-            if( zBuf>=zWorker && *zBuf=='.' ) *(zBuf--) = 0;
-          }
-          zBuf++;                            /* point to next free slot */
-        }else{    /* etEXP or etGENERIC */
-          flag_dp = (precision>0 || flag_alternateform);
-          if( prefix ) *(zBuf++) = (char)prefix;   /* Sign */
-          *(zBuf++) = (char)vxGetdigit(&realvalue,&nsd);  /* First digit */
-          if( flag_dp ) *(zBuf++) = '.';     /* Decimal point */
-          while( (precision--)>0 ) *(zBuf++) = (char)vxGetdigit(&realvalue,&nsd);
-          zBuf--;                            /* point to last digit */
-          if( flag_rtz && flag_dp ){          /* Remove tail zeros */
-            while( zBuf>=zWorker && *zBuf=='0' ) *(zBuf--) = 0;
-            if( zBuf>=zWorker && *zBuf=='.' ) *(zBuf--) = 0;
-          }
-          zBuf++;                            /* point to next free slot */
-          if( exp || flag_exp ){
-            *(zBuf++) = pInfo->charset[0];
-            if( exp<0 ){ *(zBuf++) = '-'; exp = -exp; } /* sign of exp */
-            else       { *(zBuf++) = '+'; }
-            if( exp>=100 ){
-              *(zBuf++) = (char)((exp/100)+'0');                /* 100's digit */
-              exp %= 100;
-            }
-            *(zBuf++) = (char)(exp/10+'0');                     /* 10's digit */
-            *(zBuf++) = (char)(exp%10+'0');                     /* 1's digit */
-          }
-        }
-        /* The converted number is in buf[] and zero terminated.Output it.
-        ** Note that the number is in the usual order, not reversed as with
-        ** integer conversions.*/
-        length = (int)(zBuf-zWorker);
-        zBuf = zWorker;
+		if( precision > 53 ){
+			/* php's FORMAT_CONV_MAX_PRECISION cap, with the same E_NOTICE
+			 * (message prefixed with the active function's name, like
+			 * php_error_docref). */
+			char zMsg[160];
+			SyBufferFormat(zMsg,sizeof(zMsg),
+				"%z(): Requested precision of %d digits was truncated to PHP maximum of %d digits",
+				&pCtx->pFunc->sName,precision,53);
+			PH7_VmThrowError(pCtx->pVm,0,E_NOTICE,zMsg);
+			precision = 53;
+		}
+		/* php's %f/%e extract the sign via `num < 0`, so negative zero prints
+		 * unsigned there — while %g (php_gcvt on the raw value) keeps "-0". */
+		if( xtype!=PH7_FMT_GENERIC && realvalue == 0.0 ){
+			realvalue = 0.0;
+		}
+		/* php's float conversions are correctly rounded (zend_dtoa); use libc
+		 * snprintf as the digit engine (the byte-exact-floats rule — the old
+		 * hand-rolled vxGetdigit loop stopped at 16 significant digits, so
+		 * e.g. %f of 1e308 printed zeros where php prints the exact binary64
+		 * expansion), then post-process into php's exact shapes below. */
+		nFmt = 0;
+		zFmt[nFmt++] = '%';
+		if( flag_alternateform ) zFmt[nFmt++] = '#';
+		/* php's ' ' flag selects space PADDING (its default), not C's
+		 * space-for-positive-sign — so flag_blanksign is NOT forwarded. */
+		if( flag_plussign ) zFmt[nFmt++] = '+';
+		zFmt[nFmt++] = '.';
+		zFmt[nFmt++] = '*';
+		zFmt[nFmt++] = (char)(xtype==PH7_FMT_FLOAT ? 'f' :
+			(xtype==PH7_FMT_EXP ? ((pInfo->charset[0]=='E') ? 'E' : 'e')
+			                    : ((pInfo->charset[0]=='E') ? 'G' : 'g')));
+		zFmt[nFmt] = 0;
+		nOut = snprintf(zWorker,sizeof(zWorker),zFmt,precision,realvalue);
+		if( nOut < 0 || nOut >= (int)sizeof(zWorker) ){
+			/* Cannot happen with precision capped at 53 (%f of DBL_MAX is
+			 * ~365 bytes); keep the truncated output rather than overrun. */
+			nOut = (int)SyStrlen(zWorker);
+		}
+		nOut = (int)PH7_PhpFloatShape(zWorker,(sxi32)nOut,xtype==PH7_FMT_GENERIC);
+		zBuf = zWorker;
+		length = nOut;
+		/* Let the zero-pad block below insert zeros between the sign (written
+		 * by snprintf) and the first digit, as before. */
+		prefix = (zWorker[0]=='-' || zWorker[0]=='+' || zWorker[0]==' ') ? zWorker[0] : 0;
         /* Special case:  Add leading zeros if the flag_zeropad flag is
         ** set and we are not left justified */
         if( flag_zeropad && !flag_leftjustify && length < width){

--- a/src/ph7/builtin_math.c
+++ b/src/ph7/builtin_math.c
@@ -839,9 +839,10 @@ static double MathRound(double value, int places, int mode)
 		/*
 		 * Simple division would lose precision here; round-trip through a
 		 * string exactly like php-src does (snprintf "%15fe%d" + strtod).
-		 * libc snprintf/strtod are used (not SyBufferFormat/SyStrToReal,
-		 * which are not correctly-rounded) so the low bits match PHP — the
-		 * same reason vm_serialize.c uses libc strtod for its float repr.
+		 * libc snprintf is used (not SyBufferFormat, which is not
+		 * correctly-rounded) so the low bits match PHP. (SyStrToReal now
+		 * delegates to strtod too; the direct call here simply mirrors
+		 * php-src's own snprintf+strtod pairing.)
 		 */
 		char zBuf[64];
 		snprintf(zBuf, sizeof(zBuf), "%15fe%d", tmp_value, -places);

--- a/src/ph7/memobj.c
+++ b/src/ph7/memobj.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "ph7int.h" /* This file handle low-level stuff related to indexed memory objects [i.e: ph7_value] */
+#include <stdio.h>  /* snprintf — the default float->string conversion needs
+                     * correctly-rounded digits like php (see MemObjStringValue) */
 
 /* Provide PHP-style type names for values.  This utility may be reused
  * by any subsystem that works with ph7_value.
@@ -252,6 +254,65 @@ static ph7_real MemObjRealValue(ph7_value *pObj)
 	/* NOT REACHED  */
 	return 0;
 }
+#ifndef PH7_OMIT_FLOATING_POINT
+/*
+ * Post-process a libc-formatted float into php's exact shape (php_gcvt /
+ * smart_str_append_double semantics): strip the exponent's zero padding
+ * (libc's 1e+08 becomes php's 1e+8; a zero exponent stays e+0) and, when
+ * bGeneric is set (%g-style output, including the default float->string
+ * cast), make an exponent-form mantissa keep a fractional digit
+ * (1e+20 -> 1.0e+20). zBuf must be NUL-terminated with at least two bytes
+ * of spare capacity past the NUL. Returns the new length.
+ * Defined here (not builtin.c) because the float->string cast below needs it
+ * even when builtin.c's formatting region is compiled out
+ * (PH7_DISABLE_DISK_IO); the printf family reuses it from PH7_InputFormat.
+ */
+PH7_PRIVATE sxi32 PH7_PhpFloatShape(char *zBuf,sxi32 nLen,int bGeneric)
+{
+	sxi32 iExp,i;
+	iExp = nLen - 1;
+	while( iExp > 0 && zBuf[iExp] != 'e' && zBuf[iExp] != 'E' ){
+		iExp--;
+	}
+	if( iExp <= 0 ){
+		return nLen; /* No exponent part (fixed notation) */
+	}
+	{
+		sxi32 iDig = iExp + 1;
+		sxi32 iFirst;
+		if( zBuf[iDig] == '+' || zBuf[iDig] == '-' ){
+			iDig++;
+		}
+		iFirst = iDig;
+		while( zBuf[iFirst] == '0' && iFirst + 1 < nLen
+		 && zBuf[iFirst+1] >= '0' && zBuf[iFirst+1] <= '9' ){
+			iFirst++;
+		}
+		if( iFirst > iDig ){
+			sxi32 nStrip = iFirst - iDig;
+			for( i = iDig ; i + nStrip <= nLen ; i++ ){
+				zBuf[i] = zBuf[i+nStrip]; /* moves the NUL too */
+			}
+			nLen -= nStrip;
+		}
+	}
+	if( bGeneric ){
+		int bHasDot = 0;
+		for( i = 0 ; i < iExp ; i++ ){
+			if( zBuf[i] == '.' ){ bHasDot = 1; break; }
+		}
+		if( !bHasDot ){
+			for( i = nLen ; i >= iExp ; i-- ){
+				zBuf[i+2] = zBuf[i]; /* moves the NUL too */
+			}
+			zBuf[iExp] = '.';
+			zBuf[iExp+1] = '0';
+			nLen += 2;
+		}
+	}
+	return nLen;
+}
+#endif /* PH7_OMIT_FLOATING_POINT */
 /*
  * Return the string representation of a given ph7_value.
  * This function never fail and always return SXRET_OK.
@@ -269,7 +330,23 @@ static sxi32 MemObjStringValue(SyBlob *pOut,ph7_value *pObj,sxu8 bStrictBool)
 				SyBlobAppend(&(*pOut),"INF",3);
 			}
 		}else{
+#ifndef PH7_OMIT_FLOATING_POINT
+			/* php's default float->string conversion (echo/concat/cast):
+			 * zend_gcvt with EG(precision)=14 and an uppercase exponent
+			 * marker (smart_str_append_double) — 1/3 -> "0.33333333333333",
+			 * 1e15 -> "1.0E+15", -0.0 -> "-0". libc snprintf supplies
+			 * correctly-rounded digits; PH7_PhpFloatShape applies php's
+			 * exponent/fraction quirks. */
+			char zNum[48]; /* %.14G peaks at ~22 bytes; +2 spare for ".0" */
+			sxi32 n = (sxi32)snprintf(zNum,sizeof(zNum),"%.14G",pObj->rVal);
+			if( n < 0 || n >= (sxi32)sizeof(zNum) ){
+				n = (sxi32)SyStrlen(zNum);
+			}
+			n = PH7_PhpFloatShape(zNum,n,TRUE);
+			SyBlobAppend(&(*pOut),zNum,(sxu32)n);
+#else
 			SyBlobFormat(&(*pOut),"%.15g",pObj->rVal);
+#endif
 		}
 	}else if( pObj->iFlags & MEMOBJ_INT ){
 		SyBlobFormat(&(*pOut),"%qd",pObj->x.iVal);

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1782,6 +1782,11 @@ PH7_PRIVATE int vm_builtin_json_validate(ph7_context *pCtx,int nArg,ph7_value **
 PH7_PRIVATE int vm_builtin_serialize(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE int vm_builtin_unserialize(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE void PH7_AppendShortestReal(SyBlob *pOut,double d);
+/* memobj.c float-shape helper (php_gcvt/smart_str_append_double semantics);
+ * shared by the float->string cast and builtin.c's printf float conversions */
+#ifndef PH7_OMIT_FLOATING_POINT
+PH7_PRIVATE sxi32 PH7_PhpFloatShape(char *zBuf,sxi32 nLen,int bGeneric);
+#endif
 /* vm_xml.c function prototypes */
 #ifndef PH7_DISABLE_BUILTIN_FUNC
 PH7_PRIVATE int vm_builtin_xml_parser_create(ph7_context *pCtx,int nArg,ph7_value **apArg);

--- a/src/ph7/vm_json.c
+++ b/src/ph7/vm_json.c
@@ -36,6 +36,35 @@ struct json_private_data
  */
 #define JSON_EMIT(pD, call) do { if( (call) != SXRET_OK ){ (pD)->oom = 1; return PH7_OK; } } while(0)
 /*
+ * Emit a float in php's json shape: PH7_AppendShortestReal (the shared
+ * serialize/var_export shortest-round-trip formatter, php's
+ * serialize_precision=-1) with the exponent marker lowercased (json prints
+ * 1.0e+17 where serialize prints 1.0E+17).
+ */
+static sxi32 VmJsonEmitReal(ph7_context *pCtx,double rVal)
+{
+	SyBlob sNum;
+	char *z;
+	sxu32 i,n;
+	sxi32 rc;
+	SyBlobInit(&sNum,&pCtx->pVm->sAllocator);
+	PH7_AppendShortestReal(&sNum,rVal);
+	z = (char *)SyBlobData(&sNum);
+	n = SyBlobLength(&sNum);
+	if( z == 0 || n < 1 ){
+		SyBlobRelease(&sNum);
+		return SXERR_MEM; /* treated as OOM by JSON_EMIT */
+	}
+	for( i = 0 ; i < n ; i++ ){
+		if( z[i] == 'E' ){
+			z[i] = 'e';
+		}
+	}
+	rc = ph7_result_string(pCtx,(const char *)z,(int)n);
+	SyBlobRelease(&sNum);
+	return rc;
+}
+/*
  * Returns the JSON representation of a value.In other word perform a JSON encoding operation.
  * According to wikipedia
  * JSON's basic types are:
@@ -68,18 +97,24 @@ static sxi32 VmJsonEncode(
 			iLen = iBool ? (int)sizeof("true") : (int)sizeof("false");
 			JSON_EMIT(pData,ph7_result_string(pCtx,iBool ? "true" : "false",iLen-1));
 		}else if(  ph7_value_is_numeric(pIn) && !ph7_value_is_string(pIn) ){
-			const char *zNum;
-			/* Get a string representation of the number */
-			zNum = ph7_value_to_string(pIn,&nByte);
-			JSON_EMIT(pData,ph7_result_string(pCtx,zNum,nByte));
-		}else if( ph7_value_is_string(pIn) ){
-			if( (iFlags & JSON_NUMERIC_CHECK) &&  ph7_value_is_numeric(pIn) ){
+			if( ph7_value_is_float(pIn) ){
+				/* php's json float output follows serialize_precision
+				 * (shortest round-trip, like serialize/var_export), NOT the
+				 * echo/cast precision of 14 — with a lowercase exponent
+				 * marker: 1/3 -> 0.3333333333333333, 1e17 -> 1.0e+17,
+				 * 1.0 -> 1, -0.0 -> -0. */
+				JSON_EMIT(pData,VmJsonEmitReal(pCtx,ph7_value_to_double(pIn)));
+			}else{
 				const char *zNum;
-				/* Encodes numeric strings as numbers. */
-				PH7_MemObjToReal(pIn); /* Force a numeric cast */
 				/* Get a string representation of the number */
 				zNum = ph7_value_to_string(pIn,&nByte);
 				JSON_EMIT(pData,ph7_result_string(pCtx,zNum,nByte));
+			}
+		}else if( ph7_value_is_string(pIn) ){
+			if( (iFlags & JSON_NUMERIC_CHECK) &&  ph7_value_is_numeric(pIn) ){
+				/* Encodes numeric strings as numbers (same float shapes). */
+				PH7_MemObjToReal(pIn); /* Force a numeric cast */
+				JSON_EMIT(pData,VmJsonEmitReal(pCtx,ph7_value_to_double(pIn)));
 			}else{
 				const char *zIn,*zEnd;
 				int c;

--- a/src/ph7/vm_serialize.c
+++ b/src/ph7/vm_serialize.c
@@ -563,8 +563,9 @@ static ph7_value * VmUnserializeValue(unserialize_data *ud)
 		if( ud->zCur >= ud->zEnd ){ return 0; }
 		/* INF / -INF / NAN, else a plain real literal. Parse via libc strtod (the
 		 * correctly-rounded inverse of the strtod-verified shortest repr that
-		 * VmSerializeReal emits) so unserialize(serialize($f)) is bit-exact;
-		 * SyStrToReal is not correctly-rounded and loses the low bits of e.g. 1/3. */
+		 * VmSerializeReal emits) so unserialize(serialize($f)) is bit-exact.
+		 * (SyStrToReal delegates to strtod nowadays; the direct call is kept
+		 * because the INF/NAN tags above are already split out here.) */
 		if( (ud->zCur-zStart) == 3 && SyStrnicmp(zStart,"INF",3)==0 ){ d = PH7_INF_VALUE(); }
 		else if( (ud->zCur-zStart)==4 && SyStrnicmp(zStart,"-INF",4)==0 ){ d = -PH7_INF_VALUE(); }
 		else if( (ud->zCur-zStart)==3 && SyStrnicmp(zStart,"NAN",3)==0 ){ d = PH7_NAN_VALUE(); }

--- a/src/sx/sxutils.c
+++ b/src/sx/sxutils.c
@@ -7,6 +7,7 @@
 #include "sxmacros.h"
 #include "sxutils.h"
 #include "sxstr.h"
+#include <stdlib.h> /* strtod — SyStrToReal must be correctly rounded (see its comment) */
 
 PH7_PRIVATE sxi32 SyStrIsNumeric(const char *zSrc,sxu32 nLen,sxu8 *pReal,const char  **pzTail)
 {
@@ -407,25 +408,25 @@ PH7_PRIVATE sxi32 SyBinaryStrToInt64(const char *zSrc,sxu32 nLen,void * pOutVal,
 }
 PH7_PRIVATE sxi32 SyStrToReal(const char *zSrc,sxu32 nLen,void * pOutVal,const char **zRest)
 {
-#define SXDBL_DIG        15
-#define SXDBL_MAX_EXP    308
-#define SXDBL_MIN_EXP_PLUS	307
-	static const sxreal aTab[] = {
-	10,
-	1.0e2,
-	1.0e4,
-	1.0e8,
-	1.0e16,
-	1.0e32,
-	1.0e64,
-	1.0e128,
-	1.0e256
-	};
-	sxu8 neg = FALSE;
+	/* Correctly-rounded conversion via libc strtod (the byte-exact-floats
+	 * rule): the old hand-rolled accumulator kept only 15 significant
+	 * digits, clamped exponents to +/-30x (so 1e400 silently became 1e308
+	 * and 5e-324 became 5e-307) and drifted the low mantissa bits, making
+	 * float literals and string->float casts differ from php. The accepted
+	 * numeric-prefix grammar is kept from the old parser, including the ','
+	 * decimal separator: [ws][sign]D*[(.|,)D*][(e|E)[sign]D+][ws]. The
+	 * prefix is copied (',' -> '.') into a stack buffer for strtod — or a
+	 * heap copy for the rare number longer than the buffer (e.g. hundreds of
+	 * leading fractional zeros before the significant digits), falling back
+	 * to a truncated-mantissa-plus-exponent copy only if that allocation
+	 * fails. Everything is always consumed from the input. */
+	char zBuf[512];
+	const char *zEnd = &zSrc[nLen];
+	const char *zNum;
+	const char *zExpStart = 0;
 	sxreal Val = 0.0;
-	const char *zEnd;
-	sxi32 Lim,exp;
-	sxreal *p = 0;
+	sxu32 nCopy = 0;
+	int bDigit = 0;
 #ifdef UNTRUST
 	if( SX_EMPTY_STR(zSrc)  ){
 		if( pOutVal ){
@@ -434,146 +435,73 @@ PH7_PRIVATE sxi32 SyStrToReal(const char *zSrc,sxu32 nLen,void * pOutVal,const c
 		return SXERR_EMPTY;
 	}
 #endif
-	/* Define local limits and end pointer used by the parsing loops */
-	zEnd = &zSrc[nLen];
-	Lim = SXDBL_DIG;
 	/* Skip leading spaces */
-	while( zSrc < zEnd && SyisSpace(zSrc[0]) ) zSrc++;
-
+	while( zSrc < zEnd && SyisSpace(zSrc[0]) ){
+		zSrc++;
+	}
+	zNum = zSrc;
 	/* Sign (if exists) */
 	if( zSrc < zEnd && (zSrc[0] == '-' || zSrc[0] == '+' ) ){
-		neg =  zSrc[0] == '-' ? TRUE : FALSE ;
 		zSrc++;
 	}
-
 	/* Integer part */
-	for(;;){
-		if(zSrc >= zEnd || !Lim || !SyisDigit(zSrc[0])){
-			break;
-		}
-		Val = Val * 10.0 + (zSrc[0] - '0');
+	while( zSrc < zEnd && SyisDigit(zSrc[0]) ){
+		bDigit = 1;
 		zSrc++;
-		--Lim;
-		if(zSrc >= zEnd || !Lim || !SyisDigit(zSrc[0])){
-			break;
-		}
-		Val = Val * 10.0 + (zSrc[0] - '0');
-		zSrc++;
-		--Lim;
-		if(zSrc >= zEnd || !Lim || !SyisDigit(zSrc[0])){
-			break;
-		}
-		Val = Val * 10.0 + (zSrc[0] - '0');
-		zSrc++;
-		--Lim;
-		if(zSrc >= zEnd || !Lim || !SyisDigit(zSrc[0])){
-			break;
-		}
-		Val = Val * 10.0 + (zSrc[0] - '0');
-		zSrc++;
-		--Lim;
 	}
-	Lim = SXDBL_DIG ;
-	for(;;){
-		if(zSrc >= zEnd || !Lim || !SyisDigit(zSrc[0])){
-			break;
-		}
-		Val = Val * 10.0 + (zSrc[0] - '0');
-		zSrc++;
-		--Lim;
-		if(zSrc >= zEnd || !Lim || !SyisDigit(zSrc[0])){
-			break;
-		}
-		Val = Val * 10.0 + (zSrc[0] - '0');
-		zSrc++;
-		--Lim;
-		if(zSrc >= zEnd || !Lim || !SyisDigit(zSrc[0])){
-			break;
-		}
-		Val = Val * 10.0 + (zSrc[0] - '0');
-		zSrc++;
-		--Lim;
-		if(zSrc >= zEnd || !Lim || !SyisDigit(zSrc[0])){
-			break;
-		}
-		Val = Val * 10.0 + (zSrc[0] - '0');
-		zSrc++;
-		--Lim;
-	}
+	/* Fractional part */
 	if( zSrc < zEnd && ( zSrc[0] == '.' || zSrc[0] == ',' ) ){
-		sxreal dec = 1.0;
 		zSrc++;
-		for(;;){
-			if(zSrc >= zEnd || !Lim || !SyisDigit(zSrc[0])){
-				break;
-			}
-			Val = Val * 10.0 + (zSrc[0] - '0');
-			dec *= 10.0;
-			zSrc++;
-			--Lim;
-			if(zSrc >= zEnd || !Lim || !SyisDigit(zSrc[0])){
-				break;
-			}
-			Val = Val * 10.0 + (zSrc[0] - '0');
-			dec *= 10.0;
-			zSrc++;
-			--Lim;
-			if(zSrc >= zEnd || !Lim || !SyisDigit(zSrc[0])){
-				break;
-			}
-			Val = Val * 10.0 + (zSrc[0] - '0');
-			dec *= 10.0;
-			zSrc++;
-			--Lim;
-			if(zSrc >= zEnd || !Lim || !SyisDigit(zSrc[0])){
-				break;
-			}
-			Val = Val * 10.0 + (zSrc[0] - '0');
-			dec *= 10.0;
-			zSrc++;
-			--Lim;
-		}
-		Val /= dec;
-	}
-	if( neg == TRUE && Val != 0.0 ) {
-		Val = -Val ;
-	}
-	if( Lim <= 0 ){
-		/* jump overflow digit */
-		while( zSrc < zEnd ){
-			if( zSrc[0] == 'e' || zSrc[0] == 'E' ){
-				break;
-			}
+		while( zSrc < zEnd && SyisDigit(zSrc[0]) ){
+			bDigit = 1;
 			zSrc++;
 		}
 	}
-	neg = FALSE;
-	if( zSrc < zEnd && ( zSrc[0] == 'e' || zSrc[0] == 'E' ) ){
-		zSrc++;
-		if( zSrc < zEnd && ( zSrc[0] == '-' || zSrc[0] == '+') ){
-			neg = zSrc[0] == '-' ? TRUE : FALSE ;
-			zSrc++;
+	/* Exponent — consumed only when it carries at least one digit, like
+	 * strtod, so "1e+x" leaves the "e+" unconsumed. */
+	if( bDigit && zSrc < zEnd && ( zSrc[0] == 'e' || zSrc[0] == 'E' ) ){
+		const char *zExp = &zSrc[1];
+		if( zExp < zEnd && (zExp[0] == '-' || zExp[0] == '+') ){
+			zExp++;
 		}
-		exp = 0;
-		while( zSrc < zEnd && SyisDigit(zSrc[0]) && exp < SXDBL_MAX_EXP ){
-			exp = exp * 10 + (zSrc[0] - '0');
-			zSrc++;
-		}
-		if( neg  ){
-			if( exp > SXDBL_MIN_EXP_PLUS ) exp = SXDBL_MIN_EXP_PLUS ;
-		}else if ( exp > SXDBL_MAX_EXP ){
-			exp = SXDBL_MAX_EXP;
-		}
-		for( p = (sxreal *)aTab ; exp ; exp >>= 1 , p++ ){
-			if( exp & 01 ){
-				if( neg ){
-					Val /= *p ;
-				}else{
-					Val *= *p;
-				}
+		if( zExp < zEnd && SyisDigit(zExp[0]) ){
+			zExpStart = zSrc;
+			zSrc = zExp;
+			while( zSrc < zEnd && SyisDigit(zSrc[0]) ){
+				zSrc++;
 			}
 		}
 	}
+	if( bDigit ){
+		sxu32 i, nSpan = (sxu32)((zExpStart ? zExpStart : zSrc) - zNum);
+		sxu32 nExp = zExpStart ? (sxu32)(zSrc - zExpStart) : 0;
+		char *zDup = zBuf;
+		sxu32 nDup = sizeof(zBuf);
+		if( nSpan + nExp >= sizeof(zBuf) ){
+			char *zHeap = (char *)malloc(nSpan + nExp + 1);
+			if( zHeap ){
+				zDup = zHeap;
+				nDup = nSpan + nExp + 1;
+			}
+		}
+		{
+			sxu32 nMantMax = nDup - 1 - (nExp < nDup - 1 ? nExp : 0);
+			for( i = 0 ; i < nSpan && nCopy < nMantMax ; i++ ){
+				zDup[nCopy++] = (zNum[i] == ',') ? '.' : zNum[i];
+			}
+			/* The exponent rides behind even a truncated mantissa: dropping
+			 * it would collapse "0.<hundreds of zeros>1e300" to 0.0. */
+			for( i = 0 ; i < nExp && nCopy < nDup - 1 ; i++ ){
+				zDup[nCopy++] = zExpStart[i];
+			}
+		}
+		zDup[nCopy] = 0;
+		Val = (sxreal)strtod(zDup,0);
+		if( zDup != zBuf ){
+			free(zDup);
+		}
+	}
+	/* Jump trailing spaces */
 	while( zSrc < zEnd && SyisSpace(zSrc[0]) ){
 		zSrc++;
 	}

--- a/tests/ph7/001-smoke/function/printf/printf_float_fidelity.phpt
+++ b/tests/ph7/001-smoke/function/printf/printf_float_fidelity.phpt
@@ -1,0 +1,51 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+printf float conversions match PHP byte-for-byte: exponents, %g shapes, rounding, precision cap
+--FILE--
+<?php
+$restore = set_error_handler(function ($errno, $errstr) {
+    echo "[$errno] $errstr\n";
+    return true;
+});
+// php prints exponents without zero padding, unlike C's printf
+printf("%e|%E|%.2e|%.0e\n", 12345.6789, 0.00012345, 999999.5, 9.5);
+// php's %g keeps a fractional digit on exponent-form output
+printf("%g|%G|%.10g|%g\n", 1e20, 1e-9, 1e15, 1000000.0);
+printf("%g|%g|%g|%g\n", 123456789.0, 0.000123456, 999999.0, 0.0001);
+// correctly-rounded digits, full expansion at extreme magnitudes
+printf("%.0f|%.0f|%.1f|%.1f\n", 0.5, 1.5, 0.25, 0.35);
+echo strlen(sprintf("%f", 1e308)), "|", substr(sprintf("%f", 1e308), 0, 30), "\n";
+printf("%.17e\n", 5.58924446885297306e+200);
+// negative zero: %f/%e drop the sign, %g keeps it
+printf("%f|%e|%g\n", -0.0, -0.0, -0.0);
+// zero padding goes between the sign and the digits
+printf("[%015.4e][%010.2f][%-12.3e]\n", -12345.6789, -1.5, -12345.6789);
+// precision is capped at 53 with a notice
+echo sprintf("%.60f", 0.1), "\n";
+// extreme literals parse correctly rounded (denormals, overflow to INF)
+var_export(5e-324 > 0.0); echo "\n";
+var_export(1e400); echo "\n";
+var_export((float)"1e400"); echo "\n";
+printf("%G|%g\n", 2.2250738585072014e-308, 5e-324);
+var_export((float)"5.58924446885297306e+200" === 5.58924446885297306e+200); echo "\n";
+set_error_handler($restore);
+--EXPECT--
+1.234568e+4|1.234500E-4|1.00e+6|1e+1
+1.0e+20|1.0E-9|1.0e+15|1.0e+6
+1.23457e+8|0.000123456|999999|0.0001
+0|2|0.2|0.3
+316|100000000000000001097906362944
+5.58924446885297306e+200
+0.000000|0.000000e+0|-0
+[-000001.2346e+4][-000001.50][-1.235e+4   ]
+[8] sprintf(): Requested precision of 60 digits was truncated to PHP maximum of 53 digits
+0.10000000000000000555111512312578270211815834045410156
+true
+INF
+INF
+2.22507E-308|4.94066e-324
+true
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/printf/printf_special_floats.phpt
+++ b/tests/ph7/001-smoke/function/printf/printf_special_floats.phpt
@@ -2,104 +2,25 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-printf with special float values
---SKIPIF--
-<?php echo 'skip'; ?>
+printf/sprintf special floats: INF/-INF/NaN across all conversions, width ignored
 --FILE--
 <?php
-// Test printf with special float values to cover edge cases in formatting
-echo "INF values:\n";
-printf("%%f: %f\n", INF);
-printf("%%e: %e\n", INF);
-printf("%%g: %g\n", INF);
-printf("%%E: %E\n", INF);
-printf("%%G: %G\n", INF);
-
-echo "\n-INF values:\n";
-printf("%%f: %f\n", -INF);
-printf("%%e: %e\n", -INF);
-printf("%%g: %g\n", -INF);
-printf("%%E: %E\n", -INF);
-printf("%%G: %G\n", -INF);
-
-echo "\nNAN values:\n";
-printf("%%f: %f\n", NAN);
-printf("%%e: %e\n", NAN);
-printf("%%g: %g\n", NAN);
-printf("%%E: %E\n", NAN);
-printf("%%G: %G\n", NAN);
-
-echo "\nLarge positive values:\n";
-printf("%%f: %f\n", 1e308);
-printf("%%e: %e\n", 1e308);
-printf("%%g: %g\n", 1e308);
-
-echo "\nLarge negative values:\n";
-printf("%%f: %f\n", -1e308);
-printf("%%e: %e\n", -1e308);
-printf("%%g: %g\n", -1e308);
-
-echo "\nSmall positive values:\n";
-printf("%%f: %f\n", 1e-307);
-printf("%%e: %e\n", 1e-307);
-printf("%%g: %g\n", 1e-307);
-
-echo "\nSmall negative values:\n";
-printf("%%f: %f\n", -1e-307);
-printf("%%e: %e\n", -1e-307);
-printf("%%g: %g\n", -1e-307);
-
-echo "\nUsing sprintf:\n";
-echo sprintf("INF %%f: %f\n", INF);
-echo sprintf("NAN %%e: %e\n", NAN);
-echo sprintf("-INF %%g: %g\n", -INF);
-?>
+printf("%f|%e|%g|%E|%G|%F\n", INF, INF, INF, INF, INF, INF);
+printf("%f|%e|%g|%E|%G\n", -INF, -INF, -INF, -INF, -INF);
+printf("%f|%e|%g|%E|%G\n", NAN, NAN, NAN, NAN, NAN);
+printf("[%10f][%-10f][%010f][%10.2f][%+f]\n", INF, INF, INF, NAN, INF);
+printf("[%10e][%010g][%+e][%-8g]\n", NAN, -INF, NAN, NAN);
+echo sprintf("INF %%f: %f", INF), "\n";
+echo sprintf("NAN %%e: %e", NAN), "\n";
+echo sprintf("-INF %%g: %g", -INF), "\n";
 --EXPECT--
-INF values:
-%f: 0.000000
-%e: 0.000000e+00
-%g: 0
-%E: 0.000000E+00
-%G: 0
-
--INF values:
-%f: 0.000000
-%e: 0.000000e+00
-%g: 0
-%E: 0.000000E+00
-%G: 0
-
-NAN values:
-%f: 0.000000
-%e: 0.000000e+00
-%g: 0
-%E: 0.000000E+00
-%G: 0
-
-Large positive values:
-%f: 100000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.000000
-%e: 1.000000e+308
-%g: 1e+308
-
-Large negative values:
-%f: -100000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.000000
-%e: -1.000000e+308
-%g: -1e+308
-
-Small positive values:
-%f: 0.000000
-%e: 1.000000e-307
-%g: 1e-307
-
-Small negative values:
-%f: -0.000000
-%e: -1.000000e-307
-%g: -1e-307
-
-Using sprintf:
-INF %f: 0.000000
-NAN %e: 0.000000e+00
--INF %g: 0
+INF|INF|INF|INF|INF|INF
+-INF|-INF|-INF|-INF|-INF
+NaN|NaN|NaN|NaN|NaN
+[INF][INF][INF][NaN][INF]
+[NaN][-INF][NaN][NaN]
+INF %f: INF
+NAN %e: NaN
+-INF %g: -INF
 --CLEAN--
 <?php
-

--- a/tests/ph7/001-smoke/function/round/round_precision_edge.phpt
+++ b/tests/ph7/001-smoke/function/round/round_precision_edge.phpt
@@ -2,15 +2,10 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: round() with precision edge cases (very high and negative)
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+round() with precision edge cases (very high and negative)
 --FILE--
 <?php
 // High precision beyond a double's significance: value returned unchanged.
-// (PHL-only: the float->string echo prints one more significant digit than
-// PHP here -- a pre-existing formatter divergence, not a round() difference,
-// so this stays gated with --SKIPIF--.)
 $val1 = round(2.12345678901234567890, 50);
 echo "round_precision_50=" . $val1 . "\n";
 
@@ -21,7 +16,7 @@ $val2 = round(2.5, -1);
 echo "round_precision_-1=" . $val2 . "\n";
 ?>
 --EXPECT--
-round_precision_50=2.12345678901234
+round_precision_50=2.1234567890123
 round_precision_-1=0
 --CLEAN--
 <?php

--- a/tests/ph7/001-smoke/function/tan/tan_large_value.phpt
+++ b/tests/ph7/001-smoke/function/tan/tan_large_value.phpt
@@ -2,15 +2,12 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: tan with very large value (edge case)
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+tan with very large value (edge case)
 --FILE--
 <?php
 // Test tan with very large value - covers potential edge case handling
 $large_value = 1e20; // Very large number
 $result = tan($large_value);
-// PHL may return 0 for large values that cause floating point issues
 echo "tan(1e20) = " . $result . "\n";
 if (is_numeric($result)) {
     echo "PASS: Returned numeric value\n";
@@ -19,7 +16,7 @@ if (is_numeric($result)) {
 }
 ?>
 --EXPECT--
-tan(1e20) = -0.844602463019884
+tan(1e20) = -0.84460246301988
 PASS: Returned numeric value
 --CLEAN--
 <?php

--- a/tests/ph7/001-smoke/lang/float_to_string_php_shapes.phpt
+++ b/tests/ph7/001-smoke/lang/float_to_string_php_shapes.phpt
@@ -1,0 +1,34 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Default float-to-string conversion matches PHP (precision 14, gcvt shapes, literal parsing, json)
+--FILE--
+<?php
+// php's default float->string conversion: precision=14, gcvt shapes
+echo 0.1 + 0.2, "|", 1 / 3, "|", 2.12345678901234567890, "\n";
+echo 1e15, "|", 1e14, "|", 100000000000000.0 - 1, "|", 0.0001, "|", 0.00001, "\n";
+echo -0.0, "|", 1e100, "|", -1.5e-300, "|", 987654321.12345678, "\n";
+echo (string)(7.0 / 11.0), "|", "" . 1e-320, "\n";
+// extreme literals parse correctly rounded (denormals, overflow to INF)
+echo 1e400, "|", (float)"1e400", "|", 5e-324 > 0.0 ? "denormal-ok" : "denormal-broken", "\n";
+echo (float)"5.58924446885297306e+200" === 5.58924446885297306e+200 ? "roundtrip-ok" : "roundtrip-broken", "\n";
+// json floats follow serialize_precision (shortest), lowercase exponent
+echo json_encode([1/3, 1.0, 0.1 + 0.2, 1e15, 1e17, -0.0, 1e100, 5e-324]), "\n";
+echo json_encode(["a" => "1e15", "b" => "2.5"], JSON_NUMERIC_CHECK), "\n";
+// a significant digit buried past 500 fractional zeros still parses
+$s = "0." . str_repeat("0", 520) . "1e300";
+echo (float)$s, "\n";
+--EXPECT--
+0.3|0.33333333333333|2.1234567890123
+1.0E+15|1.0E+14|99999999999999|0.0001|1.0E-5
+-0|1.0E+100|-1.5E-300|987654321.12346
+0.63636363636364|9.9998886718268E-321
+INF|INF|denormal-ok
+roundtrip-ok
+[0.3333333333333333,1,0.30000000000000004,1000000000000000,1.0e+17,-0,1.0e+100,5.0e-324]
+{"a":1000000000000000,"b":2.5}
+1.0E-221
+--CLEAN--
+<?php
+unset($s);


### PR DESCRIPTION
Started as the printf INF/NAN twin item and grew into end-to-end float formatting/parsing parity, byte-verified against php 8.5.7 by 5000 differential fuzz cases plus targeted sweeps:

- printf/sprintf float conversions (%f %F %e %E %g %G) now use libc snprintf as the digit engine (correctly rounded like php's zend_dtoa; the old hand-rolled vxGetdigit loop stopped at 16 significant digits, so %f of 1e308 printed zeros where php prints the exact binary64 expansion) and then apply php's exact shapes: NaN/INF/-INF printed bare with width ignored, exponents without zero padding (1e+8), %g keeping a fractional digit on exponent-form mantissas (1.0e+20), negative zero unsigned for %f/%e but -0 for %g, the ' ' flag treated as padding (php semantics, not C sign-space), and php's precision-53 cap raising its byte-exact E_NOTICE.

- SyStrToReal rewritten on strtod (engine-wide: float literals, string->float casts, json_decode numbers): correctly rounded values, denormals parse (5e-324), overflow yields php's INF instead of a silent 1e308 clamp, and absurdly long numerics take a heap copy so "0.<520 zeros>1e300" still parses to 1.0E-221.

- The default float->string cast (echo/concat) now follows php's zend_gcvt precision-14 shapes (1/3 -> 0.33333333333333, 1e15 -> 1.0E+15, -0.0 -> -0) via a shared PH7_PhpFloatShape helper, placed in memobj.c so the cast still links when builtin.c's formatting region is compiled out (PH7_DISABLE_DISK_IO).

- json_encode floats switched to php's serialize_precision behavior (shortest round-trip via PH7_AppendShortestReal, lowercase exponent: 1.0e+17, 1.0 -> 1), instead of riding the echo-precision cast.

Two zend-guarded tests that enshrined the old 15-digit echo output (round_precision_edge, tan_large_value) now run cross-engine; the dead printf_special_floats test (skipped everywhere, stale expectations) was rewritten cross-engine, plus two new cross-engine tests for the printf shapes and the conversion/parsing shapes. Documented residuals (PLAN.md): LC_NUMERIC locale sensitivity of the libc paths, php's ValueError on the '#' flag, var_dump float precision, json INF/NAN encode error.

test-compat green under both engines (smoke 2255, integration 846); docker ASan+UBSan clean.
