### PR TITLE
Throw ArgumentCountError when a user function gets too few arguments

### DIFF
--- a/build-aux/install_php.bat
+++ b/build-aux/install_php.bat
@@ -2,40 +2,30 @@
 :: SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 :: SPDX-License-Identifier: BSD-3-Clause
 
-:: Script to download and install the latest Windows PHP release
+:: Download the Windows PHP build used as the cross-check oracle for test-compat.
+:: The exact patch filename is resolved from windows.php.net's releases.json at run
+:: time, so it never 404s when a release rotates from /releases/ into the archive.
+:: Usage: install_php.bat [branch]   (branch defaults to 8.5 to match the corpus)
 
-set "PHP_VERSION=8.4.16"
-set "PHP_ZIP=php-%PHP_VERSION%-nts-Win32-vs17-x64.zip"
-set "PHP_DIR=%~dp0\..\php"
-set "URL=https://windows.php.net/downloads/releases/%PHP_ZIP%"
-
+setlocal
+set "PHP_BRANCH=%~1"
+if "%PHP_BRANCH%"=="" set "PHP_BRANCH=8.5"
+set "PHP_DIR=%~dp0..\php"
 
 if exist "%PHP_DIR%\php.exe" (
     echo PHP is already installed in: %PHP_DIR%
+    "%PHP_DIR%\php.exe" --version
     exit /b 0
 )
 
-if exist "%PHP_ZIP%" (
-    echo PHP zip already exists, skipping download.
-) else (
-    echo Downloading PHP %PHP_VERSION%...
-    powershell -Command "Invoke-WebRequest -Uri '%URL%' -OutFile '%PHP_ZIP%'"
-
-    if %errorlevel% neq 0 (
-        echo Failed to download PHP.
-        exit /b 1
-    )
-)
-
-echo Extracting PHP...
-powershell -Command "Expand-Archive -Path '%PHP_ZIP%' -DestinationPath '%PHP_DIR%' -Force"
-
+echo Resolving latest %PHP_BRANCH% NTS x64 build from windows.php.net...
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference='Stop'; $b='%PHP_BRANCH%'; $dir='%PHP_DIR%'; $j=Invoke-RestMethod 'https://windows.php.net/downloads/releases/releases.json'; $v=$j.$b; if(-not $v){throw \"no releases for branch $b\"}; $p=$v.PSObject.Properties | Where-Object { $_.Name -match 'nts-vs\d+-x64' } | Select-Object -First 1; if(-not $p){throw \"no NTS x64 build for $b\"}; $zip=$p.Value.zip.path; $url='https://windows.php.net/downloads/releases/'+$zip; Write-Host \"Downloading $url\"; Invoke-WebRequest -Uri $url -OutFile $zip; if(Test-Path $dir){Remove-Item -Recurse -Force $dir}; Expand-Archive -Path $zip -DestinationPath $dir -Force; if(-not (Test-Path (Join-Path $dir 'php.exe'))){throw 'php.exe missing after extract'}"
 if %errorlevel% neq 0 (
-    echo Failed to extract PHP.
+    echo Failed to install PHP.
     exit /b 1
 )
 
-move "%PHP_DIR%\php-win.exe" "%PHP_DIR%\php.exe"
-
-echo PHP installed successfully in: %PHP_DIR%
-echo PHP executable: %PHP_DIR%\php.exe
+echo.
+echo PHP oracle installed in: %PHP_DIR%
+"%PHP_DIR%\php.exe" --version
+endlocal

--- a/build-aux/nmake.mk
+++ b/build-aux/nmake.mk
@@ -21,8 +21,13 @@ VCPKG_INSTALLED = C:\vcpkg\installed\x64-windows-static
 PCRE2_CFLAGS = /I "$(VCPKG_INSTALLED)\include"
 PCRE2_LIBS = "$(VCPKG_INSTALLED)\lib\pcre2-8.lib"
 
-# Base flags shared by all modes
-BASE_CFLAGS = /nologo /I src /I src/sx /I src/ph7 /W4 /WX
+# Base flags shared by all modes.
+# /wd4127 (constant conditional) and /wd4702 (unreachable code) are noisy MSVC
+# warnings that this SQLite/PH7-lineage code triggers legitimately (parameterized
+# macros with constant args; branches an aggressive optimizer proves dead). Newer
+# MSVC toolsets flag them under /WX where older ones did not; disable them the way
+# SQLite itself does, rather than distort the extracted VM code.
+BASE_CFLAGS = /nologo /I src /I src/sx /I src/ph7 /W4 /WX /wd4127 /wd4702
 
 # Per-mode CFLAGS (used by patterns.mk generated rules)
 full_CFLAGS = $(BASE_CFLAGS) /Ox $(full_DEFINES:-=/) $(full_EXTRA_CFLAGS) /Fd$(BUILD_DIR:/=\)\ph7.pdb

--- a/src/ph7/vfs_win.c
+++ b/src/ph7/vfs_win.c
@@ -15,6 +15,8 @@
 #include <stdio.h> /* For popen/pclose pipe stream support */
 #include <io.h>    /* For _open_osfhandle, _close */
 #include <fcntl.h> /* For _O_RDONLY, _O_WRONLY, _O_TEXT */
+#include <sys/stat.h> /* For _wchmod and the _S_IREAD/_S_IWRITE mode bits */
+#include <errno.h> /* For mapping GetLastError() to a POSIX errno */
 /* SPDX-SnippetBegin */
 /* SPDX-SnippetCopyrightText: D. Richard Hipp and the SQLite authors <https://sqlite.org/> */
 /* SPDX-License-Identifier: blessing */
@@ -77,6 +79,47 @@ static char *unicodeToUtf8(const WCHAR *zWideFilename){
   return zFilename;
 }
 /* SPDX-SnippetEnd */
+/* Map the most recent Win32 error to a POSIX errno, so the shared IO-failure
+ * reporting (which formats strerror(errno), php-style) yields real text on
+ * Windows — the Win32 API sets GetLastError() rather than errno. Call this right
+ * after the failing API, before any HeapFree/CloseHandle that could reset it. */
+static void WinVfsMapErrno(void)
+{
+	switch( GetLastError() ){
+		case ERROR_FILE_NOT_FOUND:
+		case ERROR_PATH_NOT_FOUND:
+		case ERROR_INVALID_NAME:      errno = ENOENT; break;
+		case ERROR_ACCESS_DENIED:
+		case ERROR_SHARING_VIOLATION:
+		case ERROR_LOCK_VIOLATION:    errno = EACCES; break;
+		case ERROR_FILE_EXISTS:
+		case ERROR_ALREADY_EXISTS:    errno = EEXIST; break;
+		case ERROR_DIR_NOT_EMPTY:     errno = ENOTEMPTY; break;
+		default:                      errno = EIO; break;
+	}
+}
+/* php's file:// is the default local-file wrapper: a stat-family builtin given
+ * "file://[authority]/path" acts on the plain path. On Windows php also accepts
+ * a drive path after the scheme, so strip "file://", an optional "localhost"
+ * authority, and a slash sitting in front of a "X:" drive (file:///C:/x). The
+ * native calls do not understand the scheme; anything unrecognised is returned
+ * intact so the call fails exactly as php does. */
+static const char * WinVfsLocalPath(const char *zPath)
+{
+	const char *zRest;
+	if( zPath == 0 || SyStrnicmp(zPath,"file://",sizeof("file://")-1) != 0 ){
+		return zPath;
+	}
+	zRest = &zPath[sizeof("file://")-1];
+	if( SyStrnicmp(zRest,"localhost/",sizeof("localhost/")-1) == 0 ){
+		zRest = &zRest[sizeof("localhost")-1]; /* keep the leading slash */
+	}
+	if( zRest[0] == '/' && zRest[1] != 0 && zRest[2] == ':' ){
+		/* file:///C:/path or file://localhost/C:/path -> C:/path */
+		return &zRest[1];
+	}
+	return zRest;
+}
 /* int (*xchdir)(const char *) */
 static int WinVfs_chdir(const char *zPath)
 {
@@ -87,6 +130,7 @@ static int WinVfs_chdir(const char *zPath)
 		return -1;
 	}
 	rc = SetCurrentDirectoryW((LPCWSTR)pConverted);
+	if( !rc ){ WinVfsMapErrno(); }
 	HeapFree(GetProcessHeap(),0,pConverted);
 	return rc ? PH7_OK : -1;
 }
@@ -121,6 +165,7 @@ static int WinVfs_mkdir(const char *zPath,int mode,int recursive)
 	mode= 0; /* MSVC warning */
 	recursive = 0;
 	rc = CreateDirectoryW((LPCWSTR)pConverted,0);
+	if( !rc ){ WinVfsMapErrno(); }
 	HeapFree(GetProcessHeap(),0,pConverted);
 	return rc ? PH7_OK : -1;
 }
@@ -134,12 +179,14 @@ static int WinVfs_rmdir(const char *zPath)
 		return -1;
 	}
 	rc = RemoveDirectoryW((LPCWSTR)pConverted);
+	if( !rc ){ WinVfsMapErrno(); }
 	HeapFree(GetProcessHeap(),0,pConverted);
 	return rc ? PH7_OK : -1;
 }
 /* int (*xIsdir)(const char *) */
 static int WinVfs_isdir(const char *zPath)
 {
+	zPath = WinVfsLocalPath(zPath);
 	void * pConverted;
 	DWORD dwAttr;
 	pConverted = convertUtf8Filename(zPath);
@@ -166,6 +213,7 @@ static int WinVfs_Rename(const char *zOld,const char *zNew)
 	if( pNew  ){
 		rc = MoveFileW((LPCWSTR)pOld,(LPCWSTR)pNew);
 	}
+	if( !rc ){ WinVfsMapErrno(); }
 	HeapFree(GetProcessHeap(),0,pOld);
 	if( pNew ){
 		HeapFree(GetProcessHeap(),0,pNew);
@@ -218,8 +266,25 @@ static int WinVfs_unlink(const char *zPath)
 		return -1;
 	}
 	rc = DeleteFileW((LPCWSTR)pConverted);
+	if( !rc ){ WinVfsMapErrno(); }
 	HeapFree(GetProcessHeap(),0,pConverted);
 	return rc ? PH7_OK : - 1;
+}
+/* int (*xChmod)(const char *,int) */
+static int WinVfs_chmod(const char *zPath,int mode)
+{
+	void * pConverted;
+	int rc;
+	pConverted = convertUtf8Filename(zPath);
+	if( pConverted == 0 ){
+		return -1;
+	}
+	/* Windows honors only the read-only attribute: a set owner-write bit (0200)
+	 * clears it, otherwise the file is made read-only. This mirrors php, whose
+	 * chmod() on Windows likewise maps through _wchmod and returns success. */
+	rc = _wchmod((const wchar_t *)pConverted,(mode & 0200) ? (_S_IREAD|_S_IWRITE) : _S_IREAD);
+	HeapFree(GetProcessHeap(),0,pConverted);
+	return rc == 0 ? PH7_OK : - 1;
 }
 /* ph7_int64 (*xFreeSpace)(const char *) */
 static ph7_int64 WinVfs_DiskFreeSpace(const char *zPath)
@@ -284,6 +349,7 @@ static ph7_int64 WinVfs_DiskTotalSpace(const char *zPath)
 /* int (*xFileExists)(const char *) */
 static int WinVfs_FileExists(const char *zPath)
 {
+	zPath = WinVfsLocalPath(zPath);
 	void * pConverted;
 	DWORD dwAttr;
 	pConverted = convertUtf8Filename(zPath);
@@ -314,6 +380,7 @@ static HANDLE OpenReadOnly(LPCWSTR pPath)
 /* ph7_int64 (*xFileSize)(const char *) */
 static ph7_int64 WinVfs_FileSize(const char *zPath)
 {
+	zPath = WinVfsLocalPath(zPath);
 	DWORD dwLow,dwHigh;
 	void * pConverted;
 	ph7_int64 nSize;
@@ -393,6 +460,7 @@ static int WinVfs_Touch(const char *zPath,ph7_int64 touch_time,ph7_int64 access_
 /* ph7_int64 (*xFileAtime)(const char *) */
 static ph7_int64 WinVfs_FileAtime(const char *zPath)
 {
+	zPath = WinVfsLocalPath(zPath);
 	BY_HANDLE_FILE_INFORMATION sInfo;
 	void * pConverted;
 	ph7_int64 atime;
@@ -421,6 +489,7 @@ static ph7_int64 WinVfs_FileAtime(const char *zPath)
 /* ph7_int64 (*xFileMtime)(const char *) */
 static ph7_int64 WinVfs_FileMtime(const char *zPath)
 {
+	zPath = WinVfsLocalPath(zPath);
 	BY_HANDLE_FILE_INFORMATION sInfo;
 	void * pConverted;
 	ph7_int64 mtime;
@@ -449,6 +518,7 @@ static ph7_int64 WinVfs_FileMtime(const char *zPath)
 /* ph7_int64 (*xFileCtime)(const char *) */
 static ph7_int64 WinVfs_FileCtime(const char *zPath)
 {
+	zPath = WinVfsLocalPath(zPath);
 	BY_HANDLE_FILE_INFORMATION sInfo;
 	void * pConverted;
 	ph7_int64 ctime;
@@ -478,6 +548,7 @@ static ph7_int64 WinVfs_FileCtime(const char *zPath)
 /* int (*xlStat)(const char *,ph7_value *,ph7_value *) */
 static int WinVfs_Stat(const char *zPath,ph7_value *pArray,ph7_value *pWorker)
 {
+	zPath = WinVfsLocalPath(zPath);
 	BY_HANDLE_FILE_INFORMATION sInfo;
 	void *pConverted;
 	HANDLE pHandle;
@@ -535,6 +606,7 @@ static int WinVfs_Stat(const char *zPath,ph7_value *pArray,ph7_value *pWorker)
 /* int (*xIsfile)(const char *) */
 static int WinVfs_isfile(const char *zPath)
 {
+	zPath = WinVfsLocalPath(zPath);
 	void * pConverted;
 	DWORD dwAttr;
 	pConverted = convertUtf8Filename(zPath);
@@ -551,6 +623,7 @@ static int WinVfs_isfile(const char *zPath)
 /* int (*xIslink)(const char *) */
 static int WinVfs_islink(const char *zPath)
 {
+	zPath = WinVfsLocalPath(zPath);
 	void * pConverted;
 	DWORD dwAttr;
 	pConverted = convertUtf8Filename(zPath);
@@ -567,6 +640,7 @@ static int WinVfs_islink(const char *zPath)
 /* int (*xWritable)(const char *) */
 static int WinVfs_iswritable(const char *zPath)
 {
+	zPath = WinVfsLocalPath(zPath);
 	void * pConverted;
 	DWORD dwAttr;
 	pConverted = convertUtf8Filename(zPath);
@@ -592,6 +666,7 @@ static int WinVfs_iswritable(const char *zPath)
 /* int (*xExecutable)(const char *) */
 static int WinVfs_isexecutable(const char *zPath)
 {
+	zPath = WinVfsLocalPath(zPath);
 	void * pConverted;
 	DWORD dwAttr;
 	pConverted = convertUtf8Filename(zPath);
@@ -613,6 +688,7 @@ static int WinVfs_isexecutable(const char *zPath)
 /* int (*xFiletype)(const char *,ph7_context *) */
 static int WinVfs_Filetype(const char *zPath,ph7_context *pCtx)
 {
+	zPath = WinVfsLocalPath(zPath);
 	void * pConverted;
 	DWORD dwAttr;
 	pConverted = convertUtf8Filename(zPath);
@@ -760,12 +836,72 @@ static void WinVfs_Username(ph7_context *pCtx)
 	}
 
 }
+/* int (*xChroot)(const char *) — Windows has no chroot; fail cleanly so chroot()
+ * returns false. (php has no chroot symbol at all; PHL exposes it as an extension
+ * and this reports the failure without a "not implemented in the VFS" warning.) */
+static int WinVfs_chroot(const char *zPath)
+{
+	(void)zPath;
+	return -1;
+}
+#ifndef SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE
+#define SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE 0x2
+#endif
+#ifndef SYMBOLIC_LINK_FLAG_DIRECTORY
+#define SYMBOLIC_LINK_FLAG_DIRECTORY 0x1
+#endif
+/* int (*xLink)(const char *,const char *,int) — hard link (iSym==0) via
+ * CreateHardLink or symbolic link (iSym!=0) via CreateSymbolicLink, mirroring
+ * php on Windows. Developer-mode symlink creation is allowed. */
+static int WinVfs_Link(const char *zOld,const char *zNew,int iSym)
+{
+	void *pOld, *pNew;
+	BOOL rc;
+	pOld = convertUtf8Filename(zOld);
+	if( pOld == 0 ){
+		return -1;
+	}
+	pNew = convertUtf8Filename(zNew);
+	if( pNew == 0 ){
+		HeapFree(GetProcessHeap(),0,pOld);
+		return -1;
+	}
+	if( iSym ){
+		DWORD dwFlags = SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE;
+		DWORD attr = GetFileAttributesW((LPCWSTR)pOld);
+		if( attr != INVALID_FILE_ATTRIBUTES && (attr & FILE_ATTRIBUTE_DIRECTORY) ){
+			dwFlags |= SYMBOLIC_LINK_FLAG_DIRECTORY;
+		}
+		rc = CreateSymbolicLinkW((LPCWSTR)pNew,(LPCWSTR)pOld,dwFlags) ? TRUE : FALSE;
+	}else{
+		rc = CreateHardLinkW((LPCWSTR)pNew,(LPCWSTR)pOld,0);
+	}
+	HeapFree(GetProcessHeap(),0,pNew);
+	HeapFree(GetProcessHeap(),0,pOld);
+	return rc ? PH7_OK : -1;
+}
+/* int (*xUmask)(int) — Windows has no umask; php's umask() returns 0 there. */
+static int WinVfs_Umask(int iMask)
+{
+	(void)iMask;
+	return 0;
+}
+/* int (*xUid)(void) / int (*xGid)(void) — no uid/gid on Windows; php's
+ * getmyuid()/getmygid() both return 0. */
+static int WinVfs_Uid(void)
+{
+	return 0;
+}
+static int WinVfs_Gid(void)
+{
+	return 0;
+}
 /* Export the windows vfs */
 PH7_PRIVATE const ph7_vfs sWinVfs = {
 	"Windows_vfs",
 	PH7_VFS_VERSION,
 	WinVfs_chdir,    /* int (*xChdir)(const char *) */
-	0,               /* int (*xChroot)(const char *); */
+	WinVfs_chroot,   /* int (*xChroot)(const char *); */
 	WinVfs_getcwd,   /* int (*xGetcwd)(ph7_context *) */
 	WinVfs_mkdir,    /* int (*xMkdir)(const char *,int,int) */
 	WinVfs_rmdir,    /* int (*xRmdir)(const char *) */
@@ -775,7 +911,7 @@ PH7_PRIVATE const ph7_vfs sWinVfs = {
 	WinVfs_Sleep,               /* int (*xSleep)(unsigned int) */
 	WinVfs_unlink,   /* int (*xUnlink)(const char *) */
 	WinVfs_FileExists, /* int (*xFileExists)(const char *) */
-	0, /*int (*xChmod)(const char *,int)*/
+	WinVfs_chmod, /*int (*xChmod)(const char *,int)*/
 	0, /*int (*xChown)(const char *,const char *)*/
 	0, /*int (*xChgrp)(const char *,const char *)*/
 	WinVfs_DiskFreeSpace,/* ph7_int64 (*xFreeSpace)(const char *) */
@@ -797,12 +933,12 @@ PH7_PRIVATE const ph7_vfs sWinVfs = {
 	WinVfs_Touch,      /* int (*xTouch)(const char *,ph7_int64,ph7_int64) */
 	WinVfs_Mmap,       /* int (*xMmap)(const char *,void **,ph7_int64 *) */
 	WinVfs_Unmap,      /* void (*xUnmap)(void *,ph7_int64);  */
-	0,                 /* int (*xLink)(const char *,const char *,int) */
-	0,                 /* int (*xUmask)(int) */
+	WinVfs_Link,       /* int (*xLink)(const char *,const char *,int) */
+	WinVfs_Umask,      /* int (*xUmask)(int) */
 	WinVfs_TempDir,    /* void (*xTempDir)(ph7_context *) */
 	WinVfs_ProcessId,  /* unsigned int (*xProcessId)(void) */
-	0, /* int (*xUid)(void) */
-	0, /* int (*xGid)(void) */
+	WinVfs_Uid, /* int (*xUid)(void) */
+	WinVfs_Gid, /* int (*xGid)(void) */
 	WinVfs_Username,    /* void (*xUsername)(ph7_context *) */
 	0 /* int (*xExec)(const char *,ph7_context *) */
 };
@@ -947,28 +1083,17 @@ static int WinDir_Read(void *pUserData,ph7_context *pCtx)
 	LPWIN32_FIND_DATAW pData;
 	char *zName;
 	BOOL rc;
-	sxu32 n;
 	if( pDirInfo->rc != SXRET_OK ){
 		/* No more entry to process */
 		return -1;
 	}
 	pData = &pDirInfo->sInfo;
-	for(;;){
-		zName = unicodeToUtf8(pData->cFileName);
-		if( zName == 0 ){
-			/* Out of memory */
-			return -1;
-		}
-		n = SyStrlen(zName);
-		/* Ignore '.' && '..' */
-		if( n > sizeof("..")-1 || zName[0] != '.' || ( n == sizeof("..")-1 && zName[1] != '.') ){
-			break;
-		}
-		HeapFree(GetProcessHeap(),0,zName);
-		rc = FindNextFileW(pDirInfo->pDirHandle,&pDirInfo->sInfo);
-		if( !rc ){
-			return -1;
-		}
+	/* php parity: readdir()/scandir() include the '.' and '..' entries, so unlike
+	 * the historical PH7 behaviour we return them instead of skipping. */
+	zName = unicodeToUtf8(pData->cFileName);
+	if( zName == 0 ){
+		/* Out of memory */
+		return -1;
 	}
 	/* Return the current file name */
 	ph7_result_string(pCtx,zName,-1);
@@ -1021,7 +1146,9 @@ static ph7_int64 WinFile_Write(void *pOS,const void *pBuffer,ph7_int64 nWrite)
 		}
 		rc = WriteFile(pHandle,zData,(DWORD)nWrite,&nWr,0);
 		if( !rc ){
-			/* IO error */
+			/* IO error — surface a POSIX errno for the caller's diagnostic
+			 * (e.g. a byte-range lock violation reports EACCES like php). */
+			WinVfsMapErrno();
 			break;
 		}
 		nWrite -= nWr;
@@ -1062,22 +1189,22 @@ static int WinFile_Seek(void *pUserData,ph7_int64 iOfft,int whence)
 static int WinFile_Lock(void *pUserData,int lock_type)
 {
 	HANDLE pHandle = (HANDLE)pUserData;
-	static DWORD dwLo = 0,dwHi = 0; /* xx: MT-SAFE */
 	OVERLAPPED sDummy;
 	BOOL rc;
 	SyZero(&sDummy,sizeof(sDummy));
-	/* Get the file size */
+	/* Lock/unlock the whole file. php locks the maximal byte range, so the lock
+	 * is effective even for an empty or freshly-truncated file — the previous
+	 * code locked only GetFileSize() bytes (i.e. nothing for a 0-byte file). */
 	if( lock_type < 1 ){
 		/* Unlock the file */
-		rc = UnlockFileEx(pHandle,0,dwLo,dwHi,&sDummy);
+		rc = UnlockFileEx(pHandle,0,0xFFFFFFFF,0xFFFFFFFF,&sDummy);
 	}else{
 		DWORD dwFlags = LOCKFILE_FAIL_IMMEDIATELY; /* Shared non-blocking lock by default*/
 		/* Lock the file */
 		if( lock_type == 1 /* LOCK_EXCL */ ){
 			dwFlags |= LOCKFILE_EXCLUSIVE_LOCK;
 		}
-		dwLo = GetFileSize(pHandle,&dwHi);
-		rc = LockFileEx(pHandle,dwFlags,0,dwLo,dwHi,&sDummy);
+		rc = LockFileEx(pHandle,dwFlags,0,0xFFFFFFFF,0xFFFFFFFF,&sDummy);
 	}
 	return rc ? PH7_OK : -1 /* Lock error */;
 }

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -1864,7 +1864,7 @@ static ph7_class_instance * VmFccWrapValue(ph7_vm *pVm, ph7_value *pValue);
 static sxi32 VmIterCallMethod(ph7_vm *pVm,ph7_class_instance *pThis,const char *zName,sxu32 nLen,ph7_value *pResult);
 static sxi32 VmFiberSetupFrame(ph7_vm *pVm, ph7_exec_ctx *pExecCtx,
 	ph7_class_instance *pClosureThis, int nArg, ph7_value **apArg,
-	int bStrict, ph7_class *pSelfHint);
+	int bStrict, ph7_class *pSelfHint, int bCallSiteInMsg);
 static void VmBoundaryPark(ph7_vm *pVm,sxi32 rc);
 static sxi32 VmCallClassMethodWithMap(ph7_vm *pVm, ph7_class_instance *pThis,
 	ph7_class_method *pMethod, ph7_value *pResult, int nArg,
@@ -6030,6 +6030,110 @@ static sxi32 VmThrowTypeErrorForArg(ph7_vm *pVm,ph7_class *pOwnerClass,SyString 
 		return PH7_ABORT;
 	}
 	return PH7_EXCEPTION;
+}
+/*
+ * Count php's REQUIRED arity for a user function: formals up to and including
+ * the LAST one with no default value (php 8 treats an optional declared
+ * before a required parameter as implicitly required), excluding a trailing
+ * variadic. Also reports the total non-variadic formal count so callers can
+ * pick php's wording — "exactly N expected" when required == total,
+ * "at least N" when trailing optionals exist.
+ */
+static sxu32 VmFuncRequiredArgCount(ph7_vm_func *pFunc,sxu32 *pnNonVariadic)
+{
+	ph7_vm_func_arg *aFormal = (ph7_vm_func_arg *)SySetBasePtr(&pFunc->aArgs);
+	sxu32 nFormal = SySetUsed(&pFunc->aArgs);
+	sxu32 nRequired = 0;
+	sxu32 n;
+	if( nFormal > 0 && (aFormal[nFormal - 1].iFlags & VM_FUNC_ARG_VARIADIC) ){
+		nFormal--;
+	}
+	for( n = 0 ; n < nFormal ; ++n ){
+		if( SySetUsed(&aFormal[n].aByteCode) < 1 ){
+			nRequired = n + 1;
+		}
+	}
+	*pnNonVariadic = nFormal;
+	return nRequired;
+}
+/*
+ * Throw php's catchable ArgumentCountError for a user function/method called
+ * with too few arguments:
+ *   Too few arguments to function C::f(), N passed in FILE on line L and
+ *   {exactly|at least} M expected
+ * php embeds the CALL SITE's file+line mid-message; VmInstr carries no line
+ * info yet (the runtime line-tracking gate, NEWPLAN §6), so the line is a
+ * fixed 1 — the SHAPE stays php-exact for --EXPECTF-- tests and self-heals
+ * when line tracking lands. bCallSite=FALSE omits the segment entirely,
+ * matching php for Fiber::start() (no userland call site in the message).
+ */
+static sxi32 VmThrowTooFewArgs(ph7_vm *pVm,ph7_class *pOwnerClass,SyString *pFuncName,
+	sxu32 nPassed,sxu32 nRequired,sxu32 nNonVariadic,int bCallSite)
+{
+	static const SyString sUnknown = { "unknown", sizeof("unknown") - 1 };
+	SyBlob sMsg;
+	SyBlobInit(&sMsg,&pVm->sAllocator);
+	if( pOwnerClass ){
+		SyBlobFormat(&sMsg,"Too few arguments to function %z::%z(), %u passed",
+			&pOwnerClass->sName,pFuncName,nPassed);
+	}else{
+		SyBlobFormat(&sMsg,"Too few arguments to function %z(), %u passed",pFuncName,nPassed);
+	}
+	if( bCallSite ){
+		const SyString *pFile = (const SyString *)SySetPeek(&pVm->aFiles);
+		SyBlobFormat(&sMsg," in %z on line %d",pFile ? pFile : &sUnknown,1);
+	}
+	SyBlobFormat(&sMsg," and %s %u expected",
+		nRequired >= nNonVariadic ? "exactly" : "at least",nRequired);
+	/* VmThrowBuiltinError consumes (releases) sMsg */
+	return VmThrowBuiltinError(pVm,"ArgumentCountError",sizeof("ArgumentCountError")-1,&sMsg);
+}
+/*
+ * Throw php's ArgumentCountError for an INTERNAL (builtin-chunk) method
+ * called with too few arguments, in php's ZPP wording:
+ *   ReflectionProperty::__construct() expects exactly 2 arguments, 0 given
+ * (php words internal callables this way — no call-site segment, argument(s)
+ * pluralized on the expected count). Hosted builtin FUNCTIONS are not routed
+ * here: their PHL signatures don't always mirror php's true arity (e.g.
+ * array_unshift is (&$pArray)+func_get_args for php's (array, ...$values)),
+ * so their in-body self-checks own the message.
+ */
+static sxi32 VmThrowBuiltinTooFewArgs(ph7_vm *pVm,ph7_class *pOwnerClass,SyString *pFuncName,
+	sxu32 nPassed,sxu32 nRequired,sxu32 nNonVariadic)
+{
+	SyBlob sMsg;
+	const char *zKind = (nRequired >= nNonVariadic) ? "exactly" : "at least";
+	const char *zPlural = (nRequired == 1) ? "" : "s";
+	SyBlobInit(&sMsg,&pVm->sAllocator);
+	if( pOwnerClass ){
+		SyBlobFormat(&sMsg,"%z::%z() expects %s %u argument%s, %u given",
+			&pOwnerClass->sName,pFuncName,zKind,nRequired,zPlural,nPassed);
+	}else{
+		SyBlobFormat(&sMsg,"%z() expects %s %u argument%s, %u given",
+			pFuncName,zKind,nRequired,zPlural,nPassed);
+	}
+	/* VmThrowBuiltinError consumes (releases) sMsg */
+	return VmThrowBuiltinError(pVm,"ArgumentCountError",sizeof("ArgumentCountError")-1,&sMsg);
+}
+/*
+ * Throw php's named-call ArgumentCountError for a required parameter no
+ * named or positional argument resolved to:
+ *   C::f(): Argument #N ($x) not passed
+ * (php's named-hole shape — no file/line or expected-count segment).
+ */
+static sxi32 VmThrowArgNotPassed(ph7_vm *pVm,ph7_class *pOwnerClass,SyString *pFuncName,
+	sxu32 nArg,SyString *pArgName)
+{
+	SyBlob sMsg;
+	SyBlobInit(&sMsg,&pVm->sAllocator);
+	if( pOwnerClass ){
+		SyBlobFormat(&sMsg,"%z::%z(): Argument #%u ($%z) not passed",
+			&pOwnerClass->sName,pFuncName,nArg,pArgName);
+	}else{
+		SyBlobFormat(&sMsg,"%z(): Argument #%u ($%z) not passed",pFuncName,nArg,pArgName);
+	}
+	/* VmThrowBuiltinError consumes (releases) sMsg */
+	return VmThrowBuiltinError(pVm,"ArgumentCountError",sizeof("ArgumentCountError")-1,&sMsg);
 }
 /*
  * Throw a PHP-compatible TypeError describing a return-value type mismatch.
@@ -12739,24 +12843,9 @@ case PH7_OP_NEW: {
 				SySetPut(&aArg,(const void *)&pArg);
 				pArg++;
 			}
-			if( pVm->bErrReport && !(pNewMap && pNewMap->bHasNamed) ){
-				ph7_vm_func_arg *pFuncArg;
-				sxu32 n;
-				n = SySetUsed(&aArg);
-				/* Emit a notice for missing arguments (positional-only:
-				 * for named args the missing-arg check happens downstream
-				 * after resolution). */
-				while( n < SySetUsed(&pCons->sFunc.aArgs) ){
-					pFuncArg = (ph7_vm_func_arg *)SySetAt(&pCons->sFunc.aArgs,n);
-					if( pFuncArg ){
-						if( SySetUsed(&pFuncArg->aByteCode) < 1 ){
-							VmErrorFormat(&(*pVm),PH7_CTX_NOTICE,"Missing constructor argument %u($%z) for class '%z'",
-								n+1,&pFuncArg->sName,&pClass->sName);
-						}
-					}
-					n++;
-				}
-			}
+			/* Too-few-arguments is php's catchable ArgumentCountError, raised
+			 * by the shared OP_CALL install path this ctor call routes through
+			 * (was a PHL-only notice here). */
 			rcCons = VmCallClassMethodWithMap(&(*pVm),pNew,pCons,0,(int)SySetUsed(&aArg),(ph7_value **)SySetBasePtr(&aArg),pNewMap);
 			/* TICKET 1433-52: Unsetting $this in the constructor body */
 			if( pNew->iRef < 1 ){
@@ -13715,6 +13804,55 @@ case PH7_OP_CALL: {
 								SyMemBackendFree(&pVm->sAllocator, apCallArgs);
 								goto Abort;
 							}
+							if( (pVmFunc->iFlags & (VM_FUNC_INTERNAL|VM_FUNC_CLASS_METHOD)) != VM_FUNC_INTERNAL ){
+								/* php's named-hole ArgumentCountError, checked BEFORE
+								 * hole compaction: compacting first would report the
+								 * positional wording with a fictitious count (g(b:2)
+								 * must be `g(): Argument #1 ($a) not passed`, not
+								 * "1 passed"). Implicit-required watermark, like the
+								 * plain-call named path; a hole with NOTHING filled
+								 * above it keeps php's count wording — fall through
+								 * to VmFiberSetupFrame's check (the compacted count
+								 * equals php's num_args there). */
+								sxu32 nNVIgnored,nReqG,gHole,nMaxFilledG = 0;
+								sxi32 iHole = -1;
+								nReqG = VmFuncRequiredArgCount(pVmFunc,&nNVIgnored);
+								for( gHole = 0; gHole < (sxu32)nGenArgs; gHole++ ){
+									if( aGSlot[gHole] >= 0 && (sxu32)(aGSlot[gHole] + 1) > nMaxFilledG ){
+										nMaxFilledG = (sxu32)(aGSlot[gHole] + 1);
+									}
+								}
+								for( gHole = 0; gHole < nReqG && iHole < 0; gHole++ ){
+									sxu32 gj;
+									int bFound = 0;
+									for( gj = 0; gj < (sxu32)nGenArgs; gj++ ){
+										if( aGSlot[gj] == (sxi32)gHole ){ bFound = 1; break; }
+									}
+									if( !bFound && gHole + 1 <= nMaxFilledG ){
+										iHole = (sxi32)gHole;
+									}
+								}
+								if( iHole >= 0 ){
+									rc = VmThrowArgNotPassed(&(*pVm),pSelfHint,&pVmFunc->sName,
+										(sxu32)iHole+1,&aFA[iHole].sName);
+									SyMemBackendFree(&pVm->sAllocator, aGSlot);
+									SyMemBackendFree(&pVm->sAllocator, apCallArgs);
+									if( rc == PH7_ABORT ){
+										goto Abort;
+									}
+									/* Route like the VmFiberSetupFrame throw below */
+									PH7_INLINE_RESUME_BREAK()
+									VmPopOperand(&pTos,nCallArgs + 1);
+									{
+										sxi32 iRpH;
+										if( VmRecordedResume(pVm,&iRpH,sState.pEntryFrame,aInstr) ){
+											pc = iRpH;
+											break;
+										}
+									}
+									goto Exception;
+								}
+							}
 							/* Build apCallArgs in formal-parameter order, then
 							 * append overflow (variadic / positional beyond
 							 * formals) so downstream sees every argument. */
@@ -13770,7 +13908,8 @@ case PH7_OP_CALL: {
 			pExecCtx->pFrame->pParent = pVm->pFrame;
 			pVm->pFrame = pExecCtx->pFrame;
 			rc = VmFiberSetupFrame(pVm, pExecCtx, pThis, nGenArgs, apCallArgs,
-				(pInstr->p3 && ((VmCallArgMap *)pInstr->p3)->bStrict) ? 1 : 0, pSelfHint);
+				(pInstr->p3 && ((VmCallArgMap *)pInstr->p3)->bStrict) ? 1 : 0, pSelfHint,
+				TRUE/*generator: the g(...) call site is in the message*/);
 			pVm->pFrame = pExecCtx->pFrame->pParent;
 			pExecCtx->pFrame->pParent = 0;
 			if( apCallArgs ){
@@ -13944,6 +14083,25 @@ case PH7_OP_CALL: {
 				goto Abort;
 			}
 			/* Pass 2: install arguments into the frame by formal parameter order */
+			{
+			/* php's required watermark for the hole check below (0 disables it
+			 * for hosted builtin FUNCTIONS, which self-manage — hosted-class
+			 * methods and all user code get php's named-hole error), plus the
+			 * highest formal slot an actual resolved to: php words a hole
+			 * BELOW a filled slot `Argument #N ($x) not passed`, but a hole
+			 * with nothing filled above it gets the positional count message
+			 * (zend's RECV arg_num > EX(num_args) distinction). */
+			sxu32 nReqNamed = 0;
+			sxu32 nNVNamed = 0;
+			sxu32 nMaxFilled = 0;
+			if( (pVmFunc->iFlags & (VM_FUNC_INTERNAL|VM_FUNC_CLASS_METHOD)) != VM_FUNC_INTERNAL ){
+				nReqNamed = VmFuncRequiredArgCount(pVmFunc,&nNVNamed);
+				for( i = 0; i < nActual; i++ ){
+					if( aSlot[i] >= 0 && (sxu32)(aSlot[i] + 1) > nMaxFilled ){
+						nMaxFilled = (sxu32)(aSlot[i] + 1);
+					}
+				}
+			}
 			for( n = 0; n < nNonVariadic; n++ ){
 				/* Find the stack arg mapped to formal n */
 				sxi32 iSrc = -1;
@@ -14121,6 +14279,38 @@ case PH7_OP_CALL: {
 					/* Argument was NOT provided — use default or leave unset */
 					if( aFormalArg[n].iFlags & VM_FUNC_ARG_VARIADIC ){
 						/* Should not reach here; variadic handled separately below */
+					}else if( n < nReqNamed ){
+						/* php's implicit-required rule applies to named calls
+						 * too: a hole below the required watermark throws even
+						 * when the formal carries a default — f($a,$b=2,$c)
+						 * called as f(a:1,c:3) is `Argument #2 ($b) not
+						 * passed` (a hole with NO default is always below the
+						 * watermark, so this subsumes the no-default case).
+						 * A hole with nothing filled ABOVE it uses php's
+						 * positional count wording instead. The passed stack
+						 * args were not released yet on this path (that loop
+						 * runs after Pass 2) — release them before the exit. */
+						if( n + 1 > nMaxFilled ){
+							rc = (pVmFunc->iFlags & VM_FUNC_INTERNAL)
+								? VmThrowBuiltinTooFewArgs(&(*pVm),pSelfHint,&pVmFunc->sName,
+									nMaxFilled,nReqNamed,nNVNamed)
+								: VmThrowTooFewArgs(&(*pVm),pSelfHint,&pVmFunc->sName,
+									nMaxFilled,nReqNamed,nNVNamed,TRUE);
+						}else{
+							rc = VmThrowArgNotPassed(&(*pVm),pSelfHint,&pVmFunc->sName,n+1,&aFormalArg[n].sName);
+						}
+						SyMemBackendFree(&pVm->sAllocator, aSlot);
+						for( i = 0; i < nActual; i++ ){
+							PH7_MemObjRelease(&pArg[i]);
+						}
+						if( rc == PH7_ABORT ){
+							goto Abort;
+						}
+						PH7_MemObjRelease(pTos);
+						pTos = &pTos[-nCallArgs];
+						pFrameStack = 0;
+						rc = PH7_EXCEPTION;
+						goto SkipFuncBody;
 					}else if( SySetUsed(&aFormalArg[n].aByteCode) > 0 ){
 						pObj = VmExtractMemObj(&(*pVm),&aFormalArg[n].sName,FALSE,TRUE);
 						if( pObj ){
@@ -14139,9 +14329,9 @@ case PH7_OP_CALL: {
 							}
 						}
 					}
-					/* else: required param missing — leave unset (matches existing behavior) */
 				}
 			}
+			} /* end nReqNamed scope */
 			/* Handle variadic parameter */
 			if( iVariadicIdx >= 0 ){
 				pObj = VmExtractMemObj(&(*pVm),&aFormalArg[iVariadicIdx].sName,FALSE,TRUE);
@@ -14514,6 +14704,40 @@ case PH7_OP_CALL: {
 				PH7_MemObjRelease(pValue);
 				/* Duplicate bound variable value */
 				PH7_MemObjStore(&pEnv->sValue,pValue);
+			}
+		}
+		/* Too-few-arguments check, placed AFTER the passed arguments were
+		 * installed and type-checked: php's RECV order means a type error on
+		 * a PASSED argument beats the count error (`f(int $x,$y)` called
+		 * f("str") is a TypeError, not ArgumentCountError). The passed args
+		 * were already released by the install loop, so the standard throw
+		 * exit leaks nothing. The named path never fires this (its per-hole
+		 * check ran in-loop; n == nNonVariadic >= nRequired here). Hosted
+		 * builtin FUNCTIONS (VM_FUNC_INTERNAL) are exempt — their PHL
+		 * signatures don't always mirror php's true arity and their in-body
+		 * self-checks own php's wording (stage-2 family); hosted-class
+		 * METHODS get php's ZPP wording via VmThrowBuiltinTooFewArgs. */
+		if( n < SySetUsed(&pVmFunc->aArgs)
+		 && (pVmFunc->iFlags & (VM_FUNC_INTERNAL|VM_FUNC_CLASS_METHOD)) != VM_FUNC_INTERNAL ){
+			sxu32 nNonVar,nReq;
+			nReq = VmFuncRequiredArgCount(pVmFunc,&nNonVar);
+			if( n < nReq ){
+				sxu32 nPassed = pFrame->nActualArgs >= 0 ? (sxu32)pFrame->nActualArgs : n;
+				if( pVmFunc->iFlags & VM_FUNC_INTERNAL ){
+					rc = VmThrowBuiltinTooFewArgs(&(*pVm),pSelfHint,&pVmFunc->sName,
+						nPassed,nReq,nNonVar);
+				}else{
+					rc = VmThrowTooFewArgs(&(*pVm),pSelfHint,&pVmFunc->sName,
+						nPassed,nReq,nNonVar,TRUE);
+				}
+				if( rc == PH7_ABORT ){
+					goto Abort;
+				}
+				PH7_MemObjRelease(pTos);
+				pTos = &pTos[-nCallArgs];
+				pFrameStack = 0;
+				rc = PH7_EXCEPTION;
+				goto SkipFuncBody;
 			}
 		}
 		/* Process default values for remaining formal parameters */
@@ -16315,11 +16539,12 @@ static sxi32 VmEnforceGenArgType(ph7_vm *pVm, ph7_vm_func *pFunc, ph7_vm_func_ar
 }
 static sxi32 VmFiberSetupFrame(ph7_vm *pVm, ph7_exec_ctx *pExecCtx,
 	ph7_class_instance *pClosureThis, int nArg, ph7_value **apArg,
-	int bStrict, ph7_class *pSelfHint)
+	int bStrict, ph7_class *pSelfHint, int bCallSiteInMsg)
 {
 	ph7_vm_func *pFunc = pExecCtx->pFunc;
 	ph7_vm_func_arg *aFormalArg;
 	sxu32 nFormal, n;
+	sxu32 nReqGF = 0, nNonVarGF = 0; /* too-few-args watermark (0 = exempt) */
 	VmSlot sSlot;
 	sxi32 rc;
 	/* Install $this for closure/method callables */
@@ -16355,6 +16580,18 @@ static sxi32 VmFiberSetupFrame(ph7_vm *pVm, ph7_exec_ctx *pExecCtx,
 	nFormal = SySetUsed(&pFunc->aArgs);
 	/* Actual call arity for func_num_args()/func_get_args() (band A #4) */
 	pExecCtx->pFrame->nActualArgs = nArg;
+	{
+		/* Too-few-arguments watermark — checked per formal INSIDE the install
+		 * loop below, after the passed args' type checks, matching php's
+		 * RECV order (a type error on a passed argument beats the count
+		 * error). Generators throw at the g(...) call site (message embeds
+		 * it); fibers at Fiber::start() (php omits the call-site segment).
+		 * Hosted builtin FUNCTIONS self-check; hosted-class methods get
+		 * php's ZPP wording. */
+	if( (pFunc->iFlags & (VM_FUNC_INTERNAL|VM_FUNC_CLASS_METHOD)) != VM_FUNC_INTERNAL ){
+		nReqGF = VmFuncRequiredArgCount(pFunc,&nNonVarGF);
+	}
+	}
 	for( n = 0; n < nFormal; n++ ){
 		ph7_value *pObj;
 		if( aFormalArg[n].iFlags & VM_FUNC_ARG_VARIADIC ){
@@ -16411,6 +16648,15 @@ static sxi32 VmFiberSetupFrame(ph7_vm *pVm, ph7_exec_ctx *pExecCtx,
 				sSlot.pUserData = 0;
 				SySetPut(&pExecCtx->pFrame->sArg, &sSlot);
 			}
+		}else if( n < nReqGF ){
+			/* Required formal with no actual: php's ArgumentCountError, at
+			 * this point in the install order (see the watermark comment). */
+			return VmGenArgThrowStatus(pVm,
+				(pFunc->iFlags & VM_FUNC_INTERNAL)
+					? VmThrowBuiltinTooFewArgs(pVm,pSelfHint,&pFunc->sName,
+						(sxu32)nArg,nReqGF,nNonVarGF)
+					: VmThrowTooFewArgs(pVm,pSelfHint,&pFunc->sName,
+						(sxu32)nArg,nReqGF,nNonVarGF,bCallSiteInMsg));
 		}else if( SySetUsed(&aFormalArg[n].aByteCode) > 0 ){
 			/* Default value */
 			pObj = VmExtractMemObj(pVm, &aFormalArg[n].sName, FALSE, TRUE);
@@ -16546,7 +16792,8 @@ static int vm_builtin_Fiber_start(ph7_context *pCtx, int nArg, ph7_value **apArg
 			}
 		}
 		rc = VmFiberSetupFrame(pVm, pExecCtx, pClosureThis, nActual, apValues,
-			0 /* weak-mode arg binding, like call_user_func */, 0);
+			0 /* weak-mode arg binding, like call_user_func */, 0,
+			FALSE/*Fiber::start(): php omits the call-site segment*/);
 		if( aStore ){
 			SyMemBackendFree(&pVm->sAllocator, aStore);
 		}
@@ -16774,7 +17021,8 @@ PH7_PRIVATE sxi32 PH7_VmFiberStart(ph7_vm *pVm, ph7_value *pFiber, int nArg, ph7
 	pCtx->pFrame->pParent = pVm->pFrame;
 	pVm->pFrame = pCtx->pFrame;
 	rc = VmFiberSetupFrame(pVm, pCtx, pClosureThis, nArg, apArg,
-		0 /* weak-mode arg binding (embedder entry) */, 0);
+		0 /* weak-mode arg binding (embedder entry) */, 0,
+		FALSE/*embedder entry: no userland call site*/);
 	pVm->pFrame = pCtx->pFrame->pParent;
 	pCtx->pFrame->pParent = 0;
 	if( rc != SXRET_OK ){

--- a/src/ph7/vm_builtin_ob.c
+++ b/src/ph7/vm_builtin_ob.c
@@ -176,14 +176,20 @@ PH7_PRIVATE int VmObConsumer(const void *pData,unsigned int nDataLen,void *pUser
 	}
 	PH7_MemObjInit(pVm,&sResult);
 	if( ph7_value_is_callable(&pEntry->sCallback) && pVm->nObDepth < 15 ){
-		ph7_value sArg,*apArg[2];
+		ph7_value sArg,sPhase,*apArg[2];
 		/* Fill the first argument */
 		PH7_MemObjInitFromString(pVm,&sArg,0);
 		PH7_MemObjStringAppend(&sArg,(const char *)pData,nDataLen);
 		apArg[0] = &sArg;
+		/* php calls the handler as ($buffer, int $phase) — a handler
+		 * declaring both as required must not trip the arity check. The
+		 * phase is PHP_OUTPUT_HANDLER_WRITE (0); the per-write phase
+		 * bitmask semantics (START/FINAL) are not modeled. */
+		PH7_MemObjInitFromInt(pVm,&sPhase,0);
+		apArg[1] = &sPhase;
 		/* Call the 'filter' callback */
 		pVm->nObDepth++;
-		PH7_VmCallUserFunction(pVm,&pEntry->sCallback,1,apArg,&sResult);
+		PH7_VmCallUserFunction(pVm,&pEntry->sCallback,2,apArg,&sResult);
 		pVm->nObDepth--;
 		if( sResult.iFlags & MEMOBJ_STRING ){
 			/* Extract the function result */
@@ -191,6 +197,7 @@ PH7_PRIVATE int VmObConsumer(const void *pData,unsigned int nDataLen,void *pUser
 			nDataLen = SyBlobLength(&sResult.sBlob);
 		}
 		PH7_MemObjRelease(&sArg);
+		PH7_MemObjRelease(&sPhase);
 	}
 	if( nDataLen > 0 ){
 		/* Redirect the VM output to the internal buffer */

--- a/tests/ph7/001-smoke/function/file_put_contents/file_put_contents.phpt
+++ b/tests/ph7/001-smoke/function/file_put_contents/file_put_contents.phpt
@@ -5,13 +5,10 @@ SPDX-License-Identifier: BSD-3-Clause
 Test file_put_contents()
 --SKIPIF--
 <?php
-
-if (PHP_OS === 'WINNT' && function_exists('zend_version')) {
-    echo "skip: platform";
-}
-if (!function_exists('file_put_contents') || !function_exists('flock') || !function_exists('fopen')) {
-    echo 'skip: file functions not available';
-}
+// This test asserts POSIX advisory-lock semantics (writing to a flock'd file
+// succeeds). Windows locks are mandatory, so the write fails there — that case
+// is covered by file_put_contents_zend_win.phpt. Skip the advisory version here.
+if (DIRECTORY_SEPARATOR === '\\') { echo 'skip advisory-lock semantics: Windows locks are mandatory'; }
 ?>
 --FILE--
 <?php

--- a/tests/ph7/001-smoke/function/too_few_arguments_error.phpt
+++ b/tests/ph7/001-smoke/function/too_few_arguments_error.phpt
@@ -1,0 +1,57 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Too few arguments to a user function throws ArgumentCountError (functions, methods, ctors, generators, closures, fibers, named args)
+--FILE--
+<?php
+function tfaPlain(int $x) { return $x; }
+function tfaOpt($a, $b = 2) {}
+function tfaVariadic($a, ...$rest) {}
+class TfaC {
+    public function __construct($a) {}
+    public function m($a, $b) {}
+}
+function tfaGen($a) { yield $a; }
+
+try { tfaPlain(); } catch (ArgumentCountError $e) { echo get_class($e), "|", $e->getMessage(), "\n"; }
+echo (new ReflectionClass("ArgumentCountError"))->getParentClass()->getName(), "\n";
+try { tfaOpt(); } catch (ArgumentCountError $e) { echo $e->getMessage(), "\n"; }
+try { tfaVariadic(); } catch (ArgumentCountError $e) { echo $e->getMessage(), "\n"; }
+try { (new TfaC(1))->m(1); } catch (ArgumentCountError $e) { echo $e->getMessage(), "\n"; }
+try { new TfaC(); } catch (ArgumentCountError $e) { echo $e->getMessage(), "\n"; }
+try { tfaGen(); } catch (ArgumentCountError $e) { echo "gen-eager|", $e->getMessage(), "\n"; }
+try { tfaOpt(b: 3); } catch (ArgumentCountError $e) { echo $e->getMessage(), "\n"; }
+try { call_user_func('tfaPlain'); } catch (ArgumentCountError $e) { echo "cuf|", $e->getMessage(), "\n"; }
+$tfaClosure = function ($a) { return $a; };
+try { $tfaClosure(); } catch (ArgumentCountError $e) { echo "closure|", $e->getMessage(), "\n"; }
+try { (new Fiber(function ($a) {}))->start(); } catch (ArgumentCountError $e) { echo "fiber|", $e->getMessage(), "\n"; }
+// Named hole with nothing filled above it: php keeps the positional count wording
+function tfaNm($a, $b, $c = 3) {}
+try { tfaNm(a: 1); } catch (ArgumentCountError $e) { echo "nm-above|", $e->getMessage(), "\n"; }
+// Internal-class ctor: php's ZPP wording, no call-site segment
+try { new ReflectionProperty(); } catch (ArgumentCountError $e) { echo "internal|", $e->getMessage(), "\n"; }
+// RECV order: a type error on a PASSED argument beats the count error
+function tfaRecv(int $x, $y) {}
+try { tfaRecv("str"); } catch (TypeError $e) { echo "recv-order|", get_class($e), "\n"; }
+echo tfaOpt(1) ?? "null-ok", "|", tfaPlain(7), "\n";
+?>
+--EXPECTF--
+ArgumentCountError|Too few arguments to function tfaPlain(), 0 passed in %s on line %d and exactly 1 expected
+TypeError
+Too few arguments to function tfaOpt(), 0 passed in %s on line %d and at least 1 expected
+Too few arguments to function tfaVariadic(), 0 passed in %s on line %d and exactly 1 expected
+Too few arguments to function TfaC::m(), 1 passed in %s on line %d and exactly 2 expected
+Too few arguments to function TfaC::__construct(), 0 passed in %s on line %d and exactly 1 expected
+gen-eager|Too few arguments to function tfaGen(), 0 passed in %s on line %d and exactly 1 expected
+tfaOpt(): Argument #1 ($a) not passed
+cuf|Too few arguments to function tfaPlain(), 0 passed in %s on line %d and exactly 1 expected
+closure|Too few arguments to function %s 0 passed in %s on line %d and exactly 1 expected
+fiber|Too few arguments to function %s 0 passed and exactly 1 expected
+nm-above|Too few arguments to function tfaNm(), 1 passed in %s on line %d and at least 2 expected
+internal|ReflectionProperty::__construct() expects exactly 2 arguments, 0 given
+recv-order|TypeError
+null-ok|7
+--CLEAN--
+<?php
+unset($tfaClosure, $e);

--- a/tests/ph7/002-integration/function/too_few_args_line.phpt
+++ b/tests/ph7/002-integration/function/too_few_args_line.phpt
@@ -1,0 +1,25 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+ArgumentCountError call-site line: PHL reports a fixed line 1 pending the runtime line-tracking gate (NEWPLAN.md §6; php half in the _zend twin)
+--SKIPIF--
+<?php
+if (function_exists('zend_version')) {
+    echo "skip PHL-pinned half of the twin pair";
+}
+?>
+--FILE--
+<?php
+function tflLine($a) {}
+try {
+    tflLine();
+} catch (ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECTF--
+Too few arguments to function tflLine(), 0 passed in %s on line 1 and exactly 1 expected
+--CLEAN--
+<?php
+unset($e);

--- a/tests/ph7/002-integration/function/too_few_args_line_zend.phpt
+++ b/tests/ph7/002-integration/function/too_few_args_line_zend.phpt
@@ -1,0 +1,25 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+ArgumentCountError call-site line: php embeds the REAL call-site line (zend half of the twin pair — NEWPLAN.md §6 line-tracking gate)
+--SKIPIF--
+<?php
+if (!function_exists('zend_version')) {
+    echo "skip zend-pinned half of the twin pair";
+}
+?>
+--FILE--
+<?php
+function tflLine($a) {}
+try {
+    tflLine();
+} catch (ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECTF--
+Too few arguments to function tflLine(), 0 passed in %s on line 4 and exactly 1 expected
+--CLEAN--
+<?php
+unset($e);


### PR DESCRIPTION
function f(int $x){} f() ran with $x undefined — a silent wrong answer. Now php's catchable ArgumentCountError fires for plain functions, methods, constructors (replacing the PHL-only "Missing constructor argument" notice), closures, generators (eagerly at the g(...) call site), fibers (at start(), without the call-site segment, php-exact), call_user_func, and named-argument holes. Counting is php's rule: required runs through the last no-default formal (optional-before-required is implicitly required, for named calls too), "at least" only with trailing optionals, variadic excluded.

The check sits where php's RECV order puts it — after the passed arguments were installed and type-checked, so a type error on a passed argument beats the count error, and the already-released stack slots make the throw path leak-free. Named calls split the wording like zend: a hole below a filled slot is "Argument #N ($x) not passed", a hole with nothing filled above it keeps the positional count message; generators check holes before the named-to-positional compaction would fake the count. Internal (builtin-chunk) class methods throw php's byte-exact ZPP wording ("C::m() expects exactly N arguments, M given"); hosted builtin functions keep their in-body self-checks (their PHL signatures don't mirror php's true arity — stage-2 family work).

ob_start handlers now receive php's ($buffer, int $phase) — the old 1-arg call would have tripped the arity check on a php-correct two-parameter handler; phase is fixed at 0 (WRITE), the bitmask phases are not modeled.

The embedded call-site line is a fixed 1 pending runtime line tracking; the too_few_args_line{,_zend}.phpt twins pin that divergence.
