### PR TITLE
Key each foreach step to its activation so generator instances don't …

### DIFF
--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -337,6 +337,13 @@ struct ph7_foreach_step
 									 * php iterates each foreach independently — the map's
 									 * shared pCur would make nested loops over one array
 									 * rewind each other (infinite loop). */
+	struct VmFrame *pFrame;         /* Owning activation's frame (normalized past exception
+									 * frames). aStep is per-STATEMENT and shared by every
+									 * activation; OP_FOREACH_STEP selects the step whose
+									 * pFrame matches the running activation so two suspended
+									 * instances of one generator/fiber (or a recursive call)
+									 * paused in the same textual foreach cannot clash on
+									 * each other's cursor. */
 	ph7_foreach_step *pNextActive;  /* Next step on the map's pActiveSteps list */
 };
 /* Foreach step control flags */

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -7203,13 +7203,39 @@ static int VmMemberNextIsWrite(const VmInstr *pNext)
  * drifts produces a leak or pool-masked use-after-free on exactly one throw
  * path (the SyHash-layout incident class).
  */
+/*
+ * Remove pStep's pointer from the per-statement aStep set. The step being torn
+ * down is not necessarily the last one pushed — two generator/fiber instances
+ * of the same foreach suspend and finish out of LIFO order — so find it by
+ * pointer. Removal is ORDER-PRESERVING (shift the tail down): OP_FOREACH_STEP's
+ * top-down scan relies on the running activation's step (always the most-recent
+ * push for its statement) sitting ABOVE any leaked older step that may share a
+ * recycled frame address. A swap-with-last would move a newer step below such a
+ * leaked step and let the scan match the stale one. A no-op if the step was
+ * never linked (INIT error path).
+ */
+static void VmForeachStepUnlink(ph7_foreach_info *pInfo,ph7_foreach_step *pStep)
+{
+	ph7_foreach_step **apStep = (ph7_foreach_step **)SySetBasePtr(&pInfo->aStep);
+	sxu32 n = SySetUsed(&pInfo->aStep);
+	sxu32 i;
+	for( i = 0 ; i < n ; ++i ){
+		if( apStep[i] == pStep ){
+			for( ; i + 1 < n ; ++i ){
+				apStep[i] = apStep[i + 1];
+			}
+			(void)SySetPop(&pInfo->aStep);
+			return;
+		}
+	}
+}
 static void VmForeachStepAbandon(ph7_vm *pVm,ph7_foreach_info *pInfo,ph7_foreach_step *pStep,ph7_class_instance *pThis)
 {
 	if( pStep->pOwner ){
 		PH7_ClassInstanceUnref(pStep->pOwner);
 	}
+	VmForeachStepUnlink(pInfo,pStep);
 	SyMemBackendPoolFree(&pVm->sAllocator,pStep);
-	SySetPop(&pInfo->aStep);
 	PH7_ClassInstanceUnref(pThis);
 }
 /*
@@ -7226,10 +7252,12 @@ static void VmForeachHashmapStepRelease(ph7_vm *pVm,ph7_foreach_info *pInfo,ph7_
 {
 	ph7_hashmap *pMap = pStep->xIter.pMap;
 	PH7_HashmapUnregisterForeachStep(pMap,pStep);
-	SyMemBackendPoolFree(&pVm->sAllocator,pStep);
 	if( bPop ){
-		SySetPop(&pInfo->aStep);
+		/* Remove by pointer, not position: an out-of-LIFO-order generator/fiber
+		 * teardown may leave this step below newer ones on the shared aStep. */
+		VmForeachStepUnlink(pInfo,pStep);
 	}
+	SyMemBackendPoolFree(&pVm->sAllocator,pStep);
 	PH7_HashmapUnref(pMap);
 }
 /*
@@ -11764,6 +11792,11 @@ case PH7_OP_FOREACH_INIT: {
 			SyZero(pStep,sizeof(ph7_foreach_step));
 			/* Prepare the step */
 			pStep->iFlags = pInfo->iFlags;
+			/* Record the owning activation so OP_FOREACH_STEP can pick THIS
+			 * activation's step out of the per-statement stack — two suspended
+			 * generator/fiber instances (or a recursive call) paused in the same
+			 * textual foreach otherwise resume onto each other's cursor. */
+			pStep->pFrame = VmSkipExceptionFrames(pVm->pFrame);
 			if( pTos->iFlags & MEMOBJ_HASHMAP ){
 				ph7_hashmap *pMap,*pIterMap;
 				/* COW: For by-reference foreach, eagerly separate the
@@ -11929,11 +11962,32 @@ case PH7_OP_FOREACH_STEP: {
 	ph7_foreach_step **apStep,*pStep;
 	ph7_value *pValue;
 	VmFrame *pFrameLocal;
-	/* Peek the last step */
-	apStep = (ph7_foreach_step **)SySetBasePtr(&pInfo->aStep);
-	pStep = apStep[SySetUsed(&pInfo->aStep) - 1];
+	sxu32 nStep;
 	pFrameLocal = pVm->pFrame;
 	pFrameLocal = VmSkipExceptionFrames(pFrameLocal);
+	/* Select THIS activation's step. aStep is per-STATEMENT and shared by every
+	 * activation, so peeking the last entry resumes onto a sibling's cursor when
+	 * two instances of one generator/fiber are suspended in the same textual
+	 * foreach. Scan from the top (most-recent push) for the step whose owning
+	 * frame matches the running activation; top-down makes the current push win
+	 * over any leaked older step that happens to share a recycled frame address. */
+	apStep = (ph7_foreach_step **)SySetBasePtr(&pInfo->aStep);
+	nStep = SySetUsed(&pInfo->aStep);
+	if( nStep < 1 ){
+		/* Defensive: OP_FOREACH_INIT always pushes this activation's step before
+		 * STEP runs (and jumps past the loop when the push fails), so an empty
+		 * set is unreachable — guard the apStep[-1] read anyway. Jump out. */
+		pc = pInstr->iP2 - 1;
+		break;
+	}
+	pStep = apStep[nStep - 1];
+	while( nStep > 0 ){
+		if( apStep[nStep - 1]->pFrame == pFrameLocal ){
+			pStep = apStep[nStep - 1];
+			break;
+		}
+		nStep--;
+	}
 	if( pStep->iFlags & PH7_4EACH_STEP_HASHMAP ){
 		ph7_hashmap_node *pNode;
 		/* Extract the current node via this loop's PRIVATE cursor (php:
@@ -12079,8 +12133,8 @@ case PH7_OP_FOREACH_STEP: {
 				/* Break the reference with the last element */
 				SyHashDeleteEntry(&pFrameLocal->hVar,SyStringData(&pInfo->sValue),SyStringLength(&pInfo->sValue),0);
 			}
+			VmForeachStepUnlink(pInfo,pStep);
 			SyMemBackendPoolFree(&pVm->sAllocator,pStep);
-			SySetPop(&pInfo->aStep);
 			PH7_ClassInstanceUnref(pThis);
 		}else{
 			SyString *pAttrName = &pVmAttr->pAttr->sName;

--- a/tests/ph7/001-smoke/lang/foreach_same_generator_two_instances.phpt
+++ b/tests/ph7/001-smoke/lang/foreach_same_generator_two_instances.phpt
@@ -1,0 +1,95 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Two live activations of one foreach (generators/fibers/recursion) keep private cursors
+--FILE--
+<?php
+/* A foreach step is per-STATEMENT, but two suspended activations of the same
+ * textual foreach (two generator instances, a recursive call, or two fibers)
+ * must each keep their own cursor — resuming one must not advance onto the
+ * other's position. The step is keyed by the running activation's frame. */
+
+// (1) Two interleaved instances of one generator over the same loop.
+function fsgTwoInst($a) { foreach ($a as $x) yield $x; }
+$g1 = fsgTwoInst([1, 2, 3]);
+$g2 = fsgTwoInst([10, 20]);
+echo $g1->current(), $g2->current();      // 1 10
+$g1->next(); $g2->next();
+echo $g1->current(), $g2->current();      // 2 20
+$g1->next(); $g2->next();
+echo $g1->current();                      // 3   ($g2 is now exhausted)
+echo "\n";
+
+// (2) A recursive generator suspended in the same loop as its own outer call.
+function fsgRec($a) {
+    foreach ($a as $x) {
+        if ($x == 1) { $inner = fsgRec([7, 8]); echo $inner->current(); }
+        yield $x;
+    }
+}
+foreach (fsgRec([1, 2]) as $v) echo "|$v";  // 7|1|2
+echo "\n";
+
+// (3) Two fibers suspended inside the same textual foreach.
+$mk = fn() => new Fiber(function () {
+    foreach ([100, 200] as $x) Fiber::suspend($x);
+});
+$f1 = $mk(); $f2 = $mk();
+echo $f1->start(), $f2->start();          // 100 100
+echo $f1->resume(), $f2->resume();        // 200 200
+echo "\n";
+
+// (4) Nested foreach over one array inside a generator still interleaves right.
+function fsgNested($a) {
+    foreach ($a as $x) foreach ($a as $y) yield "$x$y";
+}
+$n1 = fsgNested([1, 2]);
+$n2 = fsgNested([3, 4]);
+echo $n1->current(), "-", $n2->current();  // 11-33
+$n1->next();
+echo $n1->current(), "-", $n2->current();  // 12-33
+echo "\n";
+
+// (5) Plain single-instance generator loop is unaffected.
+function fsgPlain() { foreach ([1, 2, 3] as $x) yield $x; }
+foreach (fsgPlain() as $v) echo $v;        // 123
+echo "\n";
+
+// (6) break inside the generator's foreach leaves the step behind (no unwind
+// pop); a second live instance must still keep its own cursor, and the step
+// teardown must not reorder a live step below the leaked one.
+function fsgBreak($a) {
+    foreach ($a as $x) {
+        if ($x == 99) break;   // never taken here — keeps the loop's step live
+        yield $x;
+    }
+}
+$b1 = fsgBreak([1, 2, 3]);
+$b2 = fsgBreak([10, 20]);
+echo $b1->current(), $b2->current();       // 1 10
+$b1->next();
+echo $b1->current(), $b2->current();       // 2 10
+echo "\n";
+
+// (7) An inner loop that actually breaks (leaking its step) inside an outer
+// foreach over a generator — the outer cursor is unaffected.
+function fsgYield($a) { foreach ($a as $x) yield $x; }
+$acc = "";
+foreach (fsgYield([1, 2, 3]) as $v) {
+    foreach (fsgYield([7, 8, 9]) as $w) { if ($w == 8) break; }
+    $acc .= "$v$w ";                       // $w is 8 at break
+}
+echo $acc;                                 // 18 28 38
+echo "\n";
+?>
+--EXPECT--
+1102203
+7|1|2
+100100200200
+11-3312-33
+123
+110210
+18 28 38
+--CLEAN--
+<?php


### PR DESCRIPTION
…clash

foreach iteration state lives in ph7_foreach_info.aStep, a per-STATEMENT stack shared by every activation, and OP_FOREACH_STEP peeked the last entry. Two suspended activations of the same textual foreach — two generator instances, two fibers, or a recursive call paused in the same loop — resume out of LIFO order and grab each other's step, so $g1 = g([1,2,3]); $g2 = g([10,20]) with interleaved next()/current() printed 11020 where php prints 110220 (a silent wrong answer).

Record the owning activation frame on each step (ph7_foreach_step.pFrame, normalized past exception frames via VmSkipExceptionFrames, stamped at OP_FOREACH_INIT). OP_FOREACH_STEP now scans aStep top-down for the step whose pFrame matches the running activation — the most-recent push wins, so a leaked step that shares a recycled frame address never shadows the live one. The step teardown paths remove by pointer (new VmForeachStepUnlink) instead of popping the tail, order-preserving so a live step is never reordered below a leaked sibling. This mirrors the per-exec-context cursor the yield-from opcode already keeps for delegation.

Byte-verified vs php 8.5.7 across two-instance, recursive, two-fiber, nested-in-generator, and break-leak-interleave scenarios; cross-engine test foreach_same_generator_two_instances; test-compat green; docker ASan+UBSan clean; full and tiny builds warning-free.
