### PR TITLE
Throw ValueError for negative strncmp()/strncasecmp() length

### DIFF
--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -1235,9 +1235,10 @@ static int PH7_builtin_strncmp(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	/* Desired comparison length */
 	n  = ph7_value_to_int(apArg[2]);
 	if( n < 0 ){
-		/* Invalid length */
-		ph7_result_int(pCtx,-1);
-		return PH7_OK;
+		/* PHP 8 throws a catchable ValueError for a negative length. */
+		return PH7_VmThrowException(pCtx,"ValueError",
+			"%s(): Argument #3 ($length) must be greater than or equal to 0",
+			ph7_function_name(pCtx));
 	}
 	/* Perform the comparison */
 	z1 = ph7_value_to_string(apArg[0],0);
@@ -1298,9 +1299,10 @@ static int PH7_builtin_strncasecmp(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	/* Desired comparison length */
 	n  = ph7_value_to_int(apArg[2]);
 	if( n < 0 ){
-		/* Invalid length */
-		ph7_result_int(pCtx,-1);
-		return PH7_OK;
+		/* PHP 8 throws a catchable ValueError for a negative length. */
+		return PH7_VmThrowException(pCtx,"ValueError",
+			"%s(): Argument #3 ($length) must be greater than or equal to 0",
+			ph7_function_name(pCtx));
 	}
 	/* Perform the comparison */
 	z1 = ph7_value_to_string(apArg[0],0);

--- a/tests/ph7/001-smoke/function/strncasecmp/strncasecmp_negative_length.phpt
+++ b/tests/ph7/001-smoke/function/strncasecmp/strncasecmp_negative_length.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+strncasecmp() throws ValueError for a negative length (PHP 8)
+--FILE--
+<?php
+try {
+    strncasecmp("abc", "ABD", -1);
+} catch (\ValueError $e) {
+    echo $e->getMessage(), "\n";
+}
+// A non-negative length still compares case-insensitively.
+echo strncasecmp("ABC", "abd", 2), "\n";
+?>
+--EXPECT--
+strncasecmp(): Argument #3 ($length) must be greater than or equal to 0
+0
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/strncmp/strncmp_negative_length.phpt
+++ b/tests/ph7/001-smoke/function/strncmp/strncmp_negative_length.phpt
@@ -2,20 +2,19 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: strncmp with negative length returns -1
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+strncmp() throws ValueError for a negative length (PHP 8)
 --FILE--
 <?php
-$result = strncmp("abc", "def", -1);
-if ($result === -1) {
-    echo "PASS";
-} else {
-    echo "FAIL";
+try {
+    strncmp("abc", "def", -1);
+} catch (\ValueError $e) {
+    echo $e->getMessage(), "\n";
 }
+// A non-negative length still compares normally.
+echo strncmp("abc", "abd", 2), "\n";
 ?>
 --EXPECT--
-PASS
+strncmp(): Argument #3 ($length) must be greater than or equal to 0
+0
 --CLEAN--
 <?php
-unset($result);


### PR DESCRIPTION
Both silently returned -1 on a negative $length where PHP 8 throws a catchable ValueError ("Argument #3 ($length) must be greater than or equal to 0"). Replace the -1 short-circuit in each with the byte-exact throw (function name via ph7_function_name so strncmp/strncasecmp each name themselves). Valid lengths are unchanged. Byte-verified vs php 8.5.7; the phl-only strncmp negative-length test that enshrined the old -1 is rewritten cross-engine, plus a new strncasecmp one.
