### PR TITLE
Throw catchable DivisionByZeroError for / and % by zero

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -9146,9 +9146,11 @@ case PH7_OP_MOD:{
 	a = pNos->x.iVal;
 	b = pTos->x.iVal;
 	if( b == 0 ){
-		r = 0;
-		VmErrorFormat(&(*pVm),PH7_CTX_ERR,"Division by zero %qd%%0",a);
-		/* goto Abort; */
+		/* Modulo by zero: php throws a catchable DivisionByZeroError (8.0),
+		 * not the old non-catchable warning that continued with a 0 result. */
+		rc = VmThrowFixedError(&(*pVm),"DivisionByZeroError","Modulo by zero");
+		PH7_DISPATCH_ENFORCE_RC(rc)
+		r = 0; /* unreachable — ENFORCE_RC jumps/breaks for a throw */
 	}else{
 		r = a%b;
 	}
@@ -9187,9 +9189,11 @@ case PH7_OP_MOD_STORE: {
 	a = pTos->x.iVal;
 	b = pNos->x.iVal;
 	if( b == 0 ){
-		r = 0;
-		VmErrorFormat(&(*pVm),PH7_CTX_ERR,"Division by zero %qd%%0",a);
-		/* goto Abort; */
+		/* Modulo by zero: php throws a catchable DivisionByZeroError (8.0),
+		 * not the old non-catchable warning that continued with a 0 result. */
+		rc = VmThrowFixedError(&(*pVm),"DivisionByZeroError","Modulo by zero");
+		PH7_DISPATCH_ENFORCE_RC(rc)
+		r = 0; /* unreachable — ENFORCE_RC jumps/breaks for a throw */
 	}else{
 		r = a%b;
 	}
@@ -9232,10 +9236,10 @@ case PH7_OP_DIV:{
 	a = pNos->rVal;
 	b = pTos->rVal;
 	if( b == 0 ){
-		/* Division by zero */
-		pNos->rVal = 0;
-		PH7_VmThrowError(&(*pVm),0,PH7_CTX_ERR,"Division by zero");
-		/* goto Abort; */
+		/* Division by zero: php throws a catchable DivisionByZeroError (8.0),
+		 * not the old non-catchable warning that continued with a 0 result. */
+		rc = VmThrowFixedError(&(*pVm),"DivisionByZeroError","Division by zero");
+		PH7_DISPATCH_ENFORCE_RC(rc)
 	}else{
 		r = a/b;
 		/* Push the result */
@@ -9275,10 +9279,10 @@ case PH7_OP_DIV_STORE:{
 	a = pTos->rVal;
 	b = pNos->rVal;
 	if( b == 0 ){
-		/* Division by zero */
-		r = 0;
-		VmErrorFormat(&(*pVm),PH7_CTX_ERR,"Division by zero %qd/0",a);
-		/* goto Abort; */
+		/* Division by zero: php throws a catchable DivisionByZeroError (8.0),
+		 * not the old non-catchable warning that continued with a 0 result. */
+		rc = VmThrowFixedError(&(*pVm),"DivisionByZeroError","Division by zero");
+		PH7_DISPATCH_ENFORCE_RC(rc)
 	}else{
 		r = a/b;
 		/* Push the result */

--- a/tests/ph7/001-smoke/lang/division_by_zero_throws.phpt
+++ b/tests/ph7/001-smoke/lang/division_by_zero_throws.phpt
@@ -1,0 +1,45 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: `/` and `%` by zero throw a catchable DivisionByZeroError
+--FILE--
+<?php
+function dz_probe(callable $fn): string {
+    try {
+        $fn();
+        return "no-throw";
+    } catch (DivisionByZeroError $e) {
+        return get_class($e) . ": " . $e->getMessage();
+    }
+}
+echo dz_probe(fn() => 1 / 0), "\n";
+echo dz_probe(fn() => 7.5 / 0), "\n";
+echo dz_probe(fn() => 0 / 0), "\n";
+echo dz_probe(fn() => 1 % 0), "\n";
+echo dz_probe(fn() => 5 % 0), "\n";
+echo dz_probe(function () { $x = 5; $x /= 0; }), "\n";
+echo dz_probe(function () { $x = 5; $x %= 0; }), "\n";
+echo dz_probe(function () { $a = [10]; $a[0] %= 0; }), "\n";
+// DivisionByZeroError is an ArithmeticError is an Error
+try {
+    $r = 1 % 0;
+} catch (ArithmeticError $e) {
+    echo "base-catch: ", $e->getMessage(), "\n";
+}
+// execution continues normally after a caught division-by-zero
+echo "after: ", 10 % 3, " ", 10 / 4, "\n";
+?>
+--EXPECT--
+DivisionByZeroError: Division by zero
+DivisionByZeroError: Division by zero
+DivisionByZeroError: Division by zero
+DivisionByZeroError: Modulo by zero
+DivisionByZeroError: Modulo by zero
+DivisionByZeroError: Division by zero
+DivisionByZeroError: Modulo by zero
+DivisionByZeroError: Modulo by zero
+base-catch: Modulo by zero
+after: 1 2.5
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/error/division_by_zero.phpt
+++ b/tests/ph7/002-integration/error/division_by_zero.phpt
@@ -2,17 +2,19 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-Division by zero in expressions
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+PH7 / PHP: Division by zero throws a catchable DivisionByZeroError
 --FILE--
 <?php
-$result = 10 / 0;
-echo "Result: $result\n";
+try {
+    $result = 10 / 0;
+    echo "Result: $result\n";
+} catch (DivisionByZeroError $e) {
+    echo get_class($e), ": ", $e->getMessage(), "\n";
+}
+echo "continues\n";
 ?>
---EXPECTF--
-%s Error:  Division by zero
-Result: 0
+--EXPECT--
+DivisionByZeroError: Division by zero
+continues
 --CLEAN--
 <?php
-unset($result);

--- a/tests/ph7/002-integration/error/modulo_by_zero.phpt
+++ b/tests/ph7/002-integration/error/modulo_by_zero.phpt
@@ -2,17 +2,19 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PHL: Modulo by zero produces an error
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+PH7 / PHP: Modulo by zero throws a catchable DivisionByZeroError
 --FILE--
 <?php
-$result = 10 % 0;
-echo "Result: $result\n";
+try {
+    $result = 10 % 0;
+    echo "Result: $result\n";
+} catch (DivisionByZeroError $e) {
+    echo get_class($e), ": ", $e->getMessage(), "\n";
+}
+echo "continues\n";
 ?>
---EXPECTF--
-%s Error:  Division by zero %s
-Result: 0
+--EXPECT--
+DivisionByZeroError: Modulo by zero
+continues
 --CLEAN--
 <?php
-unset($result);


### PR DESCRIPTION
`/`, `/=`, `%`, `%=` with a zero divisor raised a non-catchable warning ("Error:  Division by zero") and then continued execution with a 0 result — a PH7-ism that silently produced wrong answers and could not be caught. PHP 8 throws a catchable DivisionByZeroError ("Division by zero" for division, "Modulo by zero" for modulo).

All four opcodes (OP_DIV, OP_DIV_STORE, OP_MOD, OP_MOD_STORE) now throw via VmThrowFixedError + PH7_DISPATCH_ENFORCE_RC, so an enclosing try/catch handles it in place and execution resumes correctly after. Byte-verified vs php 8.5.7 (message, class, catch-by-base ArithmeticError/Error, post-catch continuation).

The two oracle-blind integration tests that enshrined the old warn-and-continue behavior (zend-guarded skips) are rewritten as cross-engine assertions; new smoke test division_by_zero_throws.phpt covers the operator + compound-assignment + array-element forms.
