### PR TITLE
Add array_key_first/last, substr_replace, levenshtein, similar_text, …

### DIFF
--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -592,6 +592,819 @@ static int PH7_builtin_substr_count(ph7_context *pCtx,int nArg,ph7_value **apArg
 	ph7_result_int(pCtx,iCount);
 	return PH7_OK;
 }
+/* Forward declarations: defined with the trim/addcslashes and str_contains
+ * families below. */
+static void PH7_BuildCharMask(ph7_context *pCtx,const char *zList,int nLen,char aMask[256]);
+static sxi32 StrPredicateResolveArg(ph7_context *pCtx,ph7_value *pArg,const char *zFunc,
+	int iArgNum,const char *zParamName,const char *zTypeStr,const char *zNullMsg,
+	ph7_value *pTmp,const char **pzOut,int *pnOut);
+/*
+ * Emit a formatted E_DEPRECATED diagnostic WITHOUT the active-function-name
+ * prefix that ph7_context_throw_error_format() prepends — php's implicit-
+ * conversion notices carry no prefix, and the ZPP null notices embed the
+ * function name mid-message themselves.
+ */
+static void BuiltinThrowDeprecatedFmt(ph7_vm *pVm,const char *zFmt,...)
+{
+	va_list ap;
+	va_start(ap,zFmt);
+	PH7_VmThrowErrorAp(pVm,0,E_DEPRECATED,zFmt,ap);
+	va_end(ap);
+}
+/*
+ * Validate and resolve an int-typed builtin parameter with php-8 ZPP weak-mode
+ * semantics: ints and bools pass through; null emits the 8.1 deprecation and
+ * resolves to 0; floats and float-strings convert, with the implicit-conversion
+ * E_DEPRECATED when lossy and a TypeError when NAN/INF/out of int range;
+ * integral numeric strings convert exactly; everything else (arrays, resources,
+ * objects, non-numeric strings) is a TypeError naming zTypeStr (e.g. "int",
+ * "array|int"). Returns PH7_OK with *pOut set, or the throw status.
+ */
+static sxi32 IntArgResolve(
+	ph7_context *pCtx,
+	ph7_value *pArg,
+	const char *zFunc,
+	int iArgNum,
+	const char *zParamName,
+	const char *zTypeStr,
+	sxi64 *pOut
+){
+	if( ph7_value_is_null(pArg) ){
+		BuiltinThrowDeprecatedFmt(pCtx->pVm,
+			"%s(): Passing null to parameter #%d (%s) of type %s is deprecated",
+			zFunc,iArgNum,zParamName,zTypeStr
+			);
+		*pOut = 0;
+		return PH7_OK;
+	}
+	if( ph7_value_is_float(pArg) ){
+		double dVal = ph7_value_to_double(pArg);
+		sxi64 iVal;
+		/* php: NAN/INF/out-of-int64-range floats fail ZPP outright */
+		if( dVal != dVal || dVal >= 9223372036854775808.0 || dVal < -9223372036854775808.0 ){
+			return PH7_VmThrowException(pCtx,
+				"TypeError",
+				"%s(): Argument #%d (%s) must be of type %s, float given",
+				zFunc,iArgNum,zParamName,zTypeStr
+				);
+		}
+		iVal = (sxi64)dVal;
+		if( (double)iVal != dVal ){
+			BuiltinThrowDeprecatedFmt(pCtx->pVm,
+				"Implicit conversion from float %s to int loses precision",
+				ph7_value_to_string(pArg,0)
+				);
+		}
+		*pOut = iVal;
+		return PH7_OK;
+	}
+	if( ph7_value_is_string(pArg) ){
+		const char *zNum;
+		int nSlen;
+		int i,bFloat = 0;
+		if( !PH7_MemObjStringIsNumeric(pArg) ){
+			return PH7_VmThrowException(pCtx,
+				"TypeError",
+				"%s(): Argument #%d (%s) must be of type %s, string given",
+				zFunc,iArgNum,zParamName,zTypeStr
+				);
+		}
+		zNum = ph7_value_to_string(pArg,&nSlen);
+		for( i = 0 ; i < nSlen ; i++ ){
+			if( zNum[i] == '.' || zNum[i] == 'e' || zNum[i] == 'E' ){
+				bFloat = 1;
+				break;
+			}
+		}
+		if( bFloat ){
+			double dVal = 0;
+			sxi64 iVal;
+			SyStrToReal(zNum,(sxu32)nSlen,(void *)&dVal,0);
+			if( dVal != dVal || dVal >= 9223372036854775808.0 || dVal < -9223372036854775808.0 ){
+				return PH7_VmThrowException(pCtx,
+					"TypeError",
+					"%s(): Argument #%d (%s) must be of type %s, string given",
+					zFunc,iArgNum,zParamName,zTypeStr
+					);
+			}
+			iVal = (sxi64)dVal;
+			if( (double)iVal != dVal ){
+				BuiltinThrowDeprecatedFmt(pCtx->pVm,
+					"Implicit conversion from float-string \"%s\" to int loses precision",
+					zNum
+					);
+			}
+			*pOut = iVal;
+			return PH7_OK;
+		}
+		*pOut = ph7_value_to_int64(pArg);
+		return PH7_OK;
+	}
+	if( !ph7_value_is_int(pArg) && !ph7_value_is_bool(pArg) ){
+		/* Arrays, resources and objects: php names the class for objects */
+		const char *zType = ph7_type_name(pArg);
+		if( ph7_value_is_object(pArg) ){
+			ph7_class_instance *pInst = (ph7_class_instance *)pArg->x.pOther;
+			if( pInst && pInst->pClass ){
+				zType = SyStringData(&pInst->pClass->sName);
+			}
+		}
+		return PH7_VmThrowException(pCtx,
+			"TypeError",
+			"%s(): Argument #%d (%s) must be of type %s, %s given",
+			zFunc,iArgNum,zParamName,zTypeStr,zType
+			);
+	}
+	*pOut = ph7_value_to_int64(pArg);
+	return PH7_OK;
+}
+/*
+ * Normalize a substr_replace() offset/length pair against a string of nStrLen
+ * bytes, exactly like PHP: a negative offset counts from the end (clamped to 0),
+ * an offset past the end clamps to the end; a negative length leaves that many
+ * bytes off the end of the remaining region (clamped to 0), and the length is
+ * finally clamped to the remaining region. Written without f+l additions so an
+ * INT64_MAX length cannot overflow.
+ */
+static void SubstrReplaceWindow(sxi64 *pF,sxi64 *pL,int nStrLen)
+{
+	sxi64 f = *pF,l = *pL;
+	if( f < 0 ){
+		f += nStrLen;
+		if( f < 0 ){
+			f = 0;
+		}
+	}else if( f > nStrLen ){
+		f = nStrLen;
+	}
+	if( l < 0 ){
+		l += nStrLen - f;
+		if( l < 0 ){
+			l = 0;
+		}
+	}
+	if( l > nStrLen - f ){
+		l = nStrLen - f;
+	}
+	*pF = f;
+	*pL = l;
+}
+/* A replacement string collected out of substr_replace()'s $replace array.
+ * The bytes live in a shared pool blob (walker values are transient), so the
+ * item stores pool offsets, mirroring the strtr_entry technique. */
+typedef struct substr_repl_item substr_repl_item;
+struct substr_repl_item
+{
+	sxu32 nOfft; /* Offset of the string inside the pool */
+	sxu32 nLen;  /* Length of the string */
+};
+typedef struct substr_replace_collect substr_replace_collect;
+struct substr_replace_collect
+{
+	SyBlob *pPool;  /* Byte pool for string items (string walker only) */
+	SySet *pSet;    /* substr_repl_item set (string) or sxi64 set (int) */
+	sxi32 rc;       /* SXRET_OK or SXERR_MEM on collector failure */
+};
+/* ph7_array_walk() callback: append one $replace element to the pool. */
+static int SubstrReplaceStrWalker(ph7_value *pKey,ph7_value *pData,void *pUserData)
+{
+	substr_replace_collect *pCol = (substr_replace_collect *)pUserData;
+	substr_repl_item sItem;
+	const char *zStr;
+	int nLen;
+	SXUNUSED(pKey);
+	zStr = ph7_value_to_string(pData,&nLen);
+	sItem.nOfft = SyBlobLength(pCol->pPool);
+	sItem.nLen = (sxu32)nLen;
+	if( nLen > 0 && SXRET_OK != SyBlobAppend(pCol->pPool,(const void *)zStr,(sxu32)nLen) ){
+		pCol->rc = SXERR_MEM;
+		return SXERR_ABORT;
+	}
+	if( SXRET_OK != SySetPut(pCol->pSet,(const void *)&sItem) ){
+		pCol->rc = SXERR_MEM;
+		return SXERR_ABORT;
+	}
+	return PH7_OK;
+}
+/* ph7_array_walk() callback: collect one $offset/$length element as an int. */
+static int SubstrReplaceIntWalker(ph7_value *pKey,ph7_value *pData,void *pUserData)
+{
+	substr_replace_collect *pCol = (substr_replace_collect *)pUserData;
+	sxi64 iVal = ph7_value_to_int64(pData);
+	SXUNUSED(pKey);
+	if( SXRET_OK != SySetPut(pCol->pSet,(const void *)&iVal) ){
+		pCol->rc = SXERR_MEM;
+		return SXERR_ABORT;
+	}
+	return PH7_OK;
+}
+/* Per-element state while walking substr_replace()'s array $string. */
+typedef struct substr_replace_ctx substr_replace_ctx;
+struct substr_replace_ctx
+{
+	ph7_value *pResult;   /* Result array (keys preserved) */
+	ph7_value *pScratch;  /* Reusable string value for each element */
+	SyBlob *pReplPool;    /* Pool behind aRepl items */
+	SySet *pRepl;         /* substr_repl_item set or NULL when $replace is scalar */
+	SySet *pFrom;         /* sxi64 set or NULL when $offset is scalar */
+	SySet *pLen;          /* sxi64 set or NULL when $length is scalar/absent */
+	sxu32 iReplCur;       /* Next-position cursors into the three sets */
+	sxu32 iFromCur;
+	sxu32 iLenCur;
+	const char *zRepl;    /* Scalar $replace */
+	int nRepl;
+	sxi64 iFrom;          /* Scalar $offset */
+	sxi64 iLen;           /* Scalar $length */
+	int bLenGiven;        /* FALSE: $length absent/null -> element length */
+	sxi32 rc;             /* SXRET_OK or SXERR_MEM */
+};
+/*
+ * ph7_array_walk() callback over the array $string: replace the window of one
+ * element and insert the result under the element's original key. Array-form
+ * $replace/$offset/$length are consumed positionally; when a set runs out PHP
+ * falls back to ""/0/element-length respectively.
+ */
+static int SubstrReplaceElemWalker(ph7_value *pKey,ph7_value *pData,void *pUserData)
+{
+	substr_replace_ctx *pRep = (substr_replace_ctx *)pUserData;
+	const char *zStr,*zRepl;
+	sxi64 f,l;
+	int nLen,nRepl;
+	zStr = ph7_value_to_string(pData,&nLen);
+	/* Positional $replace element ("" when exhausted) */
+	if( pRep->pRepl ){
+		if( pRep->iReplCur < SySetUsed(pRep->pRepl) ){
+			substr_repl_item *pItem = (substr_repl_item *)SySetAt(pRep->pRepl,pRep->iReplCur++);
+			zRepl = (const char *)SyBlobDataAt(pRep->pReplPool,pItem->nOfft);
+			nRepl = (int)pItem->nLen;
+		}else{
+			zRepl = "";
+			nRepl = 0;
+		}
+	}else{
+		zRepl = pRep->zRepl;
+		nRepl = pRep->nRepl;
+	}
+	/* Positional $offset element (0 when exhausted) */
+	if( pRep->pFrom ){
+		sxi64 *pVal = 0;
+		if( pRep->iFromCur < SySetUsed(pRep->pFrom) ){
+			pVal = (sxi64 *)SySetAt(pRep->pFrom,pRep->iFromCur++);
+		}
+		f = pVal ? *pVal : 0;
+	}else{
+		f = pRep->iFrom;
+	}
+	/* Positional $length element (element length when exhausted) */
+	if( pRep->pLen ){
+		sxi64 *pVal = 0;
+		if( pRep->iLenCur < SySetUsed(pRep->pLen) ){
+			pVal = (sxi64 *)SySetAt(pRep->pLen,pRep->iLenCur++);
+		}
+		l = pVal ? *pVal : nLen;
+	}else{
+		l = pRep->bLenGiven ? pRep->iLen : nLen;
+	}
+	SubstrReplaceWindow(&f,&l,nLen);
+	/* Assemble prefix + replacement + suffix in the scratch value */
+	ph7_value_reset_string_cursor(pRep->pScratch);
+	if( (f > 0 && SXRET_OK != ph7_value_string(pRep->pScratch,zStr,(int)f))
+	 || (nRepl > 0 && SXRET_OK != ph7_value_string(pRep->pScratch,zRepl,nRepl))
+	 || (nLen - (int)(f+l) > 0 && SXRET_OK != ph7_value_string(pRep->pScratch,&zStr[f+l],nLen - (int)(f+l))) ){
+		pRep->rc = SXERR_MEM;
+		return SXERR_ABORT;
+	}
+	if( SXRET_OK != ph7_array_add_elem(pRep->pResult,pKey,pRep->pScratch) ){
+		pRep->rc = SXERR_MEM;
+		return SXERR_ABORT;
+	}
+	return PH7_OK;
+}
+/*
+ * mixed substr_replace(array|string $string,array|string $replace,array|int $offset[,array|int|null $length = null])
+ *  Replace text within a portion of a string.
+ * Parameters
+ *  $string
+ *   The input string or an array of strings (each element is processed with
+ *   its own positional replace/offset/length when those are arrays too).
+ *  $replace
+ *   The replacement string. When $string is scalar and $replace is an array,
+ *   only its first element is used (PHP quirk).
+ *  $offset
+ *   Window start; negative counts from the end of the string.
+ *  $length
+ *   Window length; negative leaves that many bytes at the end; null/absent
+ *   means "to the end of the string".
+ * Return
+ *  The processed string, or an array of processed strings (keys preserved).
+ * Errors
+ *  ArgumentCountError on fewer than 3 arguments; TypeError when an array
+ *  $offset/$length is combined with a scalar $string.
+ */
+static int PH7_builtin_substr_replace(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	ph7_value sStrTmp,sReplTmp;
+	const char *zStr = 0,*zRepl = 0;
+	int nLen = 0,nRepl = 0;
+	int bLenGiven;
+	sxi64 f = 0,l = 0;
+	sxi32 rc;
+	if( nArg < 3 ){
+		return PH7_VmThrowException(pCtx,
+			"ArgumentCountError",
+			"substr_replace() expects at least 3 arguments, %d given",
+			nArg
+			);
+	}
+	/* $length counts as given unless absent or null (php: ?null semantics) */
+	bLenGiven = (nArg > 3 && !ph7_value_is_null(apArg[3]));
+	/* php ZPP validates all four args, in order, before the body runs: the
+	 * non-array forms resolve here (null deprecation, __toString objects,
+	 * numeric strings), arrays pass through to the per-mode handling. */
+	PH7_MemObjInit(pCtx->pVm,&sStrTmp);
+	PH7_MemObjInit(pCtx->pVm,&sReplTmp);
+	if( !ph7_value_is_array(apArg[0]) ){
+		rc = StrPredicateResolveArg(pCtx,apArg[0],"substr_replace",1,"$string","array|string",
+			"substr_replace(): Passing null to parameter #1 ($string) "
+			"of type array|string is deprecated",
+			&sStrTmp,&zStr,&nLen);
+		if( rc != PH7_OK ) goto out;
+	}
+	if( !ph7_value_is_array(apArg[1]) ){
+		rc = StrPredicateResolveArg(pCtx,apArg[1],"substr_replace",2,"$replace","array|string",
+			"substr_replace(): Passing null to parameter #2 ($replace) "
+			"of type array|string is deprecated",
+			&sReplTmp,&zRepl,&nRepl);
+		if( rc != PH7_OK ) goto out;
+	}
+	if( !ph7_value_is_array(apArg[2]) ){
+		rc = IntArgResolve(pCtx,apArg[2],"substr_replace",3,"$offset","array|int",&f);
+		if( rc != PH7_OK ) goto out;
+	}
+	if( bLenGiven && !ph7_value_is_array(apArg[3]) ){
+		rc = IntArgResolve(pCtx,apArg[3],"substr_replace",4,"$length","array|int|null",&l);
+		if( rc != PH7_OK ) goto out;
+	}
+	if( ph7_value_is_array(apArg[0]) ){
+		/* Array form: process each element, preserving keys */
+		substr_replace_ctx sRep;
+		substr_replace_collect sCol;
+		SyBlob sReplPool;
+		SySet sRepl,sFrom,sLen;
+		ph7_value *pResult,*pScratch;
+		sxi32 rcWalk = SXRET_OK;
+		SyBlobInit(&sReplPool,&pCtx->pVm->sAllocator);
+		SySetInit(&sRepl,&pCtx->pVm->sAllocator,sizeof(substr_repl_item));
+		SySetInit(&sFrom,&pCtx->pVm->sAllocator,sizeof(sxi64));
+		SySetInit(&sLen,&pCtx->pVm->sAllocator,sizeof(sxi64));
+		SyZero(&sRep,sizeof(substr_replace_ctx));
+		sRep.bLenGiven = bLenGiven;
+		sCol.rc = SXRET_OK;
+		/* Collect array-form $replace/$offset/$length positionally; the
+		 * scalar forms were already resolved above. */
+		if( ph7_value_is_array(apArg[1]) ){
+			sCol.pPool = &sReplPool;
+			sCol.pSet = &sRepl;
+			ph7_array_walk(apArg[1],SubstrReplaceStrWalker,&sCol);
+			sRep.pRepl = &sRepl;
+			sRep.pReplPool = &sReplPool;
+		}else{
+			sRep.zRepl = zRepl;
+			sRep.nRepl = nRepl;
+		}
+		if( sCol.rc == SXRET_OK && ph7_value_is_array(apArg[2]) ){
+			sCol.pSet = &sFrom;
+			ph7_array_walk(apArg[2],SubstrReplaceIntWalker,&sCol);
+			sRep.pFrom = &sFrom;
+		}else{
+			sRep.iFrom = f;
+		}
+		if( sCol.rc == SXRET_OK && bLenGiven ){
+			if( ph7_value_is_array(apArg[3]) ){
+				sCol.pSet = &sLen;
+				ph7_array_walk(apArg[3],SubstrReplaceIntWalker,&sCol);
+				sRep.pLen = &sLen;
+			}else{
+				sRep.iLen = l;
+			}
+		}
+		pResult = ph7_context_new_array(pCtx);
+		pScratch = ph7_context_new_scalar(pCtx);
+		if( sCol.rc != SXRET_OK || pResult == 0 || pScratch == 0 ){
+			rcWalk = SXERR_MEM;
+		}else{
+			sRep.pResult = pResult;
+			sRep.pScratch = pScratch;
+			ph7_value_string(pScratch,"",0); /* Force string representation */
+			ph7_array_walk(apArg[0],SubstrReplaceElemWalker,&sRep);
+			rcWalk = sRep.rc;
+		}
+		SyBlobRelease(&sReplPool);
+		SySetRelease(&sRepl);
+		SySetRelease(&sFrom);
+		SySetRelease(&sLen);
+		if( rcWalk != SXRET_OK ){
+			rc = PH7_ContextMemoryError(pCtx);
+			goto out;
+		}
+		ph7_result_value(pCtx,pResult);
+		rc = PH7_OK;
+		goto out;
+	}
+	/* Scalar form: array $offset/$length are a TypeError, array $replace
+	 * degrades to its first element (php quirk). */
+	if( ph7_value_is_array(apArg[2]) ){
+		rc = PH7_VmThrowException(pCtx,
+			"TypeError",
+			"substr_replace(): Argument #3 ($offset) cannot be an array when working on a single string"
+			);
+		goto out;
+	}
+	if( bLenGiven && ph7_value_is_array(apArg[3]) ){
+		rc = PH7_VmThrowException(pCtx,
+			"TypeError",
+			"substr_replace(): Argument #4 ($length) cannot be an array when working on a single string"
+			);
+		goto out;
+	}
+	if( ph7_value_is_array(apArg[1]) ){
+		/* First element of the replace array, or "" when empty */
+		ph7_hashmap *pMap = (ph7_hashmap *)apArg[1]->x.pOther;
+		zRepl = "";
+		nRepl = 0;
+		if( pMap->pFirst ){
+			ph7_value *pVal = (ph7_value *)SySetAt(&pCtx->pVm->aMemObj,pMap->pFirst->nValIdx);
+			if( pVal ){
+				zRepl = ph7_value_to_string(pVal,&nRepl);
+			}
+		}
+	}
+	if( !bLenGiven ){
+		l = nLen;
+	}
+	SubstrReplaceWindow(&f,&l,nLen);
+	/* Assemble prefix + replacement + suffix straight into the call result
+	 * (ph7_result_string appends), no scratch buffer needed. */
+	rc = SXRET_OK;
+	if( f > 0 ){
+		rc = ph7_result_string(pCtx,zStr,(int)f);
+	}
+	if( rc == SXRET_OK && nRepl > 0 ){
+		rc = ph7_result_string(pCtx,zRepl,nRepl);
+	}
+	if( rc == SXRET_OK && nLen - (int)(f+l) > 0 ){
+		rc = ph7_result_string(pCtx,&zStr[f+l],nLen - (int)(f+l));
+	}
+	if( rc != SXRET_OK ){
+		rc = PH7_ContextMemoryError(pCtx);
+		goto out;
+	}
+	/* Force a string result even when all three segments are empty */
+	rc = ph7_result_string(pCtx,"",0);
+	if( rc != SXRET_OK ){
+		rc = PH7_ContextMemoryError(pCtx);
+		goto out;
+	}
+	rc = PH7_OK;
+out:
+	PH7_MemObjRelease(&sStrTmp);
+	PH7_MemObjRelease(&sReplTmp);
+	return rc;
+}
+/*
+ * int levenshtein(string $string1,string $string2[,int $insertion_cost = 1[,int $replacement_cost = 1[,int $deletion_cost = 1]]])
+ *  Calculate the Levenshtein distance between two strings, byte per byte
+ *  (case-sensitive), with optional per-operation costs. Mirrors PHP's
+ *  reference_levdist(): two rolling rows over string2.
+ * Return
+ *  The minimal number of weighted edit operations turning $string1 into
+ *  $string2.
+ */
+static int PH7_builtin_levenshtein(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	static const char *azParam[] = { "$insertion_cost","$replacement_cost","$deletion_cost" };
+	const char *zStr1,*zStr2;
+	sxi64 iCostIns = 1,iCostRep = 1,iCostDel = 1;
+	sxi64 *p1,*p2,*pTmp;
+	sxi64 c0,c1,c2;
+	ph7_value sTmp1,sTmp2;
+	int nLen1,nLen2;
+	int i1,i2;
+	sxi32 rc;
+	int i;
+	if( nArg < 2 ){
+		return PH7_VmThrowException(pCtx,
+			"ArgumentCountError",
+			"levenshtein() expects at least 2 arguments, %d given",
+			nArg
+			);
+	}
+	/* $string1/$string2: null deprecates to "", __toString objects resolve,
+	 * everything non-stringish is a TypeError (php ZPP weak mode). */
+	PH7_MemObjInit(pCtx->pVm,&sTmp1);
+	PH7_MemObjInit(pCtx->pVm,&sTmp2);
+	rc = StrPredicateResolveArg(pCtx,apArg[0],"levenshtein",1,"$string1","string",
+		"levenshtein(): Passing null to parameter #1 ($string1) "
+		"of type string is deprecated",
+		&sTmp1,&zStr1,&nLen1);
+	if( rc != PH7_OK ) goto out;
+	rc = StrPredicateResolveArg(pCtx,apArg[1],"levenshtein",2,"$string2","string",
+		"levenshtein(): Passing null to parameter #2 ($string2) "
+		"of type string is deprecated",
+		&sTmp2,&zStr2,&nLen2);
+	if( rc != PH7_OK ) goto out;
+	/* Optional integer costs */
+	for( i = 2 ; i < nArg && i < 5 ; i++ ){
+		sxi64 iVal;
+		rc = IntArgResolve(pCtx,apArg[i],"levenshtein",i+1,azParam[i-2],"int",&iVal);
+		if( rc != PH7_OK ) goto out;
+		if( i == 2 ){
+			iCostIns = iVal;
+		}else if( i == 3 ){
+			iCostRep = iVal;
+		}else{
+			iCostDel = iVal;
+		}
+	}
+	if( nLen1 == 0 ){
+		ph7_result_int64(pCtx,(sxi64)nLen2 * iCostIns);
+		rc = PH7_OK;
+		goto out;
+	}
+	if( nLen2 == 0 ){
+		ph7_result_int64(pCtx,(sxi64)nLen1 * iCostDel);
+		rc = PH7_OK;
+		goto out;
+	}
+	/* Two rolling DP rows over string2 (auto-released on return). Reject a
+	 * string2 long enough to overflow the 32-bit allocation size. */
+	if( (sxu32)nLen2 >= (SXU32_HIGH / sizeof(sxi64)) - 1 ){
+		rc = PH7_ContextMemoryError(pCtx);
+		goto out;
+	}
+	p1 = (sxi64 *)ph7_context_alloc_chunk(pCtx,(unsigned int)(sizeof(sxi64) * (sxu32)(nLen2 + 1)),FALSE,TRUE);
+	p2 = (sxi64 *)ph7_context_alloc_chunk(pCtx,(unsigned int)(sizeof(sxi64) * (sxu32)(nLen2 + 1)),FALSE,TRUE);
+	if( p1 == 0 || p2 == 0 ){
+		rc = PH7_ContextMemoryError(pCtx);
+		goto out;
+	}
+	for( i2 = 0 ; i2 <= nLen2 ; i2++ ){
+		p1[i2] = (sxi64)i2 * iCostIns;
+	}
+	for( i1 = 0 ; i1 < nLen1 ; i1++ ){
+		p2[0] = p1[0] + iCostDel;
+		for( i2 = 0 ; i2 < nLen2 ; i2++ ){
+			c0 = p1[i2] + ((zStr1[i1] == zStr2[i2]) ? 0 : iCostRep);
+			c1 = p1[i2 + 1] + iCostDel;
+			if( c1 < c0 ){
+				c0 = c1;
+			}
+			c2 = p2[i2] + iCostIns;
+			if( c2 < c0 ){
+				c0 = c2;
+			}
+			p2[i2 + 1] = c0;
+		}
+		pTmp = p1;
+		p1 = p2;
+		p2 = pTmp;
+	}
+	ph7_result_int64(pCtx,p1[nLen2]);
+	rc = PH7_OK;
+out:
+	PH7_MemObjRelease(&sTmp1);
+	PH7_MemObjRelease(&sTmp2);
+	return rc;
+}
+/*
+ * Longest common substring scan behind similar_text() — a faithful port of
+ * PHP's php_similar_str(): O(n*m) scan recording the first longest run.
+ */
+static void SimilarStr(const char *zTxt1,int nLen1,const char *zTxt2,int nLen2,
+	int *pPos1,int *pPos2,int *pMax,int *pCount)
+{
+	const char *p,*q;
+	const char *zEnd1 = &zTxt1[nLen1];
+	const char *zEnd2 = &zTxt2[nLen2];
+	int l;
+	*pMax = 0;
+	*pCount = 0;
+	for( p = zTxt1 ; p < zEnd1 ; p++ ){
+		for( q = zTxt2 ; q < zEnd2 ; q++ ){
+			for( l = 0 ; (p+l < zEnd1) && (q+l < zEnd2) && (p[l] == q[l]) ; l++ );
+			if( l > *pMax ){
+				*pMax = l;
+				*pCount += 1;
+				*pPos1 = (int)(p - zTxt1);
+				*pPos2 = (int)(q - zTxt2);
+			}
+		}
+	}
+}
+/*
+ * Recursive divide-and-conquer behind similar_text() — a faithful port of
+ * PHP's php_similar_char(), including its quirky `count > 1` guard on the
+ * left-side recursion.
+ */
+static int SimilarChar(const char *zTxt1,int nLen1,const char *zTxt2,int nLen2)
+{
+	int nSum;
+	int nPos1 = 0,nPos2 = 0,nMax,nCount;
+	SimilarStr(zTxt1,nLen1,zTxt2,nLen2,&nPos1,&nPos2,&nMax,&nCount);
+	if( (nSum = nMax) != 0 ){
+		if( nPos1 && nPos2 && nCount > 1 ){
+			nSum += SimilarChar(zTxt1,nPos1,zTxt2,nPos2);
+		}
+		if( (nPos1 + nMax < nLen1) && (nPos2 + nMax < nLen2) ){
+			nSum += SimilarChar(&zTxt1[nPos1 + nMax],nLen1 - nPos1 - nMax,
+				&zTxt2[nPos2 + nMax],nLen2 - nPos2 - nMax);
+		}
+	}
+	return nSum;
+}
+/*
+ * int similar_text(string $string1,string $string2[,float &$percent])
+ *  Calculate the similarity between two strings, as the number of matching
+ *  characters found by PHP's greedy longest-common-substring recursion.
+ *  When $percent is given it receives the similarity in percent:
+ *  matching * 200 / (len1 + len2).
+ * Return
+ *  The number of matching characters in both strings.
+ */
+static int PH7_builtin_similar_text(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	const char *zStr1,*zStr2;
+	ph7_value sTmp1,sTmp2;
+	int nLen1,nLen2;
+	int nSim;
+	sxi32 rc;
+	if( nArg < 2 ){
+		return PH7_VmThrowException(pCtx,
+			"ArgumentCountError",
+			"similar_text() expects at least 2 arguments, %d given",
+			nArg
+			);
+	}
+	PH7_MemObjInit(pCtx->pVm,&sTmp1);
+	PH7_MemObjInit(pCtx->pVm,&sTmp2);
+	rc = StrPredicateResolveArg(pCtx,apArg[0],"similar_text",1,"$string1","string",
+		"similar_text(): Passing null to parameter #1 ($string1) "
+		"of type string is deprecated",
+		&sTmp1,&zStr1,&nLen1);
+	if( rc != PH7_OK ) goto out;
+	rc = StrPredicateResolveArg(pCtx,apArg[1],"similar_text",2,"$string2","string",
+		"similar_text(): Passing null to parameter #2 ($string2) "
+		"of type string is deprecated",
+		&sTmp2,&zStr2,&nLen2);
+	if( rc != PH7_OK ) goto out;
+	if( nLen1 + nLen2 == 0 ){
+		nSim = 0;
+	}else{
+		nSim = SimilarChar(zStr1,nLen1,zStr2,nLen2);
+	}
+	if( nArg > 2 ){
+		/* Write the percentage through the by-ref out-param */
+		ph7_value *pPercent = ph7_context_new_scalar(pCtx);
+		if( pPercent == 0 ){
+			rc = PH7_ContextMemoryError(pCtx);
+			goto out;
+		}else{
+			double dPct = (nLen1 + nLen2 == 0) ? 0.0 : (double)nSim * 200.0 / (double)(nLen1 + nLen2);
+			ph7_value_double(pPercent,dPct);
+			PH7_VmStoreArgByRef(pCtx->pVm,apArg[2],pPercent);
+		}
+	}
+	ph7_result_int(pCtx,nSim);
+	rc = PH7_OK;
+out:
+	PH7_MemObjRelease(&sTmp1);
+	PH7_MemObjRelease(&sTmp2);
+	return rc;
+}
+/*
+ * array|int str_word_count(string $string[,int $format = 0[,?string $characters = null]])
+ *  Count (or return) the words inside a string. A word is a run of alphabetic
+ *  characters, which may contain (but not start the string with) "'" and "-";
+ *  $characters adds extra bytes to the word set ("a..z" ranges supported, as
+ *  in PHP's php_charmask).
+ *  $format: 0 -> word count, 1 -> array of words, 2 -> array of words keyed
+ *  by their byte position in $string.
+ * Errors
+ *  ValueError when $format is not 0, 1 or 2.
+ */
+static int PH7_builtin_str_word_count(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	const char *zIn,*zEnd,*zPtr;
+	ph7_value *pArray = 0,*pValue = 0;
+	ph7_value sTmp,sListTmp;
+	char aMask[256];
+	int bMask = 0;
+	int iFormat = 0;
+	int nCount = 0;
+	int nLen;
+	sxi32 rc;
+	if( nArg < 1 ){
+		return PH7_VmThrowException(pCtx,
+			"ArgumentCountError",
+			"str_word_count() expects at least 1 argument, %d given",
+			nArg
+			);
+	}
+	PH7_MemObjInit(pCtx->pVm,&sTmp);
+	PH7_MemObjInit(pCtx->pVm,&sListTmp);
+	rc = StrPredicateResolveArg(pCtx,apArg[0],"str_word_count",1,"$string","string",
+		"str_word_count(): Passing null to parameter #1 ($string) "
+		"of type string is deprecated",
+		&sTmp,&zIn,&nLen);
+	if( rc != PH7_OK ) goto out;
+	if( nArg > 1 ){
+		sxi64 iVal;
+		rc = IntArgResolve(pCtx,apArg[1],"str_word_count",2,"$format","int",&iVal);
+		if( rc != PH7_OK ) goto out;
+		if( iVal < 0 || iVal > 2 ){
+			rc = PH7_VmThrowException(pCtx,
+				"ValueError",
+				"str_word_count(): Argument #2 ($format) must be a valid format value"
+				);
+			goto out;
+		}
+		iFormat = (int)iVal;
+	}
+	if( nArg > 2 && !ph7_value_is_null(apArg[2]) ){
+		/* $characters is ?string: null (skipped above) simply keeps the
+		 * default word set, no deprecation. */
+		const char *zList;
+		int nList;
+		rc = StrPredicateResolveArg(pCtx,apArg[2],"str_word_count",3,"$characters","?string",
+			"" /* unreachable: null never gets here */,
+			&sListTmp,&zList,&nList);
+		if( rc != PH7_OK ) goto out;
+		PH7_BuildCharMask(pCtx,zList,nList,aMask);
+		bMask = 1;
+	}
+	if( iFormat != 0 ){
+		pArray = ph7_context_new_array(pCtx);
+		pValue = ph7_context_new_scalar(pCtx);
+		if( pArray == 0 || pValue == 0 ){
+			rc = PH7_ContextMemoryError(pCtx);
+			goto out;
+		}
+	}
+	zPtr = zIn;
+	zEnd = &zIn[nLen];
+	if( nLen > 0 ){
+		/* php: the string's first byte cannot be ' or -, and its last byte
+		 * cannot be -, unless the charlist explicitly allows them. */
+		if( (zPtr[0] == '\'' && (!bMask || !aMask[(unsigned char)'\''])) ||
+			(zPtr[0] == '-'  && (!bMask || !aMask[(unsigned char)'-'])) ){
+			zPtr++;
+		}
+		if( zEnd[-1] == '-' && (!bMask || !aMask[(unsigned char)'-']) ){
+			zEnd--;
+		}
+	}
+	while( zPtr < zEnd ){
+		const char *zStart = zPtr;
+		while( zPtr < zEnd && ( SyisAlpha((unsigned char)zPtr[0])
+			|| (bMask && aMask[(unsigned char)zPtr[0]])
+			|| zPtr[0] == '\'' || zPtr[0] == '-' ) ){
+			zPtr++;
+		}
+		if( zPtr > zStart ){
+			if( iFormat == 0 ){
+				nCount++;
+			}else{
+				ph7_value_reset_string_cursor(pValue);
+				if( SXRET_OK != ph7_value_string(pValue,zStart,(int)(zPtr-zStart)) ){
+					rc = PH7_ContextMemoryError(pCtx);
+					goto out;
+				}
+				if( iFormat == 1 ){
+					if( SXRET_OK != ph7_array_add_elem(pArray,0,pValue) ){
+						rc = PH7_ContextMemoryError(pCtx);
+						goto out;
+					}
+				}else{
+					if( SXRET_OK != ph7_array_add_intkey_elem(pArray,(int)(zStart-zIn),pValue) ){
+						rc = PH7_ContextMemoryError(pCtx);
+						goto out;
+					}
+				}
+			}
+		}
+		zPtr++;
+	}
+	if( iFormat == 0 ){
+		ph7_result_int(pCtx,nCount);
+	}else{
+		ph7_result_value(pCtx,pArray);
+	}
+	rc = PH7_OK;
+out:
+	PH7_MemObjRelease(&sTmp);
+	PH7_MemObjRelease(&sListTmp);
+	return rc;
+}
 /*
  * string chunk_split(string $body[,int $chunklen = 76 [, string $end = "\r\n" ]])
  *   Split a string into smaller chunks.
@@ -2479,6 +3292,7 @@ static sxi32 StrPredicateResolveArg(
 	const char *zFunc,
 	int iArgNum,
 	const char *zParamName,
+	const char *zTypeStr, /* Declared type in the TypeError, e.g. "string" / "?string" */
 	const char *zNullMsg,
 	ph7_value *pTmp,
 	const char **pzOut,
@@ -2506,8 +3320,8 @@ static sxi32 StrPredicateResolveArg(
 		}
 		return PH7_VmThrowException(pCtx,
 			"TypeError",
-			"%s(): Argument #%d (%s) must be of type string, %s given",
-			zFunc, iArgNum, zParamName, zType
+			"%s(): Argument #%d (%s) must be of type %s, %s given",
+			zFunc, iArgNum, zParamName, zTypeStr, zType
 			);
 	}
 	if( ph7_value_is_object(pArg) ){
@@ -2543,12 +3357,12 @@ static int PH7_builtin_str_contains(ph7_context *pCtx,int nArg,ph7_value **apArg
 	}
 	PH7_MemObjInit(pCtx->pVm,&sHayTmp);
 	PH7_MemObjInit(pCtx->pVm,&sNeedleTmp);
-	rc = StrPredicateResolveArg(pCtx,apArg[0],"str_contains",1,"$haystack",
+	rc = StrPredicateResolveArg(pCtx,apArg[0],"str_contains",1,"$haystack","string",
 		"str_contains(): Passing null to parameter #1 ($haystack) "
 		"of type string is deprecated",
 		&sHayTmp,&zHaystack,&nHayLen);
 	if( rc != PH7_OK ) goto out;
-	rc = StrPredicateResolveArg(pCtx,apArg[1],"str_contains",2,"$needle",
+	rc = StrPredicateResolveArg(pCtx,apArg[1],"str_contains",2,"$needle","string",
 		"str_contains(): Passing null to parameter #2 ($needle) "
 		"of type string is deprecated",
 		&sNeedleTmp,&zNeedle,&nNeedleLen);
@@ -2590,12 +3404,12 @@ static int PH7_builtin_str_starts_with(ph7_context *pCtx,int nArg,ph7_value **ap
 	}
 	PH7_MemObjInit(pCtx->pVm,&sHayTmp);
 	PH7_MemObjInit(pCtx->pVm,&sNeedleTmp);
-	rc = StrPredicateResolveArg(pCtx,apArg[0],"str_starts_with",1,"$haystack",
+	rc = StrPredicateResolveArg(pCtx,apArg[0],"str_starts_with",1,"$haystack","string",
 		"str_starts_with(): Passing null to parameter #1 ($haystack) "
 		"of type string is deprecated",
 		&sHayTmp,&zHaystack,&nHayLen);
 	if( rc != PH7_OK ) goto out;
-	rc = StrPredicateResolveArg(pCtx,apArg[1],"str_starts_with",2,"$needle",
+	rc = StrPredicateResolveArg(pCtx,apArg[1],"str_starts_with",2,"$needle","string",
 		"str_starts_with(): Passing null to parameter #2 ($needle) "
 		"of type string is deprecated",
 		&sNeedleTmp,&zNeedle,&nNeedleLen);
@@ -2636,12 +3450,12 @@ static int PH7_builtin_str_ends_with(ph7_context *pCtx,int nArg,ph7_value **apAr
 	}
 	PH7_MemObjInit(pCtx->pVm,&sHayTmp);
 	PH7_MemObjInit(pCtx->pVm,&sNeedleTmp);
-	rc = StrPredicateResolveArg(pCtx,apArg[0],"str_ends_with",1,"$haystack",
+	rc = StrPredicateResolveArg(pCtx,apArg[0],"str_ends_with",1,"$haystack","string",
 		"str_ends_with(): Passing null to parameter #1 ($haystack) "
 		"of type string is deprecated",
 		&sHayTmp,&zHaystack,&nHayLen);
 	if( rc != PH7_OK ) goto out;
-	rc = StrPredicateResolveArg(pCtx,apArg[1],"str_ends_with",2,"$needle",
+	rc = StrPredicateResolveArg(pCtx,apArg[1],"str_ends_with",2,"$needle","string",
 		"str_ends_with(): Passing null to parameter #2 ($needle) "
 		"of type string is deprecated",
 		&sNeedleTmp,&zNeedle,&nNeedleLen);
@@ -8497,6 +9311,10 @@ static const ph7_builtin_func aBuiltInFunc[] = {
 	{ "substr",          PH7_builtin_substr     },
 	{ "substr_compare",  PH7_builtin_substr_compare },
 	{ "substr_count",    PH7_builtin_substr_count },
+	{ "substr_replace",  PH7_builtin_substr_replace },
+	{ "levenshtein",     PH7_builtin_levenshtein },
+	{ "similar_text",    PH7_builtin_similar_text },
+	{ "str_word_count",  PH7_builtin_str_word_count },
 	{ "chunk_split",     PH7_builtin_chunk_split},
 	{ "addslashes" ,     PH7_builtin_addslashes },
 	{ "addcslashes",     PH7_builtin_addcslashes},

--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -11700,6 +11700,7 @@ static sxu32 GenStateByRefBuiltinMask(SyString *pName)
 		{ "preg_match_all",        14, 1u<<2 },  /* $matches (apArg[2]) */
 		{ "preg_replace",          12, 1u<<4 },  /* &$count  (apArg[4]) */
 		{ "preg_replace_callback", 21, 1u<<4 },  /* &$count  (apArg[4]) */
+		{ "similar_text",          12, 1u<<2 },  /* &$percent (apArg[2]) */
 	};
 	sxu32 i;
 	if( pName == 0 || pName->zString == 0 || pName->nByte == 0 ){

--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -3348,6 +3348,21 @@ static int ph7_hashmap_reset(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	return PH7_OK;
 }
 /*
+ * Emit a node's key (integer or blob) as the call result — shared by key(),
+ * array_key_first() and array_key_last().
+ */
+static void HashmapResultNodeKey(ph7_context *pCtx,ph7_hashmap_node *pNode)
+{
+	if( pNode->iType == HASHMAP_INT_NODE ){
+		/* Key is integer */
+		ph7_result_int64(pCtx,pNode->xKey.iKey);
+	}else{
+		/* Key is blob */
+		ph7_result_string(pCtx,
+			(const char *)SyBlobData(&pNode->xKey.sKey),(int)SyBlobLength(&pNode->xKey.sKey));
+	}
+}
+/*
  * value key(array $array)
  *   Fetch a key from an array
  * Parameter
@@ -3381,14 +3396,7 @@ static int ph7_hashmap_simple_key(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		ph7_result_null(pCtx);
 		return PH7_OK;
 	}
-	if( pCur->iType == HASHMAP_INT_NODE){
-		/* Key is integer */
-		ph7_result_int64(pCtx,pCur->xKey.iKey);
-	}else{
-		/* Key is blob */
-		ph7_result_string(pCtx,
-			(const char *)SyBlobData(&pCur->xKey.sKey),(int)SyBlobLength(&pCur->xKey.sKey));
-	}
+	HashmapResultNodeKey(pCtx,pCur);
 	return PH7_OK;
 }
 /*
@@ -7942,6 +7950,51 @@ static int ph7_hashmap_last(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	return HashmapFirstLast(pCtx,nArg,apArg,1);
 }
 /*
+ * int|string|null array_key_first(array $array)
+ * int|string|null array_key_last(array $array)
+ *  Return the key of the first (respectively last) element of the array,
+ *  or NULL when the array is empty. The internal array pointer is left
+ *  untouched.
+ */
+static int HashmapKeyFirstLast(ph7_context *pCtx,int nArg,ph7_value **apArg,int bLast)
+{
+	ph7_hashmap *pMap;
+	ph7_hashmap_node *pNode;
+	const char *zName = bLast ? "array_key_last" : "array_key_first";
+	if( nArg < 1 ){
+		return PH7_VmThrowException(pCtx,
+			"ArgumentCountError",
+			"%s() expects exactly 1 argument, 0 given",
+			zName
+			);
+	}
+	if( !ph7_value_is_array(apArg[0]) ){
+		return PH7_VmThrowException(pCtx,
+			"TypeError",
+			"%s(): Argument #1 ($array) must be of type array, %s given",
+			zName,
+			ph7_type_name(apArg[0])
+			);
+	}
+	pMap = (ph7_hashmap *)apArg[0]->x.pOther;
+	pNode = bLast ? pMap->pLast : pMap->pFirst;
+	if( pNode == 0 ){
+		/* Empty array: PHP returns NULL */
+		ph7_result_null(pCtx);
+		return PH7_OK;
+	}
+	HashmapResultNodeKey(pCtx,pNode);
+	return PH7_OK;
+}
+static int ph7_hashmap_key_first(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	return HashmapKeyFirstLast(pCtx,nArg,apArg,0);
+}
+static int ph7_hashmap_key_last(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	return HashmapKeyFirstLast(pCtx,nArg,apArg,1);
+}
+/*
  * Fetch the element identified by 'pKey' from 'pRow' which may be either an
  * array (hashmap lookup) or an object (public attribute lookup). Used by
  * array_column() for both the column value and the index key.
@@ -8379,6 +8432,8 @@ static const ph7_builtin_func aHashmapFunc[] = {
 	{"array_is_list",     ph7_hashmap_is_list },
 	{"array_first",       ph7_hashmap_first   },
 	{"array_last",        ph7_hashmap_last    },
+	{"array_key_first",   ph7_hashmap_key_first },
+	{"array_key_last",    ph7_hashmap_key_last  },
 	{"array_find",        ph7_hashmap_find    },
 	{"array_find_key",    ph7_hashmap_find_key},
 	{"array_any",         ph7_hashmap_any     },

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1821,6 +1821,7 @@ PH7_PRIVATE void  PH7_VmExpandConstantValue(ph7_value *pVal,void *pUserData);
 PH7_PRIVATE sxi32 PH7_VmDump(ph7_vm *pVm,ProcConsumer xConsumer,void *pUserData);
 PH7_PRIVATE sxi32 PH7_VmEvalBuiltinChunk(ph7_vm *pVm,const char *zSrc,sxu32 nLen);
 PH7_PRIVATE const char * PH7_VmBuiltinSigLookup(const char *zName,sxu32 nLen,const char **pzRet);
+PH7_PRIVATE void PH7_VmStoreArgByRef(ph7_vm *pVm,ph7_value *pArg,ph7_value *pNewVal);
 PH7_PRIVATE sxi32 PH7_VmInstallReflection(ph7_vm *pVm); /* vm_builtin_reflection.c */
 PH7_PRIVATE ph7_class_instance * PH7_VmNewClosure(ph7_vm *pVm,const SyString *pName,
 	ph7_class_instance *pBoundThis,const SyString *pScope);

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -3017,6 +3017,8 @@ static const struct VmBuiltinSig {
 	{ "array_intersect_key", "array $array, array ...$arrays = ?", "array" },
 	{ "array_is_list", "array $array", "bool" },
 	{ "array_key_exists", "$key, array $array", "bool" },
+	{ "array_key_first", "array $array", "string|int|null" },
+	{ "array_key_last", "array $array", "string|int|null" },
 	{ "array_keys", "array $array, mixed $filter_value = ?, bool $strict = false", "array" },
 	{ "array_last", "array $array", "mixed" },
 	{ "array_map", "?callable $callback, array $array, array ...$arrays = ?", "array" },
@@ -3233,6 +3235,7 @@ static const struct VmBuiltinSig {
 	{ "krsort", "array &$array, int $flags = 0", "true" },
 	{ "ksort", "array &$array, int $flags = 0", "true" },
 	{ "lcfirst", "string $string", "string" },
+	{ "levenshtein", "string $string1, string $string2, int $insertion_cost = 1, int $replacement_cost = 1, int $deletion_cost = 1", "int" },
 	{ "link", "string $target, string $link", "bool" },
 	{ "localtime", "?int $timestamp = NULL, bool $associative = false", "array" },
 	{ "log", "float $num, float $base = 2.718281828459045", "float" },
@@ -3328,6 +3331,7 @@ static const struct VmBuiltinSig {
 	{ "sha1", "string $string, bool $binary = false", "string" },
 	{ "sha1_file", "string $filename, bool $binary = false", "string|false" },
 	{ "shuffle", "array &$array", "true" },
+	{ "similar_text", "string $string1, string $string2, &$percent = NULL", "int" },
 	{ "sin", "float $num", "float" },
 	{ "sinh", "float $num", "float" },
 	{ "sizeof", "Countable|array $value, int $mode = 0", "int" },
@@ -3354,6 +3358,7 @@ static const struct VmBuiltinSig {
 	{ "str_shuffle", "string $string", "string" },
 	{ "str_split", "string $string, int $length = 1", "array" },
 	{ "str_starts_with", "string $haystack, string $needle", "bool" },
+	{ "str_word_count", "string $string, int $format = 0, ?string $characters = NULL", "array|int" },
 	{ "strcasecmp", "string $string1, string $string2", "int" },
 	{ "strchr", "string $haystack, string $needle, bool $before_needle = false", "string|false" },
 	{ "strcmp", "string $string1, string $string2", "int" },
@@ -3383,6 +3388,7 @@ static const struct VmBuiltinSig {
 	{ "substr", "string $string, int $offset, ?int $length = NULL", "string" },
 	{ "substr_compare", "string $haystack, string $needle, int $offset, ?int $length = NULL, bool $case_insensitive = false", "int" },
 	{ "substr_count", "string $haystack, string $needle, int $offset = 0, ?int $length = NULL", "int" },
+	{ "substr_replace", "array|string $string, array|string $replace, array|int $offset, array|int|null $length = NULL", "array|string" },
 	{ "symlink", "string $target, string $link", "bool" },
 	{ "sys_get_temp_dir", "", "string" },
 	{ "tan", "float $num", "float" },
@@ -3483,6 +3489,37 @@ PH7_PRIVATE const char * PH7_VmBuiltinSigLookup(const char *zName,sxu32 nLen,con
 		}
 	}
 	return 0;
+}
+/*
+ * Write a value back to the caller's variable through a builtin argument's
+ * stack-slot nIdx — the shared write-back for builtin by-reference
+ * out-parameters (preg_match $matches, preg_replace &$count, similar_text
+ * &$percent, ...).
+ *
+ * For a positional out-param argument the call compiler auto-vivifies known
+ * by-reference out-params (see GenStateByRefBuiltinMask in compile.c), so a
+ * bare undefined variable, an array subscript, and a declared/untyped
+ * property all arrive with a real nIdx and are written back here, matching
+ * PHP's reference semantics.
+ *
+ * nIdx stays SXU32_HIGH and the write-back to the caller is skipped (the
+ * value still lands in the local stack slot) when the argument cannot expose
+ * a stable memobj slot: a literal, a function-call result, a subscript of a
+ * non-lvalue parent (foo()['k']), or any variable in a call that also uses
+ * named or spread arguments (compile-time positions no longer map to the
+ * runtime arg slots, so the compiler conservatively does not vivify). An
+ * uninitialized typed property is also not wired (it throws before the
+ * write) -- see PLAN.md deferrals.
+ */
+PH7_PRIVATE void PH7_VmStoreArgByRef(ph7_vm *pVm,ph7_value *pArg,ph7_value *pNewVal)
+{
+	if( pArg->nIdx != SXU32_HIGH ){
+		ph7_value *pObj = (ph7_value *)SySetAt(&pVm->aMemObj,pArg->nIdx);
+		if( pObj ){
+			PH7_MemObjStore(pNewVal,pObj);
+		}
+	}
+	PH7_MemObjStore(pNewVal,pArg);
 }
 PH7_PRIVATE sxi32 PH7_VmMakeReady(
 	ph7_vm *pVm /* Target VM */

--- a/src/ph7/vm_pcre.c
+++ b/src/ph7/vm_pcre.c
@@ -247,35 +247,6 @@ static pcre2_code *PcreCompile(
 	return pCode;
 }
 
-/*
- * Write a value back to the caller's variable through the stack slot's nIdx.
- *
- * For a positional out-param argument the call compiler auto-vivifies known
- * by-reference out-params (see GenStateByRefBuiltinMask in compile.c), so a
- * bare undefined variable (e.g. preg_match($p,$s,$m) with $m never assigned),
- * an array subscript (preg_match($p,$s,$a['k'])), and a declared/untyped
- * property (preg_match($p,$s,$o->prop)) all arrive with a real nIdx and are
- * written back here, matching PHP's reference semantics.
- *
- * nIdx stays SXU32_HIGH and the write-back to the caller is skipped (the value
- * still lands in the local stack slot) when the argument cannot expose a stable
- * memobj slot: a literal, a function-call result, a subscript of a non-lvalue
- * parent (foo()['k']), or any variable in a call that also uses named or spread
- * arguments (compile-time positions no longer map to the runtime arg slots, so
- * the compiler conservatively does not vivify). An uninitialized typed property
- * is also not wired (it throws before the write) -- see PLAN.md deferrals.
- */
-static void PcreStoreByRef(ph7_vm *pVm, ph7_value *pArg, ph7_value *pNewVal)
-{
-	if( pArg->nIdx != SXU32_HIGH ){
-		ph7_value *pObj = (ph7_value *)SySetAt(&pVm->aMemObj, pArg->nIdx);
-		if( pObj ){
-			PH7_MemObjStore(pNewVal, pObj);
-		}
-	}
-	PH7_MemObjStore(pNewVal, pArg);
-}
-
 /* ===== Map PCRE2 match error to PHP error code ===== */
 static void PcreSetMatchError(ph7_vm *pVm, int rc)
 {
@@ -487,7 +458,7 @@ static int PH7_builtin_preg_match(ph7_context *pCtx, int nArg, ph7_value **apArg
 		/* Populate empty matches if requested */
 		if( nArg >= 3 ){
 			ph7_value *pEmpty = ph7_context_new_array(pCtx);
-			PcreStoreByRef(pCtx->pVm, apArg[2], pEmpty);
+			PH7_VmStoreArgByRef(pCtx->pVm, apArg[2], pEmpty);
 			ph7_context_release_value(pCtx, pEmpty);
 		}
 		pcre2_match_data_free(pMatchData);
@@ -501,7 +472,7 @@ static int PH7_builtin_preg_match(ph7_context *pCtx, int nArg, ph7_value **apArg
 		ovector = pcre2_get_ovector_pointer(pMatchData);
 		PcrePopulateMatches(pCtx, pArray, zSubject, ovector, rc, pCode, iFlags);
 		/* Write the array back to the caller's variable */
-		PcreStoreByRef(pCtx->pVm, apArg[2], pArray);
+		PH7_VmStoreArgByRef(pCtx->pVm, apArg[2], pArray);
 		ph7_context_release_value(pCtx, pArray);
 	}
 	pcre2_match_data_free(pMatchData);
@@ -644,7 +615,7 @@ static int PH7_builtin_preg_match_all(ph7_context *pCtx, int nArg, ph7_value **a
 		}
 		/* Write output array to caller's variable */
 		if( pOutArray && nArg >= 3 ){
-			PcreStoreByRef(pCtx->pVm, apArg[2], pOutArray);
+			PH7_VmStoreArgByRef(pCtx->pVm, apArg[2], pOutArray);
 			ph7_context_release_value(pCtx, pOutArray);
 		}
 	}
@@ -1136,7 +1107,7 @@ set_count:
 	if( nArg >= 5 ){
 		ph7_value sCount;
 		PH7_MemObjInitFromInt(pCtx->pVm, &sCount, count);
-		PcreStoreByRef(pCtx->pVm, apArg[4], &sCount);
+		PH7_VmStoreArgByRef(pCtx->pVm, apArg[4], &sCount);
 		PH7_MemObjRelease(&sCount);
 	}
 	return PH7_OK;
@@ -1251,7 +1222,7 @@ static int PH7_builtin_preg_replace_callback(ph7_context *pCtx, int nArg, ph7_va
 	if( nArg >= 5 ){
 		ph7_value sCount;
 		PH7_MemObjInitFromInt(pCtx->pVm, &sCount, count);
-		PcreStoreByRef(pCtx->pVm, apArg[4], &sCount);
+		PH7_VmStoreArgByRef(pCtx->pVm, apArg[4], &sCount);
 		PH7_MemObjRelease(&sCount);
 	}
 	return PH7_OK;

--- a/tests/ph7/001-smoke/array/array_key_first_last.phpt
+++ b/tests/ph7/001-smoke/array/array_key_first_last.phpt
@@ -1,0 +1,48 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+array_key_first/array_key_last return first/last key, NULL for empty, pointer untouched
+--FILE--
+<?php
+// int and string keys, insertion order
+echo array_key_first([3 => "a", "x" => "b"]), "\n";
+echo array_key_last([3 => "a", "x" => "b"]), "\n";
+// list form
+echo array_key_first([10, 20, 30]), "\n";
+echo array_key_last([10, 20, 30]), "\n";
+// canonicalized keys keep their integer identity
+$akfl = [true => "t", -7 => "neg"];
+var_export(array_key_first($akfl));
+echo "\n";
+var_export(array_key_last($akfl));
+echo "\n";
+// empty array -> NULL
+var_export(array_key_first([]));
+echo "\n";
+var_export(array_key_last([]));
+echo "\n";
+// internal pointer is left untouched (unlike reset()/end())
+$akfl2 = [1, 2, 3];
+next($akfl2);
+array_key_first($akfl2);
+array_key_last($akfl2);
+echo current($akfl2), "\n";
+// argument validation matches php
+try { array_key_first(); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+try { array_key_last("x"); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+?>
+--EXPECT--
+3
+x
+0
+2
+1
+-7
+NULL
+NULL
+2
+ArgumentCountError: array_key_first() expects exactly 1 argument, 0 given
+TypeError: array_key_last(): Argument #1 ($array) must be of type array, string given
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/levenshtein/levenshtein_basic.phpt
+++ b/tests/ph7/001-smoke/function/levenshtein/levenshtein_basic.phpt
@@ -1,0 +1,36 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+levenshtein distances, empty strings, case sensitivity, custom costs
+--FILE--
+<?php
+echo levenshtein("kitten", "sitting"), "\n";
+echo levenshtein("", "abc"), "\n";
+echo levenshtein("a", ""), "\n";
+echo levenshtein("abc", "abc"), "\n";
+echo levenshtein("Kitten", "kitten"), "\n";
+// custom insertion/replacement/deletion costs
+echo levenshtein("flaw", "lawn", 2, 3, 4), "\n";
+echo levenshtein("flaw", "lawn", 2), "\n";
+echo levenshtein("gumbo", "gambol", 2, 1, 3), "\n";
+echo levenshtein("frog", "fog", 100, 100, 100), "\n";
+// no 255-byte limit in php 8
+echo levenshtein(str_repeat("ab", 150), str_repeat("ba", 150)), "\n";
+// numeric-string cost is accepted in weak mode
+echo levenshtein("a", "b", "7"), "\n";
+?>
+--EXPECT--
+3
+3
+1
+0
+1
+6
+3
+3
+100
+2
+1
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/levenshtein/levenshtein_errors.phpt
+++ b/tests/ph7/001-smoke/function/levenshtein/levenshtein_errors.phpt
@@ -1,0 +1,37 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+levenshtein argument errors match php
+--FILE--
+<?php
+class LevErrStr { public function __toString(): string { return "kitten"; } }
+class LevErrPlain {}
+try { levenshtein("a"); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+try { levenshtein([], "b"); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+try { levenshtein("a", "b", "x"); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+try { levenshtein("a", "b", 2, [], 1); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+// a numeric PREFIX is not a numeric string
+try { levenshtein("a", "b", "10abc"); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+// NAN/INF and out-of-range floats fail outright
+try { levenshtein("a", "b", NAN); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+try { levenshtein("a", "b", 1e20); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+// objects: TypeError names the class, __toString objects are accepted as strings
+try { levenshtein("a", "b", new LevErrPlain); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+echo levenshtein(new LevErrStr, "sitting"), "\n";
+// float subjects are stringified in weak mode
+echo levenshtein("1.5", 1.5), "\n";
+?>
+--EXPECT--
+ArgumentCountError: levenshtein() expects at least 2 arguments, 1 given
+TypeError: levenshtein(): Argument #1 ($string1) must be of type string, array given
+TypeError: levenshtein(): Argument #3 ($insertion_cost) must be of type int, string given
+TypeError: levenshtein(): Argument #4 ($replacement_cost) must be of type int, array given
+TypeError: levenshtein(): Argument #3 ($insertion_cost) must be of type int, string given
+TypeError: levenshtein(): Argument #3 ($insertion_cost) must be of type int, float given
+TypeError: levenshtein(): Argument #3 ($insertion_cost) must be of type int, float given
+TypeError: levenshtein(): Argument #3 ($insertion_cost) must be of type int, LevErrPlain given
+3
+0
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/similar_text/similar_text_basic.phpt
+++ b/tests/ph7/001-smoke/function/similar_text/similar_text_basic.phpt
@@ -1,0 +1,33 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+similar_text match counts and by-ref percent
+--FILE--
+<?php
+echo similar_text("World", "Word"), "\n";
+echo similar_text("", ""), "\n";
+echo similar_text("abc", ""), "\n";
+echo similar_text("Hello World", "Hello PHP World"), "\n";
+echo similar_text("abcdef", "fedcba"), "\n";
+echo similar_text("test", "text"), "\n";
+// percent lands in an undefined variable through the by-ref out-param
+similar_text("World", "Word", $simPct1);
+echo round($simPct1, 6), "\n";
+similar_text("", "", $simPct2);
+echo round($simPct2, 6), "\n";
+similar_text("aaa", "aaa", $simPct3);
+echo round($simPct3, 6), "\n";
+?>
+--EXPECT--
+4
+0
+0
+11
+1
+3
+88.888889
+0
+100
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/similar_text/similar_text_errors.phpt
+++ b/tests/ph7/001-smoke/function/similar_text/similar_text_errors.phpt
@@ -1,0 +1,25 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+similar_text argument errors match php
+--FILE--
+<?php
+class SimErrStr { public function __toString(): string { return "kitten"; } }
+class SimErrPlain {}
+try { similar_text("a"); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+try { similar_text([], ""); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+// objects: TypeError names the class, __toString objects are accepted
+try { similar_text("ab", new SimErrPlain); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+echo similar_text(new SimErrStr, "kitten"), "\n";
+// ints are stringified in weak mode
+echo similar_text(1122, 21), "\n";
+?>
+--EXPECT--
+ArgumentCountError: similar_text() expects at least 2 arguments, 1 given
+TypeError: similar_text(): Argument #1 ($string1) must be of type string, array given
+TypeError: similar_text(): Argument #2 ($string2) must be of type string, SimErrPlain given
+6
+1
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/str_word_count/str_word_count_basic.phpt
+++ b/tests/ph7/001-smoke/function/str_word_count/str_word_count_basic.phpt
@@ -1,0 +1,34 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+str_word_count formats 0/1/2 and the apostrophe/hyphen word rules
+--FILE--
+<?php
+echo str_word_count("Hello fri3nd, you're looking good today!"), "\n";
+echo json_encode(str_word_count("Hello fri3nd, you're looking good today!", 1)), "\n";
+echo json_encode(str_word_count("Hello fri3nd, you're looking good today!", 2)), "\n";
+// ' and - belong to words, but the string cannot start with '
+// and cannot end with -
+echo json_encode(str_word_count("don't -stop- me", 1)), "\n";
+echo json_encode(str_word_count("'hi ho' -x ab", 1)), "\n";
+echo str_word_count("me-"), "\n";
+echo str_word_count("-"), "\n";
+echo str_word_count("--"), "\n";
+// empty input
+echo str_word_count(""), "\n";
+echo json_encode(str_word_count("", 2)), "\n";
+?>
+--EXPECT--
+7
+["Hello","fri","nd","you're","looking","good","today"]
+{"0":"Hello","6":"fri","10":"nd","14":"you're","21":"looking","29":"good","34":"today"}
+["don't","-stop-","me"]
+["hi","ho'","-x","ab"]
+1
+0
+0
+0
+[]
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/str_word_count/str_word_count_charlist.phpt
+++ b/tests/ph7/001-smoke/function/str_word_count/str_word_count_charlist.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+str_word_count charlist extends the word set, with a..z ranges
+--FILE--
+<?php
+echo json_encode(str_word_count("Hello fri3nd!", 1, "3")), "\n";
+echo json_encode(str_word_count("abc1def2ghi", 1, "0..9")), "\n";
+echo json_encode(str_word_count("h_llo w~rld", 1, "_")), "\n";
+// charlist can re-allow leading ' and trailing -
+echo json_encode(str_word_count("'hi me-", 1, "'")), "\n";
+echo json_encode(str_word_count("'hi me-", 1, "-")), "\n";
+?>
+--EXPECT--
+["Hello","fri3nd"]
+["abc1def2ghi"]
+["h_llo","w","rld"]
+["'hi","me"]
+["hi","me-"]
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/str_word_count/str_word_count_errors.phpt
+++ b/tests/ph7/001-smoke/function/str_word_count/str_word_count_errors.phpt
@@ -1,0 +1,36 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+str_word_count argument errors match php
+--FILE--
+<?php
+class SwcErrStr { public function __toString(): string { return "b"; } }
+class SwcErrPlain {}
+try { str_word_count(); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+try { str_word_count([]); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+try { str_word_count("x", 5); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+try { str_word_count("x", -1); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+try { str_word_count("x", 0, []); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+// non-numeric string format is a TypeError, not a silent 0
+try { str_word_count("a b", "abc"); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+try { str_word_count("a b", 0, new SwcErrPlain); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+// __toString objects are accepted for $string and $characters
+echo str_word_count(new SwcErrStr), "\n";
+echo json_encode(str_word_count("a b abc", 1, new SwcErrStr)), "\n";
+// numeric-string format is accepted in weak mode
+echo json_encode(str_word_count("a b", "1")), "\n";
+?>
+--EXPECT--
+ArgumentCountError: str_word_count() expects at least 1 argument, 0 given
+TypeError: str_word_count(): Argument #1 ($string) must be of type string, array given
+ValueError: str_word_count(): Argument #2 ($format) must be a valid format value
+ValueError: str_word_count(): Argument #2 ($format) must be a valid format value
+TypeError: str_word_count(): Argument #3 ($characters) must be of type ?string, array given
+TypeError: str_word_count(): Argument #2 ($format) must be of type int, string given
+TypeError: str_word_count(): Argument #3 ($characters) must be of type ?string, SwcErrPlain given
+1
+["a","b","abc"]
+["a","b"]
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/substr_replace/substr_replace_array.phpt
+++ b/tests/ph7/001-smoke/function/substr_replace/substr_replace_array.phpt
@@ -1,0 +1,31 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+substr_replace array form: per-element positional replace/offset/length, keys preserved
+--FILE--
+<?php
+// scalar replace applied to each element
+echo json_encode(substr_replace(["ab", "cd"], "X", 1)), "\n";
+// positional arrays consumed element by element
+echo json_encode(substr_replace(["ab", "cd"], ["X", "Y"], [0, 1], [1, 1])), "\n";
+// exhausted arrays fall back to ""/0/element-length
+echo json_encode(substr_replace(["ab", "cd", "ef"], ["X"], [0, 1], 1)), "\n";
+echo json_encode(substr_replace(["ab"], "X", [], [])), "\n";
+// string keys preserved
+echo json_encode(substr_replace(["k1" => "ab", "k2" => "cd"], "X", 0, 1)), "\n";
+// non-string elements are stringified
+echo json_encode(substr_replace([7, "cd"], "X", 1)), "\n";
+// empty subject array
+echo json_encode(substr_replace([], "X", 0)), "\n";
+?>
+--EXPECT--
+["aX","cX"]
+["Xb","cY"]
+["Xb","c","f"]
+["X"]
+{"k1":"Xb","k2":"Xd"}
+["7X","cX"]
+[]
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/substr_replace/substr_replace_basic.phpt
+++ b/tests/ph7/001-smoke/function/substr_replace/substr_replace_basic.phpt
@@ -1,0 +1,45 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+substr_replace scalar form: offset/length normalization matches php
+--FILE--
+<?php
+echo substr_replace("Hello", "World", 0), "\n";
+echo substr_replace("Hello", "World", 1, 2), "\n";
+echo substr_replace("Hello", "X", -2, 1), "\n";
+echo substr_replace("Hello", "X", 10, 5), "\n";
+echo substr_replace("Hello", "X", 2, -1), "\n";
+echo substr_replace("Hello", "X", -10, 2), "\n";
+echo substr_replace("Hello", "X", 2, null), "\n";
+echo substr_replace("", "abc", 0), "\n";
+echo substr_replace("abc", "", 1, 1), "\n";
+echo substr_replace("Hello", "X", PHP_INT_MAX, PHP_INT_MAX), "\n";
+echo substr_replace("Hello", "X", PHP_INT_MIN, PHP_INT_MIN), "\n";
+echo substr_replace("Hello", "X", 2, PHP_INT_MAX), "\n";
+echo substr_replace("Hello", "X", -3, PHP_INT_MIN), "\n";
+// scalar string + array replace uses the first element ("" when empty)
+echo substr_replace("hello", ["X", "Y"], 1), "\n";
+echo substr_replace("hello", [], 1), "\n";
+// int subject is stringified
+echo substr_replace(12345, "X", 1, 2), "\n";
+?>
+--EXPECT--
+World
+HWorldlo
+HelXo
+HelloX
+HeXo
+Xllo
+HeX
+abc
+ac
+HelloX
+XHello
+HeX
+HeXllo
+hX
+h
+1X45
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/substr_replace/substr_replace_errors.phpt
+++ b/tests/ph7/001-smoke/function/substr_replace/substr_replace_errors.phpt
@@ -1,0 +1,37 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+substr_replace error cases match php
+--FILE--
+<?php
+class SbrErrStr { public function __toString(): string { return "xy"; } }
+class SbrErrPlain {}
+try { substr_replace("a"); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+try { substr_replace("a", "b"); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+try { substr_replace("hello", "X", [1], 1); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+try { substr_replace("hello", "X", 1, [1]); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+// php validates all args ZPP-style before the body runs
+try { substr_replace(new SbrErrPlain, "X", 1); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+try { substr_replace("ab", new SbrErrPlain, 1); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+try { substr_replace(["ab"], new SbrErrPlain, 1); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+try { substr_replace("hello", "X", "zz", 1); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+try { substr_replace("hello", "X", 1, "zz"); } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+// __toString objects resolve for $string and $replace
+echo substr_replace(new SbrErrStr, "R", 1), "\n";
+echo substr_replace("ab", new SbrErrStr, 1), "\n";
+?>
+--EXPECT--
+ArgumentCountError: substr_replace() expects at least 3 arguments, 1 given
+ArgumentCountError: substr_replace() expects at least 3 arguments, 2 given
+TypeError: substr_replace(): Argument #3 ($offset) cannot be an array when working on a single string
+TypeError: substr_replace(): Argument #4 ($length) cannot be an array when working on a single string
+TypeError: substr_replace(): Argument #1 ($string) must be of type array|string, SbrErrPlain given
+TypeError: substr_replace(): Argument #2 ($replace) must be of type array|string, SbrErrPlain given
+TypeError: substr_replace(): Argument #2 ($replace) must be of type array|string, SbrErrPlain given
+TypeError: substr_replace(): Argument #3 ($offset) must be of type array|int, string given
+TypeError: substr_replace(): Argument #4 ($length) must be of type array|int|null, string given
+xR
+axy
+--CLEAN--
+<?php


### PR DESCRIPTION
…str_word_count

Six missing builtins with php-8.5-exact semantics, byte-verified against the oracle across ~60 paired probes plus a 1900-case php-generated fuzz corpus:

- substr_replace: full scalar+array forms — positional array replace/offset/ length with php's exhaustion fallbacks (""/0/element-length), keys preserved, the scalar-string+array-replace first-element quirk, overflow-safe sxi64 window normalization, ZPP-style validation of all four args before the body.
- levenshtein: weighted-cost rolling-row DP (php's reference_levdist), no 255-byte limit, allocation-size overflow guard.
- similar_text: php's greedy LCS recursion including the count>1 left-recursion quirk; by-ref $percent auto-vivified via GenStateByRefBuiltinMask.
- str_word_count: formats 0/1/2, charlist with a..z ranges (PH7_BuildCharMask), php's first/last-byte apostrophe/hyphen rules. Locale note: php's word set is LC_CTYPE-dependent; PHL stays C-locale (recorded divergence).
- array_key_first/array_key_last via a node-key emit helper shared with key().

Shared ZPP plumbing extracted along the way: StrPredicateResolveArg gained a type-name param and now backs all string params here (Stringable accepted, null deprecates with php's prefixed message, TypeError names the class); new IntArgResolve implements php's weak-mode int contract (null deprecation, lossy float/float-string E_DEPRECATED, NAN/INF/out-of-range TypeError, PH7_MemObjStringIsNumeric instead of prefix-matching SyStrIsNumeric); the pcre-private by-ref write-back was promoted to PH7_VmStoreArgByRef and is now shared by preg_* and similar_text.

Reflection signatures registered for all six. 11 new cross-engine smoke tests; test-compat green under both engines; MODE=tiny build clean; docker ASan/UBSan suites plus the fuzz corpus clean.
