### PR TITLE
Grow the operand stack on unpack overflow

### DIFF
--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -577,6 +577,8 @@ struct ph7_exec_ctx
 	ph7_vm_func *pFunc;       /* The function being executed */
 	VmFrame *pFrame;          /* Detached execution frame */
 	ph7_value *pStack;        /* Private operand stack */
+	sxu32 nStackCap;          /* Its allocated slot count (VmNewOperandStack size); grows
+	                           * with pStack when an OP_SPREAD in this body reallocs it */
 	sxi32 nTos;               /* Saved top-of-stack index */
 	sxi32 pc;                 /* Saved program counter (resume point) */
 	sxi32 iState;             /* One of PH7_CTX_STATE_* */

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -7156,11 +7156,6 @@ static void VmSpreadExpandMap(ph7_vm *pVm, ph7_value **ppTos, ph7_hashmap *pMap)
 		VmSpreadCaptureRun(pVm, pTos, pMap, 0); /* empty run: keeps compile-arg alignment */
 		VmPopOperand(&pTos, 1);
 		pVm->iSpreadExtra--; /* One expression produced zero args */
-	}else if( pVm->iSpreadExtra + (sxi32)(nEntry - 1) >= VM_STACK_GUARD ){
-		/* Safety: refuse to expand beyond the stack guard margin */
-		VmErrorFormat(&(*pVm), PH7_CTX_ERR,
-			"Argument unpacking: cumulative expansion exceeds stack guard (%d)",
-			VM_STACK_GUARD);
 	}else{
 		ph7_hashmap_node *pNode;
 		ph7_value *pElem;
@@ -7511,6 +7506,9 @@ struct VmExecState
 	VmInstr *aInstr;        /* Bytecode of this activation */
 	ph7_value *pStack;      /* Operand-stack base (owned by this activation) */
 	ph7_value *pTos;        /* Top-of-stack (synced at boundaries) */
+	sxu32 nStackCap;        /* pStack's allocated slot count; grows when an OP_SPREAD in
+	                         * this activation reallocs the operand stack (see
+	                         * VmGrowOperandStack). Saved/restored with the activation. */
 	sxi32 pc;               /* Program counter (synced at boundaries) */
 	sxu32 nExceptionBase;   /* Exception-stack depth at entry (finally-drain floor) */
 	VmFrame *pEntryFrame;   /* Active frame at entry (exec identity for VmRecordedResume) */
@@ -7530,6 +7528,9 @@ struct VmCallRecord
 	ph7_vm_func *pVmFunc;   /* Callee */
 	VmFrame *pFrame;        /* Callee's VM frame (entered by the OP_CALL setup) */
 	ph7_value *pFrameStack; /* Callee's operand stack (owned; freed here). NULL when the body was skipped */
+	sxu32 nStackCap;        /* pFrameStack's allocated slot count — nMaxStack+VM_STACK_GUARD
+	                         * at setup, updated if an OP_SPREAD in the callee grew it; the
+	                         * pop-time recycle releases exactly this many slots */
 	sxu32 nLastRef;         /* Callee body's last-referenced slot (by-ref return) */
 	sxu8 bSelfPushed;       /* TRUE when the setup pushed onto pVm->aSelf */
 };
@@ -7551,6 +7552,129 @@ struct VmCallFrame
 	VmCallRecord sCall;    /* The in-flight call, finished (VmCallFinish) on pop */
 	VmCallFrame *pPrev;    /* Next-outer record, or NULL at this invocation's base */
 };
+/*
+ * OP_SPREAD stack growth (removes the old VM_STACK_GUARD expansion cap).
+ *
+ * The operand stack of the CURRENTLY-RUNNING activation is about to receive more
+ * spread elements than its remaining slack holds. Realloc the buffer so the
+ * expansion — and the rest of the body's normal pushes — fit, then fix up every
+ * pointer that aimed into the old buffer. Returns 1 on success (the caller may
+ * proceed with the expansion), 0 on OOM (the caller keeps the old buffer and
+ * raises the historical guard error, preserving pre-growth soundness).
+ *
+ * nNeed is the live-slot count the stack must hold after the pending expansion;
+ * the grown capacity adds VM_STACK_GUARD back on top so the remainder of the body
+ * keeps its slack. ONLY this activation's references move, and they are all here:
+ *   - the dispatch locals pStack/pTos (via *ppStack / *ppTos) and the boundary
+ *     copies in sState (pState->pStack/pTos + the tracked capacity nStackCap)
+ *   - the owner slot: for a trampoline callee, its record's pFrameStack and the
+ *     recycle capacity nStackCap; for the base activation (top-level, mini-program,
+ *     coroutine body, callback), *ppBaseOwner / *pnBaseCap — whatever storage the
+ *     native entry frees (a local, pVm->aOps, or pCtx->pStack/nStackCap)
+ *   - aSpreadRun[].pStart entries anchored in the OLD buffer (this call's earlier
+ *     spreads) — an unfixed pStart would desync PHP 8.1 named-arg replay after the
+ *     realloc. Enclosing activations own DISTINCT buffers, so their runs (pStart
+ *     outside [pOld, pOld+nOldCap)) are deliberately left untouched.
+ */
+static int VmGrowOperandStack(ph7_vm *pVm, sxu32 nNeed,
+	ph7_value **ppStack, ph7_value **ppTos, VmExecState *pState,
+	VmCallFrame *pCallTop, ph7_value **ppBaseOwner, sxu32 *pnBaseCap)
+{
+	ph7_value *pOld = *ppStack;
+	sxu32 nOldCap = pState->nStackCap;
+	sxu32 nUsed = (sxu32)(*ppTos - pOld + 1); /* live slots incl. the spread source */
+	sxu32 nDelta = nNeed - nUsed;             /* extra slots this spread adds (== nEntry-1) */
+	sxu32 nNewCap, nReq, nMaxCap, i, nRun;
+	ph7_value *pNew;
+	VmSpreadRun *aRun;
+	/* The grown buffer must preserve the ORIGINAL compile-time headroom, not just
+	 * the immediate expansion: only OP_SPREAD re-checks capacity, so any ordinary
+	 * arg pushes that FOLLOW this spread in the same call rely on the slack that
+	 * nOldCap (= nMaxStack + VM_STACK_GUARD, plus prior spreads' growth) already
+	 * budgeted. Shift that whole budget up by this expansion's delta — nOldCap +
+	 * nDelta — so `foo(...$big, a1..aN)` keeps room for the trailing args. That
+	 * dominates nNeed+VM_STACK_GUARD (nUsed <= nOldCap - VM_STACK_GUARD by the
+	 * static depth bound), but keep the latter as an explicit floor. */
+	nReq = nNeed + VM_STACK_GUARD;
+	if( nOldCap + nDelta > nReq ){
+		nReq = nOldCap + nDelta; /* overflow-safe: nOldCap, nDelta each < nMaxCap < 2^31 */
+	}
+	/* SyMemBackendRealloc's size argument is sxu32, so the byte count
+	 * nNewCap*sizeof(ph7_value) must not overflow 32 bits — a huge unpack
+	 * (~2^32/sizeof elements) would otherwise truncate to a tiny allocation and
+	 * the init loop below would run off it. If the true requirement exceeds the
+	 * representable cap, treat it as OOM (the caller raises the guard error). */
+	nMaxCap = SXU32_HIGH / (sxu32)sizeof(ph7_value);
+	if( nReq > nMaxCap ){
+		return 0;
+	}
+	if( nReq <= nOldCap ){
+		return 1; /* already fits — no growth needed */
+	}
+	nNewCap = nReq;
+	/* Amortize repeated spreads in one argument list: at least double, but never
+	 * past the byte-count cap. (nOldCap <= nMaxCap < 2^31, so nOldCap*2 can't
+	 * itself overflow.) */
+	if( nNewCap < nOldCap * 2 ){
+		sxu32 nDbl = nOldCap * 2;
+		if( nDbl > nMaxCap ){ nDbl = nMaxCap; }
+		if( nNewCap < nDbl ){ nNewCap = nDbl; }
+	}
+	pNew = (ph7_value *)SyMemBackendRealloc(&pVm->sAllocator, pOld,
+		nNewCap * sizeof(ph7_value));
+	if( pNew == 0 ){
+		return 0; /* OOM: caller keeps pOld and raises the guard error */
+	}
+	/* realloc preserves [0, nOldCap); initialize the freshly grown slots. */
+	for( i = nOldCap; i < nNewCap; i++ ){
+		PH7_MemObjInit(pVm, &pNew[i]);
+		pNew[i].nIdx = SXU32_HIGH;
+	}
+	/* Fix up every pointer into the old buffer (delta = pNew - pOld). */
+	*ppTos = pNew + (*ppTos - pOld);
+	*ppStack = pNew;
+	pState->pStack = pNew + (pState->pStack - pOld);
+	pState->pTos = pNew + (pState->pTos - pOld);
+	pState->nStackCap = nNewCap;
+	if( pCallTop ){
+		/* This activation is a trampoline callee: its record owns the buffer. */
+		pCallTop->sCall.pFrameStack = pNew;
+		pCallTop->sCall.nStackCap = nNewCap;
+	}else{
+		/* Base activation: the native entry frees *ppBaseOwner (and, for a
+		 * resumable coroutine, persists *pnBaseCap across suspend/resume). */
+		if( ppBaseOwner ){ *ppBaseOwner = pNew; }
+		if( pnBaseCap ){ *pnBaseCap = nNewCap; }
+	}
+	/* Re-anchor this activation's captured spread runs (pStart into the old
+	 * buffer). Enclosing-activation runs live in other buffers — leave them. */
+	nRun = SySetUsed(&pVm->aSpreadRun);
+	aRun = (VmSpreadRun *)SySetBasePtr(&pVm->aSpreadRun);
+	for( i = 0; i < nRun; i++ ){
+		if( aRun[i].pStart >= pOld && aRun[i].pStart < pOld + nOldCap ){
+			aRun[i].pStart = pNew + (aRun[i].pStart - pOld);
+		}
+	}
+	return 1;
+}
+/*
+ * Ensure the running activation's operand stack can hold a spread of nEntry
+ * elements pushed at *ppTos (the source slot becomes the first element, so the
+ * net new slots are nEntry-1). Grows via VmGrowOperandStack when it can't.
+ * Returns 1 if the caller may proceed with VmSpreadExpandMap, 0 on OOM.
+ */
+static int VmSpreadEnsureCapacity(ph7_vm *pVm, sxu32 nEntry,
+	ph7_value **ppStack, ph7_value **ppTos, VmExecState *pState,
+	VmCallFrame *pCallTop, ph7_value **ppBaseOwner, sxu32 *pnBaseCap)
+{
+	sxu32 nNeed;
+	if( nEntry == 0 ){
+		return 1; /* empty spread never grows the stack */
+	}
+	nNeed = (sxu32)(*ppTos - *ppStack + 1) + (nEntry - 1);
+	return VmGrowOperandStack(pVm, nNeed, ppStack, ppTos, pState,
+		pCallTop, ppBaseOwner, pnBaseCap);
+}
 /*
  * BYTECODE stage 4: a Fiber::suspend() from inside a nested PHP call parks the
  * whole trampoline record segment here instead of unwinding it. The records,
@@ -7690,9 +7814,9 @@ static sxi32 VmCallFinish(ph7_vm *pVm,VmExecState *pCaller,VmCallRecord *pCallee
 		}
 	}
 	/* Recycle the operand stack for the next same-size call (BYTECODE stage 7),
-	 * or free it if the pool is full. Its allocated size is the callee's cached
-	 * nMaxStack + VM_STACK_GUARD — exactly what VmOperandStackAlloc handed out.
-	 * (NULL when the function body was skipped.)
+	 * or free it if the pool is full. Its allocated size is tracked in
+	 * pCallee->nStackCap (nMaxStack + VM_STACK_GUARD, or larger if an OP_SPREAD grew
+	 * it) — exactly what the buffer holds. (NULL when the function body was skipped.)
 	 *
 	 * Never on rc == PH7_SUSPEND: that path (unreachable in the stage-4 model,
 	 * where a deep suspend parks its whole record segment before reaching here)
@@ -7700,8 +7824,10 @@ static sxi32 VmCallFinish(ph7_vm *pVm,VmExecState *pCaller,VmCallRecord *pCallee
 	 * would hand a live fiber's operand stack to the next call. The guard keeps
 	 * that invariant explicit and robust to future coroutine changes. */
 	if( rc != PH7_SUSPEND && pCallee->pFrameStack ){
-		VmOperandStackRecycle(pVm,pCallee->pFrameStack,
-			pCallee->pVmFunc->nMaxStack + VM_STACK_GUARD);
+		/* nStackCap is nMaxStack+VM_STACK_GUARD unless an OP_SPREAD in this callee
+		 * grew the buffer (VmGrowOperandStack updated the record) — recycle exactly
+		 * the allocated slot count either way. */
+		VmOperandStackRecycle(pVm,pCallee->pFrameStack,pCallee->nStackCap);
 	}
 	/* Leave the frame */
 	VmLeaveFrame(&(*pVm));
@@ -7737,7 +7863,8 @@ static sxi32 VmCallFinish(ph7_vm *pVm,VmExecState *pCaller,VmCallRecord *pCallee
  */
 static sxi32 VmByteCodeExecBody(ph7_vm *pVm,VmInstr *aInstr,ph7_value *pStack,int nTos,
 	ph7_value *pResult,sxu32 *pLastRef,int is_callback,sxi32 nPc,
-	ph7_vm_func *pEnforceRetFunc,int bReturnPropagates,VmParkedSegment *pAdoptSegment);
+	ph7_vm_func *pEnforceRetFunc,int bReturnPropagates,VmParkedSegment *pAdoptSegment,
+	ph7_value **ppBaseOwner,sxu32 *pnBaseCap);
 /*
  * Native-nesting guard around the executor. PHP->PHP calls run iteratively
  * (the stage-2 trampoline), but every OTHER (re-)entry — mini-programs,
@@ -7767,7 +7894,9 @@ static sxi32 VmByteCodeExec(
 	sxi32 nPc,           /* Starting program counter (0 for normal, >0 for resume) */
 	ph7_vm_func *pEnforceRetFunc, /* NULL except when this invocation is a user-fn body; when set, the terminating OP_DONE validates the return value against pEnforceRetFunc's declared type. */
 	int bReturnPropagates, /* TRUE only for a catch/finally mini-program: an explicit-return OP_DONE (iP2=1) defers its value onto the enclosing body frame's sRet slot for that body to return. */
-	VmParkedSegment *pAdoptSegment /* NULL except on a deep-fiber RESUME (VmResumeCtx): the parked record segment this body invocation re-enters inside (BYTECODE stage 4). */
+	VmParkedSegment *pAdoptSegment, /* NULL except on a deep-fiber RESUME (VmResumeCtx): the parked record segment this body invocation re-enters inside (BYTECODE stage 4). */
+	ph7_value **ppBaseOwner, /* Storage slot the native entry frees for this invocation's BASE (pCallTop==0) operand stack — a local, pVm->aOps or pCtx->pStack. An OP_SPREAD that grows the base stack writes the new pointer here so the entry frees the right buffer. */
+	sxu32 *pnBaseCap /* Storage for the base stack's capacity (resumable coroutines persist it across suspend/resume); updated alongside *ppBaseOwner on base-stack growth. Also the initial capacity read at entry. */
 	)
 {
 	sxi32 rc;
@@ -7786,7 +7915,7 @@ static sxi32 VmByteCodeExec(
 	pVm->nBoundaryRc = 0;
 	pVm->nVmExecDepth++;
 	rc = VmByteCodeExecBody(&(*pVm),aInstr,pStack,nTos,pResult,pLastRef,is_callback,nPc,
-		pEnforceRetFunc,bReturnPropagates,pAdoptSegment);
+		pEnforceRetFunc,bReturnPropagates,pAdoptSegment,ppBaseOwner,pnBaseCap);
 	pVm->nVmExecDepth--;
 	if( nSavedBrc != 0 && (nSavedBrc == PH7_ABORT || pVm->nBoundaryRc == 0) ){
 		pVm->nBoundaryRc = nSavedBrc;
@@ -7804,7 +7933,9 @@ static sxi32 VmByteCodeExecBody(
 	sxi32 nPc,           /* Starting program counter (0 for normal, >0 for resume) */
 	ph7_vm_func *pEnforceRetFunc, /* NULL except when this invocation is a user-fn body; when set, the terminating OP_DONE validates the return value against pEnforceRetFunc's declared type. */
 	int bReturnPropagates, /* TRUE only for a catch/finally mini-program: an explicit-return OP_DONE (iP2=1) defers its value onto the enclosing body frame's sRet slot for that body to return. */
-	VmParkedSegment *pAdoptSegment /* NULL except on a deep-fiber RESUME (VmResumeCtx): the parked record segment this body invocation re-enters inside (BYTECODE stage 4). */
+	VmParkedSegment *pAdoptSegment, /* NULL except on a deep-fiber RESUME (VmResumeCtx): the parked record segment this body invocation re-enters inside (BYTECODE stage 4). */
+	ph7_value **ppBaseOwner, /* Base (pCallTop==0) operand-stack owner slot the native entry frees; OP_SPREAD growth of the base stack writes the new pointer here (see VmGrowOperandStack). */
+	sxu32 *pnBaseCap /* Base stack capacity (persisted across coroutine suspend/resume); read for the initial capacity and updated on base-stack growth. */
 	)
 {
 	VmInstr *pInstr;
@@ -7822,6 +7953,7 @@ static sxi32 VmByteCodeExecBody(
 	sxi32 rc;
 	sState.aInstr = aInstr;
 	sState.pStack = pStack;
+	sState.nStackCap = pnBaseCap ? *pnBaseCap : 0; /* base capacity for OP_SPREAD growth */
 	sState.pResult = pResult;
 	sState.pLastRef = pLastRef;
 	sState.pEnforceRetFunc = pEnforceRetFunc;
@@ -11123,12 +11255,31 @@ case PH7_OP_SPREAD: {
 			if( rcW == PH7_ABORT ){ goto Abort; }
 			goto Exception;
 		}
+		/* Grow the operand stack if this expansion would overflow it (no longer a
+		 * VM_STACK_GUARD cap). On OOM keep the old buffer and leave the source as a
+		 * single argument — the historical bounded-fallback, now only under OOM. */
+		if( !VmSpreadEnsureCapacity(pVm, pTmpMap->nEntry, &pStack, &pTos, &sState,
+		                            pCallTop, ppBaseOwner, pnBaseCap) ){
+			PH7_HashmapRelease(pTmpMap,TRUE);
+			VmErrorFormat(&(*pVm), PH7_CTX_ERR,
+				"Argument unpacking: out of memory while expanding %u elements",
+				pTmpMap->nEntry);
+			break;
+		}
 		VmSpreadExpandMap(pVm, &pTos, pTmpMap);
 		PH7_HashmapRelease(pTmpMap,TRUE);
 		break;
 	}
 	if( pTos->iFlags & MEMOBJ_HASHMAP ){
-		VmSpreadExpandMap(pVm, &pTos, (ph7_hashmap *)pTos->x.pOther);
+		ph7_hashmap *pMap = (ph7_hashmap *)pTos->x.pOther;
+		if( !VmSpreadEnsureCapacity(pVm, pMap->nEntry, &pStack, &pTos, &sState,
+		                            pCallTop, ppBaseOwner, pnBaseCap) ){
+			VmErrorFormat(&(*pVm), PH7_CTX_ERR,
+				"Argument unpacking: out of memory while expanding %u elements",
+				pMap->nEntry);
+			break;
+		}
+		VmSpreadExpandMap(pVm, &pTos, pMap);
 	}
 	/* else: not an array — leave as-is (single arg) */
 	break;
@@ -15257,6 +15408,7 @@ SkipFuncBody:
 			sCallee.pVmFunc = pVmFunc;
 			sCallee.pFrame = pFrame;
 			sCallee.pFrameStack = pFrameStack;
+			sCallee.nStackCap = pVmFunc->nMaxStack + VM_STACK_GUARD;
 			sCallee.nLastRef = SXU32_HIGH;
 			sCallee.bSelfPushed = (sxu8)(pSelf ? 1 : 0);
 			sState.pTos = pTos;
@@ -15303,6 +15455,7 @@ SkipFuncBody:
 			pRec->sCall.pVmFunc = pVmFunc;
 			pRec->sCall.pFrame = pFrame;
 			pRec->sCall.pFrameStack = pFrameStack;
+			pRec->sCall.nStackCap = pVmFunc->nMaxStack + VM_STACK_GUARD;
 			pRec->sCall.nLastRef = SXU32_HIGH;
 			pRec->sCall.bSelfPushed = (sxu8)(pSelf ? 1 : 0);
 			pRec->pPrev = pCallTop;
@@ -15315,6 +15468,7 @@ SkipFuncBody:
 			pc = 0;
 			sState.aInstr = aInstr;
 			sState.pStack = pStack;
+			sState.nStackCap = pRec->sCall.nStackCap; /* callee's operand-stack capacity for OP_SPREAD growth */
 			sState.pTos = pTos;
 			sState.pc = 0;
 			sState.nExceptionBase = SySetUsed(&pVm->aException);
@@ -15621,14 +15775,17 @@ Unwind:
 PH7_PRIVATE sxi32 VmLocalExec(ph7_vm *pVm,SySet *pByteCode,ph7_value *pResult,int bReturnPropagates)
 {
 	ph7_value *pStack;
+	sxu32 nCap;
 	sxi32 rc;
 	/* Allocate a new operand stack */
 	pStack = VmNewOperandStack(&(*pVm),SySetUsed(pByteCode));
 	if( pStack == 0 ){
 		return SXERR_MEM;
 	}
-	/* Execute the program */
-	rc = VmByteCodeExec(&(*pVm),(VmInstr *)SySetBasePtr(pByteCode),pStack,-1,&(*pResult),0,FALSE,0,0,bReturnPropagates,0);
+	nCap = SySetUsed(pByteCode) + VM_STACK_GUARD; /* what VmNewOperandStack handed out */
+	/* Execute the program. A base-level OP_SPREAD may realloc pStack (updating it +
+	 * nCap through the owner slots) — free whatever pStack ends up pointing at. */
+	rc = VmByteCodeExec(&(*pVm),(VmInstr *)SySetBasePtr(pByteCode),pStack,-1,&(*pResult),0,FALSE,0,0,bReturnPropagates,0,&pStack,&nCap);
 	/* Free the operand stack */
 	SyMemBackendFree(&pVm->sAllocator,pStack);
 	/* Execution result */
@@ -15703,8 +15860,12 @@ PH7_PRIVATE sxi32 PH7_VmByteCodeExec(ph7_vm *pVm)
 	}
 	/* Set the execution magic number  */
 	pVm->nMagic = PH7_VM_EXEC;
-	/* Execute the program */
-	VmByteCodeExec(&(*pVm),(VmInstr *)SySetBasePtr(pVm->pByteContainer),pVm->aOps,-1,&pVm->sExec,0,FALSE,0,0,FALSE,0);
+	/* Execute the program. A top-level OP_SPREAD may realloc the operand stack;
+	 * pass &pVm->aOps so the growth updates the field that VM release frees. */
+	{
+		sxu32 nOpsCap = SySetUsed(pVm->pByteContainer) + VM_STACK_GUARD;
+		VmByteCodeExec(&(*pVm),(VmInstr *)SySetBasePtr(pVm->pByteContainer),pVm->aOps,-1,&pVm->sExec,0,FALSE,0,0,FALSE,0,&pVm->aOps,&nOpsCap);
+	}
 	/* Invoke any shutdown callbacks */
 	VmInvokeShutdownCallbacks(&(*pVm));
 	/*
@@ -15757,6 +15918,7 @@ static ph7_exec_ctx * VmNewExecCtx(ph7_vm *pVm, ph7_vm_func *pFunc)
 		return 0;
 	}
 	pCtx->pStack = pStack;
+	pCtx->nStackCap = SySetUsed(&pFunc->aByteCode) + VM_STACK_GUARD; /* grows with pStack on OP_SPREAD */
 	/* Create a detached frame for the fiber */
 	pFrame = VmNewFrame(pVm, pFunc, 0);
 	if( pFrame == 0 ){
@@ -15959,10 +16121,12 @@ static sxi32 VmStartCtx(ph7_vm *pVm, ph7_exec_ctx *pCtx, ph7_value *pResult)
 	 * Fiber::suspend() at a deeper depth is inside a C->PHP callback and gets a
 	 * FiberError instead of parking across the native frame (stage 4). */
 	pCtx->nBodyExecDepth = pVm->nVmExecDepth + 1;
-	/* Execute from the beginning (no parked segment). */
+	/* Execute from the beginning (no parked segment). An OP_SPREAD in the body may
+	 * realloc pCtx->pStack — pass &pCtx->pStack / &pCtx->nStackCap so the grown
+	 * buffer + capacity persist for the next resume and for ctx teardown. */
 	rc = VmByteCodeExec(pVm, (VmInstr *)SySetBasePtr(&pCtx->pFunc->aByteCode),
 		pCtx->pStack, -1, &pCtx->sRetValue, 0, FALSE, 0,
-		VmCtxEnforceRetFunc(pCtx), FALSE, 0);
+		VmCtxEnforceRetFunc(pCtx), FALSE, 0, &pCtx->pStack, &pCtx->nStackCap);
 	return VmFinishCtxRun(pVm, pCtx, pOldCtx, rc, pResult);
 }
 /*
@@ -16046,7 +16210,7 @@ static sxi32 VmResumeCtx(ph7_vm *pVm, ph7_exec_ctx *pCtx, ph7_value *pResumeValu
 	 * re-enter inside the innermost parked callee (deep fiber resume, stage 4). */
 	rc = VmByteCodeExec(pVm, (VmInstr *)SySetBasePtr(&pCtx->pFunc->aByteCode),
 		pCtx->pStack, pCtx->nTos, &pCtx->sRetValue, 0, FALSE, pCtx->pc,
-		VmCtxEnforceRetFunc(pCtx), FALSE, pSeg);
+		VmCtxEnforceRetFunc(pCtx), FALSE, pSeg, &pCtx->pStack, &pCtx->nStackCap);
 	return VmFinishCtxRun(pVm, pCtx, pOldCtx, rc, pResult);
 }
 /*
@@ -18621,7 +18785,10 @@ static sxi32 VmCallClassMethodWithMap(
 	aInstr[1].iP1 = 1;
 	aInstr[1].iP2 = 0;
 	aInstr[1].p3  = 0;
-	rc = VmByteCodeExec(&(*pVm),aInstr,aStack,iCursor,pResult,0,TRUE,0,0,FALSE,0);
+	{
+		sxu32 nStkCap = (sxu32)(2+nArg) + VM_STACK_GUARD; /* what VmNewOperandStack handed out */
+		rc = VmByteCodeExec(&(*pVm),aInstr,aStack,iCursor,pResult,0,TRUE,0,0,FALSE,0,&aStack,&nStkCap);
+	}
 	SyMemBackendFree(&pVm->sAllocator,aStack);
 	/* Propagate the real exec status (PH7_EXCEPTION / PH7_ABORT) so callers
 	 * can unwind instead of continuing past a method that raised — and park
@@ -19002,7 +19169,8 @@ PH7_PRIVATE sxi32 PH7_VmCallUserFunctionWithMap(
 	/* Execute the function body (if available) */
 	{
 		sxi32 rcExec;
-		rcExec = VmByteCodeExec(&(*pVm),aInstr,aStack,nArg,pResult,0,TRUE,0,0,FALSE,0);
+		sxu32 nStkCap = (sxu32)(1+nArg) + VM_STACK_GUARD; /* what VmNewOperandStack handed out */
+		rcExec = VmByteCodeExec(&(*pVm),aInstr,aStack,nArg,pResult,0,TRUE,0,0,FALSE,0,&aStack,&nStkCap);
 		/* Clean up the mess left behind */
 		SyMemBackendFree(&pVm->sAllocator,aStack);
 		/* Propagate PH7_EXCEPTION/PH7_ABORT so a callback that raised unwinds —

--- a/tests/ph7/001-smoke/lang/spread_grows_operand_stack.phpt
+++ b/tests/ph7/001-smoke/lang/spread_grows_operand_stack.phpt
@@ -1,0 +1,86 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Argument unpacking expands past the operand-stack guard (grows the stack)
+--FILE--
+<?php
+/* A spread of more than VM_STACK_GUARD (16) elements used to hit a PHL-native
+ * "cumulative expansion exceeds stack guard" error and then bind the whole map
+ * as a single argument. The operand stack now grows (realloc + pointer fixups)
+ * at OP_SPREAD, so an unpack of any size — ordinary php code — works. Verified
+ * byte-identical to php 8.5.7 across the call kinds and the named-key replay
+ * that the growth must keep aligned. */
+
+// Plain positional spread well past the old 16 cap.
+function sgrowV(...$xs) { return count($xs) . "/" . array_sum($xs); }
+echo sgrowV(...range(1, 20)), "\n";        // 20/210
+echo sgrowV(...range(1, 200)), "\n";       // 200/20100
+
+// Leading positional args + a growing spread.
+function sgrowH($a, $b, ...$rest) { return "$a|$b|" . count($rest); }
+echo sgrowH(1, 2, ...range(3, 40)), "\n";  // 1|2|38
+
+// Two spreads in one call, both crossing the cap.
+echo sgrowV(...range(1, 10), ...range(11, 30)), "\n"; // 30/465
+
+// Named string keys must survive the realloc (aSpreadRun re-anchor).
+function sgrowN(...$xs) { return json_encode($xs); }
+$sgrowMap = [];
+for ($i = 0; $i < 20; $i++) { $sgrowMap["k$i"] = $i; }
+echo sgrowN(...$sgrowMap), "\n";
+
+// A growing positional spread followed by a compile-time named arg.
+function sgrowM($x, $y, ...$rest) { return "$x/$y/" . json_encode($rest); }
+echo sgrowM(...range(1, 20), z: 99), "\n";
+
+// Methods, static, closures, arrow fns.
+class SgrowC {
+    public function m(...$xs) { return count($xs); }
+    public static function s(...$xs) { return count($xs); }
+}
+echo (new SgrowC)->m(...range(1, 30)), "\n";   // 30
+echo SgrowC::s(...range(1, 25)), "\n";         // 25
+$sgrowClosure = function (...$xs) { return count($xs); };
+echo $sgrowClosure(...range(1, 25)), "\n";     // 25
+
+// Generator body running a growing spread call.
+function sgrowGen() { yield sgrowV(...range(1, 20)); }
+foreach (sgrowGen() as $sgrowY) { echo $sgrowY, "\n"; } // 20/210
+
+// call_user_func_array with a large argument array.
+echo call_user_func_array("sgrowV", range(1, 50)), "\n"; // 50/1275
+
+// A growing spread whose element is itself a growing-spread call result: the
+// inner call's realloc + per-call spread scope must leave the outer intact.
+function sgrowInner(...$xs) { return array_sum($xs); }
+echo sgrowV(sgrowInner(...range(1, 30)), ...range(1, 20)), "\n"; // 21/675
+
+// A growing spread FOLLOWED by many more pushes in the same call: only OP_SPREAD
+// re-checks capacity, so the grown buffer must keep the body's original headroom
+// (not just 16 slack) or the trailing pushes overflow it. Here a 100-element
+// spread grows the stack, then a 60-element array literal (a named arg's value)
+// pushes 60 transient slots — far past a 16-slot guard — before OP_LOAD_MAP.
+function sgrowT($x = 0, ...$rest) { return count($rest) . ":" . count($rest['k']); }
+echo sgrowT(...range(1, 100), k: [
+    1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,
+    21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,
+    41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,
+]), "\n"; // 100:60
+?>
+--EXPECT--
+20/210
+200/20100
+1|2|38
+30/465
+{"k0":0,"k1":1,"k2":2,"k3":3,"k4":4,"k5":5,"k6":6,"k7":7,"k8":8,"k9":9,"k10":10,"k11":11,"k12":12,"k13":13,"k14":14,"k15":15,"k16":16,"k17":17,"k18":18,"k19":19}
+1/2/{"0":3,"1":4,"2":5,"3":6,"4":7,"5":8,"6":9,"7":10,"8":11,"9":12,"10":13,"11":14,"12":15,"13":16,"14":17,"15":18,"16":19,"17":20,"z":99}
+30
+25
+25
+20/210
+50/1275
+21/675
+100:60
+--CLEAN--
+<?php


### PR DESCRIPTION
A spread of more than VM_STACK_GUARD (16) elements emitted a PHL-native "cumulative expansion exceeds stack guard" error and then bound the whole map as one argument (v(...range(1,20)) gave count 1 where php gives 20) — ordinary 8.x code silently wrong.

The per-activation operand stack now reallocs at OP_SPREAD when an expansion would overflow (VmGrowOperandStack / VmSpreadEnsureCapacity), re-anchoring every pointer into the moved buffer: the dispatch locals, the boundary sState, the owning trampoline record, and this activation's aSpreadRun[].pStart named-arg capture pointers (enclosing activations own distinct buffers and are left untouched). The true allocated capacity is tracked alongside every operand-stack pointer (VmExecState.nStackCap, VmCallRecord.nStackCap, ph7_exec_ctx.nStackCap) so the pop-time recycle releases the exact slot count, and ppBaseOwner/pnBaseCap thread the base owner slot through VmByteCodeExec so top-level, mini-program, callback and coroutine entries all free the grown buffer. OOM keeps the old buffer and raises a diagnostic.

The grown capacity is floored at nOldCap + (nEntry-1) to preserve the body's original compile-time headroom, since only OP_SPREAD re-checks capacity and ordinary arg pushes may follow a spread in the same call; the byte count is capped at SXU32_HIGH/sizeof(ph7_value) to avoid truncating the sxu32 realloc size argument on a huge unpack.

Works across top-level, function/method/closure bodies, generators, call_user_func_array, and Traversable unpacking. Verified byte-vs-php 8.5.7 (incl. 10000-element spreads), ASan+UBSan clean over the full smoke corpus plus growth/trailing-push stress, MODE=tiny builds.

