### PR TITLE
Fix rand()/mt_rand() range, sign, and arg-count semantics

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -17220,23 +17220,56 @@ PH7_PRIVATE void PH7_VmRandomString(ph7_vm *pVm,char *zBuf,int nLen)
  */
 static int vm_builtin_rand(ph7_context *pCtx,int nArg,ph7_value **apArg)
 {
+	SyString *pName = &pCtx->pFunc->sName;
+	int bMt = (pName->nByte == sizeof("mt_rand")-1
+		&& SyMemcmp(pName->zString,"mt_rand",sizeof("mt_rand")-1) == 0);
 	sxu32 iNum;
+	/* php accepts exactly 0 or exactly 2 arguments (min,max); 1 or 3+ is an
+	 * ArgumentCountError. The central arity table can't express "0 or 2", so
+	 * it is enforced here (was a silent wrong result for the raw draw). */
+	if( nArg == 1 || nArg > 2 ){
+		return PH7_VmThrowException(pCtx,
+			"ArgumentCountError",
+			"%z() expects exactly 2 arguments, %d given",
+			pName, nArg
+			);
+	}
 	/* Generate the random number */
 	iNum = PH7_VmRandomNum(pCtx->pVm);
-	if( nArg > 1 ){
-		sxu32 iMin,iMax;
-		iMin = (sxu32)ph7_value_to_int(apArg[0]);
-		iMax = (sxu32)ph7_value_to_int(apArg[1]);
-		if( iMin < iMax ){
-			sxu32 iDiv = iMax+1-iMin;
-			if( iDiv > 0 ){
-				iNum = (iNum % iDiv)+iMin;
+	if( nArg == 2 ){
+		sxi64 iMin,iMax;
+		sxu64 iSpan;
+		/* Signed 64-bit endpoints: the old unsigned math wrapped negative
+		 * ranges to huge positives (rand(-10,-1) -> ~4e9) and mis-handled
+		 * min==max. */
+		iMin = ph7_value_to_int64(apArg[0]);
+		iMax = ph7_value_to_int64(apArg[1]);
+		if( iMin > iMax ){
+			if( bMt ){
+				/* mt_rand() is strict: php throws a catchable ValueError. */
+				return PH7_VmThrowException(pCtx,
+					"ValueError",
+					"mt_rand(): Argument #2 ($max) must be greater than or equal to argument #1 ($min)"
+					);
 			}
-		}else if(iMax > 0 ){
-			iNum %= iMax;
+			/* rand() swaps the bounds for backward compatibility (php keeps
+			 * this quirk; only mt_rand() rejects a reversed range). */
+			{ sxi64 iTmp = iMin; iMin = iMax; iMax = iTmp; }
 		}
+		/* Map the draw into [iMin,iMax] inclusive using a 64-bit span so a
+		 * full-width range never overflows. Subtract in unsigned space: the
+		 * signed (iMax-iMin) would overflow for a range wider than 2^63
+		 * (up to the full PHP_INT domain), which is C undefined behavior. */
+		iSpan = ((sxu64)iMax - (sxu64)iMin) + 1;
+		if( iSpan == 0 ){
+			/* Range spans the entire 64-bit domain (PHP_INT_MIN..PHP_INT_MAX). */
+			ph7_result_int64(pCtx,(sxi64)((sxu64)iMin + (sxu64)iNum));
+			return SXRET_OK;
+		}
+		ph7_result_int64(pCtx,(sxi64)((sxu64)iMin + (iNum % iSpan)));
+		return SXRET_OK;
 	}
-	/* Return the number */
+	/* No-argument form: return the raw draw */
 	ph7_result_int64(pCtx,(ph7_int64)iNum);
 	return SXRET_OK;
 }

--- a/tests/ph7/001-smoke/function/mt_rand/mt_rand_range_errors.phpt
+++ b/tests/ph7/001-smoke/function/mt_rand/mt_rand_range_errors.phpt
@@ -1,0 +1,54 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: mt_rand()/rand() range + arg-count errors and signed ranges
+--FILE--
+<?php
+function rng_probe($fn): string {
+    try {
+        $fn();
+        return "no-throw";
+    } catch (\Throwable $e) {
+        return get_class($e) . ": " . $e->getMessage();
+    }
+}
+function in_range(int $r, int $lo, int $hi): bool {
+    return $r >= $lo && $r <= $hi;
+}
+// mt_rand() is strict: a reversed range is a catchable ValueError
+echo rng_probe(fn() => mt_rand(5, 1)), "\n";
+// rand() keeps php's backward-compat swap for a reversed range
+echo (in_range(rand(5, 1), 1, 5) ? "swap-ok" : "swap-bad"), "\n";
+// wrong argument count -> ArgumentCountError (exactly 0 or 2 args)
+echo rng_probe(fn() => rand(5)), "\n";
+echo rng_probe(fn() => mt_rand(5)), "\n";
+echo rng_probe(fn() => rand(1, 2, 3)), "\n";
+echo rng_probe(fn() => mt_rand(1, 2, 3)), "\n";
+// signed ranges: negatives and equal bounds land in [min,max]
+$ok = true;
+for ($i = 0; $i < 200; $i++) {
+    $ok = $ok
+        && in_range(rand(-10, -1), -10, -1)
+        && in_range(mt_rand(-10, -1), -10, -1)
+        && in_range(rand(-5, 5), -5, 5)
+        && in_range(mt_rand(1, 6), 1, 6);
+}
+echo ($ok ? "signed-ok" : "signed-bad"), "\n";
+// equal bounds return exactly that value
+echo (rand(7, 7) === 7 && mt_rand(0, 0) === 0 ? "equal-ok" : "equal-bad"), "\n";
+// no-arg form still returns a non-negative int
+echo (is_int(rand()) && rand() >= 0 && is_int(mt_rand()) ? "noarg-ok" : "noarg-bad"), "\n";
+?>
+--EXPECT--
+ValueError: mt_rand(): Argument #2 ($max) must be greater than or equal to argument #1 ($min)
+swap-ok
+ArgumentCountError: rand() expects exactly 2 arguments, 1 given
+ArgumentCountError: mt_rand() expects exactly 2 arguments, 1 given
+ArgumentCountError: rand() expects exactly 2 arguments, 3 given
+ArgumentCountError: mt_rand() expects exactly 2 arguments, 3 given
+signed-ok
+equal-ok
+noarg-ok
+--CLEAN--
+<?php


### PR DESCRIPTION
vm_builtin_rand (shared by rand and mt_rand) computed the bounded draw in unsigned 32-bit arithmetic and silently produced wrong answers:
  - a reversed range returned a wrong/out-of-range value instead of php's mt_rand() ValueError (mt_rand is strict) or rand()'s BC swap;
  - a negative range wrapped to a huge positive (rand(-10,-1) -> ~4.3e9);
  - equal bounds misbehaved (rand(0,0) -> a full random draw, mt_rand(2,2) -> 0 or 1) instead of returning the bound;
  - 1 or 3+ args returned a raw draw instead of php's ArgumentCountError.

Rewritten with signed 64-bit endpoints mapped into [min,max] via a 64-bit span (computed in unsigned space so a range wider than 2^63 — up to the full PHP_INT domain — doesn't invoke signed-overflow UB; negatives correct, min==max returns the bound). The called name (pCtx->pFunc->sName) splits the two builtins: mt_rand() throws the byte-exact ValueError on a reversed range, rand() swaps for backward compat (php keeps this quirk). The exactly-0-or-2-arguments rule — which the central aBuiltinArity table can't express — is enforced in-function with php's byte-exact ArgumentCountError.

Byte-verified vs php 8.5.7 (messages) and range-verified across negative / reversed / equal / full-domain / no-arg forms. New cross-engine test mt_rand_range_errors.phpt.

Residuals (out of scope): a non-numeric-string or array $min/$max is coerced rather than raising php's TypeError (broader stage-2 type sweep); a span wider than 2^32 is under-filled by the 32-bit draw (result stays in [min,max], only the distribution is capped — pre-existing, the PRNG is 32-bit); the no-arg draw still spans phl's 2^32-1 getrandmax rather than php's 2^31-1 (pre-existing RNG-range difference, values not compared).
