### PR TITLE
Compare null against strings as the empty string and fix php's falsy-…

### DIFF
--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -927,30 +927,23 @@ static int HashmapFindValue(
 		/* Extract node value */
 		pVal = HashmapExtractNodeValue(pEntry);
 		if( pVal ){
-			if( (pVal->iFlags|pNeedle->iFlags) & MEMOBJ_NULL ){
-				sxi32 iF1 = pVal->iFlags&~MEMOBJ_AUX;
-				sxi32 iF2 = pNeedle->iFlags&~MEMOBJ_AUX;
-				if( iF1 == iF2 ){
-					/* NULL values are equals */
-					if( ppNode ){
-						*ppNode = pEntry;
-					}
-					return SXRET_OK;
+			/* Compare on duplicates (PH7_MemObjCmp converts its operands in
+			 * place). PH7_MemObjCmp implements php's full comparison table for
+			 * null too — loose null == ""/0/false, strict null === null only —
+			 * so null needles/values take the same path as everything else
+			 * (the historical null-to-null shortcut here made
+			 * in_array(null, [""]) false where php says true). */
+			PH7_MemObjLoad(pVal,&sVal);
+			PH7_MemObjLoad(pNeedle,&sNeedle);
+			rc = PH7_MemObjCmp(&sNeedle,&sVal,bStrict,0);
+			PH7_MemObjRelease(&sVal);
+			PH7_MemObjRelease(&sNeedle);
+			if( rc == 0 ){
+				if( ppNode ){
+					*ppNode = pEntry;
 				}
-			}else{
-				/* Duplicate value */
-				PH7_MemObjLoad(pVal,&sVal);
-				PH7_MemObjLoad(pNeedle,&sNeedle);
-				rc = PH7_MemObjCmp(&sNeedle,&sVal,bStrict,0);
-				PH7_MemObjRelease(&sVal);
-				PH7_MemObjRelease(&sNeedle);
-				if( rc == 0 ){
-					if( ppNode ){
-						*ppNode = pEntry;
-					}
-					/* Match found*/
-					return SXRET_OK;
-				}
+				/* Match found*/
+				return SXRET_OK;
 			}
 		}
 		/* Point to the next entry */
@@ -4186,9 +4179,16 @@ static int ph7_hashmap_keys(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		if( nArg > 1 ){
 			ph7_value *pValue = HashmapExtractNodeValue(pNode);
 			if( pValue ){
+				ph7_value sNeedle;
+				PH7_MemObjInit(pMap->pVm,&sNeedle);
 				PH7_MemObjLoad(pValue,&sVal);
-				/* Filter key */
-				rc = ph7_value_compare(&sVal,apArg[1],bStrict);
+				/* Filter key — compare on duplicates of BOTH sides:
+				 * PH7_MemObjCmp converts its operands in place, and a needle
+				 * mutated on the first element (e.g. null coerced) would
+				 * corrupt every later comparison. */
+				PH7_MemObjLoad(apArg[1],&sNeedle);
+				rc = ph7_value_compare(&sVal,&sNeedle,bStrict);
+				PH7_MemObjRelease(&sNeedle);
 				PH7_MemObjRelease(&sVal);
 			}
 		}
@@ -5180,7 +5180,19 @@ static int ph7_hashmap_diff_assoc(ph7_context *pCtx,int nArg,ph7_value **apArg)
 				/* directly compare with value at pN1 rather than searching again */
 				ph7_value *pVal2 = HashmapExtractNodeValue(pN1);
 				if( pVal2 ){
-					sxi32 cmp = PH7_MemObjCmp(pVal, pVal2, TRUE, 0);
+					ph7_value sV1,sV2;
+					sxi32 cmp;
+					/* Compare on duplicates: PH7_MemObjCmp converts its
+					 * operands in place and these are LIVE array elements (a
+					 * null element used to come back bool(false) in the
+					 * caller's array). */
+					PH7_MemObjInit(pEntry->pMap->pVm,&sV1);
+					PH7_MemObjInit(pEntry->pMap->pVm,&sV2);
+					PH7_MemObjLoad(pVal,&sV1);
+					PH7_MemObjLoad(pVal2,&sV2);
+					cmp = PH7_MemObjCmp(&sV1,&sV2,TRUE,0);
+					PH7_MemObjRelease(&sV1);
+					PH7_MemObjRelease(&sV2);
 					if( cmp == 0 ){
 						/* identical key+value found in one of the arrays => drop it */
 						keep = 0;
@@ -5366,7 +5378,18 @@ static int ph7_hashmap_diff_uassoc(ph7_context *pCtx,int nArg,ph7_value **apArg)
 						ph7_value *pVal1 = HashmapExtractNodeValue(pEntry);
 						ph7_value *pVal2 = HashmapExtractNodeValue(pIt);
 						if( pVal1 && pVal2 ){
-							if( PH7_MemObjCmp(pVal1,pVal2,TRUE,0) == 0 ){
+							ph7_value sV1,sV2;
+							sxi32 cmp;
+							/* Compare on duplicates: PH7_MemObjCmp converts in
+							 * place and these are LIVE array elements. */
+							PH7_MemObjInit(pEntry->pMap->pVm,&sV1);
+							PH7_MemObjInit(pEntry->pMap->pVm,&sV2);
+							PH7_MemObjLoad(pVal1,&sV1);
+							PH7_MemObjLoad(pVal2,&sV2);
+							cmp = PH7_MemObjCmp(&sV1,&sV2,TRUE,0);
+							PH7_MemObjRelease(&sV1);
+							PH7_MemObjRelease(&sV2);
+							if( cmp == 0 ){
 								keep = 0;
 								PH7_MemObjRelease(&result);
 								/* release keys too before breaking */

--- a/src/ph7/memobj.c
+++ b/src/ph7/memobj.c
@@ -393,13 +393,16 @@ static sxi32 MemObjStringValue(SyBlob *pOut,ph7_value *pObj,sxu8 bStrictBool)
 /*
  * Return some kind of boolean value which is the best we can do
  * at representing the value that pObj describes as a boolean.
- * When converting to boolean, the following values are considered FALSE:
+ * When converting to boolean, the following values are considered FALSE
+ * (php's exact set):
  * NULL
  * the boolean FALSE itself.
  * the integer 0 (zero).
  * the real 0.0 (zero).
- * the empty string,a stream of zero [i.e: "0","00","000",...] and the string
- * "false".
+ * the empty string "" and the string "0" (nothing else: "00", "0.0", " ",
+ * and "false" are all TRUE in php — the historical PH7 zero-stream and
+ * "false"/"on"/"yes" special cases changed the meaning of valid PHP source
+ * and were removed under the §10 PH7-ism policy).
  * an array with zero elements.
  */
 static sxi32 MemObjBooleanValue(ph7_value *pObj)
@@ -417,24 +420,14 @@ static sxi32 MemObjBooleanValue(ph7_value *pObj)
 	}else if (iFlags & MEMOBJ_STRING) {
 		SyString sString;
 		SyStringInitFromBuf(&sString,SyBlobData(&pObj->sBlob),SyBlobLength(&pObj->sBlob));
+		/* php: a string is FALSE iff it is empty or exactly "0" */
 		if( sString.nByte == 0 ){
-			/* Empty string */
 			return 0;
-		}else if( (sString.nByte == sizeof("true") - 1 && SyStrnicmp(sString.zString,"true",sizeof("true")-1) == 0) ||
-			(sString.nByte == sizeof("on") - 1 && SyStrnicmp(sString.zString,"on",sizeof("on")-1) == 0) ||
-			(sString.nByte == sizeof("yes") - 1 && SyStrnicmp(sString.zString,"yes",sizeof("yes")-1) == 0) ){
-				return 1;
-		}else if( sString.nByte == sizeof("false") - 1 && SyStrnicmp(sString.zString,"false",sizeof("false")-1) == 0 ){
-			return 0;
-		}else{
-			const char *zIn,*zEnd;
-			zIn = sString.zString;
-			zEnd = &zIn[sString.nByte];
-			while( zIn < zEnd && zIn[0] == '0' ){
-				zIn++;
-			}
-			return zIn >= zEnd ? 0 : 1;
 		}
+		if( sString.nByte == 1 && sString.zString[0] == '0' ){
+			return 0;
+		}
+		return 1;
 	}else if( iFlags & MEMOBJ_NULL ){
 		return 0;
 	}else if( iFlags & MEMOBJ_HASHMAP ){
@@ -1299,6 +1292,25 @@ PH7_PRIVATE sxi32 PH7_MemObjCmp(ph7_value *pObj1,ph7_value *pObj2,int bStrict,in
 	}
 	/* Combine flag together */
 	iComb = pObj1->iFlags|pObj2->iFlags;
+	if( !bStrict
+	 && (iComb & MEMOBJ_NULL) != 0
+	 && (iComb & MEMOBJ_STRING) != 0
+	 && (iComb & (MEMOBJ_BOOL|MEMOBJ_RES|MEMOBJ_HASHMAP|MEMOBJ_OBJ)) == 0 ){
+		/*
+		 * PHP 8 comparison table: null loosely compared with a STRING is
+		 * compared as the empty string (a string comparison), not through
+		 * bool coercion — so null == "0" is FALSE and null < "0" is TRUE
+		 * (php 7 and the historical PH7 behavior coerced both to bool,
+		 * making any non-empty non-"0"-insensitive string "equal" to null).
+		 * Convert the null side to "" and let the string branch below run.
+		 */
+		if( pObj1->iFlags & MEMOBJ_NULL ){
+			PH7_MemObjToString(pObj1);
+		}else{
+			PH7_MemObjToString(pObj2);
+		}
+		iComb = pObj1->iFlags|pObj2->iFlags;
+	}
 	if( iComb & (MEMOBJ_NULL|MEMOBJ_RES|MEMOBJ_BOOL) ){
 		/* Convert to boolean: Keep in mind FALSE < TRUE */
 		if( (pObj1->iFlags & MEMOBJ_BOOL) == 0 ){

--- a/tests/ph7/001-smoke/lang/null_string_comparison_php8.phpt
+++ b/tests/ph7/001-smoke/lang/null_string_comparison_php8.phpt
@@ -1,0 +1,89 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PHP 8 comparison table: null loosely compared with a string compares as ""
+--FILE--
+<?php
+// null vs string is a STRING comparison against "", not bool coercion
+var_export(null == "0"); echo "\n";
+var_export(null == ""); echo "\n";
+var_export(null == "a"); echo "\n";
+var_export(null == "00"); echo "\n";
+var_export(null < "0"); echo "\n";
+var_export(null > "0"); echo "\n";
+echo null <=> "0", " ", "0" <=> null, " ", null <=> "", " ", null <=> "a", "\n";
+var_export(null <= ""); echo "\n";
+var_export(null >= ""); echo "\n";
+// strict comparisons unaffected
+var_export(null === ""); echo "\n";
+var_export(null !== "0"); echo "\n";
+// null vs non-strings keeps the bool-table behavior
+var_export(null == 0); echo "\n";
+var_export(null == 0.0); echo "\n";
+var_export(null == false); echo "\n";
+var_export(null == true); echo "\n";
+var_export(null == []); echo "\n";
+var_export(null < 1); echo "\n";
+// bool vs string still compares as bool
+var_export(false == "0"); echo "\n";
+var_export(true == "a"); echo "\n";
+// the same table drives in_array / array_search / array_keys
+var_export(in_array(null, ["0", "x"])); echo "\n";
+var_export(in_array(null, ["", "x"])); echo "\n";
+var_export(in_array(null, ["0"], true)); echo "\n";
+var_export(in_array(null, [0])); echo "\n";
+var_export(in_array("", [null])); echo "\n";
+var_export(array_search(null, ["0", "", null])); echo "\n";
+var_export(array_search(null, ["0", "", null], true)); echo "\n";
+echo json_encode(array_keys([null, "", "0", null, 0], null)), "\n";
+echo json_encode(array_keys([null, "", "0", null, 0], null, true)), "\n";
+// a needle must not be corrupted by the first comparison (regression:
+// array_keys mutated its needle in place, breaking later elements)
+echo json_encode(array_keys(["1", 1, "1", 1], "1", true)), "\n";
+echo json_encode(array_keys(["a", "b", "a"], "a")), "\n";
+// max/min follow the same ordering
+var_export(max(null, "0")); echo "\n";
+var_export(min("a", null)); echo "\n";
+// regression: array_diff_assoc's strict compare must not corrupt the caller's
+// live null elements (they used to come back as bool(false))
+$nscA = ["x" => null, "y" => 1];
+array_diff_assoc($nscA, ["x" => null]);
+var_export($nscA["x"]); echo "\n";
+?>
+--EXPECT--
+false
+true
+false
+false
+true
+false
+-1 1 0 -1
+true
+true
+false
+true
+true
+true
+true
+false
+true
+true
+true
+true
+false
+true
+false
+true
+true
+1
+2
+[0,1,3,4]
+[0,3]
+[0,2]
+[0,2]
+'0'
+NULL
+NULL
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/string_to_bool_php8.phpt
+++ b/tests/ph7/001-smoke/lang/string_to_bool_php8.phpt
@@ -1,0 +1,50 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+string to bool: only "" and "0" are false (no "00"/"false"/"on" special cases)
+--FILE--
+<?php
+// php's exact falsy-string set
+var_export((bool)""); echo "\n";
+var_export((bool)"0"); echo "\n";
+// everything else is true, including php-8 look-alikes ph7 used to special-case
+var_export((bool)"00"); echo "\n";
+var_export((bool)"000"); echo "\n";
+var_export((bool)"0.0"); echo "\n";
+var_export((bool)" "); echo "\n";
+var_export((bool)"false"); echo "\n";
+var_export((bool)"FALSE"); echo "\n";
+var_export((bool)"on"); echo "\n";
+var_export((bool)"off"); echo "\n";
+var_export((bool)"yes"); echo "\n";
+var_export((bool)"no"); echo "\n";
+var_export((bool)"true"); echo "\n";
+var_export((bool)"\0"); echo "\n";
+// the same set drives conditions and loose bool comparison
+echo ("00" ? "t" : "f"), ("false" ? "t" : "f"), ("0" ? "t" : "f"), ("" ? "t" : "f"), "\n";
+var_export("false" == true); echo "\n";
+var_export("00" == false); echo "\n";
+var_export(!"false"); echo "\n";
+?>
+--EXPECT--
+false
+false
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+ttff
+true
+false
+false
+--CLEAN--
+<?php


### PR DESCRIPTION
…string set

PH7_MemObjCmp now implements php 8's comparison table for null vs string: loose comparisons convert the null side to the empty string and compare as strings (null == "0" is false, null < "0" is true) instead of coercing both operands to bool. Strict comparisons are unaffected.

Three adjacent bugs fell in the same sweep:
- MemObjBooleanValue special-cased "false"/"on"/"yes" and zero-streams ("00" was false) - a PH7-ism that changed the meaning of valid PHP source. php's falsy-string set is exactly "" and "0", now enforced.
- HashmapFindValue had a null-to-null shortcut that made in_array(null, [""]) false where php says true; removed - the generic duplicate-and-compare path handles null for both loose and strict.
- array_keys passed its search needle straight into the mutating comparator, corrupting it on the first element (array_keys([null,"","0",null,0], null, true) returned [0] instead of [0,3]); array_diff_assoc/array_diff_uassoc strict-compared LIVE array elements, turning the caller's null elements into bool(false). All three sites now compare on duplicates.

Byte-verified vs php 8.5.7 including a 20x20 cross-type <=>/==/=== matrix; operand mutation confirmed invisible to user variables (VM compares stack copies). Cross-engine tests null_string_comparison_php8.phpt and string_to_bool_php8.phpt; test-compat green under both engines with zero fallout; MODE=tiny clean; docker ASan/UBSan suites clean.
