### PR TITLE
Route exceptions thrown across C-boundary calls instead of swallowing…

### DIFF
--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1128,6 +1128,14 @@ struct ph7_vm
 	void *pInlineInstr;         /* Owner bytecode array of the catching inline try (0 = none) */
 	sxu32 iInlinePc;            /* 0-based target pc (iHandlerPc or iFinallyPc) */
 	sxi32 iInlineDrain;         /* Operand-stack base to drain to before landing (0-based TOS idx) */
+	sxi32 nBoundaryRc;          /* C-boundary parked throw status (0 / PH7_EXCEPTION / PH7_ABORT).
+	                             * Set by VmBoundaryPark when a PHP callee invoked from a C site
+	                             * (magic method, cast hook, __destruct, user callback) raised and
+	                             * that C site has no status channel to route it. Consumed once per
+	                             * dispatch at the executor's fetch point (and cleared wherever the
+	                             * same in-flight throw is landed via VmRecordedResume or the inline
+	                             * redirect), so a swallowed throw outlives at most the C remainder
+	                             * of one opcode instead of silently resuming execution. */
 	SySet aIOstream;            /* Installed IO stream container */
 	const ph7_io_stream *pDefStream; /* Default IO stream [i.e: typically this is the 'file://' stream] */
 	ph7_value sExec;           /* Compiled script return value [Can be extracted via the PH7_VM_CONFIG_EXEC_VALUE directive]*/

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -1121,6 +1121,10 @@ static int VmRecordedResume(ph7_vm *pVm,sxi32 *pResumePc,VmFrame *pEntryFrame,Vm
 	}
 	*pResumePc = (sxi32)pVm->iResumePc - 1;
 	pVm->pResumeFrame = 0; /* one-shot consume */
+	/* Landing at the catch pad consumes any C-boundary parked copy of the same
+	 * in-flight throw (VmBoundaryPark): the status is routed now, so the fetch-
+	 * point router must not re-fire it after this resume. */
+	pVm->nBoundaryRc = 0;
 	return TRUE;
 }
 /*
@@ -2416,6 +2420,7 @@ PH7_PRIVATE sxi32 PH7_VmInit(
 	pVm->iResumePc = 0;
 	pVm->pResumeInstr = 0;
 	pVm->iResumeStackDepth = 0;
+	pVm->nBoundaryRc = 0;
 	/* Configuration containers */
 	SySetInit(&pVm->aFiles,&pVm->sAllocator,sizeof(SyString));
 	SySetInit(&pVm->aPaths,&pVm->sAllocator,sizeof(SyString));
@@ -3744,6 +3749,7 @@ PH7_PRIVATE sxi32 PH7_VmReset(ph7_vm *pVm)
 	pVm->iResumePc = 0;
 	pVm->pResumeInstr = 0;
 	pVm->iResumeStackDepth = 0;
+	pVm->nBoundaryRc = 0;
 	pVm->nExceptDepth = 0;
 	/* spl_autoload_register() callbacks are per request */
 	for( n = 0 ; n < SySetUsed(&pVm->aAutoload) ; ++n ){
@@ -4708,7 +4714,22 @@ static sxi32 VmInvokeErrorHandler(ph7_vm *pVm, sxi32 iErr, const char *zMessage,
 		apArgPtr[2] = &apArg[2];
 		apArgPtr[3] = &apArg[3];
 		/* Call the handler */
-		PH7_VmCallUserFunction(pVm,&pVm->aErrCB[1],4,apArgPtr,&sResult);
+		{
+			sxi32 rcCb = PH7_VmCallUserFunction(pVm,&pVm->aErrCB[1],4,apArgPtr,&sResult);
+			if( rcCb == PH7_EXCEPTION || rcCb == PH7_ABORT ){
+				/* The handler threw (or aborted) instead of returning: php never
+				 * reports the original diagnostic then — the exception supersedes
+				 * it (and is routed by the boundary parking / fetch-point router).
+				 * Reporting it here would print a spurious Warning AFTER the
+				 * user's catch already ran. */
+				PH7_MemObjRelease(&apArg[0]);
+				PH7_MemObjRelease(&apArg[1]);
+				PH7_MemObjRelease(&apArg[2]);
+				PH7_MemObjRelease(&apArg[3]);
+				PH7_MemObjRelease(&sResult);
+				return FALSE;
+			}
+		}
 		/* Check return value */
 		if( (sResult.iFlags & MEMOBJ_BOOL) == 0 ){
 			PH7_MemObjToBool(&sResult);
@@ -7195,13 +7216,26 @@ static sxi32 VmByteCodeExec(
 	)
 {
 	sxi32 rc;
+	sxi32 nSavedBrc;
 	if( VmNativeNestingExceeded(pVm) ){
 		return VmNativeNestingFatal(pVm);
 	}
+	/* A fresh native exec entered while a C-boundary throw is parked
+	 * (nBoundaryRc — e.g. a __destruct fired by an operand release inside the
+	 * very opcode that swallowed the throw) must run CLEAN: the parked status
+	 * belongs to the interrupted outer exec's fetch-point router, not to this
+	 * one. Save+clear on entry, merge back on exit — the outer status is
+	 * restored unless this exec parked its own unconsumed (newer) one, with
+	 * PH7_ABORT dominating either way. */
+	nSavedBrc = pVm->nBoundaryRc;
+	pVm->nBoundaryRc = 0;
 	pVm->nVmExecDepth++;
 	rc = VmByteCodeExecBody(&(*pVm),aInstr,pStack,nTos,pResult,pLastRef,is_callback,nPc,
 		pEnforceRetFunc,bReturnPropagates,pAdoptSegment);
 	pVm->nVmExecDepth--;
+	if( nSavedBrc != 0 && (nSavedBrc == PH7_ABORT || pVm->nBoundaryRc == 0) ){
+		pVm->nBoundaryRc = nSavedBrc;
+	}
 	return rc;
 }
 static sxi32 VmByteCodeExecBody(
@@ -7312,6 +7346,7 @@ static sxi32 VmByteCodeExecBody(
 		while( (sxi32)(pTos - pStack) > pVm->iInlineDrain ){ PH7_MemObjRelease(pTos); pTos--; } \
 		pc = (sxi32)pVm->iInlinePc - 1; \
 		pVm->pInlineInstr = 0; \
+		pVm->nBoundaryRc = 0; /* redirect consumed: drop any parked copy of this throw */ \
 		break; \
 	}
 #define PH7_DISPATCH_ENFORCE_RC(rcVar) \
@@ -7483,6 +7518,51 @@ static sxi32 VmByteCodeExecBody(
 	/* Execute as much as we can */
 	for(;;){
 VmLoopFetch:
+		/* C-boundary throw routing (band A #1): a PHP callee invoked from a C
+		 * site with no status channel — a __toString/__toInt cast, __get/__set/
+		 * offsetGet/offsetSet, __clone, __destruct, a user callback inside a
+		 * builtin — raised, and the site continued with a fallback value; the
+		 * invocation boundary parked the status here (VmBoundaryPark). Route it
+		 * exactly as the throw site's dispatch macro would have: abort, land at
+		 * an inline-try redirect, resume at a recorded in-place catch (draining
+		 * the abandoned mid-expression operands to the catching try's base), or
+		 * propagate out of this exec. Checked at the fetch point, so a swallowed
+		 * throw outlives at most the C remainder of ONE opcode instead of
+		 * silently resuming the surrounding PHP code with a bogus value. */
+		if( pVm->nBoundaryRc != 0 ){
+			sxi32 rcBr = pVm->nBoundaryRc;
+			pVm->nBoundaryRc = 0;
+			if( rcBr == PH7_ABORT ){
+				goto Abort;
+			}
+			if( pVm->pInlineInstr == (void *)aInstr ){
+				/* Caught by an inline try (generator body) THIS exec owns: drain
+				 * and land (pre-fetch path: pc is used directly, no trailing ++). */
+				while( (sxi32)(pTos - pStack) > pVm->iInlineDrain ){
+					PH7_MemObjRelease(pTos);
+					pTos--;
+				}
+				pc = (sxi32)pVm->iInlinePc;
+				pVm->pInlineInstr = 0;
+			}else{
+				sxi32 iBrPc;
+				if( VmRecordedResume(pVm,&iBrPc,sState.pEntryFrame,aInstr) ){
+					/* Caught in place by a try THIS exec owns: drain the abandoned
+					 * operands to the catching try's base and land at its pad
+					 * (iBrPc is landing-1 for the dispatcher's trailing pc++;
+					 * pre-fetch here, so +1 lands on the pad itself). */
+					while( (sxi32)(pTos - pStack) > pVm->iResumeStackDepth ){
+						PH7_MemObjRelease(pTos);
+						pTos--;
+					}
+					pc = iBrPc + 1;
+				}else{
+					/* Caught by an outer exec (or uncaught-with-report pending):
+					 * unwind out of this exec; the owner's macros/router land it. */
+					goto Exception;
+				}
+			}
+		}
 		/* Fetch the instruction to execute */
 		pInstr = &aInstr[pc];
 		rc = SXRET_OK;
@@ -17040,6 +17120,29 @@ PH7_PRIVATE ph7_class * PH7_VmPeekDeclaringClass(ph7_vm *pVm)
  * return value indicates failure.
  */
 /*
+ * Park a C-boundary throw status on the VM (band A #1). Every C->PHP
+ * invocation funnels through VmCallClassMethodWithMap or
+ * PH7_VmCallUserFunctionWithMap; when the callee raised (PH7_EXCEPTION /
+ * PH7_ABORT) and the C caller has no channel to route that status — the
+ * __toString/__toInt cast helpers, __get/__set/offsetGet/offsetSet,
+ * __clone, __destruct, error/shutdown/autoload/ob callbacks, and every
+ * builtin that coerces an object argument — the status would be silently
+ * dropped and PHP execution would resume with a bogus fallback value (the
+ * catch, if any, having ALSO run: a double-execution silent wrong answer).
+ * Parking it here lets the executor's fetch-point router (VmLoopFetch)
+ * land it exactly as the throw site would have. Callers that DO route
+ * their rc are unaffected: the routing consumers (VmRecordedResume, the
+ * inline-redirect breaks, the fetch-point router itself) clear the parked
+ * copy when the throw is landed. PH7_ABORT dominates a parked EXCEPTION;
+ * a generalization of the older iCmpCallbackExc comparator flag.
+ */
+static void VmBoundaryPark(ph7_vm *pVm,sxi32 rc)
+{
+	if( (rc == PH7_EXCEPTION || rc == PH7_ABORT) && pVm->nBoundaryRc != PH7_ABORT ){
+		pVm->nBoundaryRc = rc;
+	}
+}
+/*
  * Internal variant of PH7_VmCallClassMethod that threads a VmCallArgMap
  * through to the synthetic CALL instruction.  Used by the NEW handler so
  * that constructor calls with named arguments reach the named-arg path
@@ -17093,7 +17196,10 @@ static sxi32 VmCallClassMethodWithMap(
 	rc = VmByteCodeExec(&(*pVm),aInstr,aStack,iCursor,pResult,0,TRUE,0,0,FALSE,0);
 	SyMemBackendFree(&pVm->sAllocator,aStack);
 	/* Propagate the real exec status (PH7_EXCEPTION / PH7_ABORT) so callers
-	 * can unwind instead of continuing past a method that raised. */
+	 * can unwind instead of continuing past a method that raised — and park
+	 * it on the VM for the callers that CAN'T (the fetch-point router lands
+	 * it; see VmBoundaryPark). */
+	VmBoundaryPark(&(*pVm),rc);
 	return rc;
 }
 PH7_PRIVATE sxi32 PH7_VmCallClassMethod(
@@ -17471,7 +17577,9 @@ PH7_PRIVATE sxi32 PH7_VmCallUserFunctionWithMap(
 		rcExec = VmByteCodeExec(&(*pVm),aInstr,aStack,nArg,pResult,0,TRUE,0,0,FALSE,0);
 		/* Clean up the mess left behind */
 		SyMemBackendFree(&pVm->sAllocator,aStack);
-		/* Propagate PH7_EXCEPTION/PH7_ABORT so a callback that raised unwinds. */
+		/* Propagate PH7_EXCEPTION/PH7_ABORT so a callback that raised unwinds —
+		 * and park it for the callers with no status channel (VmBoundaryPark). */
+		VmBoundaryPark(&(*pVm),rcExec);
 		return rcExec;
 	}
 }

--- a/tests/ph7/001-smoke/oo/magic/boundary_exception_routing.phpt
+++ b/tests/ph7/001-smoke/oo/magic/boundary_exception_routing.phpt
@@ -1,0 +1,90 @@
+--TEST--
+Exceptions thrown by PHP callees invoked from engine C sites propagate (no silent resume)
+--DESCRIPTION--
+A throw inside __toString / offsetGet / offsetSet / count() / __clone /
+__destruct / a builtin's callback / an error handler must unwind to the
+enclosing catch and must NOT let the surrounding expression resume with a
+fallback value (the pre-fix engine ran the catch AND kept executing).
+--FILE--
+<?php
+class BdryThrowStr { public function __toString(): string { throw new Exception("ts"); } }
+
+// 1. concat: catch runs, the try body does NOT resume, $s keeps its prior value
+$s = "prior";
+try { $s = "a" . new BdryThrowStr(); echo "resumed-concat\n"; }
+catch (Exception $e) { echo "caught-concat:", $e->getMessage(), "\n"; }
+echo "s=", $s, "\n";
+
+// 2. argument coercion: the outer call is never entered
+function bdry_take_str($x) { echo "entered-f\n"; }
+try { bdry_take_str("a" . new BdryThrowStr()); echo "resumed-arg\n"; }
+catch (Exception $e) { echo "caught-arg\n"; }
+
+// 3. builtin-internal coercion (sprintf)
+try { $r = sprintf("%s", new BdryThrowStr()); echo "resumed-sprintf\n"; }
+catch (Exception $e) { echo "caught-sprintf\n"; }
+
+// 4. ArrayAccess offsetGet / offsetSet
+class BdryAA implements ArrayAccess {
+    public function offsetExists($o): bool { return true; }
+    public function offsetGet($o): mixed { throw new Exception("og"); }
+    public function offsetSet($o, $v): void { throw new Exception("os"); }
+    public function offsetUnset($o): void {}
+}
+$aa = new BdryAA();
+try { $x = $aa[1]; echo "resumed-og\n"; } catch (Exception $e) { echo "caught-og\n"; }
+try { $aa[1] = 2; echo "resumed-os\n"; } catch (Exception $e) { echo "caught-os\n"; }
+
+// 5. Countable::count()
+class BdryCnt implements Countable { public function count(): int { throw new Exception("c"); } }
+try { $n = count(new BdryCnt()); echo "resumed-count\n"; } catch (Exception $e) { echo "caught-count\n"; }
+
+// 6. __clone
+class BdryClone { public function __clone() { throw new Exception("cl"); } }
+try { $c = clone new BdryClone(); echo "resumed-clone\n"; } catch (Exception $e) { echo "caught-clone\n"; }
+
+// 7. __destruct on unset
+class BdryDtor { public function __destruct() { throw new Exception("d"); } }
+try { $d = new BdryDtor(); unset($d); echo "resumed-dtor\n"; } catch (Exception $e) { echo "caught-dtor\n"; }
+
+// 8. callback inside a builtin (usort / array_map)
+try { $arr = [3, 1, 2]; usort($arr, function ($x, $y) { throw new Exception("u"); }); echo "resumed-usort\n"; }
+catch (Exception $e) { echo "caught-usort\n"; }
+try { array_map(function ($v) { throw new Exception("m"); }, [1, 2]); echo "resumed-map\n"; }
+catch (Exception $e) { echo "caught-map\n"; }
+
+// 9. a throwing error handler supersedes the diagnostic (no Warning printed).
+// error_reporting must be live here: PHL only consults the handler when
+// reporting is on (php calls it regardless — recorded divergence, NEWPLAN §6),
+// and an earlier suite test may leak error_reporting(0) into this shared
+// interpreter.
+error_reporting(E_ALL);
+set_error_handler(function ($no, $str) { throw new Exception("eh"); });
+try { trigger_error("boom", E_USER_WARNING); echo "resumed-eh\n"; }
+catch (Exception $e) { echo "caught-eh\n"; }
+restore_error_handler();
+
+// 10. inline try inside a generator catches a __toString throw at the yield
+function bdry_gen() {
+    $b = new BdryThrowStr();
+    try { yield "a" . $b; } catch (Exception $e) { echo "caught-in-gen\n"; yield "z"; }
+}
+foreach (bdry_gen() as $v) { echo "got:", $v, "\n"; }
+echo "done\n";
+?>
+--EXPECT--
+caught-concat:ts
+s=prior
+caught-arg
+caught-sprintf
+caught-og
+caught-os
+caught-count
+caught-clone
+caught-dtor
+caught-usort
+caught-map
+caught-eh
+caught-in-gen
+got:z
+done

--- a/tests/ph7/002-integration/error/uncaught_tostring_halts.phpt
+++ b/tests/ph7/002-integration/error/uncaught_tostring_halts.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Uncaught exception from __toString inside a concat halts execution (exit 255)
+--DESCRIPTION--
+Pre-fix, the engine printed the uncaught report and KEPT EXECUTING with the
+"Object" fallback string (silent wrong answer, exit 0). The fatal report
+format differs per engine (%A), but both must stop before the echo and both
+must print the pre-throw marker.
+--FILE--
+<?php
+class UncStrHalt { public function __toString(): string { throw new Exception("halt"); } }
+echo "before\n";
+$s = "a" . new UncStrHalt();
+echo "resumed: ", $s, "\n";
+?>
+--EXPECTF--
+before
+%AUncaught Exception: halt%A


### PR DESCRIPTION
… them

A PHP callee invoked from a C site with no status channel — __toString/ __toInt casts, ArrayAccess offsetGet/offsetSet, Countable count(), __clone, __destruct, jsonSerialize/__serialize hooks, error/shutdown/ autoload/ob callbacks, and any builtin coercing an object argument or looping a user callback — discarded PH7_EXCEPTION/PH7_ABORT: the catch (if any) ran in place and execution then RESUMED with a fallback value ('x' . new B() with a throwing __toString left $s === 'xObject' after the catch ran), and an uncaught throw printed its report then kept executing with exit 0.

One routing rule instead of ~15 per-site patches: the two invocation boundaries every C->PHP call funnels through (VmCallClassMethodWithMap, PH7_VmCallUserFunctionWithMap) park a raised status on pVm->nBoundaryRc (VmBoundaryPark, generalizing the sort family's iCmpCallbackExc), and the executor routes it once per dispatch at the fetch point exactly as the throw site's macro would have: abort, inline-try redirect, recorded in-place-catch resume (draining abandoned operands to the catching try's base, like the Generator::throw() inject gate), or propagate. VmByteCodeExec save/clears/restores the flag around nested native entries so destructors and catch/finally mini-programs fired mid-swallow run clean; VmRecordedResume and the inline-redirect breaks clear the parked copy when a well-behaved site lands the same throw.

Also fixed: a throwing set_error_handler callback suppresses the original diagnostic (php never reports it; we printed the Warning after the user's catch had run), and a finally { throw } during generator close (unset($gen)) is now catchable — the VmCloseCtx status threaded out of the destructor finally routes.

Byte-verified vs php 8.5.7 across ~25 paired probes; new cross-engine tests (13-scenario smoke + uncaught-halts integration); test-compat green both engines; docker ASan+UBSan clean; tiny build ok; dispatch cost 0% on call-heavy code, ~2% worst-case on a tight arithmetic loop.
