### PR TITLE
Give each foreach a private cursor and iterate by-ref loops on the li…

### DIFF
--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -157,6 +157,20 @@ static void HashmapNodeLink(ph7_hashmap *pMap,ph7_hashmap_node *pNode,sxu32 nBuc
 	}else{
 		MACRO_LD_PUSH(pMap->pLast,pNode);
 	}
+	if( pMap->pActiveSteps ){
+		/* Re-arm any live foreach cursor parked past the end: php's by-ref
+		 * foreach iterates the LIVE array, so an element appended while the
+		 * loop stands on the last node (worklist idiom), or after the body
+		 * emptied the map, is still visited. A registered step with a NULL
+		 * cursor is always mid-loop — natural exhaustion unregisters before
+		 * the loop ends. */
+		ph7_foreach_step *pStep;
+		for( pStep = pMap->pActiveSteps ; pStep ; pStep = pStep->pNextActive ){
+			if( pStep->pCursor == 0 ){
+				pStep->pCursor = pNode;
+			}
+		}
+	}
 	++pMap->nEntry;
 }
 /*
@@ -182,6 +196,16 @@ PH7_PRIVATE void PH7_HashmapUnlinkNode(ph7_hashmap_node *pNode,int bRestore)
 	if( pMap->pCur == pNode ){
 		/* Advance the node cursor */
 		pMap->pCur = pMap->pCur->pPrev; /* Reverse link */
+	}
+	if( pMap->pActiveSteps ){
+		/* Advance any live foreach cursor parked on this node (delete during
+		 * live-map iteration: by-ref foreach, $GLOBALS, snapshot fallbacks). */
+		ph7_foreach_step *pStep;
+		for( pStep = pMap->pActiveSteps ; pStep ; pStep = pStep->pNextActive ){
+			if( pStep->pCursor == pNode ){
+				pStep->pCursor = pNode->pPrev; /* Reverse link */
+			}
+		}
 	}
 	/* Unlink from the map list */
 	MACRO_LD_REMOVE(pMap->pLast,pNode);
@@ -1371,10 +1395,33 @@ PH7_PRIVATE sxi32 PH7_HashmapDupMaterialized(ph7_hashmap *pSrc,ph7_hashmap *pDes
 	return SXRET_OK;
 }
 /*
+ * Count the map references held by BY-REFERENCE foreach steps iterating the
+ * given hashmap. php's `foreach ($a as &$v)` iterates the LIVE array —
+ * appends/deletes inside the body are visited — so a by-ref step's retain
+ * must not make writes through the source variable COW-separate away from
+ * the loop's map. By-VALUE steps are deliberately NOT discounted: their
+ * retain is exactly what makes an in-loop write separate, which is php's
+ * iterate-a-snapshot semantic.
+ */
+static sxi32 HashmapByRefStepRefs(ph7_hashmap *pMap)
+{
+	ph7_foreach_step *pStep;
+	sxi32 nRef = 0;
+	for( pStep = pMap->pActiveSteps ; pStep ; pStep = pStep->pNextActive ){
+		if( pStep->iFlags & PH7_4EACH_STEP_REF ){
+			nRef++;
+		}
+	}
+	return nRef;
+}
+/*
  * Copy-on-write separation for arrays.
  * If the hashmap inside pValue has iRef > 1 (shared), duplicate it so that
  * pValue owns a private copy. The original map's refcount is decremented.
  * Returns the (possibly new) hashmap pointer.
+ * References held by active by-ref foreach steps do not count as sharers
+ * (see HashmapByRefStepRefs): writes during `foreach ($a as &$v)` must land
+ * on the live map the loop is walking, like php.
  */
 PH7_PRIVATE ph7_hashmap * PH7_HashmapCowSeparate(ph7_vm *pVm,ph7_value *pValue)
 {
@@ -1383,7 +1430,8 @@ PH7_PRIVATE ph7_hashmap * PH7_HashmapCowSeparate(ph7_vm *pVm,ph7_value *pValue)
 	ph7_value *pBacking;
 	sxu32 nValIdx;
 	int bValueInPool;
-	if( pMap->iRef < 2 ){
+	sxi32 nByRefSteps = pMap->pActiveSteps ? HashmapByRefStepRefs(pMap) : 0;
+	if( pMap->iRef - nByRefSteps < 2 ){
 		/* Sole owner, no separation needed */
 		return pMap;
 	}
@@ -1403,7 +1451,7 @@ PH7_PRIVATE ph7_hashmap * PH7_HashmapCowSeparate(ph7_vm *pVm,ph7_value *pValue)
 			&& (ph7_hashmap *)pBacking->x.pOther == pMap ){
 			/* Undo the stack ref to reveal true sharing count */
 			pMap->iRef--;
-			if( pMap->iRef < 2 ){
+			if( pMap->iRef - nByRefSteps < 2 ){
 				/* After undoing stack ref, sole owner — no separation */
 				pMap->iRef++;
 				return pMap;
@@ -1684,6 +1732,18 @@ PH7_PRIVATE sxi32 PH7_HashmapRelease(ph7_hashmap *pMap,int FreeDS)
 		PH7_VmThrowError(pMap->pVm,0,PH7_CTX_NOTICE,"$GLOBALS is a read-only array,deletion is forbidden");
 		return SXRET_OK;
 	}
+	if( pMap->pActiveSteps ){
+		/* Every node is about to be freed WITHOUT going through
+		 * PH7_HashmapUnlinkNode, so its cursor fixup never runs. Park any
+		 * live foreach cursor on this map (reachable: array_erase() on the
+		 * live map of a by-ref foreach — the CowSeparate discount keeps the
+		 * loop's map writable). A NULL cursor ends the loop cleanly at the
+		 * next step, or resumes on a fresh insert via the link-time re-arm. */
+		ph7_foreach_step *pStep;
+		for( pStep = pMap->pActiveSteps ; pStep ; pStep = pStep->pNextActive ){
+			pStep->pCursor = 0;
+		}
+	}
 	/* Start the release process */
 	n = 0;
 	pEntry = pMap->pFirst;
@@ -1832,12 +1892,36 @@ PH7_PRIVATE sxi32 PH7_HashmapInsertByRef(
 	return rc;
 }
 /*
- * Reset the node cursor of a given hashmap.
+ * Register a foreach step as an active iterator of the given hashmap.
+ * Each foreach owns a PRIVATE cursor (pStep->pCursor) — php semantics:
+ * nested loops over the same array never disturb each other. The map keeps
+ * the list of active steps so PH7_HashmapUnlinkNode can advance any cursor
+ * parked on a node being deleted (live-map iteration: by-ref foreach,
+ * $GLOBALS, OOM snapshot fallbacks).
  */
-PH7_PRIVATE void PH7_HashmapResetLoopCursor(ph7_hashmap *pMap)
+PH7_PRIVATE void PH7_HashmapRegisterForeachStep(ph7_hashmap *pMap,ph7_foreach_step *pStep)
 {
-	/* Reset the loop cursor */
-	pMap->pCur = pMap->pFirst;
+	pStep->pCursor = pMap->pFirst;
+	pStep->pNextActive = pMap->pActiveSteps;
+	pMap->pActiveSteps = pStep;
+}
+/*
+ * Unregister a foreach step from the map's active-iterator list. Must run
+ * before the step is freed AND before the step's map reference is dropped —
+ * a step left on the list after its pool slot is recycled is a use-after-free
+ * on the next unlink fixup (the SyHash-layout incident class).
+ */
+PH7_PRIVATE void PH7_HashmapUnregisterForeachStep(ph7_hashmap *pMap,ph7_foreach_step *pStep)
+{
+	ph7_foreach_step **ppLink = &pMap->pActiveSteps;
+	while( *ppLink ){
+		if( *ppLink == pStep ){
+			*ppLink = pStep->pNextActive;
+			pStep->pNextActive = 0;
+			return;
+		}
+		ppLink = &(*ppLink)->pNextActive;
+	}
 }
 /*
  * Return a pointer to the node currently pointed by the node cursor.

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -268,8 +268,19 @@ struct ph7_hashmap
 	sxu32 (*xIntHash)(sxi64);     /* Hash function for int_keys */
 	sxu32 (*xBlobHash)(const void *,sxu32); /* Hash function for blob_keys */
 	sxi64 iNextIdx;               /* Next available automatically assigned index */
-	sxi32 iRef;                   /* Reference count */
+	sxi32 iRef;                   /* Reference count. INVARIANT: the number of
+								   * SHARERS for copy-on-write purposes is
+								   * iRef minus the by-REFERENCE foreach steps
+								   * on pActiveSteps (a by-ref loop iterates
+								   * the LIVE map, php semantics) — any future
+								   * separate/dup gate must use the discounted
+								   * count like PH7_HashmapCowSeparate, never
+								   * raw iRef. */
 	sxi32 iFlags;                 /* Control flags (see HASHMAP_* below) */
+	ph7_foreach_step *pActiveSteps; /* foreach steps currently iterating this map
+									 * (per-step cursors — PH7_HashmapUnlinkNode
+									 * advances any cursor parked on a dying node,
+									 * node link re-arms parked cursors) */
 };
 /*
  * Hashmap control flags.
@@ -301,6 +312,11 @@ struct ph7_foreach_step
 		ph7_class_instance *pThis;  /* Class instance [i.e: object] iteration */
 	}xIter;
 	ph7_class_instance *pOwner;     /* IteratorAggregate: keeps aggregate alive during foreach */
+	ph7_hashmap_node *pCursor;      /* Hashmap iteration: this loop's PRIVATE cursor.
+									 * php iterates each foreach independently — the map's
+									 * shared pCur would make nested loops over one array
+									 * rewind each other (infinite loop). */
+	ph7_foreach_step *pNextActive;  /* Next step on the map's pActiveSteps list */
 };
 /* Foreach step control flags */
 #define PH7_4EACH_STEP_HASHMAP 0x001 /* Hashmap iteration */
@@ -2113,7 +2129,8 @@ PH7_PRIVATE sxi32 PH7_HashmapDup(ph7_hashmap *pSrc,ph7_hashmap *pDest);
 PH7_PRIVATE sxi32 PH7_HashmapDupMaterialized(ph7_hashmap *pSrc,ph7_hashmap *pDest);
 PH7_PRIVATE ph7_hashmap * PH7_HashmapCowSeparate(ph7_vm *pVm,ph7_value *pValue);
 PH7_PRIVATE sxi32 PH7_HashmapCmp(ph7_hashmap *pLeft,ph7_hashmap *pRight,int bStrict);
-PH7_PRIVATE void PH7_HashmapResetLoopCursor(ph7_hashmap *pMap);
+PH7_PRIVATE void PH7_HashmapRegisterForeachStep(ph7_hashmap *pMap,ph7_foreach_step *pStep);
+PH7_PRIVATE void PH7_HashmapUnregisterForeachStep(ph7_hashmap *pMap,ph7_foreach_step *pStep);
 PH7_PRIVATE ph7_hashmap_node * PH7_HashmapGetNextEntry(ph7_hashmap *pMap);
 PH7_PRIVATE void PH7_HashmapExtractNodeValue(ph7_hashmap_node *pNode,ph7_value *pValue,int bStore);
 PH7_PRIVATE void PH7_HashmapExtractNodeKey(ph7_hashmap_node *pNode,ph7_value *pKey);

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -7079,6 +7079,26 @@ static void VmForeachStepAbandon(ph7_vm *pVm,ph7_foreach_info *pInfo,ph7_foreach
 	PH7_ClassInstanceUnref(pThis);
 }
 /*
+ * Tear down a HASHMAP-mode foreach step: unhook its private cursor from the
+ * map's active-step registry, free the step, optionally pop it off the info's
+ * step stack, then drop the step's map reference. The single home for this
+ * teardown (the hashmap twin of VmForeachStepAbandon above) — the ordering is
+ * load-bearing: a step freed while still registered is walked by the next
+ * PH7_HashmapUnlinkNode as a recycled pool slot (the SyHash-layout incident
+ * class), and the unregister must precede the unref in case the step held the
+ * map's last reference.
+ */
+static void VmForeachHashmapStepRelease(ph7_vm *pVm,ph7_foreach_info *pInfo,ph7_foreach_step *pStep,int bPop)
+{
+	ph7_hashmap *pMap = pStep->xIter.pMap;
+	PH7_HashmapUnregisterForeachStep(pMap,pStep);
+	SyMemBackendPoolFree(&pVm->sAllocator,pStep);
+	if( bPop ){
+		SySetPop(&pInfo->aStep);
+	}
+	PH7_HashmapUnref(pMap);
+}
+/*
  * Boundary state of one VmByteCodeExec activation (BYTECODE.md stage 1):
  * everything the executor must restore to continue an activation after a
  * nested call returns. pc/pTos are authoritative here only at activation
@@ -11567,7 +11587,7 @@ case PH7_OP_FOREACH_INIT: {
 			/* Prepare the step */
 			pStep->iFlags = pInfo->iFlags;
 			if( pTos->iFlags & MEMOBJ_HASHMAP ){
-				ph7_hashmap *pMap;
+				ph7_hashmap *pMap,*pIterMap;
 				/* COW: For by-reference foreach, eagerly separate the
 				 * source array so mutations don't affect other sharers. */
 				if( (pStep->iFlags & PH7_4EACH_STEP_REF) && pTos->nIdx != SXU32_HIGH ){
@@ -11588,6 +11608,7 @@ case PH7_OP_FOREACH_INIT: {
 					}
 				}
 				pMap = (ph7_hashmap *)pTos->x.pOther;
+				pIterMap = pMap;
 				if( pMap == pVm->pGlobal && (pStep->iFlags & PH7_4EACH_STEP_REF) == 0 ){
 					/* php 8.1: foreach ($GLOBALS as ...) by value iterates a
 					 * SNAPSHOT of the symbol table — globals created inside
@@ -11596,27 +11617,21 @@ case PH7_OP_FOREACH_INIT: {
 					 * map, like php. On OOM fall back to the live map. */
 					ph7_hashmap *pSnap = PH7_NewHashmap(&(*pVm),0,0);
 					if( pSnap && PH7_HashmapDupMaterialized(pMap,pSnap) == SXRET_OK ){
-						PH7_HashmapResetLoopCursor(pSnap);
-						pStep->iFlags |= PH7_4EACH_STEP_HASHMAP;
 						/* The step consumes the snapshot's initial reference */
-						pStep->xIter.pMap = pSnap;
-					}else{
-						if( pSnap ){
-							PH7_HashmapUnref(pSnap);
-						}
-						PH7_HashmapResetLoopCursor(pMap);
-						pStep->iFlags |= PH7_4EACH_STEP_HASHMAP;
-						pStep->xIter.pMap = pMap;
-						pMap->iRef++;
+						pIterMap = pSnap;
+					}else if( pSnap ){
+						PH7_HashmapUnref(pSnap);
 					}
-				}else{
-					/* Reset the internal loop cursor */
-					PH7_HashmapResetLoopCursor(pMap);
-					/* Mark the step */
-					pStep->iFlags |= PH7_4EACH_STEP_HASHMAP;
-					pStep->xIter.pMap = pMap;
+				}
+				pStep->iFlags |= PH7_4EACH_STEP_HASHMAP;
+				pStep->xIter.pMap = pIterMap;
+				if( pIterMap == pMap ){
 					pMap->iRef++;
 				}
+				/* Private cursor + registry (php: nested foreach over one
+				 * array are independent; foreach never moves the internal
+				 * pointer — see PH7_HashmapRegisterForeachStep) */
+				PH7_HashmapRegisterForeachStep(pIterMap,pStep);
 			}else{
 				ph7_class_instance *pThis = (ph7_class_instance *)pTos->x.pOther;
 				ph7_class *pIteratorClass;
@@ -11714,7 +11729,11 @@ case PH7_OP_FOREACH_INIT: {
 		if( pStep ){
 			if( SXRET_OK != SySetPut(&pInfo->aStep,(const void *)&pStep) ){
 				PH7_VmThrowError(&(*pVm),0,PH7_CTX_ERR,"PH7 is running out of memory while preparing the 'foreach' step");
-				SyMemBackendPoolFree(&pVm->sAllocator,pStep);
+				if( pStep->iFlags & PH7_4EACH_STEP_HASHMAP ){
+					VmForeachHashmapStepRelease(&(*pVm),pInfo,pStep,FALSE/*never made it onto aStep*/);
+				}else{
+					SyMemBackendPoolFree(&pVm->sAllocator,pStep);
+				}
 				/* Jump out of the loop */
 				pc = pInstr->iP2 - 1;
 			}
@@ -11738,10 +11757,10 @@ case PH7_OP_FOREACH_STEP: {
 	pFrameLocal = pVm->pFrame;
 	pFrameLocal = VmSkipExceptionFrames(pFrameLocal);
 	if( pStep->iFlags & PH7_4EACH_STEP_HASHMAP ){
-		ph7_hashmap *pMap = pStep->xIter.pMap;
 		ph7_hashmap_node *pNode;
-		/* Extract the current node value */
-		pNode = PH7_HashmapGetNextEntry(pMap);
+		/* Extract the current node via this loop's PRIVATE cursor (php:
+		 * nested foreach over the same array are independent iterations) */
+		pNode = pStep->pCursor;
 		if( pNode == 0 ){
 			/* No more entry to process */
 			pc = pInstr->iP2 - 1; /* Jump to this destination */
@@ -11749,13 +11768,11 @@ case PH7_OP_FOREACH_STEP: {
 				/* Break the reference with the last element */
 				SyHashDeleteEntry(&pFrameLocal->hVar,SyStringData(&pInfo->sValue),SyStringLength(&pInfo->sValue),0);
 			}
-			/* Automatically reset the loop cursor */
-			PH7_HashmapResetLoopCursor(pMap);
 			/* Cleanup the mess left behind */
-			SyMemBackendPoolFree(&pVm->sAllocator,pStep);
-			SySetPop(&pInfo->aStep);
-			PH7_HashmapUnref(pMap);
+			VmForeachHashmapStepRelease(&(*pVm),pInfo,pStep,TRUE);
 		}else{
+			/* Advance the private cursor */
+			pStep->pCursor = pNode->pPrev; /* Reverse link */
 			if( (pStep->iFlags & PH7_4EACH_STEP_KEY) && SyStringLength(&pInfo->sKey) > 0 ){
 				ph7_value *pKey = VmExtractMemObj(&(*pVm),&pInfo->sKey,FALSE,TRUE);
 				if( pKey ){

--- a/tests/ph7/001-smoke/array/array_cursor_unset.phpt
+++ b/tests/ph7/001-smoke/array/array_cursor_unset.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Array cursor unset operation
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 // Test array cursor operations to cover hashmap edge cases
@@ -31,7 +29,7 @@ echo "Current after unset: " . current($arr) . "\n";
 --EXPECT--
 Current before unset: 2
 Array after unset: a => 1 c => 3 
-Current after unset: 1
+Current after unset: 3
 --CLEAN--
 <?php
 unset($arr, $current);

--- a/tests/ph7/001-smoke/array/foreach_byref_live_array.phpt
+++ b/tests/ph7/001-smoke/array/foreach_byref_live_array.phpt
@@ -1,0 +1,97 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+foreach by reference iterates the live array; by value iterates a snapshot
+--FILE--
+<?php
+// By reference: appends made inside the body ARE visited (live array).
+$a = [1, 2];
+foreach ($a as &$v) {
+    echo $v, ",";
+    if ($v < 5) {
+        $a[] = $v + 10;
+    }
+}
+unset($v);
+echo count($a), "\n";
+
+// By reference: deleting an upcoming element skips it.
+$b = [1, 2, 3];
+foreach ($b as &$w) {
+    echo $w, ",";
+    unset($b[2]);
+}
+unset($w);
+echo count($b), "\n";
+
+// By reference: deleting the current and the next element mid-loop.
+$c = [1, 2, 3, 4];
+foreach ($c as $k => &$u) {
+    echo $k, ":", $u, ",";
+    if ($k == 1) {
+        unset($c[1]);
+        unset($c[2]);
+    }
+}
+unset($u);
+echo implode("/", array_keys($c)), "\n";
+
+// A pre-existing value copy is protected from by-ref loop writes.
+$d = [1, 2];
+$e = $d;
+foreach ($d as &$t) {
+    $t *= 10;
+}
+unset($t);
+echo implode(",", $d), " ", implode(",", $e), "\n";
+
+// By reference: an element appended while the loop stands on the LAST
+// element is still visited (worklist idiom).
+$g = [1, 2];
+$out = "";
+foreach ($g as &$s) {
+    $out .= $s . ",";
+    if ($s == 2) {
+        $g[] = 3;
+    }
+}
+unset($s);
+echo $out, "|", count($g), "\n";
+
+// By reference: delete-current-then-append keeps the loop alive through an
+// empty array (php visits every appended element).
+$h = [1];
+$n = 0;
+foreach ($h as $k => &$r) {
+    $keep = $r;
+    echo $k, "=", $keep, ",";
+    unset($h[$k]);
+    if ($n++ < 3) {
+        $h[] = $keep + 10;
+    }
+}
+unset($r);
+echo count($h), "\n";
+
+// By value: the loop iterates a snapshot — appends are NOT visited.
+$f = [1, 2];
+foreach ($f as $x) {
+    echo $x, ",";
+    if ($x < 5) {
+        $f[] = $x + 10;
+    }
+}
+echo count($f), "\n";
+?>
+--EXPECT--
+1,2,11,12,4
+1,2,2
+0:1,1:2,3:4,0/3
+10,20 1,2
+1,2,3,|3
+0=1,1=11,2=21,3=31,0
+1,2,4
+--CLEAN--
+<?php
+unset($a, $b, $c, $d, $e, $f, $g, $h, $k, $keep, $n, $out, $x);

--- a/tests/ph7/001-smoke/array/foreach_nested_same_array.phpt
+++ b/tests/ph7/001-smoke/array/foreach_nested_same_array.phpt
@@ -1,0 +1,55 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Nested foreach over the same array iterate independently (php: each loop has its own position)
+--FILE--
+<?php
+// Regression: the inner loop used to rewind a cursor shared with the outer
+// loop, re-yielding index 0 forever (silent infinite loop).
+$a = [1, 2];
+foreach ($a as $i => $x) {
+    foreach ($a as $y) {
+        echo $y;
+    }
+    echo "|", $i, ";";
+}
+echo "\n";
+
+// Triple nesting
+$b = ['x', 'y'];
+foreach ($b as $p) {
+    foreach ($b as $q) {
+        foreach ($b as $r) {
+            echo $r;
+        }
+        echo ",";
+    }
+    echo ";";
+}
+echo "\n";
+
+// Keyed inner + outer over the same map with string keys
+$m = ['a' => 1, 'b' => 2];
+foreach ($m as $k1 => $v1) {
+    foreach ($m as $k2 => $v2) {
+        echo $k1, $k2, ":";
+    }
+}
+echo "\n";
+
+// foreach does not move the internal array pointer (php 8)
+$c = [10, 20, 30];
+next($c);
+foreach ($c as $unused) {
+}
+echo current($c), "\n";
+?>
+--EXPECT--
+12|0;12|1;
+xy,xy,;xy,xy,;
+aa:ab:ba:bb:
+20
+--CLEAN--
+<?php
+unset($a, $b, $c, $m, $i, $x, $y, $p, $q, $r, $k1, $v1, $k2, $v2, $unused);

--- a/tests/ph7/002-integration/array/foreach_byref_alias_cow.phpt
+++ b/tests/ph7/002-integration/array/foreach_byref_alias_cow.phpt
@@ -1,0 +1,29 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Value alias taken INSIDE a by-ref foreach: PHL's COW hands the writer a fresh map, detaching the loop (php follows the variable live — divergence recorded in NEWPLAN.md §7)
+--SKIPIF--
+<?php
+if (function_exists('zend_version')) {
+    echo "skip PHL-pinned half of the twin pair";
+}
+?>
+--FILE--
+<?php
+$a = [1, 2];
+foreach ($a as &$v) {
+    if ($v == 1) {
+        $b = $a;
+        $a[] = 3;
+    }
+    $v *= 100;
+}
+unset($v);
+echo implode(",", $a), " | ", implode(",", $b), "\n";
+?>
+--EXPECT--
+1,2,3 | 100,200
+--CLEAN--
+<?php
+unset($a, $b);

--- a/tests/ph7/002-integration/array/foreach_byref_alias_cow_zend.phpt
+++ b/tests/ph7/002-integration/array/foreach_byref_alias_cow_zend.phpt
@@ -1,0 +1,29 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Value alias taken INSIDE a by-ref foreach: php's by-ref loop follows $a live and the alias shares the current element's reference (zend half of the twin pair — NEWPLAN.md §7)
+--SKIPIF--
+<?php
+if (!function_exists('zend_version')) {
+    echo "skip zend-pinned half of the twin pair";
+}
+?>
+--FILE--
+<?php
+$a = [1, 2];
+foreach ($a as &$v) {
+    if ($v == 1) {
+        $b = $a;
+        $a[] = 3;
+    }
+    $v *= 100;
+}
+unset($v);
+echo implode(",", $a), " | ", implode(",", $b), "\n";
+?>
+--EXPECT--
+100,200,300 | 100,2
+--CLEAN--
+<?php
+unset($a, $b);

--- a/tests/ph7/002-integration/array/foreach_byref_array_erase.phpt
+++ b/tests/ph7/002-integration/array/foreach_byref_array_erase.phpt
@@ -1,0 +1,44 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+array_erase() on the live map of a by-ref foreach ends the loop cleanly (regression: dangling private cursor read freed nodes); a fresh insert resumes it
+--SKIPIF--
+<?php
+if (function_exists('zend_version')) {
+    echo "skip array_erase is a PHL extension (documented PH7-ism, NEWPLAN.md §10)";
+}
+?>
+--FILE--
+<?php
+// The CowSeparate by-ref discount keeps the loop's map writable, so
+// array_erase() guts the very map the cursor walks. The Release-time
+// cursor parking must end the loop instead of reading freed nodes.
+$a = [1, 2, 3];
+foreach ($a as &$v) {
+    echo $v, ",";
+    array_erase($a);
+}
+unset($v);
+echo "end,", count($a), "\n";
+
+// Erase then insert inside the body: the link-time re-arm resumes the loop
+// on the fresh element (live-array semantics), bounded here by the counter.
+$b = [1, 2, 3];
+$n = 0;
+foreach ($b as &$w) {
+    echo $w, ",";
+    array_erase($b);
+    if ($n++ < 2) {
+        $b[] = 99;
+    }
+}
+unset($w);
+echo "end,", count($b), "\n";
+?>
+--EXPECT--
+1,end,0
+1,99,99,end,0
+--CLEAN--
+<?php
+unset($a, $b, $n);


### PR DESCRIPTION
…ve array

Nested foreach over the same array looped forever: every hashmap foreach iterated via the map's single internal cursor, so the inner loop's reset rewound the outer loop's position. Each ph7_foreach_step now owns a private cursor and registers on the map's active-step list; PH7_HashmapUnlinkNode advances any registered cursor parked on a dying node, HashmapNodeLink re-arms cursors parked past the end (php's live worklist semantics: appends made while the loop stands on the last element, or after the body emptied the map, are still visited), and PH7_HashmapRelease parks cursors before bulk-freeing nodes (array_erase on the live map of a by-ref loop no longer leaves a dangling cursor). foreach no longer touches the internal array pointer, matching php 8.

By-ref foreach now iterates the LIVE array like php: PH7_HashmapCowSeparate discounts references held by by-ref steps (by-value steps still count — that retain is exactly php's iterate-a-snapshot semantic), so in-loop appends are visited and deletes are skipped instead of the loop silently detaching onto a stale copy. The discounted-sharers invariant is documented on iRef.

Accepted divergences pinned and recorded: a value alias taken inside a by-ref loop detaches the loop from its source variable (twin pair foreach_byref_alias_cow{,_zend}.phpt); in-place sort under a live by-ref cursor visits node order, not php's positional order.
