### PR TITLE
Cap array_pad length at php's HT_MAX_SIZE with a catchable ValueError

### DIFF
--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -599,19 +599,6 @@ static sxi32 StrPredicateResolveArg(ph7_context *pCtx,ph7_value *pArg,const char
 	int iArgNum,const char *zParamName,const char *zTypeStr,const char *zNullMsg,
 	ph7_value *pTmp,const char **pzOut,int *pnOut);
 /*
- * Emit a formatted E_DEPRECATED diagnostic WITHOUT the active-function-name
- * prefix that ph7_context_throw_error_format() prepends — php's implicit-
- * conversion notices carry no prefix, and the ZPP null notices embed the
- * function name mid-message themselves.
- */
-static void BuiltinThrowDeprecatedFmt(ph7_vm *pVm,const char *zFmt,...)
-{
-	va_list ap;
-	va_start(ap,zFmt);
-	PH7_VmThrowErrorAp(pVm,0,E_DEPRECATED,zFmt,ap);
-	va_end(ap);
-}
-/*
  * Validate and resolve an int-typed builtin parameter with php-8 ZPP weak-mode
  * semantics: ints and bools pass through; null emits the 8.1 deprecation and
  * resolves to 0; floats and float-strings convert, with the implicit-conversion
@@ -630,7 +617,7 @@ static sxi32 IntArgResolve(
 	sxi64 *pOut
 ){
 	if( ph7_value_is_null(pArg) ){
-		BuiltinThrowDeprecatedFmt(pCtx->pVm,
+		PH7_VmThrowDeprecatedFmt(pCtx->pVm,
 			"%s(): Passing null to parameter #%d (%s) of type %s is deprecated",
 			zFunc,iArgNum,zParamName,zTypeStr
 			);
@@ -650,7 +637,7 @@ static sxi32 IntArgResolve(
 		}
 		iVal = (sxi64)dVal;
 		if( (double)iVal != dVal ){
-			BuiltinThrowDeprecatedFmt(pCtx->pVm,
+			PH7_VmThrowDeprecatedFmt(pCtx->pVm,
 				"Implicit conversion from float %s to int loses precision",
 				ph7_value_to_string(pArg,0)
 				);
@@ -689,7 +676,7 @@ static sxi32 IntArgResolve(
 			}
 			iVal = (sxi64)dVal;
 			if( (double)iVal != dVal ){
-				BuiltinThrowDeprecatedFmt(pCtx->pVm,
+				PH7_VmThrowDeprecatedFmt(pCtx->pVm,
 					"Implicit conversion from float-string \"%s\" to int loses precision",
 					zNum
 					);

--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -7103,11 +7103,44 @@ static int ph7_hashmap_chunk(ph7_context *pCtx,int nArg,ph7_value **apArg)
  * $pad_value
  *   Value to pad if input is less than pad_size.
  */
+/*
+ * Shared "requested array size too large" guard (band A #8). php throws a
+ * catchable ValueError when a builtin's caller-controlled target length
+ * exceeds its hashtable capacity HT_MAX_SIZE (2^30 elements; probed against
+ * php 8.5.7 — the boundary sits exactly between 1073741824 and 1073741825,
+ * independent of the input array's size and symmetric for negative lengths).
+ * Without this, a call like array_pad([1,2], 2000000000, 0) sits in the fill
+ * loop for minutes and then OOMs. nRequested is the ABSOLUTE requested
+ * length; pass a still-negative value (e.g. the unnegatable INT64_MIN,
+ * mirroring php's ZEND_ABS overflow) to fail the guard unconditionally.
+ * Returns SXRET_OK when the size is acceptable, else the throw status to
+ * propagate. The cap constant is shared with range()'s guards
+ * (PH7_RANGE_HT_MAX_SIZE above).
+ */
+static sxi32 HashmapGuardArraySize(
+	ph7_context *pCtx,
+	const char *zFunc,     /* Function name for the message */
+	int iArg,              /* 1-based argument position */
+	const char *zParam     /* "$length"-style parameter name */,
+	sxi64 nRequested       /* Absolute requested element count */
+	)
+{
+	if( nRequested < 0 || nRequested > PH7_RANGE_HT_MAX_SIZE ){
+		return PH7_VmThrowException(pCtx,
+			"ValueError",
+			"%s(): Argument #%d (%s) must not exceed the maximum allowed array size",
+			zFunc,iArg,zParam
+			);
+	}
+	return SXRET_OK;
+}
 static int ph7_hashmap_pad(ph7_context *pCtx,int nArg,ph7_value **apArg)
 {
 	ph7_hashmap *pMap;
 	ph7_value *pArray;
+	sxi64 iLen,iAbs;
 	int nEntry;
+	sxi32 rc;
 	if( nArg != 3 ){
 		return PH7_VmThrowException(pCtx,
 			"ArgumentCountError",
@@ -7147,17 +7180,47 @@ static int ph7_hashmap_pad(ph7_context *pCtx,int nArg,ph7_value **apArg)
 				"array_pad(): Argument #2 ($length) must be of type int, string given"
 				);
 		}
-		nEntry = (int)(iKind == RANGE_IN_DOUBLE ? (sxi64)dReal : iLong);
+		if( iKind == RANGE_IN_DOUBLE ){
+			/* php ZPP: a float-string outside the int64 range (or NaN) fails
+			 * outright — also keeps the (sxi64) cast below UB-free. */
+			if( dReal != dReal || dReal >= 9223372036854775808.0 || dReal < -9223372036854775808.0 ){
+				return PH7_VmThrowException(pCtx,
+					"TypeError",
+					"array_pad(): Argument #2 ($length) must be of type int, string given"
+					);
+			}
+			iLen = (sxi64)dReal;
+			if( (double)iLen != dReal ){
+				PH7_VmThrowDeprecatedFmt(pCtx->pVm,
+					"Implicit conversion from float-string \"%s\" to int loses precision",
+					zStr
+					);
+			}
+		}else{
+			iLen = iLong;
+		}
 	}else{
-		nEntry = ph7_value_to_int(apArg[1]);
+		iLen = ph7_value_to_int64(apArg[1]);
 	}
+	/* Point to the internal representation of the input hashmap */
+	pMap = (ph7_hashmap *)apArg[0]->x.pOther;
+	/* php caps abs($length) at HT_MAX_SIZE either direction (INT64_MIN stays
+	 * negative through the ABS, failing the guard like php's own ZEND_ABS
+	 * overflow). */
+	iAbs = iLen;
+	if( iAbs < 0 && iAbs != (sxi64)-9223372036854775807LL - 1 ){
+		iAbs = -iAbs;
+	}
+	rc = HashmapGuardArraySize(pCtx,"array_pad",2,"$length",iAbs);
+	if( rc != SXRET_OK ){
+		return rc;
+	}
+	nEntry = (int)iLen;
 	/* Create a new array */
 	pArray = ph7_context_new_array(pCtx);
 	if( pArray == 0 ){
 		return PH7_ContextMemoryError(pCtx);
 	}
-	/* Point to the internal representation of the input hashmap */
-	pMap = (ph7_hashmap *)apArg[0]->x.pOther;
 	if( nEntry < 0 ){
 		nEntry = -nEntry;
 		if( nEntry > (int)pMap->nEntry ){

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1822,6 +1822,7 @@ PH7_PRIVATE sxi32 PH7_VmDump(ph7_vm *pVm,ProcConsumer xConsumer,void *pUserData)
 PH7_PRIVATE sxi32 PH7_VmEvalBuiltinChunk(ph7_vm *pVm,const char *zSrc,sxu32 nLen);
 PH7_PRIVATE const char * PH7_VmBuiltinSigLookup(const char *zName,sxu32 nLen,const char **pzRet);
 PH7_PRIVATE void PH7_VmStoreArgByRef(ph7_vm *pVm,ph7_value *pArg,ph7_value *pNewVal);
+PH7_PRIVATE void PH7_VmThrowDeprecatedFmt(ph7_vm *pVm,const char *zFmt,...);
 PH7_PRIVATE sxi32 PH7_VmInstallReflection(ph7_vm *pVm); /* vm_builtin_reflection.c */
 PH7_PRIVATE ph7_class_instance * PH7_VmNewClosure(ph7_vm *pVm,const SyString *pName,
 	ph7_class_instance *pBoundThis,const SyString *pScope);

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -3521,6 +3521,19 @@ PH7_PRIVATE void PH7_VmStoreArgByRef(ph7_vm *pVm,ph7_value *pArg,ph7_value *pNew
 	}
 	PH7_MemObjStore(pNewVal,pArg);
 }
+/*
+ * Emit a formatted E_DEPRECATED diagnostic WITHOUT the active-function-name
+ * prefix that ph7_context_throw_error_format() prepends — php's implicit-
+ * conversion notices carry no prefix, and the ZPP null notices embed the
+ * function name mid-message themselves.
+ */
+PH7_PRIVATE void PH7_VmThrowDeprecatedFmt(ph7_vm *pVm,const char *zFmt,...)
+{
+	va_list ap;
+	va_start(ap,zFmt);
+	PH7_VmThrowErrorAp(pVm,0,E_DEPRECATED,zFmt,ap);
+	va_end(ap);
+}
 PH7_PRIVATE sxi32 PH7_VmMakeReady(
 	ph7_vm *pVm /* Target VM */
 	)

--- a/tests/ph7/001-smoke/array/array_pad_size_guard.phpt
+++ b/tests/ph7/001-smoke/array/array_pad_size_guard.phpt
@@ -1,0 +1,37 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+array_pad length beyond php's HT_MAX_SIZE (2^30) is a catchable ValueError
+--FILE--
+<?php
+function apgT($fn) { try { $r = $fn(); echo "OK:", count($r), "\n"; } catch (\Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; } }
+// beyond the cap: ValueError instead of a multi-minute fill loop + OOM
+apgT(fn() => array_pad([1, 2], 2000000000, 0));
+apgT(fn() => array_pad([1, 2], -2000000000, 0));
+apgT(fn() => array_pad([1, 2], 1073741825, 0));
+apgT(fn() => array_pad([1, 2], -1073741825, 0));
+apgT(fn() => array_pad([1, 2], PHP_INT_MAX, 0));
+apgT(fn() => array_pad([1, 2], PHP_INT_MIN, 0));
+// the cap ignores the input array's size
+apgT(fn() => array_pad(range(1, 20), 1073741825, 0));
+// normal pads still work on both sides
+apgT(fn() => array_pad([1, 2], 5, "p"));
+apgT(fn() => array_pad([1, 2], -5, "p"));
+apgT(fn() => array_pad([1, 2, 3], 2, "x"));
+apgT(fn() => array_pad([], 100, 9));
+?>
+--EXPECT--
+ValueError: array_pad(): Argument #2 ($length) must not exceed the maximum allowed array size
+ValueError: array_pad(): Argument #2 ($length) must not exceed the maximum allowed array size
+ValueError: array_pad(): Argument #2 ($length) must not exceed the maximum allowed array size
+ValueError: array_pad(): Argument #2 ($length) must not exceed the maximum allowed array size
+ValueError: array_pad(): Argument #2 ($length) must not exceed the maximum allowed array size
+ValueError: array_pad(): Argument #2 ($length) must not exceed the maximum allowed array size
+ValueError: array_pad(): Argument #2 ($length) must not exceed the maximum allowed array size
+OK:5
+OK:5
+OK:3
+OK:100
+--CLEAN--
+<?php


### PR DESCRIPTION
array_pad([1,2], 2000000000, 0) sat in the fill loop for minutes and then OOMed where php throws a catchable ValueError. A shared HashmapGuardArraySize helper now throws php's exact "must not exceed the maximum allowed array size" error; the cap was probed rather than assumed: php 8.5.7's boundary is abs($length) > 2^30 (HT_MAX_SIZE, the constant range() already carries), independent of the input array's size, symmetric for negative lengths, with INT64_MIN failing via the unnegatable-ABS path like php's ZEND_ABS.

The length is now computed in 64 bits (it was truncated through int, which is how 2e9 slipped past), and the float-string path is fixed on the way: "1e300" used to go through an out-of-range double->int64 cast (undefined behavior) - now php's TypeError - and lossy float-strings like "5.5" emit php's implicit-conversion E_DEPRECATED. That notice must not carry the function-name prefix ph7_context_throw_error_format prepends, so the no-prefix helper from the builtins ZPP work is promoted to PH7_VmThrowDeprecatedFmt in vm.c and shared.

Counts under the cap but over available memory still churn (php hits its memory_limit fatal quickly; PHL has no memory_limit yet) and array_fill's uncatchable-fatal class is untouched - both recorded in NEWPLAN.

Byte-verified vs php 8.5.7 on both boundary sides; cross-engine test array_pad_size_guard.phpt; test-compat green under both engines; MODE=tiny clean; docker ASan/UBSan suites clean.
