### PR TITLE
Promote overflowing integer arithmetic to float

### DIFF
--- a/src/ph7/memobj.c
+++ b/src/ph7/memobj.c
@@ -7,6 +7,56 @@
 #include <stdio.h>  /* snprintf — the default float->string conversion needs
                      * correctly-rounded digits like php (see MemObjStringValue) */
 
+/* Portable 64-bit overflow-detecting arithmetic for compilers that lack the
+ * GCC/Clang __builtin_*_overflow intrinsics (i.e. MSVC). The header exposes
+ * these through the PH7_{ADD,SUB,MUL}_OVERFLOW64 macros; the intrinsic path
+ * needs no out-of-line definition, so gate the whole block off there to avoid
+ * an unused-function warning. Each sets *pR to the two's-complement wrapped
+ * result and returns non-zero on overflow. The additive checks compute the
+ * wrapped result via unsigned math (no signed-overflow UB) and test the sign
+ * bits; the multiplicative check mirrors vm.c's proven bound-check form. */
+#if !(defined(__GNUC__) || defined(__clang__))
+PH7_PRIVATE int PH7_AddOverflow64(sxi64 a,sxi64 b,sxi64 *pR)
+{
+	*pR = (sxi64)((sxu64)a + (sxu64)b);
+	/* Overflow iff the operands share a sign and the result's sign differs. */
+	return ((a ^ *pR) & (b ^ *pR)) < 0;
+}
+PH7_PRIVATE int PH7_SubOverflow64(sxi64 a,sxi64 b,sxi64 *pR)
+{
+	*pR = (sxi64)((sxu64)a - (sxu64)b);
+	/* Overflow iff the operands differ in sign and the result's sign differs
+	 * from the minuend's. */
+	return ((a ^ b) & (a ^ *pR)) < 0;
+}
+PH7_PRIVATE int PH7_MulOverflow64(sxi64 a,sxi64 b,sxi64 *pR)
+{
+	*pR = (sxi64)((sxu64)a * (sxu64)b);
+	if( a == 0 || b == 0 || a == 1 || b == 1 ){
+		return 0;
+	}
+	if( a == -1 ){
+		return b == SMALLEST_INT64;
+	}
+	if( b == -1 ){
+		return a == SMALLEST_INT64;
+	}
+	if( a > 0 ){
+		if( b > 0 ){
+			return a > LARGEST_INT64 / b;
+		}else{
+			return b < SMALLEST_INT64 / a;
+		}
+	}else{
+		if( b > 0 ){
+			return a < SMALLEST_INT64 / b;
+		}else{
+			return b < LARGEST_INT64 / a;
+		}
+	}
+}
+#endif
+
 /* Provide PHP-style type names for values.  This utility may be reused
  * by any subsystem that works with ph7_value.
  */
@@ -1474,12 +1524,24 @@ PH7_PRIVATE sxi32 PH7_MemObjAdd(ph7_value *pObj1,ph7_value *pObj2,int bAddStore)
 				/* Try to get an integer representation also */
 				MemObjTryIntger(&(*pObj1));
 			}else{
-				/* Integer arithmetic */
-				sxi64 a,b;
+				/* Integer arithmetic; PHP promotes an overflowing sum to float.
+				 * The integer-only build (PH7_OMIT_FLOATING_POINT) has no float
+				 * type, so it wraps like OP_POW's OMIT path. */
+				sxi64 a,b,r;
 				a = pObj1->x.iVal;
 				b = pObj2->x.iVal;
-				pObj1->x.iVal = a+b;
-				MemObjSetType(pObj1,MEMOBJ_INT);
+				if( PH7_ADD_OVERFLOW64(a,b,&r) ){
+#ifndef PH7_OMIT_FLOATING_POINT
+					pObj1->rVal = (ph7_real)a + (ph7_real)b;
+					MemObjSetType(pObj1,MEMOBJ_REAL);
+#else
+					pObj1->x.iVal = r;
+					MemObjSetType(pObj1,MEMOBJ_INT);
+#endif
+				}else{
+					pObj1->x.iVal = r;
+					MemObjSetType(pObj1,MEMOBJ_INT);
+				}
 			}
 	}else{
 		if( (pObj1->iFlags|pObj2->iFlags) & MEMOBJ_HASHMAP ){

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -115,6 +115,27 @@ struct ph7_value
  * it with the given one.
  */
 #define MemObjSetType(OBJ,TYPE) ((OBJ)->iFlags = ((OBJ)->iFlags&~MEMOBJ_ALL)|TYPE)
+/*
+ * Signed 64-bit arithmetic with overflow detection. PHP promotes an integer
+ * operation that overflows sxi64 to a floating-point result, so the executor
+ * checks for overflow on every +,-,* (and ++/--) and re-runs the operation in
+ * double precision when it trips. GCC/Clang expose the __builtin_*_overflow
+ * intrinsics (zero cost, no UB); MSVC lacks them, so we fall back to portable
+ * implementations defined in memobj.c. Each macro sets *pR to the wrapped
+ * result and evaluates to non-zero on overflow.
+ */
+#if defined(__GNUC__) || defined(__clang__)
+#define PH7_ADD_OVERFLOW64(a,b,pR) __builtin_add_overflow((a),(b),(pR))
+#define PH7_SUB_OVERFLOW64(a,b,pR) __builtin_sub_overflow((a),(b),(pR))
+#define PH7_MUL_OVERFLOW64(a,b,pR) __builtin_mul_overflow((a),(b),(pR))
+#else
+PH7_PRIVATE int PH7_AddOverflow64(sxi64 a,sxi64 b,sxi64 *pR);
+PH7_PRIVATE int PH7_SubOverflow64(sxi64 a,sxi64 b,sxi64 *pR);
+PH7_PRIVATE int PH7_MulOverflow64(sxi64 a,sxi64 b,sxi64 *pR);
+#define PH7_ADD_OVERFLOW64(a,b,pR) PH7_AddOverflow64((a),(b),(pR))
+#define PH7_SUB_OVERFLOW64(a,b,pR) PH7_SubOverflow64((a),(b),(pR))
+#define PH7_MUL_OVERFLOW64(a,b,pR) PH7_MulOverflow64((a),(b),(pR))
+#endif
 /* ph7_value cast method signature */
 typedef sxi32 (*ProcMemObjCast)(ph7_value *);
 /* Forward reference */

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -9,49 +9,10 @@
 #ifndef PH7_OMIT_FLOATING_POINT
 #include <math.h>
 #endif
-/* Signed 64-bit multiplication with overflow detection. GCC/Clang expose
- * __builtin_mul_overflow; MSVC does not, so we fall back to a portable
- * UB-free bound-check implementation. Sets *pR to the wrapped product and
- * returns non-zero on overflow. The fallback never divides a potentially-
- * overflowed intermediate: all divisions are of compile-time constants
- * (LARGEST_INT64/SMALLEST_INT64) by a factor already proven not to be -1,
- * and the product itself is computed via unsigned multiplication to avoid
- * signed-overflow UB. */
-#if defined(__GNUC__) || defined(__clang__)
-#define VmMulOverflow64(a,b,pR) __builtin_mul_overflow((a),(b),(pR))
-#else
-static int VmMulOverflow64(sxi64 a, sxi64 b, sxi64 *pR)
-{
-	*pR = (sxi64)((sxu64)a * (sxu64)b);
-	/* Factors of 0 or ±1 never overflow; handle up front so the divisions
-	 * below are guaranteed safe (no SMALLEST_INT64 / -1, no /0). */
-	if( a == 0 || b == 0 || a == 1 || b == 1 ){
-		return 0;
-	}
-	if( a == -1 ){
-		return b == SMALLEST_INT64;
-	}
-	if( b == -1 ){
-		return a == SMALLEST_INT64;
-	}
-	/* |a|,|b| >= 2 and neither is -1.  Bound check against the MAX/MIN
-	 * thresholds.  No division by -1 is possible here, and the quotients
-	 * of compile-time constants by {a,b} always fit in sxi64. */
-	if( a > 0 ){
-		if( b > 0 ){
-			return a > LARGEST_INT64 / b;
-		}else{
-			return b < SMALLEST_INT64 / a;
-		}
-	}else{
-		if( b > 0 ){
-			return a < SMALLEST_INT64 / b;
-		}else{
-			return b < LARGEST_INT64 / a;
-		}
-	}
-}
-#endif
+/* Signed 64-bit integer overflow detection lives in ph7int.h as the shared
+ * PH7_{ADD,SUB,MUL}_OVERFLOW64 macros (GCC/Clang intrinsics, MSVC fallbacks in
+ * memobj.c). The executor uses them to promote an overflowing integer
+ * operation to a float, matching PHP. */
 /*
  * The code in this file implements execution method of the PH7 Virtual Machine.
  * The PH7 compiler (implemented in 'compiler.c' and 'parse.c') generates a bytecode program
@@ -9565,7 +9526,19 @@ case PH7_OP_INCR:
 						 * integer-valued real. */
 						PH7_MemObjTryInteger(pObj);
 					}else{
-						pObj->x.iVal++;
+						/* PHP promotes PHP_INT_MAX++ to float; the integer-only
+						 * build wraps like OP_POW's OMIT path. */
+						sxi64 r;
+						if( PH7_ADD_OVERFLOW64(pObj->x.iVal,1,&r) ){
+#ifndef PH7_OMIT_FLOATING_POINT
+							pObj->rVal = (ph7_real)pObj->x.iVal + 1.0;
+							MemObjSetType(pObj,MEMOBJ_REAL);
+#else
+							pObj->x.iVal = r;
+#endif
+						}else{
+							pObj->x.iVal = r;
+						}
 					}
 					if( pInstr->iP1 ){
 						/* Pre-increment: result is the new value. */
@@ -9588,8 +9561,21 @@ case PH7_OP_INCR:
 						/* Try to get an integer representation */
 						PH7_MemObjTryInteger(pTos);
 					}else{
-						pTos->x.iVal++;
-						MemObjSetType(pTos,MEMOBJ_INT);
+						/* PHP promotes PHP_INT_MAX++ to float; the integer-only
+						 * build wraps like OP_POW's OMIT path. */
+						sxi64 r;
+						if( PH7_ADD_OVERFLOW64(pTos->x.iVal,1,&r) ){
+#ifndef PH7_OMIT_FLOATING_POINT
+							pTos->rVal = (ph7_real)pTos->x.iVal + 1.0;
+							MemObjSetType(pTos,MEMOBJ_REAL);
+#else
+							pTos->x.iVal = r;
+							MemObjSetType(pTos,MEMOBJ_INT);
+#endif
+						}else{
+							pTos->x.iVal = r;
+							MemObjSetType(pTos,MEMOBJ_INT);
+						}
 					}
 				}
 			}
@@ -9645,7 +9631,19 @@ case PH7_OP_DECR:
 						 * integer-valued real. */
 						PH7_MemObjTryInteger(pObj);
 					}else{
-						pObj->x.iVal--;
+						/* PHP promotes PHP_INT_MIN-- to float; the integer-only
+						 * build wraps like OP_POW's OMIT path. */
+						sxi64 r;
+						if( PH7_SUB_OVERFLOW64(pObj->x.iVal,1,&r) ){
+#ifndef PH7_OMIT_FLOATING_POINT
+							pObj->rVal = (ph7_real)pObj->x.iVal - 1.0;
+							MemObjSetType(pObj,MEMOBJ_REAL);
+#else
+							pObj->x.iVal = r;
+#endif
+						}else{
+							pObj->x.iVal = r;
+						}
 					}
 					if( pInstr->iP1 ){
 						/* Pre-decrement: result is the new value. */
@@ -9667,8 +9665,21 @@ case PH7_OP_DECR:
 						/* Keep the cached int consistent with the new rVal. */
 						PH7_MemObjTryInteger(pTos);
 					}else{
-						pTos->x.iVal--;
-						MemObjSetType(pTos,MEMOBJ_INT);
+						/* PHP promotes PHP_INT_MIN-- to float; the integer-only
+						 * build wraps like OP_POW's OMIT path. */
+						sxi64 r;
+						if( PH7_SUB_OVERFLOW64(pTos->x.iVal,1,&r) ){
+#ifndef PH7_OMIT_FLOATING_POINT
+							pTos->rVal = (ph7_real)pTos->x.iVal - 1.0;
+							MemObjSetType(pTos,MEMOBJ_REAL);
+#else
+							pTos->x.iVal = r;
+							MemObjSetType(pTos,MEMOBJ_INT);
+#endif
+						}else{
+							pTos->x.iVal = r;
+							MemObjSetType(pTos,MEMOBJ_INT);
+						}
 					}
 				}
 			}
@@ -9692,7 +9703,25 @@ case PH7_OP_UMINUS:
 		pTos->rVal = -pTos->rVal;
 	}
 	if( pTos->iFlags & MEMOBJ_INT ){
-		pTos->x.iVal = -pTos->x.iVal;
+		if( pTos->x.iVal == SMALLEST_INT64 ){
+			/* -PHP_INT_MIN overflows sxi64; PHP promotes it to float. When a
+			 * REAL representation is already present it is the negated
+			 * authoritative value, so just drop the now-stale cached int. The
+			 * integer-only build has no float type, so it wraps (two's
+			 * complement -INT_MIN == INT_MIN) like OP_POW's OMIT path. */
+#ifndef PH7_OMIT_FLOATING_POINT
+			if( (pTos->iFlags & MEMOBJ_REAL) == 0 ){
+				pTos->rVal = -(ph7_real)pTos->x.iVal;
+				MemObjSetType(pTos,MEMOBJ_REAL);
+			}else{
+				pTos->iFlags &= ~MEMOBJ_INT;
+			}
+#else
+			pTos->x.iVal = (sxi64)(0 - (sxu64)pTos->x.iVal);
+#endif
+		}else{
+			pTos->x.iVal = -pTos->x.iVal;
+		}
 	}
 	break;
 /*
@@ -9787,14 +9816,23 @@ case PH7_OP_MUL_STORE: {
 		/* Try to get an integer representation */
 		PH7_MemObjTryInteger(pNos);
 	}else{
-		/* Integer arithmetic */
+		/* Integer arithmetic; PHP promotes an overflowing product to float.
+		 * The integer-only build wraps like OP_POW's OMIT path. */
 		sxi64 a,b,r;
 		a = pNos->x.iVal;
 		b = pTos->x.iVal;
-		r = a * b;
-		/* Push the result */
-		pNos->x.iVal = r;
-		MemObjSetType(pNos,MEMOBJ_INT);
+		if( PH7_MUL_OVERFLOW64(a,b,&r) ){
+#ifndef PH7_OMIT_FLOATING_POINT
+			pNos->rVal = (ph7_real)a * (ph7_real)b;
+			MemObjSetType(pNos,MEMOBJ_REAL);
+#else
+			pNos->x.iVal = r;
+			MemObjSetType(pNos,MEMOBJ_INT);
+#endif
+		}else{
+			pNos->x.iVal = r;
+			MemObjSetType(pNos,MEMOBJ_INT);
+		}
 	}
 	if( pInstr->iOp == PH7_OP_MUL_STORE ){
 		ph7_value *pObj;
@@ -9866,14 +9904,14 @@ case PH7_OP_POW_STORE: {
 		int overflow = 0;
 		while( cur_exp > 0 ){
 			if( cur_exp & 1 ){
-				if( VmMulOverflow64(result_i, cur_base, &result_i) ){
+				if( PH7_MUL_OVERFLOW64(result_i, cur_base, &result_i) ){
 					overflow = 1;
 					break;
 				}
 			}
 			cur_exp >>= 1;
 			if( cur_exp > 0 ){
-				if( VmMulOverflow64(cur_base, cur_base, &cur_base) ){
+				if( PH7_MUL_OVERFLOW64(cur_base, cur_base, &cur_base) ){
 					overflow = 1;
 					break;
 				}
@@ -10017,14 +10055,23 @@ case PH7_OP_SUB: {
 		/* Try to get an integer representation */
 		PH7_MemObjTryInteger(pNos);
 	}else{
-		/* Integer arithmetic */
+		/* Integer arithmetic; PHP promotes an overflowing difference to float.
+		 * The integer-only build wraps like OP_POW's OMIT path. */
 		sxi64 a,b,r;
 		a = pNos->x.iVal;
 		b = pTos->x.iVal;
-		r = a - b;
-		/* Push the result */
-		pNos->x.iVal = r;
-		MemObjSetType(pNos,MEMOBJ_INT);
+		if( PH7_SUB_OVERFLOW64(a,b,&r) ){
+#ifndef PH7_OMIT_FLOATING_POINT
+			pNos->rVal = (ph7_real)a - (ph7_real)b;
+			MemObjSetType(pNos,MEMOBJ_REAL);
+#else
+			pNos->x.iVal = r;
+			MemObjSetType(pNos,MEMOBJ_INT);
+#endif
+		}else{
+			pNos->x.iVal = r;
+			MemObjSetType(pNos,MEMOBJ_INT);
+		}
 	}
 	VmPopOperand(&pTos,1);
 	break;
@@ -10061,14 +10108,23 @@ case PH7_OP_SUB_STORE: {
 		/* Try to get an integer representation */
 		PH7_MemObjTryInteger(pNos);
 	}else{
-		/* Integer arithmetic */
+		/* Integer arithmetic; PHP promotes an overflowing difference to float.
+		 * The integer-only build wraps like OP_POW's OMIT path. */
 		sxi64 a,b,r;
 		a = pTos->x.iVal;
 		b = pNos->x.iVal;
-		r = a - b;
-		/* Push the result */
-		pNos->x.iVal = r;
-		MemObjSetType(pNos,MEMOBJ_INT);
+		if( PH7_SUB_OVERFLOW64(a,b,&r) ){
+#ifndef PH7_OMIT_FLOATING_POINT
+			pNos->rVal = (ph7_real)a - (ph7_real)b;
+			MemObjSetType(pNos,MEMOBJ_REAL);
+#else
+			pNos->x.iVal = r;
+			MemObjSetType(pNos,MEMOBJ_INT);
+#endif
+		}else{
+			pNos->x.iVal = r;
+			MemObjSetType(pNos,MEMOBJ_INT);
+		}
 	}
 	if( pTos->nIdx == SXU32_HIGH ){
 		PH7_VmThrowError(&(*pVm),0,PH7_CTX_ERR,"Cannot perform assignment on a constant class attribute");
@@ -10113,6 +10169,12 @@ case PH7_OP_MOD:{
 		rc = VmThrowFixedError(&(*pVm),"DivisionByZeroError","Modulo by zero");
 		PH7_DISPATCH_ENFORCE_RC(rc)
 		r = 0; /* unreachable — ENFORCE_RC jumps/breaks for a throw */
+	}else if( b == -1 ){
+		/* `a % -1` is 0 for every a. Computing it as `a%b` would be a signed
+		 * -overflow trap (SIGFPE on x86) when a == PHP_INT_MIN, since the CPU
+		 * evaluates the overflowing quotient PHP_INT_MIN/-1 alongside the
+		 * remainder. php's result here is 0. */
+		r = 0;
 	}else{
 		r = a%b;
 	}
@@ -10156,6 +10218,10 @@ case PH7_OP_MOD_STORE: {
 		rc = VmThrowFixedError(&(*pVm),"DivisionByZeroError","Modulo by zero");
 		PH7_DISPATCH_ENFORCE_RC(rc)
 		r = 0; /* unreachable — ENFORCE_RC jumps/breaks for a throw */
+	}else if( b == -1 ){
+		/* `a % -1` is 0 for every a; see OP_MOD — computing `a%b` would trap
+		 * (SIGFPE on x86) for a == PHP_INT_MIN. php's result here is 0. */
+		r = 0;
 	}else{
 		r = a%b;
 	}

--- a/tests/ph7/001-smoke/lang/integer_arithmetic_overflow_float.phpt
+++ b/tests/ph7/001-smoke/lang/integer_arithmetic_overflow_float.phpt
@@ -1,0 +1,101 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Integer arithmetic that overflows the signed 64-bit range promotes to float
+--FILE--
+<?php
+/* PHP promotes an integer +, -, *, ++ or -- whose exact result exceeds the
+ * signed 64-bit range to a float instead of wrapping. The int/float
+ * classification and the resulting value are byte-identical to php 8.5.7. The
+ * promoted values are asserted with === against the equivalent overflow
+ * literals (which php parses as the same doubles); var_dump is avoided because
+ * php's serialize-precision float shape is a separate tracked divergence. */
+function tyArith($v) { return is_float($v) ? "float" : (is_int($v) ? "int" : "?"); }
+
+// Addition
+echo tyArith(PHP_INT_MAX + 1), "\n";                 // float
+echo (PHP_INT_MAX + 1) === 9223372036854775808 ? "add_ok\n" : "add_bad\n";
+echo tyArith(PHP_INT_MAX + PHP_INT_MAX), "\n";       // float
+echo tyArith(PHP_INT_MAX + 0), "\n";                 // int (no overflow)
+echo tyArith(1000 + 2000), "\n";                     // int
+
+// Subtraction
+echo tyArith(PHP_INT_MIN - 1), "\n";                 // float
+echo (PHP_INT_MIN - 1) === -9223372036854775809 ? "sub_ok\n" : "sub_bad\n";
+echo tyArith(PHP_INT_MIN - PHP_INT_MAX), "\n";       // float
+echo tyArith(5 - 9), "\n";                           // int
+
+// Multiplication
+echo tyArith(PHP_INT_MAX * 2), "\n";                 // float
+echo (PHP_INT_MAX * 2) === 18446744073709551616 ? "mul_ok\n" : "mul_bad\n";
+echo tyArith(4611686018427387904 * 2), "\n";         // 2^62 * 2 == 2^63 -> float
+echo tyArith(PHP_INT_MAX * PHP_INT_MAX), "\n";       // float
+echo tyArith(PHP_INT_MAX * 1), "\n";                 // int (no overflow)
+echo tyArith(-1 * PHP_INT_MIN), "\n";                // float (|min| overflows)
+echo tyArith(6 * 7), "\n";                           // int
+
+// Unary minus on PHP_INT_MIN (its magnitude overflows)
+echo tyArith(-PHP_INT_MIN), "\n";                    // float
+echo (-PHP_INT_MIN) === 9223372036854775808 ? "neg_ok\n" : "neg_bad\n";
+echo tyArith(-PHP_INT_MAX), "\n";                    // int (fits)
+
+// Increment / decrement
+$a = PHP_INT_MAX; $a++; echo tyArith($a), "\n";      // float
+echo $a === 9223372036854775808 ? "incr_ok\n" : "incr_bad\n";
+$b = PHP_INT_MIN; $b--; echo tyArith($b), "\n";      // float
+echo $b === -9223372036854775809 ? "decr_ok\n" : "decr_bad\n";
+$c = 41; $c++; echo tyArith($c), " ", $c, "\n";      // int 42 (no overflow)
+
+// Post-increment value semantics at the boundary: old value is still the int
+$d = PHP_INT_MAX;
+$old = $d++;
+echo tyArith($old), " ", tyArith($d), "\n";               // int float
+
+// Compound assignment overflows too
+$e = PHP_INT_MAX; $e += 1; echo tyArith($e), "\n";   // float
+$f = PHP_INT_MAX; $f *= 2; echo tyArith($f), "\n";   // float
+$g = PHP_INT_MIN; $g -= 1; echo tyArith($g), "\n";   // float
+
+// In-range compound assignment stays int
+$h = 10; $h += 5; $h *= 3; echo tyArith($h), " ", $h, "\n"; // int 45
+
+// Modulo at the INT_MIN / -1 boundary: `a % -1` is 0 for every a. Computing it
+// as a%b would trap (SIGFPE) on x86 for PHP_INT_MIN, so it is special-cased.
+echo (PHP_INT_MIN % -1), " ", (7 % -1), " ", (PHP_INT_MIN % -2), "\n"; // 0 0 0
+$m = PHP_INT_MIN; $m %= -1; echo $m, "\n";                             // 0
+?>
+--EXPECT--
+float
+add_ok
+float
+int
+int
+float
+sub_ok
+float
+int
+float
+mul_ok
+float
+float
+int
+float
+int
+float
+neg_ok
+int
+float
+incr_ok
+float
+decr_ok
+int 42
+int float
+float
+float
+float
+int 45
+0 0 0
+0
+--CLEAN--
+<?php


### PR DESCRIPTION
PHP_INT_MAX + 1 wrapped to -9223372036854775808 where php promotes the result to float(9.2233720368548E+18). Add shared PH7_{ADD,SUB,MUL}_OVERFLOW64 macros (GCC/Clang __builtin_*_overflow intrinsics, MSVC fallbacks in memobj.c) and route every integer +, -, *, ++, -- and unary minus through them: on overflow the operation is re-run in double precision and the value flips to MEMOBJ_REAL, matching php's ZEND overflow formula. Sites: PH7_MemObjAdd, OP_SUB/SUB_STORE, OP_MUL/MUL_STORE, OP_INCR/DECR (both int paths each), and OP_UMINUS (-PHP_INT_MIN, previously a signed-overflow UB). OP_POW's private VmMulOverflow64 helper is folded into the shared macro.

The integer-only build (PH7_OMIT_FLOATING_POINT / MODE=tiny) has no float type, so every promotion site is guarded to keep wrapping like OP_POW's existing OMIT path.

Also guard OP_MOD/OP_MOD_STORE against a % -1: computing a%b there is a signed-overflow trap (SIGFPE on x86-64) when a == PHP_INT_MIN. The result is 0 for every a, so short-circuit it — the same INT_MIN/-1 boundary the unary minus case hardens.

Byte-verified vs php 8.5.7; cross-engine test integer_arithmetic_overflow_float; full/tiny warning-free under -Werror; docker ASan+UBSan clean.
