### PR TITLE
Windows php oracle: force TLS 1.2, ship a php.ini, pin CI to 8.5

### DIFF
--- a/.github/actions/setup-action/action.yml
+++ b/.github/actions/setup-action/action.yml
@@ -40,6 +40,10 @@ runs:
     - if: runner.os == 'Windows'
       shell: cmd
       run: build-aux\install_opencppcoverage.bat
+    # Pin the Windows oracle php to the version PHL targets (8.5), matching the
+    # Linux/macOS oracle above. The runner's DEFAULT php drifts by image version,
+    # so test-compat was silently comparing against an arbitrary php on Windows.
     - if: runner.os == 'Windows'
-      shell: cmd
-      run: rem PHP is installed by default on Windows runners
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.5'

--- a/build-aux/install_php.bat
+++ b/build-aux/install_php.bat
@@ -19,7 +19,12 @@ if exist "%PHP_DIR%\php.exe" (
 )
 
 echo Resolving latest %PHP_BRANCH% NTS x64 build from windows.php.net...
-powershell -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference='Stop'; $b='%PHP_BRANCH%'; $dir='%PHP_DIR%'; $j=Invoke-RestMethod 'https://windows.php.net/downloads/releases/releases.json'; $v=$j.$b; if(-not $v){throw \"no releases for branch $b\"}; $p=$v.PSObject.Properties | Where-Object { $_.Name -match 'nts-vs\d+-x64' } | Select-Object -First 1; if(-not $p){throw \"no NTS x64 build for $b\"}; $zip=$p.Value.zip.path; $url='https://windows.php.net/downloads/releases/'+$zip; Write-Host \"Downloading $url\"; Invoke-WebRequest -Uri $url -OutFile $zip; if(Test-Path $dir){Remove-Item -Recurse -Force $dir}; Expand-Archive -Path $zip -DestinationPath $dir -Force; if(-not (Test-Path (Join-Path $dir 'php.exe'))){throw 'php.exe missing after extract'}"
+:: TLS 1.2 is mandatory: Windows PowerShell 5.1 negotiates TLS 1.0/1.1 by default,
+:: which windows.php.net's CDN refuses ("underlying connection was closed"), so the
+:: download fails on a stock VM without it. A php.ini pinning the oracle's config to
+:: match CI (assertions off like php's production ini; UTC clock) is written next to
+:: php.exe so test-compat is reproducible instead of depending on ambient defaults.
+powershell -NoProfile -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12; $ErrorActionPreference='Stop'; $b='%PHP_BRANCH%'; $dir='%PHP_DIR%'; $j=Invoke-RestMethod 'https://windows.php.net/downloads/releases/releases.json'; $v=$j.$b; if(-not $v){throw \"no releases for branch $b\"}; $p=$v.PSObject.Properties | Where-Object { $_.Name -match 'nts-vs\d+-x64' } | Select-Object -First 1; if(-not $p){throw \"no NTS x64 build for $b\"}; $zip=$p.Value.zip.path; $url='https://windows.php.net/downloads/releases/'+$zip; Write-Host \"Downloading $url\"; Invoke-WebRequest -Uri $url -OutFile $zip; if(Test-Path $dir){Remove-Item -Recurse -Force $dir}; Expand-Archive -Path $zip -DestinationPath $dir -Force; if(-not (Test-Path (Join-Path $dir 'php.exe'))){throw 'php.exe missing after extract'}; Set-Content -Path (Join-Path $dir 'php.ini') -Value @('zend.assertions=-1','date.timezone=UTC') -Encoding ASCII"
 if %errorlevel% neq 0 (
     echo Failed to install PHP.
     exit /b 1


### PR DESCRIPTION
The cross-engine test-compat oracle was unreproducible and unfaithful on Windows in three ways, each a silent gate-vs-CI divergence:

- install_php.bat could not fetch php on a stock VM: Windows PowerShell 5.1 negotiates TLS 1.0/1.1 by default and windows.php.net's CDN refuses it, so the download died with "the underlying connection was closed". Force TLS 1.2.

- the freshly-extracted php had no php.ini, so zend.assertions defaulted to the built-in 1 and assert()-off tests (asserting PHL's -1 CLI default) threw and aborted the oracle run. Write a php.ini next to php.exe (assertions off like php's production ini; UTC clock to match CI).

- CI installed no specific php on Windows ("installed by default"), so the oracle compared against whatever php the runner image happened to ship, while Linux/macOS pin 8.5. Pin Windows to 8.5 too via setup-php.
