### PR TITLE
Apply PHP 8 saner string-to-number comparison semantics

### DIFF
--- a/src/ph7/memobj.c
+++ b/src/ph7/memobj.c
@@ -1268,17 +1268,18 @@ PH7_PRIVATE sxi32 PH7_MemObjCmp(ph7_value *pObj1,ph7_value *pObj2,int bStrict,in
 		SyString s1,s2;
 		if( !bStrict ){
 			/*
-			 * According to the PHP language reference manual:
-			 *
-			 *  If you compare a number with a string or the comparison involves numerical
-			 *  strings, then each string is converted to a number and the comparison
-			 *  performed numerically.
+			 * PHP 8 "saner string to number comparisons" (RFC): a numeric
+			 * comparison is performed only when BOTH operands are numbers or
+			 * numeric strings. A number compared with a NON-numeric string is
+			 * compared as strings, with the number cast to its string form —
+			 * so 0 == "abc" is false, "abc" < 10 is false, and max("abc",10)
+			 * is "abc". (PHP 7 cast the non-numeric string to 0 and compared
+			 * numerically; comparing when EITHER side was numeric is what this
+			 * replaces.) Two non-numeric strings, or one numeric and one
+			 * non-numeric string, still fall through to the string comparison
+			 * below, unchanged.
 			 */
-			if( PH7_MemObjIsNumeric(pObj1) ){
-				/* Perform a numeric comparison */
-				goto Numeric;
-			}
-			if( PH7_MemObjIsNumeric(pObj2) ){
+			if( PH7_MemObjIsNumeric(pObj1) && PH7_MemObjIsNumeric(pObj2) ){
 				/* Perform a numeric comparison */
 				goto Numeric;
 			}

--- a/tests/ph7/001-smoke/function/base_convert/base_convert_empty_input.phpt
+++ b/tests/ph7/001-smoke/function/base_convert/base_convert_empty_input.phpt
@@ -2,13 +2,14 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-base_convert with empty input string
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+base_convert with empty input string returns "0"
 --FILE--
 <?php
+// Empty input converts to "0". Assert the exact value with === (the old == ''
+// check only held under PHP-7 loose comparison, where "0" == "" was true; under
+// PHP 8 "0" == "" is false because "" is not a numeric string).
 $result = base_convert('', 10, 10);
-echo $result == '' ? 'PASS' : 'FAIL';
+echo $result === '0' ? 'PASS' : 'FAIL';
 ?>
 --EXPECT--
 PASS

--- a/tests/ph7/001-smoke/lang/string_number_comparison_php8.phpt
+++ b/tests/ph7/001-smoke/lang/string_number_comparison_php8.phpt
@@ -1,0 +1,44 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PHP 8 saner string-to-number comparisons
+--FILE--
+<?php
+// A number compared with a NON-numeric string is compared as strings (the number
+// cast to its string form). Only a numeric string triggers a numeric comparison.
+// Bools printed via (int) as 1/0 to dodge the var_dump bool-casing divergence.
+
+// number vs non-numeric string -> string comparison
+echo (int)(0 == "abc"), "\n";     // 0  ("0" != "abc")
+echo (int)(0 == ""), "\n";        // 0  ("0" != "")   (PHP 8: was true in PHP 7)
+echo (int)("abc" < 10), "\n";     // 0  ("abc" > "10")
+echo (int)(10 < "abc"), "\n";     // 1
+echo ("abc" <=> 10), "\n";        // 1
+
+// number vs numeric string -> numeric comparison (unchanged)
+echo (int)(0 == "0"), "\n";       // 1
+echo (int)("10" == 10), "\n";     // 1
+echo (int)(1.5 < "2"), "\n";      // 1
+
+// reduction / sort use the same comparator
+echo max("abc", 10), "\n";    // abc
+echo min("abc", 10), "\n";    // 10
+$a = [10, "abc", 2];
+sort($a);
+echo implode(",", $a), "\n";  // 2,10,abc
+?>
+--EXPECT--
+0
+0
+0
+1
+1
+1
+1
+1
+abc
+10
+2,10,abc
+--CLEAN--
+<?php


### PR DESCRIPTION
PH7_MemObjCmp's non-strict string branch did a numeric comparison whenever EITHER operand was numeric, so a number compared with a non-numeric string cast the string to 0 and compared numerically (PHP 7): 0 == "abc" was true, "abc" < 10 was true, and max("abc", 10) was 10. PHP 8's "saner string to number comparisons" compares numerically only when BOTH operands are numbers or numeric strings; otherwise the number is cast to its string form and the two are compared as strings. Change the gate from "either numeric" to "both numeric" (the single && below), so the fall-through string comparison now handles number-vs-non- numeric-string exactly like php: 0 == "abc" and "" == 0 are false, "abc" < 10 is false, 10 < "abc" is true, and max/min/sort over mixed values order correctly. The whole engine routes loose comparison through this one function, so ==, <, <=>, sort, in_array, array_search all follow. Byte-verified vs php 8.5.7 across ~600 type-pair comparisons; the only remaining diffs are the pre-existing too-loose numeric-string classifier (below) and null-vs-string, both untouched here. test-compat green (smoke 2280 / integration 851, both engines); one phl-only test that had enshrined the PHP-7 `"0" == ""` result is now a correct cross-engine `=== '0'` assertion; new cross-engine test.

Residuals (separate root causes, recorded in PLAN §3.1 as follow-ups): PH7_MemObjIsNumeric (shared with is_numeric()) wrongly treats "10abc"/"0x1A"/ "0b101" as numeric and rejects ".5", so those comparison/is_numeric edge cases still diverge; and null-vs-string uses bool coercion where PHP 8 compares null as "" (null == "0" -> php false, null < "0" -> php true).
