### PR TITLE
Fix argument unpacking of temporary arrays, ctor calls, and multi-spr…

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -11962,18 +11962,30 @@ static sxi32 GenStateEmitExprCode(
 				bFcc = 1;
 				nArgs = 0;
 			}
-			/* Validate: no positional arguments after named arguments */
+			/* Validate argument order like php: no positional argument after a
+			 * named one OR after unpacking, and `name: ...$x` is a parse error. */
 			{
 				int seenNamed = 0;
+				int seenSpread = 0;
 				for( n = 0; n < nArgs; ++n ){
-					if( apNode[n]->iFlags & EXPR_NODE_NAMED_ARG ){
+					if( apNode[n]->iFlags & EXPR_NODE_SPREAD ){
+						bAnySpread = 1;
+						seenSpread = 1;
+						if( apNode[n]->iFlags & EXPR_NODE_NAMED_ARG ){
+							rc = PH7_GenCompileError(&(*pGen),E_ERROR,apNode[n]->pStart->nLine,
+								"syntax error, unexpected token \"...\"");
+							return SXERR_SYNTAX;
+						}
+					}else if( apNode[n]->iFlags & EXPR_NODE_NAMED_ARG ){
 						seenNamed = 1;
 						hasNamed = 1;
-					}else if( apNode[n]->iFlags & EXPR_NODE_SPREAD ){
-						bAnySpread = 1;
 					}else if( seenNamed ){
 						rc = PH7_GenCompileError(&(*pGen),E_ERROR,apNode[n]->pStart->nLine,
 							"Cannot use positional argument after named argument");
+						return SXERR_SYNTAX;
+					}else if( seenSpread ){
+						rc = PH7_GenCompileError(&(*pGen),E_ERROR,apNode[n]->pStart->nLine,
+							"Cannot use positional argument after argument unpacking");
 						return SXERR_SYNTAX;
 					}
 				}
@@ -12132,20 +12144,23 @@ static sxi32 GenStateEmitExprCode(
 						nQual = GenStateNsQualifyName(pGen,nOrig,&pGen->hUseFuncImports,&fromImport);
 						pInstr->iP2 = (sxi32)nQual;
 						if( nQual != nOrig ){
-							/* Store original literal index in CALL's iP2 so the
-							 * NEW handler can recover the unqualified name. */
-							iP2 = (sxi32)(nOrig + 1); /* +1 to distinguish from default 0 */
-							if( !fromImport ){
-								/* Mark as namespace-qualified via VmCallArgMap */
-								if( p3 == 0 ){
-									VmCallArgMap *pMap = (VmCallArgMap *)SyMemBackendAlloc(
-										&pGen->pVm->sAllocator, sizeof(VmCallArgMap));
-									if( pMap ){
-										SyZero(pMap, sizeof(VmCallArgMap));
-										p3 = (void *)pMap;
-									}
+							/* Record the original literal index in the arg map
+							 * (NOT in the CALL's iP2 — that is the hasSpread
+							 * flag) so the NEW handler can recover the
+							 * unqualified name and re-qualify with CLASS
+							 * imports. */
+							if( p3 == 0 ){
+								VmCallArgMap *pMap = (VmCallArgMap *)SyMemBackendAlloc(
+									&pGen->pVm->sAllocator, sizeof(VmCallArgMap));
+								if( pMap ){
+									SyZero(pMap, sizeof(VmCallArgMap));
+									p3 = (void *)pMap;
 								}
-								if( p3 ){
+							}
+							if( p3 ){
+								((VmCallArgMap *)p3)->nOrigNameLit = nOrig + 1;
+								if( !fromImport ){
+									/* Mark as namespace-qualified */
 									((VmCallArgMap *)p3)->bIsNamespaced = 1;
 								}
 							}
@@ -12332,11 +12347,15 @@ static sxi32 GenStateEmitExprCode(
 				if( pPeek && pPeek->iOp == PH7_OP_LOADC ){
 					int bAbsolute = (pPeek->iP1 & PH7_LOADC_ABSOLUTE) != 0;
 					sxu32 nLitForClass;
-					/* If the CALL handler already qualified the name using
-					 * function imports, recover the original unqualified
-					 * literal so we can re-qualify with class imports. */
-					if( pCallInstr && pCallInstr->iP2 > 0 ){
-						nLitForClass = (sxu32)(pCallInstr->iP2 - 1); /* undo +1 encoding */
+					VmCallArgMap *pCallNsMap = pCallInstr ? (VmCallArgMap *)pCallInstr->p3 : 0;
+					/* If the CALL handler qualified the name with FUNCTION
+					 * imports, recover the original literal (recorded in the
+					 * arg map — OP_CALL's iP2 is the hasSpread flag, and
+					 * misreading it as a literal index made `new C(...$args)`
+					 * fatal with "Class ' ' is not defined") and re-qualify
+					 * with class imports. */
+					if( pCallNsMap && pCallNsMap->nOrigNameLit > 0 ){
+						nLitForClass = pCallNsMap->nOrigNameLit - 1;
 					}else{
 						nLitForClass = (sxu32)pPeek->iP2;
 					}
@@ -12353,8 +12372,11 @@ static sxi32 GenStateEmitExprCode(
 				VmInstr *pPrev;
 				pPrev = PH7_VmPeekNextInstr(pGen->pVm);
 				if( pPrev == 0 || pPrev->iOp != PH7_OP_MEMBER ){
-					/* Pop the call instruction, preserve named-arg map */
+					/* Pop the call instruction, preserve named-arg map and
+					 * the hasSpread flag (OP_NEW consumes the spread
+					 * accumulator exactly like OP_CALL would have). */
 					iP1 = pInstr->iP1;
+					iP2 = pInstr->iP2;
 					if( pInstr->p3 ){
 						p3 = pInstr->p3; /* Transfer VmCallArgMap to NEW */
 					}

--- a/src/ph7/parse.c
+++ b/src/ph7/parse.c
@@ -1389,7 +1389,29 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 					ExprFreeTree(&(*pGen),apNode[iNode]);
 					apNode[iNode] = 0;
 			}
-			ExprMakeTree(&(*pGen),&apNode[iNode],iCur-iNode);
+			{
+				/* `...$expr` flags the argument's FIRST node at extraction
+				 * time; when the expression is more than a lone terminal
+				 * (a call, member access, ...) tree-building roots the span
+				 * at a DIFFERENT node — carry the spread mark onto the root
+				 * or the code generator never emits OP_SPREAD (f(...mk())
+				 * used to pass the whole array as one argument). Scan for
+				 * the first LIVE node: an outer paren pass may already have
+				 * collapsed a leading group — `...(new S)->pair()` — leaving
+				 * NULL slots ahead of the flagged subtree. */
+				int bSpreadArg = 0;
+				sxi32 iScan;
+				for( iScan = iNode ; iScan < iCur ; iScan++ ){
+					if( apNode[iScan] ){
+						bSpreadArg = (apNode[iScan]->iFlags & EXPR_NODE_SPREAD) != 0;
+						break;
+					}
+				}
+				ExprMakeTree(&(*pGen),&apNode[iNode],iCur-iNode);
+				if( bSpreadArg && apNode[iNode] ){
+					apNode[iNode]->iFlags |= EXPR_NODE_SPREAD;
+				}
+			}
 			if( apNode[iNode] ){
 				if( sArgName.nByte > 0 ){
 					apNode[iNode]->iFlags |= EXPR_NODE_NAMED_ARG;
@@ -1478,10 +1500,14 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 			 }
 			 /* Mark the subtree root as coming from an explicit parenthesised
 			  * group. Consumed by the ** precedence-5 phase so it does not
-			  * hoist a unary operator that the user explicitly isolated. */
+			  * hoist a unary operator that the user explicitly isolated.
+			  * A spread mark on the '(' itself — `...($expr)` flags the paren
+			  * node at extraction — must survive onto the root too, or the
+			  * group's free below silently drops the unpacking. */
 			 for( j = iLeft + 1 ; j < iCur ; ++j ){
 				 if( apNode[j] ){
-					 apNode[j]->iFlags |= EXPR_NODE_PARENS;
+					 apNode[j]->iFlags |= EXPR_NODE_PARENS
+						 | (apNode[iLeft]->iFlags & EXPR_NODE_SPREAD);
 					 break;
 				 }
 			 }

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -928,6 +928,11 @@ struct VmCallArgMap
 	sxu8 bHasNamed;      /* 1 if any argument uses name: syntax */
 	sxu8 bIsNamespaced;  /* 1 if compiler namespace-qualified the call */
 	sxu8 bStrict;        /* 1 if the call site's file declared strict_types=1 */
+	sxu32 nOrigNameLit;  /* Original (unqualified) name-literal index + 1, stored
+						  * when the CALL handler namespace-qualified the name so
+						  * a following NEW can re-qualify with CLASS imports.
+						  * 0 = unset. (Formerly abused OP_CALL's iP2, colliding
+						  * with the hasSpread flag: `new N\C(...$args)`.) */
 	sxu32 nTotal;        /* Total number of compile-time arguments */
 	SyString *aNames;    /* Array of nTotal names. nByte==0 means positional. */
 };

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -7069,6 +7069,75 @@ static sxi32 VmSpreadValuesStep(ph7_vm *pVm, ph7_value *pKey, ph7_value *pValue,
 	return SXRET_OK;
 }
 /*
+ * Shared OP_SPREAD expansion tail: replace the stack slot holding an
+ * array-to-unpack with the map's elements in insertion order, accumulating
+ * the net stack growth in pVm->iSpreadExtra. Used by both the plain-array
+ * path (*ppTos holds the map value) and the materialized-Traversable path
+ * (*ppTos holds the iterator object; pMap is the temp).
+ * The map is kept alive across the walk — the stack slot may hold its ONLY
+ * reference (literal / call-result temp), and releasing it mid-walk restores
+ * the nodes' value slots to the freelist (the old open-coded copy then read
+ * the reset slots and pushed nulls: f(...[1,2]) bound null/null). A
+ * sole-owner temp's elements are deep-copied (PH7_MemObjStore) so nested
+ * containers and blobs survive the trailing unref; a shared map keeps the
+ * historical zero-copy aliasing (PH7_MemObjLoad) for f(...$var).
+ */
+static void VmSpreadExpandMap(ph7_vm *pVm, ph7_value **ppTos, ph7_hashmap *pMap)
+{
+	ph7_value *pTos = *ppTos;
+	sxu32 nEntry = pMap->nEntry;
+	if( nEntry == 0 ){
+		/* Nothing to unpack — remove the source from the stack */
+		VmPopOperand(&pTos, 1);
+		pVm->iSpreadExtra--; /* One expression produced zero args */
+	}else if( pVm->iSpreadExtra + (sxi32)(nEntry - 1) >= VM_STACK_GUARD ){
+		/* Safety: refuse to expand beyond the stack guard margin */
+		VmErrorFormat(&(*pVm), PH7_CTX_ERR,
+			"Argument unpacking: cumulative expansion exceeds stack guard (%d)",
+			VM_STACK_GUARD);
+	}else{
+		ph7_hashmap_node *pNode;
+		ph7_value *pElem;
+		sxu32 i;
+		int bTemp;
+		pMap->iRef++;
+		bTemp = (pMap->iRef == 2); /* the stack slot held the only reference */
+		/* Overwrite the source slot with the first element */
+		pNode = pMap->pFirst;
+		pElem = (ph7_value *)SySetAt(&pVm->aMemObj, pNode->nValIdx);
+		PH7_MemObjRelease(pTos);
+		if( pElem ){
+			if( bTemp ){
+				PH7_MemObjStore(pElem, pTos);
+			}else{
+				PH7_MemObjLoad(pElem, pTos);
+			}
+		}
+		pTos->nIdx = SXU32_HIGH;
+		/* Traverse in insertion order (pPrev is the forward link
+		 * in PHL's circular doubly-linked hashmap node list). */
+		pNode = pNode->pPrev;
+		/* Push the remaining elements */
+		for( i = 1; i < nEntry; i++ ){
+			pTos++;
+			PH7_MemObjInit(pVm, pTos);
+			pTos->nIdx = SXU32_HIGH;
+			pElem = (ph7_value *)SySetAt(&pVm->aMemObj, pNode->nValIdx);
+			if( pElem ){
+				if( bTemp ){
+					PH7_MemObjStore(pElem, pTos);
+				}else{
+					PH7_MemObjLoad(pElem, pTos);
+				}
+			}
+			pNode = pNode->pPrev;
+		}
+		pVm->iSpreadExtra += (sxi32)(nEntry - 1);
+		PH7_HashmapUnref(pMap);
+	}
+	*ppTos = pTos;
+}
+/*
  * Raise the PHP "Cannot use <type> as array" warning for a non-array source used in a
  * list / array-destructuring assignment. Shared by the positional OP_LOAD_LIST path and the
  * keyed OP_LOAD_IDX (iP2=7) path. The CALLER decides whether to warn at all — the two paths
@@ -10699,6 +10768,8 @@ case PH7_OP_NULLC_STORE: {
  * Replace TOS with the array's individual elements pushed onto the stack.
  * Accumulates the net stack growth in pVm->iSpreadExtra so the next CALL
  * can adjust its argument count (the CALL may not be the next instruction).
+ * The expansion tail is shared between the plain-array and the materialized
+ * Traversable paths — see VmSpreadExpandMap right above the dispatch loop.
  */
 case PH7_OP_SPREAD: {
 #ifdef UNTRUST
@@ -10714,7 +10785,6 @@ case PH7_OP_SPREAD: {
 	if( VmValueIsTraversable(pVm,pTos) ){
 		ph7_hashmap *pTmpMap = PH7_NewHashmap(&(*pVm),0,0);
 		sxi32 rcW;
-		sxu32 nEnt;
 		if( pTmpMap == 0 ){ goto Abort; }
 		rcW = PH7_VmIteratorWalk(&(*pVm),pTos,VmSpreadValuesStep,pTmpMap);
 		if( rcW == PH7_EXCEPTION || rcW == PH7_ABORT ){
@@ -10722,74 +10792,12 @@ case PH7_OP_SPREAD: {
 			if( rcW == PH7_ABORT ){ goto Abort; }
 			goto Exception;
 		}
-		nEnt = pTmpMap->nEntry;
-		if( nEnt == 0 ){
-			VmPopOperand(&pTos,1);
-			pVm->iSpreadExtra--;
-		}else if( pVm->iSpreadExtra + (sxi32)(nEnt - 1) >= VM_STACK_GUARD ){
-			VmErrorFormat(&(*pVm), PH7_CTX_ERR,
-				"Argument unpacking: cumulative expansion exceeds stack guard (%d)", VM_STACK_GUARD);
-		}else{
-			ph7_hashmap_node *pNodeT = pTmpMap->pFirst;
-			ph7_value *pElemT;
-			sxu32 iT;
-			pElemT = (ph7_value *)SySetAt(&pVm->aMemObj, pNodeT->nValIdx);
-			if( pElemT ){ PH7_MemObjStore(pElemT, pTos); }else{ PH7_MemObjRelease(pTos); }
-			pTos->nIdx = SXU32_HIGH;
-			pNodeT = pNodeT->pPrev;
-			for( iT = 1; iT < nEnt; iT++ ){
-				pTos++;
-				PH7_MemObjInit(pVm, pTos);
-				pTos->nIdx = SXU32_HIGH;
-				pElemT = (ph7_value *)SySetAt(&pVm->aMemObj, pNodeT->nValIdx);
-				if( pElemT ){ PH7_MemObjStore(pElemT, pTos); }
-				pNodeT = pNodeT->pPrev;
-			}
-			pVm->iSpreadExtra += (sxi32)(nEnt - 1);
-		}
+		VmSpreadExpandMap(pVm, &pTos, pTmpMap);
 		PH7_HashmapRelease(pTmpMap,TRUE);
 		break;
 	}
 	if( pTos->iFlags & MEMOBJ_HASHMAP ){
-		ph7_hashmap *pMap = (ph7_hashmap *)pTos->x.pOther;
-		sxu32 nEntry = pMap->nEntry;
-		if( nEntry == 0 ){
-			/* Empty array — remove from stack */
-			VmPopOperand(&pTos, 1);
-			pVm->iSpreadExtra--; /* One expression produced zero args */
-		}else if( pVm->iSpreadExtra + (sxi32)(nEntry - 1) >= VM_STACK_GUARD ){
-			/* Safety: refuse to expand beyond the stack guard margin */
-			VmErrorFormat(&(*pVm), PH7_CTX_ERR,
-				"Argument unpacking: cumulative expansion exceeds stack guard (%d)",
-				VM_STACK_GUARD);
-		}else{
-			ph7_hashmap_node *pNode2;
-			ph7_value *pElem;
-			sxu32 i;
-			/* Overwrite TOS with first element */
-			pNode2 = pMap->pFirst;
-			pElem = (ph7_value *)SySetAt(&pVm->aMemObj, pNode2->nValIdx);
-			PH7_MemObjRelease(pTos);
-			if( pElem ){
-				PH7_MemObjLoad(pElem, pTos);
-			}
-			pTos->nIdx = SXU32_HIGH;
-			/* Traverse in insertion order (pPrev is the forward link
-			 * in PHL's circular doubly-linked hashmap node list). */
-			pNode2 = pNode2->pPrev;
-			/* Push remaining elements */
-			for( i = 1; i < nEntry; i++ ){
-				pTos++;
-				PH7_MemObjInit(pVm, pTos);
-				pTos->nIdx = SXU32_HIGH;
-				pElem = (ph7_value *)SySetAt(&pVm->aMemObj, pNode2->nValIdx);
-				if( pElem ){
-					PH7_MemObjLoad(pElem, pTos);
-				}
-				pNode2 = pNode2->pPrev;
-			}
-			pVm->iSpreadExtra += (sxi32)(nEntry - 1);
-		}
+		VmSpreadExpandMap(pVm, &pTos, (ph7_hashmap *)pTos->x.pOther);
 	}
 	/* else: not an array — leave as-is (single arg) */
 	break;
@@ -12757,9 +12765,19 @@ case PH7_OP_MEMBER: {
  *  Create a new class instance (Object in the PHP jargon) and push that object on the stack.
  */
 case PH7_OP_NEW: {
-	ph7_value *pArg = &pTos[-pInstr->iP1]; /* Constructor arguments (if available) */
+	/* Constructor arg count: compile-time args plus any pending spread
+	 * expansion (iP2 = hasSpread, transferred from the popped OP_CALL —
+	 * `new C(...$args)` used to ignore the extras, leaving the expanded
+	 * elements ABOVE the class-name slot and fataling "Class ' ' is not
+	 * defined"). Consume the accumulator only when this NEW owns it. */
+	sxi32 nCtorArgs = pInstr->iP1 + (pInstr->iP2 ? pVm->iSpreadExtra : 0);
+	ph7_value *pArg;
 	ph7_class *pClass = 0;
 	ph7_class_instance *pNew;
+	if( pInstr->iP2 ){
+		pVm->iSpreadExtra = 0;
+	}
+	pArg = &pTos[-nCtorArgs]; /* Constructor arguments (if available) */
 	if( (pTos->iFlags & MEMOBJ_STRING) && SyBlobLength(&pTos->sBlob) > 0 ){
 		/* Try to extract the desired class */
 		pClass = PH7_VmExtractClass(&(*pVm),(const char *)SyBlobData(&pTos->sBlob),
@@ -12775,9 +12793,9 @@ case PH7_OP_NEW: {
 			);
 		/* Release the class operand and any constructor arguments, then abort */
 		PH7_MemObjRelease(pTos);
-		if( pInstr->iP1 > 0 ){
+		if( nCtorArgs > 0 ){
 			/* Pop given arguments */
-			VmPopOperand(&pTos,pInstr->iP1);
+			VmPopOperand(&pTos,nCtorArgs);
 		}
 		goto Abort;
 	}else{
@@ -12809,8 +12827,8 @@ case PH7_OP_NEW: {
 				/* Pop ctor args + release the class-name operand, leave NULL
 				 * as the expression value; the fetch-point router lands the
 				 * throw. No instance was created. */
-				if( pInstr->iP1 > 0 ){
-					VmPopOperand(&pTos,pInstr->iP1);
+				if( nCtorArgs > 0 ){
+					VmPopOperand(&pTos,nCtorArgs);
 				}
 				PH7_MemObjRelease(pTos);
 				pTos->nIdx = SXU32_HIGH;
@@ -12825,9 +12843,9 @@ case PH7_OP_NEW: {
 				&pClass->sName
 			);
 			PH7_MemObjRelease(pTos);
-			if( pInstr->iP1 > 0 ){
+			if( nCtorArgs > 0 ){
 				/* Pop given arguments */
-				VmPopOperand(&pTos,pInstr->iP1);
+				VmPopOperand(&pTos,nCtorArgs);
 			}
 			break;
 		}
@@ -12864,8 +12882,8 @@ case PH7_OP_NEW: {
 				if( VmRecordedResume(pVm,&iResumePc,sState.pEntryFrame,aInstr) ){
 					/* This frame's own try caught it in-place: tidy the stack
 					 * (pop ctor args + release the class-name slot) and resume. */
-					if( pInstr->iP1 > 0 ){
-						VmPopOperand(&pTos,pInstr->iP1);
+					if( nCtorArgs > 0 ){
+						VmPopOperand(&pTos,nCtorArgs);
 					}
 					PH7_MemObjRelease(pTos);
 					pc = iResumePc;
@@ -12874,9 +12892,9 @@ case PH7_OP_NEW: {
 				goto Exception;
 			}
 		}
-		if( pInstr->iP1 > 0 ){
+		if( nCtorArgs > 0 ){
 			/* Pop given arguments */
-			VmPopOperand(&pTos,pInstr->iP1);
+			VmPopOperand(&pTos,nCtorArgs);
 		}
 		PH7_MemObjRelease(pTos);
 		pTos->x.pOther = pNew;
@@ -13457,9 +13475,16 @@ yf_propagate:
  *  function on the stack.
  */
 case PH7_OP_CALL: {
-	sxi32 nCallArgs = pInstr->iP1 + pVm->iSpreadExtra;
+	/* iP2 = hasSpread (compile-time). Consume the spread accumulator ONLY
+	 * when this call's own argument list contains a spread — an INNER call
+	 * evaluated between an earlier spread and this one (f(...[1,2], ...mk()))
+	 * used to steal the pending extras: mk() received a phantom argument and
+	 * the outer call dropped the expanded elements. */
+	sxi32 nCallArgs = pInstr->iP1 + (pInstr->iP2 ? pVm->iSpreadExtra : 0);
 	ph7_value *pArg;
-	pVm->iSpreadExtra = 0; /* Always reset, even if zero */
+	if( pInstr->iP2 ){
+		pVm->iSpreadExtra = 0;
+	}
 	pArg = &pTos[-nCallArgs];
 	SyHashEntry *pEntry;
 	SyString sName;

--- a/tests/ph7/001-smoke/function/spread_temporary_arrays.phpt
+++ b/tests/ph7/001-smoke/function/spread_temporary_arrays.phpt
@@ -1,0 +1,74 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Spreading temporary arrays (literals, call results) into fixed parameters binds the values
+--FILE--
+<?php
+function staSum($a, $b) { return $a + $b; }
+function staMk() { return [7, 8]; }
+class StaC {
+    public function pair() { return [3, 4]; }
+}
+
+// Array literal spread (used to bind null/null: the temp map's slots were
+// recycled before the elements were read).
+echo staSum(...[1, 2]), "\n";
+// Call-result spread (the parser used to lose the ... flag when the argument
+// tree roots at a call node — no expansion at all).
+echo staSum(...staMk()), "\n";
+echo staSum(...array_values([10, 20])), "\n";
+// Method-call spread (paren-headed argument) into a FIXED-arity function —
+// max() can't distinguish spread-vs-single-array, staSum can.
+echo staSum(...(new StaC)->pair()), "\n";
+// Mixed positional + literal spread.
+echo staSum(1, ...[2]), "\n";
+// Nested container element survives the temp map's release.
+$staNested = staMk();
+echo implode(",", [...staMk(), 9]), "|", count($staNested), "\n";
+// Element that is itself an array.
+function staFirst($x) { return $x[0]; }
+echo staFirst(...[[5, 6]]), "\n";
+// Variable spread unchanged, source array intact afterwards.
+$staArgs = [1, 2];
+echo staSum(...$staArgs), "|", implode(",", $staArgs), "\n";
+// Under-arity literal spread still counts correctly.
+try {
+    staSum(...[1]);
+} catch (ArgumentCountError $e) {
+    echo "count-ok\n";
+}
+// Constructor spread (used to fatal: OP_NEW ignored the expansion).
+class StaK {
+    public $v;
+    public function __construct($a, $b) { $this->v = $a + $b; }
+}
+$staCtor = [10, 20];
+echo (new StaK(...$staCtor))->v, "|", (new StaK(...[1, 2]))->v, "\n";
+// Two spreads with an inner call between them (accumulator theft regression).
+function staVar(...$all) { return implode(",", $all); }
+echo staVar(...[1, 2], ...staMk()), "\n";
+// Parenthesized spread argument.
+$staParen = [1, 2];
+echo staSum(...($staParen)), "|", staSum(...(true ? [3, 4] : [5, 6])), "\n";
+// Named argument after a spread is legal.
+function staNamed($a, $b = 0, $c = 0) { return "$a/$b/$c"; }
+echo staNamed(...[1], c: 3), "\n";
+?>
+--EXPECT--
+3
+15
+30
+7
+3
+7,8,9|2
+5
+3|1,2
+count-ok
+30|3
+1,2,7,8
+3|7
+1/0/3
+--CLEAN--
+<?php
+unset($staNested, $staArgs, $staCtor, $staParen, $e);


### PR DESCRIPTION
…ead lists

f(...[1,2]) bound null/null: OP_SPREAD released the stack temp before reading the elements, so a literal or call result — whose only reference that was — expanded from freelist-recycled slots. The expansion (now the shared VmSpreadExpandMap, also used by the Traversable path) holds a map reference across the walk; a sole-owner temp's elements are deep-copied, a shared map keeps the zero-copy aliasing f(...$var) always had.

f(...mk()) passed the whole array as one argument: the parser flags the argument's first node when it consumes '...', and tree-building roots the expression at a different node for calls and member access — the paren pass also freed a flagged leading group ('...($x)', '...(new S)->pair()'). The spread mark now survives onto the group root and the argument root.

new C(...$args) fataled "Class ' ' is not defined": OP_CALL's iP2 was double-booked between the hasSpread flag and a legacy original-name-literal channel for namespaced new; the channel moved to VmCallArgMap.nOrigNameLit, and OP_NEW now consumes the spread accumulator like OP_CALL.

f(...[1,2], ...mk()) dropped elements: the inner call consumed and reset the VM-global accumulator; consumption is gated on the instruction's own hasSpread flag. php's compile-time argument-order rules now hold: a positional argument after unpacking and name: ...$x are compile errors.
