### PR TITLE
Throw ValueError/TypeError for array_rand() domain-invalid args

### DIFF
--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -6727,24 +6727,73 @@ static int ph7_hashmap_rand(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	ph7_hashmap *pMap;
 	int nItem = 1;
 	if( nArg < 1 ){
-		/* Missing argument,return NULL */
+		/* Missing argument (arity is enforced upstream; defensive) */
 		ph7_result_null(pCtx);
 		return PH7_OK;
 	}
-	/* Make sure we are dealing with an array */
+	/* php 8: $array must be an array (TypeError, not a silent NULL return) */
 	if( !ph7_value_is_array(apArg[0]) ){
-		ph7_result_null(pCtx);
-		return PH7_OK;
+		return PH7_VmThrowException(pCtx,
+			"TypeError",
+			"array_rand(): Argument #1 ($array) must be of type array, %s given",
+			ph7_type_name(apArg[0])
+			);
+	}
+	/* php validates $num (and weak-coerces it) BEFORE the empty-array body
+	 * check, matching its ZPP-before-body ordering. */
+	if( nArg > 1 ){
+		ph7_value *pNum = apArg[1];
+		if( ph7_value_is_array(pNum) || ph7_value_is_object(pNum)
+			|| ph7_value_is_resource(pNum) ){
+			return PH7_VmThrowException(pCtx,
+				"TypeError",
+				"array_rand(): Argument #2 ($num) must be of type int, %s given",
+				ph7_type_name(pNum)
+				);
+		}
+		if( ph7_value_is_string(pNum) ){
+			/* Weak int coercion of a string $num follows php's numeric-string
+			 * grammar (whole string, int or float): a non-numeric string
+			 * (incl. leading-numeric junk like "2abc" or "0x1A") is a TypeError,
+			 * a well-formed float-string ("1e3") coerces like a float value.
+			 * Reuses the range() ZPP number parser (§3.9 shared-helper note). */
+			int len;
+			const char *zStr = ph7_value_to_string(pNum, &len);
+			sxi64 iLong; double dReal;
+			sxu8 iKind = RangeStrToNumber(zStr, (sxu32)len, &iLong, &dReal);
+			if( iKind == RANGE_IN_ERROR ){
+				return PH7_VmThrowException(pCtx,
+					"TypeError",
+					"array_rand(): Argument #2 ($num) must be of type int, string given"
+					);
+			}
+			/* Clamp into a signed-int band so an absurd magnitude still yields
+			 * the out-of-range ValueError below without an out-of-int cast. */
+			if( iKind == RANGE_IN_DOUBLE ){
+				iLong = dReal <= 0.0 ? 0 : (dReal >= 2147483647.0 ? 2147483647 : (sxi64)dReal);
+			}
+			if( iLong > 2147483647 ){ iLong = 2147483647; }
+			else if( iLong < -2147483647 ){ iLong = -2147483647; }
+			nItem = (int)iLong;
+		}else{
+			nItem = ph7_value_to_int(pNum);
+		}
 	}
 	/* Point to the internal representation of the input hashmap */
 	pMap = (ph7_hashmap *)apArg[0]->x.pOther;
-	if(pMap->nEntry < 1 ){
-		/* Empty hashmap,return NULL */
-		ph7_result_null(pCtx);
-		return PH7_OK;
+	/* php 8: an empty array is a ValueError, not a NULL return */
+	if( pMap->nEntry < 1 ){
+		return PH7_VmThrowException(pCtx,
+			"ValueError",
+			"array_rand(): Argument #1 ($array) must not be empty"
+			);
 	}
-	if( nArg > 1 ){
-		nItem = ph7_value_to_int(apArg[1]);
+	/* php 8: $num outside [1, count] is a ValueError, not a clamp/wrong value */
+	if( nItem < 1 || nItem > (int)pMap->nEntry ){
+		return PH7_VmThrowException(pCtx,
+			"ValueError",
+			"array_rand(): Argument #2 ($num) must be between 1 and the number of elements in argument #1 ($array)"
+			);
 	}
 	if( nItem < 2 ){
 		sxu32 nEntry;

--- a/tests/ph7/001-smoke/function/array_rand/array_rand_domain_errors.phpt
+++ b/tests/ph7/001-smoke/function/array_rand/array_rand_domain_errors.phpt
@@ -1,0 +1,61 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: array_rand() throws ValueError/TypeError on domain-invalid args
+--FILE--
+<?php
+function ar_probe($fn): string {
+    try {
+        $fn();
+        return "no-throw";
+    } catch (\Throwable $e) {
+        return get_class($e) . ": " . $e->getMessage();
+    }
+}
+// empty array -> ValueError (fires even when $num is also out of range)
+echo ar_probe(fn() => array_rand([])), "\n";
+echo ar_probe(fn() => array_rand([], 5)), "\n";
+// $num outside [1, count($array)] -> ValueError
+echo ar_probe(fn() => array_rand([1, 2, 3], 0)), "\n";
+echo ar_probe(fn() => array_rand([1, 2, 3], -1)), "\n";
+echo ar_probe(fn() => array_rand([1, 2, 3], 4)), "\n";
+// wrong types -> TypeError
+echo ar_probe(fn() => array_rand("x")), "\n";
+echo ar_probe(fn() => array_rand([1, 2, 3], [])), "\n";
+echo ar_probe(fn() => array_rand([1, 2, 3], "abc")), "\n";
+// a leading-numeric-junk / non-numeric-base string $num is a TypeError, not a
+// silent coercion of its numeric prefix
+echo ar_probe(fn() => array_rand([1, 2, 3], "2abc")), "\n";
+echo ar_probe(fn() => array_rand([1, 2, 3], "0x1A")), "\n";
+// a well-formed float-string coerces like a float value, then range-checks
+echo ar_probe(fn() => array_rand([1, 2, 3], "1e3")), "\n";
+// $num type-check fires before the empty-array body check (php ZPP ordering)
+echo ar_probe(fn() => array_rand([], [])), "\n";
+// valid calls still work: single key vs array of keys
+$in = [10, 20, 30];
+$k = array_rand($in);
+echo (in_array($k, [0, 1, 2], true) ? "key-ok" : "key-bad"), "\n";
+$keys = array_rand($in, 3);
+echo (is_array($keys) && count($keys) === 3 ? "all-ok" : "all-bad"), "\n";
+$one = array_rand($in, 1);
+echo (is_int($one) ? "one-scalar-ok" : "one-bad"), "\n";
+?>
+--EXPECT--
+ValueError: array_rand(): Argument #1 ($array) must not be empty
+ValueError: array_rand(): Argument #1 ($array) must not be empty
+ValueError: array_rand(): Argument #2 ($num) must be between 1 and the number of elements in argument #1 ($array)
+ValueError: array_rand(): Argument #2 ($num) must be between 1 and the number of elements in argument #1 ($array)
+ValueError: array_rand(): Argument #2 ($num) must be between 1 and the number of elements in argument #1 ($array)
+TypeError: array_rand(): Argument #1 ($array) must be of type array, string given
+TypeError: array_rand(): Argument #2 ($num) must be of type int, array given
+TypeError: array_rand(): Argument #2 ($num) must be of type int, string given
+TypeError: array_rand(): Argument #2 ($num) must be of type int, string given
+TypeError: array_rand(): Argument #2 ($num) must be of type int, string given
+ValueError: array_rand(): Argument #2 ($num) must be between 1 and the number of elements in argument #1 ($array)
+TypeError: array_rand(): Argument #2 ($num) must be of type int, array given
+key-ok
+all-ok
+one-scalar-ok
+--CLEAN--
+<?php


### PR DESCRIPTION
array_rand() silently returned wrong values instead of php 8's catchable errors: an empty array returned NULL, an out-of-range $num returned a wrong-shaped result (or a clamped array), and a non-array $array / non-int $num returned NULL. PHP 8 throws:
  - TypeError  when $array is not an array, or $num is not int-coercible
  - ValueError when $array is empty
  - ValueError when $num is outside [1, count($array)]

The checks run in php's ZPP-before-body order ($array type → $num type → empty → range), byte-verified vs php 8.5.7. Arity (0-arg ArgumentCountError) is already enforced by the central aBuiltinArity table. Valid single-key (scalar) and multi-key (array) results are unchanged.

A string $num is validated against php's numeric-string grammar via the range() ZPP number parser (RangeStrToNumber, reused in-file per the §3.9 shared-helper note): leading-numeric junk ("2abc") or a non-decimal base ("0x1A") is a TypeError, not a silent coercion of the numeric prefix; a well-formed float-string ("1e3") coerces like a float and range-checks. The coerced value is clamped into a signed-int band so an absurd magnitude yields the range ValueError without an out-of-int cast.

Residuals (documented): a float / float-string $num that loses precision (1.9 / "1.5") or a null $num is coerced silently where php also emits an E_DEPRECATED notice (the existing float→int / null deprecation class); an out-of-long-range numeric string (integer or float, e.g. "1e300" / "9223372036854775808") raises PHL's range ValueError where php raises a TypeError (loud either way, exotic).

New cross-engine test array_rand_domain_errors.phpt.
