### PR TITLE
Fill consecutive keys for array_fill() negative start (PHP 8)

### DIFF
--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -6074,13 +6074,13 @@ static int ph7_hashmap_fill(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		return PH7_ContextMemoryError(pCtx);
 	}
 
-	/* Insert the first entry alone because it has its own key */
-	if( ph7_array_add_intkey_elem(pArray, ph7_value_to_int(apArg[0]), apArg[2]) != SXRET_OK ){
-		return PH7_ContextMemoryError(pCtx);
-	}
-	/* Repeat insertion of the desired value */
-	for( i = 1 ; i < nEntry ; i++ ){
-		if( ph7_array_add_elem(pArray, 0/*Automatic index assign */, apArg[2]) != SXRET_OK ){
+	/* PHP 8 fills consecutive integer keys start_index, start_index+1, … even
+	 * when start_index is negative (PHP 7 restarted the remaining keys from 0,
+	 * so array_fill(-5,3) gave -5,0,1 instead of -5,-4,-3). Assign each key
+	 * explicitly rather than relying on automatic (append) indexing. */
+	int iStart = ph7_value_to_int(apArg[0]);
+	for( i = 0 ; i < nEntry ; i++ ){
+		if( ph7_array_add_intkey_elem(pArray, iStart + i, apArg[2]) != SXRET_OK ){
 			/* Allocation failure: surface a fatal instead of a partial array */
 			return PH7_ContextMemoryError(pCtx);
 		}

--- a/tests/ph7/001-smoke/function/array_fill/array_fill_negative_start.phpt
+++ b/tests/ph7/001-smoke/function/array_fill/array_fill_negative_start.phpt
@@ -2,16 +2,20 @@
 SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-array_fill: negative start index is allowed and used as key
+array_fill: a negative start index fills consecutive keys (PHP 8)
 --FILE--
 <?php
-$a = array_fill(-2, 2, 'z');
-echo count($a) . "\n";
-echo array_keys($a)[0] . "\n";
+// PHP 8 fills consecutive keys start, start+1, … even when start is negative
+// (PHP 7 restarted the remaining keys from 0, giving -5,0,1 instead of -5,-4,-3).
+echo json_encode(array_fill(-2, 2, 'z')), "\n";
+echo json_encode(array_fill(-5, 3, 0)), "\n";
+echo json_encode(array_fill(-3, 5, 'x')), "\n";
+echo json_encode(array_fill(5, 3, 0)), "\n";
 ?>
 --EXPECT--
-2
--2
+{"-2":"z","-1":"z"}
+{"-5":0,"-4":0,"-3":0}
+{"-3":"x","-2":"x","-1":"x","0":"x","1":"x"}
+{"5":0,"6":0,"7":0}
 --CLEAN--
 <?php
-unset($a);


### PR DESCRIPTION
After inserting the first entry with the explicit start key, the fill loop used automatic (append) indexing, which restarts at 0 — so array_fill(-5, 3, $v) gave keys -5,0,1 (PHP 7) instead of PHP 8's consecutive -5,-4,-3. Assign each key explicitly as start_index + i so the whole run is consecutive regardless of sign (a positive start was already consecutive and is unchanged). Byte-verified vs php 8.5.7 across negative/positive starts and zero count; the existing negative-start test is broadened to assert the full key set cross-engine.
