### PR TITLE
Fix five engine bugs surfaced by the Reflection work

### DIFF
--- a/src/ph7/oo.c
+++ b/src/ph7/oo.c
@@ -128,10 +128,14 @@ PH7_PRIVATE ph7_class_method * PH7_NewClassMethod(ph7_vm *pVm,ph7_class *pClass,
 		zName = (char *)pNamePtr->zString;
 	}
 	if( iProtection != PH7_CLASS_PROT_PUBLIC ){
-		if( (pName->nByte == sizeof("__construct") - 1 && SyMemcmp(pName->zString,"__construct",sizeof("__construct") - 1 ) == 0)
-			|| (pName->nByte == sizeof("__destruct") - 1 && SyMemcmp(pName->zString,"__destruct",sizeof("__destruct") - 1 ) == 0)
+		if( (pName->nByte == sizeof("__destruct") - 1 && SyMemcmp(pName->zString,"__destruct",sizeof("__destruct") - 1 ) == 0)
 			|| SyStringCmp(pName,&pClass->sName,SyMemcmp) == 0 ){
-				/* Switch to public visibility when dealing with constructor/destructor */
+				/* Switch to public visibility for destructors and legacy class-name
+				 * constructors (the engine invokes destructors internally, bypassing
+				 * visibility either way). __construct KEEPS its declared visibility
+				 * (band A #4): php enforces it at `new` — a private/protected ctor
+				 * from the wrong scope is a catchable Error, checked at OP_NEW —
+				 * and ReflectionClass::isInstantiable()/newInstance() now see it. */
 				iProtection = PH7_CLASS_PROT_PUBLIC;
 		}
 	}

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -507,6 +507,11 @@ struct VmFrame
 	ph7_value sRet;   /* Deferred catch/finally `return` value targeting THIS body frame */
 	int bHasRet;      /* TRUE when sRet holds a live pending return */
 	sxu32 nRetGen;    /* Bumped on every sRet write (see VmThrowException finally path) */
+	int nActualArgs;  /* Actual call arity (band A #4): how many arguments the CALLER passed,
+	                   * stamped by the OP_CALL / generator-fiber install sites; -1 when
+	                   * unknown (non-call frames) - func_num_args()/func_get_args() then fall
+	                   * back to the installed-formals count. Unlike sArg this excludes
+	                   * defaulted params and counts variadic-packed args individually. */
 };
 #define VM_FRAME_EXCEPTION  0x01 /* Special Exception frame */
 #define VM_FRAME_THROW      0x02 /* An exception was thrown */

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -915,6 +915,7 @@ static VmFrame * VmNewFrame(
 	SySetInit(&pFrame->sArg,&pVm->sAllocator,sizeof(VmSlot));
 	SySetInit(&pFrame->sLocal,&pVm->sAllocator,sizeof(VmSlot));
 	SySetInit(&pFrame->sRef,&pVm->sAllocator,sizeof(VmSlot));
+	pFrame->nActualArgs = -1; /* unknown until an arg-install site stamps it */
 	/* Per-frame pending catch/finally return slot (always-init so release is
 	 * unconditional; bHasRet is already 0 from SyZero). */
 	PH7_MemObjInit(&(*pVm),&pFrame->sRet);
@@ -12610,6 +12611,41 @@ case PH7_OP_NEW: {
 		goto Abort;
 	}else{
 		ph7_class_method *pCons;
+		/* Check if a constructor is available — BEFORE instantiation: a
+		 * visibility-denied `new` must not construct (nor later destruct)
+		 * the object (band A #4). */
+		pCons = PH7_ClassExtractMethod(pClass,"__construct",sizeof("__construct")-1);
+		if( pCons == 0 ){
+			SyString *pName = &pClass->sName;
+			/* Check for a constructor with the same base class name */
+			pCons = PH7_ClassExtractMethod(pClass,pName->zString,pName->nByte);
+		}
+		/* Constructor visibility (band A #4): __construct now KEEPS its
+		 * declared protection (PH7_NewClassMethod no longer forces it
+		 * public), so `new C()` on a private/protected constructor from
+		 * the wrong scope is php's catchable Error. Reflection's
+		 * newInstance path sets bReflectBypass like method invoke. */
+		if( pCons && pCons->iProtection != PH7_CLASS_PROT_PUBLIC ){
+			if( pVm->bReflectBypass ){
+				pVm->bReflectBypass = 0;
+			}else if( !PH7_VmClassMemberAccess(&(*pVm),pClass,&pCons->sFunc.sName,pCons->iProtection,FALSE) ){
+				SyBlob sErrMsg;
+				const char *zVis = pCons->iProtection == PH7_CLASS_PROT_PRIVATE ? "private" : "protected";
+				SyBlobInit(&sErrMsg,&pVm->sAllocator);
+				SyBlobFormat(&sErrMsg,"Call to %s %z::__construct() from global scope",
+					zVis,&pClass->sName);
+				VmBoundaryPark(&(*pVm),VmThrowBuiltinError(&(*pVm),"Error",sizeof("Error")-1,&sErrMsg));
+				/* Pop ctor args + release the class-name operand, leave NULL
+				 * as the expression value; the fetch-point router lands the
+				 * throw. No instance was created. */
+				if( pInstr->iP1 > 0 ){
+					VmPopOperand(&pTos,pInstr->iP1);
+				}
+				PH7_MemObjRelease(pTos);
+				pTos->nIdx = SXU32_HIGH;
+				break;
+			}
+		}
 		/* Create a new class instance */
 		pNew = PH7_NewClassInstance(&(*pVm),pClass);
 		if( pNew == 0 ){
@@ -12623,13 +12659,6 @@ case PH7_OP_NEW: {
 				VmPopOperand(&pTos,pInstr->iP1);
 			}
 			break;
-		}
-		/* Check if a constructor is available */
-		pCons = PH7_ClassExtractMethod(pClass,"__construct",sizeof("__construct")-1);
-		if( pCons == 0 ){
-			SyString *pName = &pClass->sName;
-			/* Check for a constructor with the same base class name */
-			pCons = PH7_ClassExtractMethod(pClass,pName->zString,pName->nByte);
 		}
 		if( pCons ){
 			/* Call the class constructor.  Collect args in stack order and
@@ -13764,6 +13793,10 @@ case PH7_OP_CALL: {
 			 * resolves against it (Closure::bindTo($o, Scope::class) / call($o)). */
 			pFrame->pBoundScope = pClosureScope;
 		}
+		/* Stamp the ACTUAL call arity for func_num_args()/func_get_args() (band
+		 * A #4): sArg over-counts (defaulted params installed, variadic packed
+		 * as one entry) so php's answers can't be derived from it. */
+		pFrame->nActualArgs = (int)(pTos - pArg);
 		if( pThis && ((pVmFunc->iFlags & VM_FUNC_CLASS_METHOD) || bClosureThis) ){
 			/* Install the '$this' variable (a method call, or a bound plain closure — Increment 2). */
 			static const SyString sThis = { "this" , sizeof("this") - 1 };
@@ -16253,6 +16286,8 @@ static sxi32 VmFiberSetupFrame(ph7_vm *pVm, ph7_exec_ctx *pExecCtx,
 	/* Install arguments with type casting and default values (matching OP_CALL) */
 	aFormalArg = (ph7_vm_func_arg *)SySetBasePtr(&pFunc->aArgs);
 	nFormal = SySetUsed(&pFunc->aArgs);
+	/* Actual call arity for func_num_args()/func_get_args() (band A #4) */
+	pExecCtx->pFrame->nActualArgs = nArg;
 	for( n = 0; n < nFormal; n++ ){
 		ph7_value *pObj;
 		if( aFormalArg[n].iFlags & VM_FUNC_ARG_VARIADIC ){
@@ -17253,7 +17288,14 @@ static int vm_builtin_func_num_args(ph7_context *pCtx,int nArg,ph7_value **apArg
 		ph7_result_int(pCtx,-1);
 		return SXRET_OK;
 	}
-	/* Total number of arguments passed to the enclosing function */
+	/* Total number of arguments passed to the enclosing function. The stamped
+	 * actual arity (band A #4) is php's answer — sArg over-counts (defaulted
+	 * params are installed too, and it once returned the FORMAL count for
+	 * `function f($a,$b=2){}; f(1)` — 2 where php says 1). */
+	if( pFrame->nActualArgs >= 0 ){
+		ph7_result_int(pCtx,pFrame->nActualArgs);
+		return SXRET_OK;
+	}
 	nArg = (int)SySetUsed(&pFrame->sArg);
 	ph7_result_int(pCtx,nArg);
 	return SXRET_OK;
@@ -17383,8 +17425,62 @@ static int vm_builtin_func_get_args(ph7_context *pCtx,int nArg,ph7_value **apArg
 		ph7_result_bool(pCtx,0);
 		return SXRET_OK;
 	}
-	/* Start filling the array with the given arguments */
+	/* Start filling the array with the given arguments. With a stamped actual
+	 * arity (band A #4) reconstruct php's flat ACTUAL list: the first
+	 * min(actual, non-variadic-formal) installed slots, then the elements of
+	 * the variadic packed array (sArg's last entry) — never defaulted params,
+	 * and never the packed array itself (the pre-fix behavior listed defaults
+	 * AND the array, once even twice). */
 	aSlot = (VmSlot *)SySetBasePtr(&pFrame->sArg);
+	{
+		ph7_vm_func *pVmFunc = (ph7_vm_func *)pFrame->pUserData;
+		int nActual = pFrame->nActualArgs;
+		if( nActual >= 0 && pVmFunc ){
+			sxu32 nFormal = SySetUsed(&pVmFunc->aArgs);
+			ph7_vm_func_arg *aFormal = (ph7_vm_func_arg *)SySetBasePtr(&pVmFunc->aArgs);
+			sxu32 nHead = nFormal;
+			if( nFormal > 0 && (aFormal[nFormal-1].iFlags & VM_FUNC_ARG_VARIADIC) ){
+				nHead = nFormal - 1;
+			}
+			for( n = 0; n < (sxu32)nActual && n < nHead && n < SySetUsed(&pFrame->sArg); n++ ){
+				pObj = (ph7_value *)SySetAt(&pCtx->pVm->aMemObj,aSlot[n].nIdx);
+				if( pObj ){
+					ph7_array_add_elem(pArray,0,pObj);
+				}
+			}
+			if( (sxu32)nActual > nHead && nHead < SySetUsed(&pFrame->sArg) ){
+				if( nHead < nFormal ){
+					/* A variadic formal exists: the extras live, in order,
+					 * inside its packed array */
+					pObj = (ph7_value *)SySetAt(&pCtx->pVm->aMemObj,aSlot[nHead].nIdx);
+					if( pObj && (pObj->iFlags & MEMOBJ_HASHMAP) ){
+						ph7_hashmap *pMap = (ph7_hashmap *)pObj->x.pOther;
+						ph7_hashmap_node *pNode = pMap->pFirst;
+						sxu32 i;
+						for( i = 0; i < pMap->nEntry && pNode; ++i ){
+							ph7_value *pElem = (ph7_value *)SySetAt(&pCtx->pVm->aMemObj,pNode->nValIdx);
+							if( pElem ){
+								ph7_array_add_elem(pArray,0,pElem);
+							}
+							pNode = pNode->pPrev;
+						}
+					}
+				}else{
+					/* No variadic formal: extra positional args are plain sArg
+					 * entries beyond the formals (e.g. Fiber::start()'s own
+					 * zero-formal func_get_args() relay). */
+					for( n = nHead; n < SySetUsed(&pFrame->sArg) && n < (sxu32)nActual; n++ ){
+						pObj = (ph7_value *)SySetAt(&pCtx->pVm->aMemObj,aSlot[n].nIdx);
+						if( pObj ){
+							ph7_array_add_elem(pArray,0,pObj);
+						}
+					}
+				}
+			}
+			ph7_result_value(pCtx,pArray);
+			return SXRET_OK;
+		}
+	}
 	for( n = 0;  n < SySetUsed(&pFrame->sArg) ; n++ ){
 		pObj = (ph7_value *)SySetAt(&pCtx->pVm->aMemObj,aSlot[n].nIdx);
 		if( pObj ){
@@ -18373,12 +18469,46 @@ static int vm_builtin_constant(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	}
 	/* Extract the constant name */
 	zName = ph7_value_to_string(apArg[0],&nLen);
+	/* Class-constant form "C::K" (band A #4): resolve the class — interfaces
+	 * included — and read the mounted constant slot; php throws a catchable
+	 * Error for an unknown class or constant (pre-fix this path warned
+	 * "Undefined constant" and returned NULL without ever looking at the
+	 * class). */
+	{
+		int iSep;
+		for( iSep = 0; iSep + 1 < nLen; iSep++ ){
+			if( zName[iSep] == ':' && zName[iSep+1] == ':' ){
+				break;
+			}
+		}
+		if( iSep + 1 < nLen ){
+			ph7_class *pClass = iSep > 0 ?
+				PH7_VmExtractClass(pCtx->pVm,zName,(sxu32)iSep,FALSE,0) : 0;
+			if( pClass == 0 ){
+				return PH7_VmThrowException(pCtx,"Error",
+					"Class \"%.*s\" not found",iSep,zName);
+			}
+			if( iSep + 2 < nLen ){
+				ph7_class_attr *pAttr = PH7_ClassExtractAttribute(pClass,
+					&zName[iSep+2],(sxu32)(nLen - iSep - 2));
+				if( pAttr && (pAttr->iFlags & PH7_CLASS_ATTR_CONSTANT) ){
+					ph7_value *pValue = (ph7_value *)SySetAt(&pCtx->pVm->aMemObj,pAttr->nIdx);
+					if( pValue ){
+						ph7_result_value(pCtx,pValue);
+						return SXRET_OK;
+					}
+				}
+			}
+			return PH7_VmThrowException(pCtx,"Error",
+				"Undefined constant %.*s",nLen,zName);
+		}
+	}
 	/* Perform the query */
 	pEntry = SyHashGet(&pCtx->pVm->hConstant,(const void *)zName,(sxu32)nLen);
 	if( pEntry == 0 ){
-		ph7_context_throw_error_format(pCtx,PH7_CTX_NOTICE,"'%.*s': Undefined constant",nLen,zName);
-		ph7_result_null(pCtx);
-		return SXRET_OK;
+		/* php 8: a catchable Error, not a notice + NULL (band A #4) */
+		return PH7_VmThrowException(pCtx,"Error",
+			"Undefined constant \"%.*s\"",nLen,zName);
 	}
 	PH7_MemObjInit(pCtx->pVm,&sVal);
 	/* Point to the structure that describe the constant */

--- a/src/ph7/vm_builtin_class.c
+++ b/src/ph7/vm_builtin_class.c
@@ -491,15 +491,77 @@ PH7_PRIVATE int vm_builtin_get_class_methods(ph7_context *pCtx,int nArg,ph7_valu
 		ph7_result_null(pCtx);
 		return PH7_OK;
 	}
-	/* Fill the array with the defined methods */
-	SyHashResetLoopCursor(&pClass->hMethod);
-	while((pEntry = SyHashGetNextEntry(&pClass->hMethod)) != 0 ){
-		ph7_class_method *pMethod = (ph7_class_method *)pEntry->pUserData;
-		/* Insert method name */
-		ph7_value_string(pName,SyStringData(&pMethod->sFunc.sName),(int)SyStringLength(&pMethod->sFunc.sName));
-		ph7_array_add_elem(pArray,0/*Automatic index assign*/,pName); /* Will make it's own copy */
-		/* Reset the cursor */
-		ph7_value_reset_string_cursor(pName);
+	/* Fill the array with the defined methods, in php's order: the class's own
+	 * methods in DECLARATION order, then each ancestor's in ITS declaration
+	 * order (band A #4 — the raw hash walk returned reverse-insertion/LIFO
+	 * order). SyHash iterates newest-first, so a reversed walk restores
+	 * insertion order; grouping by declaring class (sFunc.pUserData, the class
+	 * a method was compiled into) walks own-then-parent like php. An override
+	 * lives once in the hash under the subclass, so no dedup is needed. */
+	{
+		SySet aTmp;
+		SyHashEntry **apEntry;
+		ph7_class *pLevel;
+		sxu32 n;
+		SySetInit(&aTmp,&pCtx->pVm->sAllocator,sizeof(SyHashEntry *));
+		SyHashResetLoopCursor(&pClass->hMethod);
+		while((pEntry = SyHashGetNextEntry(&pClass->hMethod)) != 0 ){
+			SySetPut(&aTmp,(const void *)&pEntry);
+		}
+		apEntry = (SyHashEntry **)SySetBasePtr(&aTmp);
+		for( pLevel = pClass; pLevel; pLevel = pLevel->pBase ){
+			/* Collect this level's methods, then emit in DECLARATION order
+			 * (sorted by nLine — same-level methods share a source file; a
+			 * hash-order fallback covers line-less internal methods). */
+			SySet aLvl;
+			ph7_class_method **apLvl;
+			sxu32 i,j;
+			SySetInit(&aLvl,&pCtx->pVm->sAllocator,sizeof(ph7_class_method *));
+			/* Hash-order fallback for same-line methods: the class's OWN entries
+			 * come out in declaration order when walked newest-first, while
+			 * inherited copies (inserted by PH7_ClassInherit's walk of the base
+			 * hash) come out in declaration order walked oldest-first. */
+			for( n = 0; n < SySetUsed(&aTmp); n++ ){
+				sxu32 nPick = (pLevel == pClass) ? (SySetUsed(&aTmp) - 1 - n) : n;
+				ph7_class_method *pMethod = (ph7_class_method *)apEntry[nPick]->pUserData;
+				ph7_class *pDecl = (ph7_class *)pMethod->sFunc.pUserData;
+				if( pDecl != pLevel ){
+					/* A declarer outside the base chain (a used trait, or none)
+					 * counts as the class's own level, like php. */
+					ph7_class *pWalk;
+					if( pLevel != pClass || pDecl == pClass ){
+						continue;
+					}
+					for( pWalk = pClass; pWalk; pWalk = pWalk->pBase ){
+						if( pWalk == pDecl ){
+							break;
+						}
+					}
+					if( pWalk != 0 ){
+						continue; /* in-chain: its own level emits it */
+					}
+				}
+				SySetPut(&aLvl,(const void *)&pMethod);
+			}
+			apLvl = (ph7_class_method **)SySetBasePtr(&aLvl);
+			/* Insertion sort by declaration line (stable) */
+			for( i = 1; i < SySetUsed(&aLvl); i++ ){
+				ph7_class_method *pKey = apLvl[i];
+				for( j = i; j > 0 && apLvl[j-1]->nLine > pKey->nLine; j-- ){
+					apLvl[j] = apLvl[j-1];
+				}
+				apLvl[j] = pKey;
+			}
+			for( i = 0; i < SySetUsed(&aLvl); i++ ){
+				/* Insert method name */
+				ph7_value_string(pName,SyStringData(&apLvl[i]->sFunc.sName),(int)SyStringLength(&apLvl[i]->sFunc.sName));
+				ph7_array_add_elem(pArray,0/*Automatic index assign*/,pName); /* Will make it's own copy */
+				/* Reset the cursor */
+				ph7_value_reset_string_cursor(pName);
+			}
+			SySetRelease(&aLvl);
+		}
+		SySetRelease(&aTmp);
 	}
 	/* Return the created array */
 	ph7_result_value(pCtx,pArray);

--- a/src/ph7/vm_json.c
+++ b/src/ph7/vm_json.c
@@ -152,9 +152,33 @@ static sxi32 VmJsonEncode(
 						JSON_EMIT(pData,ph7_result_string(pCtx,"\\u0022",(int)sizeof("\\u0022")-1));
 						continue;
 					}
-					if( c == '"' || (c == '\\' && ((iFlags & JSON_UNESCAPED_SLASHES)==0)) ){
-						/* Unescape the character */
+					if( c == '"' || c == '\\' ){
+						/* Escape the quote/backslash (php escapes the backslash
+						 * unconditionally — the old code wrongly tied it to
+						 * JSON_UNESCAPED_SLASHES, which governs '/' below) */
 						JSON_EMIT(pData,ph7_result_string(pCtx,"\\",(int)sizeof(char)));
+					}else if( c == '/' && (iFlags & JSON_UNESCAPED_SLASHES) == 0 ){
+						/* php escapes forward slashes by default */
+						JSON_EMIT(pData,ph7_result_string(pCtx,"\\",(int)sizeof(char)));
+					}else if( (unsigned char)c < 0x20 ){
+						/* Control characters (band A #4): php emits the short
+						 * escapes for \b \f \n \r \t and \u00xx for the rest —
+						 * pre-fix these were emitted RAW (invalid JSON). */
+						static const char zHex[] = "0123456789abcdef";
+						char zEsc[6] = { '\\', 'u', '0', '0', 0, 0 };
+						switch(c){
+						case '\b': JSON_EMIT(pData,ph7_result_string(pCtx,"\\b",2)); break;
+						case '\f': JSON_EMIT(pData,ph7_result_string(pCtx,"\\f",2)); break;
+						case '\n': JSON_EMIT(pData,ph7_result_string(pCtx,"\\n",2)); break;
+						case '\r': JSON_EMIT(pData,ph7_result_string(pCtx,"\\r",2)); break;
+						case '\t': JSON_EMIT(pData,ph7_result_string(pCtx,"\\t",2)); break;
+						default:
+							zEsc[4] = zHex[(c >> 4) & 0x0F];
+							zEsc[5] = zHex[c & 0x0F];
+							JSON_EMIT(pData,ph7_result_string(pCtx,zEsc,6));
+							break;
+						}
+						continue;
 					}
 					/* Append character verbatim */
 					JSON_EMIT(pData,ph7_result_string(pCtx,(const char *)&c,(int)sizeof(char)));

--- a/tests/ph7/001-smoke/function/engine_bug_batch.phpt
+++ b/tests/ph7/001-smoke/function/engine_bug_batch.phpt
@@ -1,0 +1,88 @@
+--TEST--
+func_num_args/func_get_args arity, json control chars, get_class_methods order, constant('C::K'), ctor visibility
+--DESCRIPTION--
+Band A #4 batch, all surfaced by the Reflection work: func_num_args()
+returned the FORMAL count for defaulted params (and func_get_args() listed
+defaults and the packed variadic array); json_encode() emitted control
+characters raw and tied backslash-escaping to JSON_UNESCAPED_SLASHES;
+get_class_methods() returned reverse declaration order; constant('C::K')
+did not resolve class constants (and missing constants were a notice+NULL,
+not php 8's Error); non-public constructors were forced public so `new` on
+a private-ctor class succeeded.
+--FILE--
+<?php
+// --- func_num_args / func_get_args
+function ebFn($a, $b = 2) { return func_num_args(); }
+echo ebFn(1), ebFn(1, 2), "\n";
+function ebGa($a, $b = 2, ...$c) { echo implode(",", func_get_args()), "\n"; }
+ebGa(1);
+ebGa(1, 2, 3, 4);
+function ebEx($a, $b) { echo implode(",", func_get_args()), "\n"; }
+ebEx(1, 2, 3, 4, 5);
+class EbM { public function m($a = 1) { return func_num_args(); } }
+echo (new EbM())->m(), (new EbM())->m(9), "\n";
+
+// --- json_encode escapes
+echo json_encode("a\nb\tc\x01"), "\n";
+echo json_encode("http://x/y"), "\n";
+echo json_encode("a/b", JSON_UNESCAPED_SLASHES), "\n";
+echo json_encode("q\\w"), "\n";
+
+// --- get_class_methods declaration order (own then parent)
+class EbP {
+    public function pa() {}
+    public function pb() {}
+}
+class EbC extends EbP {
+    public function ca() {}
+    public function cb() {}
+}
+echo implode(",", get_class_methods("EbC")), "\n";
+
+// --- constant() with class constants + php 8 Errors
+class EbK { const K = 7; }
+interface EbI { const J = "i"; }
+var_export(constant("EbK::K")); echo "\n";
+echo constant("EbI::J"), "\n";
+try { constant("EB_NOPE"); } catch (Error $e) { echo $e->getMessage(), "\n"; }
+try { constant("EbK::MISS"); } catch (Error $e) { echo $e->getMessage(), "\n"; }
+try { constant("EbNoCls::K"); } catch (Error $e) { echo $e->getMessage(), "\n"; }
+
+// --- constructor visibility
+class EbPriv {
+    private function __construct() { echo "ctor\n"; }
+    public static function make() { return new EbPriv(); }
+}
+try { new EbPriv(); echo "made\n"; } catch (Error $e) { echo "caught:", $e->getMessage(), "\n"; }
+echo get_class(EbPriv::make()), "\n";
+class EbProt { protected function __construct() {} }
+class EbSub extends EbProt { public static function make() { return new EbSub(); } }
+echo get_class(EbSub::make()), "\n";
+$r = new ReflectionClass("EbPriv");
+var_export($r->isInstantiable()); echo "\n";
+try { $r->newInstance(); } catch (ReflectionException $e) { echo "RE\n"; }
+echo "done\n";
+?>
+--EXPECT--
+12
+1
+1,2,3,4
+1,2,3,4,5
+01
+"a\nb\tc\u0001"
+"http:\/\/x\/y"
+"a/b"
+"q\\w"
+ca,cb,pa,pb
+7
+i
+Undefined constant "EB_NOPE"
+Undefined constant EbK::MISS
+Class "EbNoCls" not found
+caught:Call to private EbPriv::__construct() from global scope
+ctor
+EbPriv
+EbSub
+false
+RE
+done

--- a/tests/ph7/001-smoke/oo/constructor_visibility.phpt
+++ b/tests/ph7/001-smoke/oo/constructor_visibility.phpt
@@ -1,10 +1,14 @@
 --CREDITS--
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --TEST--
-OO constructor visibility (private constructors are made public)
+OO constructor visibility (private constructor from outside is a catchable Error)
+--DESCRIPTION--
+Rewritten cross-engine with the band A #4 fix: __construct keeps its declared
+visibility (the engine previously forced it public, so `new` on a
+private-ctor class succeeded from any scope — this test used to enshrine
+that). Construction from inside the class still works; destructors are
+engine-invoked so a private __destruct always runs.
 --FILE--
 <?php
 class ConstructorVisibilityTest {
@@ -12,23 +16,32 @@ class ConstructorVisibilityTest {
         echo "Private constructor called\n";
     }
 
-    private function __destruct() {
-        echo "Private destructor called\n";
+    public function __destruct() {
+        echo "Destructor called\n";
+    }
+
+    public static function make(): ConstructorVisibilityTest {
+        return new ConstructorVisibilityTest();
     }
 }
 
 echo "Testing constructor visibility...\n";
 
-$test = new ConstructorVisibilityTest();
+try {
+    $test = new ConstructorVisibilityTest();
+    echo "constructed from global scope\n";
+} catch (Error $e) {
+    echo "Caught: ", $e->getMessage(), "\n";
+}
+
+$test = ConstructorVisibilityTest::make();
 unset($test);
 
 echo "Constructor visibility test completed\n";
 ?>
---EXPECTF--
+--EXPECT--
 Testing constructor visibility...
+Caught: Call to private ConstructorVisibilityTest::__construct() from global scope
 Private constructor called
-Private destructor called
+Destructor called
 Constructor visibility test completed
---CLEAN--
-<?php
-unset($test);

--- a/tests/ph7/002-integration/function/constant/constant.phpt
+++ b/tests/ph7/002-integration/function/constant/constant.phpt
@@ -2,24 +2,30 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-constant retrieves defined constant value
+constant() retrieves defined constants; undefined names throw Error (php 8)
+--DESCRIPTION--
+Rewritten cross-engine with the band A #4 fix: an undefined constant is a
+catchable Error ("Undefined constant \"X\""), not the old PHL notice + NULL
+this test used to enshrine.
 --SKIPIF--
 <?php
 if (!function_exists('constant')) { echo 'skip: constant not available'; }
-if (function_exists('zend_version')) { echo 'skip: PHP throws fatal error for undefined constants, PHL returns null'; }
 ?>
 --FILE--
 <?php
 define('TEST_CONST', 42);
 $val = constant('TEST_CONST');
 if ($val === 42) { echo "defined_ok\n"; } else { echo "defined_failed\n"; }
-$undef = constant('UNDEFINED_CONST');
-if ($undef === null) { echo "undefined_ok\n"; } else { echo "undefined_failed\n"; }
+try {
+    constant('UNDEFINED_CONST');
+    echo "no_throw\n";
+} catch (Error $e) {
+    echo "caught: ", $e->getMessage(), "\n";
+}
 ?>
---EXPECTF--
+--EXPECT--
 defined_ok
-%s Notice:  constant(): 'UNDEFINED_CONST': Undefined constant
-undefined_ok
+caught: Undefined constant "UNDEFINED_CONST"
 --CLEAN--
 <?php
-unset($val, $undef);
+unset($val);


### PR DESCRIPTION
func_num_args()/func_get_args(): a new VmFrame.nActualArgs (stamped at the OP_CALL install site and the generator/fiber installer) records how many arguments the caller actually passed, so f($a,$b=2); f(1) reports 1 (was 2, the formal count) and func_get_args() returns php's flat actual list — defaults excluded, variadic-packed extras listed individually (the old code listed the packed array, once even twice), extras beyond the formals still listed (Fiber::start()'s zero-formal func_get_args() relay depends on that shape).

json_encode(): control characters were emitted raw, producing invalid JSON — now \b \f \n \r \t and lowercase \u00xx like php; forward slashes are escaped by default (honoring JSON_UNESCAPED_SLASHES) and backslashes unconditionally (the old code wrongly tied backslash escaping to the slashes flag).

get_class_methods(): was raw LIFO hash iteration; now php's order — the class's own methods in declaration order, then each ancestor's in its declaration order (grouped by declaring class, trait/foreign declarers counting as own, insertion-sorted by declaration line).

constant(): resolves class and interface constants ("C::K") from the mounted constant slot, and unknown constants/classes raise php 8's catchable Errors byte-exactly (Undefined constant "X" / Undefined constant C::K / Class "X" not found) instead of a notice + NULL.

Constructor visibility: PH7_NewClassMethod no longer forces __construct public (destructors keep the forcing — the engine invokes them internally); OP_NEW checks visibility BEFORE instantiation, so new on a private/protected constructor from the wrong scope raises php's catchable "Call to private C::__construct() from global scope" without constructing (or spuriously destructing) anything, while subclass and inside-class construction and ReflectionClass::newInstance (bReflectBypass) keep working — isInstantiable() is now real.

Two phl-only tests that enshrined the old behavior (forced-public constructors; constant() notice+NULL) rewritten cross-engine. ~20 paired probes byte-identical to php 8.5.7; new cross-engine batch test; test-compat green both engines; docker ASan+UBSan clean; tiny build ok.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
