### PR TITLE
Implement PHP 8.1 enums with lazy constants

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -9364,6 +9364,228 @@ static int GenStateClassIsExceptionOrError(ph7_class *pBase)
 	return FALSE;
 }
 /*
+ * Compile a single `case NAME [= value];` member of an enum body (PHP 8.1).
+ * A case is stored as a class constant (PH7_CLASS_ATTR_CONSTANT|ENUMCASE) whose
+ * aByteCode holds the BACKING value expression for backed enums (empty for pure
+ * enums). The case's runtime value — the singleton instance — is materialized
+ * lazily on first access (VmEnumMaterialize, vm.c), matching PHP's lazy
+ * backing-value type/duplicate checks. Declaration order is recorded in
+ * pClass->aEnumCases for cases().
+ */
+static sxi32 GenStateCompileEnumCase(ph7_gen_state *pGen,ph7_class *pClass)
+{
+	sxu32 nLine = pGen->pIn->nLine;
+	SySet *pInstrContainer;
+	ph7_class_attr *pCase;
+	SyString *pName;
+	sxi32 rc;
+	pGen->pIn++; /* Jump the 'case' keyword */
+	if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & (PH7_TK_ID|PH7_TK_KEYWORD)) == 0 ){
+		rc = PH7_GenCompileError(pGen,E_ERROR,nLine,
+			"Invalid enum case name inside enum '%z'",&pClass->sName);
+		if( rc == SXERR_ABORT ){
+			return SXERR_ABORT;
+		}
+		goto Synchronize;
+	}
+	pName = &pGen->pIn->sData;
+	/* Cases share the class-constant namespace (php: "Cannot redefine class constant") */
+	if( SyHashGet(&pClass->hAttr,(const void *)pName->zString,pName->nByte) != 0 ){
+		rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,
+			"Cannot redefine class constant %z::%z",&pClass->sName,pName);
+		if( rc == SXERR_ABORT ){
+			return SXERR_ABORT;
+		}
+		goto Synchronize;
+	}
+	pCase = PH7_NewClassAttr(pGen->pVm,pName,pGen->pIn->nLine,PH7_CLASS_PROT_PUBLIC,
+		PH7_CLASS_ATTR_CONSTANT|PH7_CLASS_ATTR_ENUMCASE);
+	if( pCase == 0 ){
+		PH7_GenCompileError(pGen,E_ERROR,nLine,"Fatal, PH7 is running out of memory");
+		return SXERR_ABORT;
+	}
+	GenStateConsumeDoc(&(*pGen),&pCase->sDoc);
+	if( GenStateConsumeAttrs(&(*pGen),&pCase->aAttrs) == SXERR_ABORT ){
+		return SXERR_ABORT;
+	}
+	pGen->pIn++; /* Jump the case name */
+	if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_EQUAL /* '=' */) ){
+		if( pClass->nEnumBacking == 0 ){
+			rc = PH7_GenCompileError(pGen,E_ERROR,nLine,
+				"Case %z of non-backed enum %z must not have a value",pName,&pClass->sName);
+			if( rc == SXERR_ABORT ){
+				return SXERR_ABORT;
+			}
+			goto Synchronize;
+		}
+		pGen->pIn++; /* Jump the equal sign */
+		/* Compile the backing value expression into the case's own container
+		 * (same technique as class constants). */
+		pInstrContainer = PH7_VmGetByteCodeContainer(pGen->pVm);
+		PH7_VmSetByteCodeContainer(pGen->pVm,&pCase->aByteCode);
+		rc = PH7_CompileExpr(&(*pGen),EXPR_FLAG_COMMA_STATEMENT,0);
+		if( rc == SXERR_EMPTY ){
+			rc = PH7_GenCompileError(pGen,E_ERROR,nLine,
+				"Empty value for enum case %z::%z",&pClass->sName,pName);
+		}
+		PH7_VmEmitInstr(pGen->pVm,PH7_OP_DONE,1,0,0,0);
+		PH7_VmSetByteCodeContainer(pGen->pVm,pInstrContainer);
+		if( rc == SXERR_ABORT ){
+			return SXERR_ABORT;
+		}
+	}else{
+		if( pClass->nEnumBacking != 0 ){
+			rc = PH7_GenCompileError(pGen,E_ERROR,nLine,
+				"Case %z of backed enum %z must have a value",pName,&pClass->sName);
+			if( rc == SXERR_ABORT ){
+				return SXERR_ABORT;
+			}
+			goto Synchronize;
+		}
+	}
+	rc = PH7_ClassInstallAttr(pClass,pCase);
+	if( rc != SXRET_OK ){
+		PH7_GenCompileError(pGen,E_ERROR,nLine,"Fatal, PH7 is running out of memory");
+		return SXERR_ABORT;
+	}
+	SySetPut(&pClass->aEnumCases,(const void *)&pCase);
+	return SXRET_OK;
+Synchronize:
+	/* Synchronize with the first semi-colon */
+	while( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_SEMI/*';'*/) == 0 ){
+		pGen->pIn++;
+	}
+	return SXERR_CORRUPT;
+}
+/*
+ * Synthesize the enum interface methods (PHP 8.1): cases() for every enum,
+ * plus from()/tryFrom() for backed enums. Each is an ordinary public static
+ * method whose body forwards to a __phl_enum_* engine thunk (vm.c) with the
+ * enum's FQN embedded as a literal — the same forwarder pattern the
+ * Generator/Fiber/Reflection builtins use. The source buffer is owned by the
+ * VM allocator and never freed: tokens (method and parameter names) keep
+ * pointers into it (see the constructor-promotion precedent above).
+ */
+static sxi32 GenStateCompileEnumMethods(ph7_gen_state *pGen,ph7_class *pClass)
+{
+	SyToken *pSaveIn,*pSaveEnd;
+	const char *zBack;
+	SySet sToken;
+	char *zSrc;
+	sxu32 nSrc,nMax;
+	sxi32 rc = SXRET_OK;
+	nMax = 3*(sxu32)sizeof("function tryFrom(string $value){return __phl_enum_tryfrom('',$value);}")
+		+ 3*SyStringLength(&pClass->sName) + 64;
+	zSrc = (char *)SyMemBackendAlloc(&pGen->pVm->sAllocator,nMax);
+	if( zSrc == 0 ){
+		PH7_GenCompileError(pGen,E_ERROR,pClass->nLine,"Fatal, PH7 is running out of memory");
+		return SXERR_ABORT;
+	}
+	zBack = (pClass->nEnumBacking == MEMOBJ_INT) ? "int" : "string";
+	if( pClass->nEnumBacking != 0 ){
+		nSrc = SyBufferFormat(zSrc,nMax,
+			"function cases(){return __phl_enum_cases('%z');}"
+			"function from(%s $value){return __phl_enum_from('%z',$value);}"
+			"function tryFrom(%s $value){return __phl_enum_tryfrom('%z',$value);}",
+			&pClass->sName,zBack,&pClass->sName,zBack,&pClass->sName);
+	}else{
+		nSrc = SyBufferFormat(zSrc,nMax,
+			"function cases(){return __phl_enum_cases('%z');}",&pClass->sName);
+	}
+	SySetInit(&sToken,&pGen->pVm->sAllocator,sizeof(SyToken));
+	PH7_TokenizePHP(zSrc,nSrc,pClass->nLine,&sToken,0);
+	pSaveIn = pGen->pIn;
+	pSaveEnd = pGen->pEnd;
+	pGen->pIn = (SyToken *)SySetBasePtr(&sToken);
+	pGen->pEnd = &pGen->pIn[SySetUsed(&sToken)];
+	while( pGen->pIn < pGen->pEnd && rc != SXERR_ABORT ){
+		rc = GenStateCompileClassMethod(&(*pGen),PH7_TKWRD_PUBLIC,PH7_CLASS_ATTR_STATIC,TRUE,pClass);
+	}
+	pGen->pIn = pSaveIn;
+	pGen->pEnd = pSaveEnd;
+	SySetRelease(&sToken);
+	return (rc == SXERR_ABORT) ? SXERR_ABORT : SXRET_OK;
+}
+/*
+ * Magic methods an enum may not declare (php 8.1, zend_enum.c list —
+ * __call/__callStatic/__invoke stay allowed).
+ */
+static const char *azEnumBannedMagic[] = {
+	"__construct","__destruct","__clone","__get","__set","__isset","__unset",
+	"__toString","__sleep","__wakeup","__serialize","__unserialize","__set_state"
+};
+/*
+ * Enum post-body validation + synthesis: reject declared properties (including
+ * trait-imported ones) and banned magic methods, install the readonly `name`
+ * (and, for backed enums, `value`) instance properties the case singletons
+ * carry, and synthesize cases()/from()/tryFrom(). Runs after trait application
+ * and before the class is installed.
+ */
+static sxi32 GenStateEnumFinalize(ph7_gen_state *pGen,ph7_class *pClass,sxu32 nLine)
+{
+	SyHashEntry *pEntry;
+	sxi32 rc;
+	sxu32 n;
+	/* php: "Enum %s cannot include properties" */
+	SyHashResetLoopCursor(&pClass->hAttr);
+	while( (pEntry = SyHashGetNextEntry(&pClass->hAttr)) != 0 ){
+		ph7_class_attr *pAttr = (ph7_class_attr *)pEntry->pUserData;
+		if( (pAttr->iFlags & PH7_CLASS_ATTR_CONSTANT) == 0 ){
+			rc = PH7_GenCompileError(pGen,E_ERROR,pAttr->nLine ? pAttr->nLine : nLine,
+				"Enum %z cannot include properties",&pClass->sName);
+			if( rc == SXERR_ABORT ){
+				return SXERR_ABORT;
+			}
+			break;
+		}
+	}
+	/* php: "Enum %s cannot include magic method %s" */
+	for( n = 0 ; n < SX_ARRAYSIZE(azEnumBannedMagic) ; n++ ){
+		if( SyHashGet(&pClass->hMethod,(const void *)azEnumBannedMagic[n],
+			SyStrlen(azEnumBannedMagic[n])) != 0 ){
+			rc = PH7_GenCompileError(pGen,E_ERROR,nLine,
+				"Enum %z cannot include magic method %s",&pClass->sName,azEnumBannedMagic[n]);
+			if( rc == SXERR_ABORT ){
+				return SXERR_ABORT;
+			}
+		}
+	}
+	/* Install the case-singleton instance properties: readonly `name` (every
+	 * enum) and `value` (backed only). Materialization (vm.c) fills them and
+	 * clears the readonly write-once latch; user writes then raise php's
+	 * "Cannot modify readonly property" through the normal store path. */
+	{
+		static const SyString sNameProp = { "name",sizeof("name")-1 };
+		static const SyString sValueProp = { "value",sizeof("value")-1 };
+		ph7_class_attr *pAttr;
+		pAttr = PH7_NewClassAttr(pGen->pVm,&sNameProp,nLine,PH7_CLASS_PROT_PUBLIC,
+			PH7_CLASS_ATTR_READONLY|PH7_CLASS_ATTR_TYPED);
+		if( pAttr == 0 ){
+			PH7_GenCompileError(pGen,E_ERROR,nLine,"Fatal, PH7 is running out of memory");
+			return SXERR_ABORT;
+		}
+		pAttr->nType = MEMOBJ_STRING;
+		SyStringInitFromBuf(&pAttr->sTypeName,"string",sizeof("string")-1);
+		PH7_ClassInstallAttr(pClass,pAttr);
+		if( pClass->nEnumBacking != 0 ){
+			pAttr = PH7_NewClassAttr(pGen->pVm,&sValueProp,nLine,PH7_CLASS_PROT_PUBLIC,
+				PH7_CLASS_ATTR_READONLY|PH7_CLASS_ATTR_TYPED);
+			if( pAttr == 0 ){
+				PH7_GenCompileError(pGen,E_ERROR,nLine,"Fatal, PH7 is running out of memory");
+				return SXERR_ABORT;
+			}
+			pAttr->nType = pClass->nEnumBacking;
+			if( pClass->nEnumBacking == MEMOBJ_INT ){
+				SyStringInitFromBuf(&pAttr->sTypeName,"int",sizeof("int")-1);
+			}else{
+				SyStringInitFromBuf(&pAttr->sTypeName,"string",sizeof("string")-1);
+			}
+			PH7_ClassInstallAttr(pClass,pAttr);
+		}
+	}
+	return GenStateCompileEnumMethods(&(*pGen),pClass);
+}
+/*
  * Compile a class declaration, named or anonymous.
  *
  * For a named class pAnonName is 0 and the class name is read from the token
@@ -9435,6 +9657,31 @@ static sxi32 GenStateCompileClassEx(ph7_gen_state *pGen,sxi32 iFlags,
 		PH7_GenCompileError(pGen,E_ERROR,nLine,"Fatal, PH7 is running out of memory");
 		return SXERR_ABORT;
 	}
+	if( (iFlags & PH7_CLASS_ENUM) && pGen->pIn < pGen->pEnd
+		&& (pGen->pIn->nType & PH7_TK_COLON /* ':' */) ){
+		/* Backed enum: `enum Name: int|string` (PHP 8.1) */
+		pGen->pIn++; /* Jump ':' */
+		if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_KEYWORD)
+			&& SX_PTR_TO_INT(pGen->pIn->pUserData) == PH7_TKWRD_INT ){
+			pClass->nEnumBacking = MEMOBJ_INT;
+			pGen->pIn++;
+		}else if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_KEYWORD)
+			&& SX_PTR_TO_INT(pGen->pIn->pUserData) == PH7_TKWRD_STRING ){
+			pClass->nEnumBacking = MEMOBJ_STRING;
+			pGen->pIn++;
+		}else{
+			SyToken *pTok = pGen->pIn;
+			if( pTok >= pGen->pEnd ){ pTok--; }
+			rc = PH7_GenCompileError(pGen,E_ERROR,pTok->nLine,
+				"Enum backing type must be int or string, %z given",&pTok->sData);
+			if( rc == SXERR_ABORT ){
+				return SXERR_ABORT;
+			}
+			if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_OCB) == 0 ){
+				pGen->pIn++; /* Skip the bogus type token */
+			}
+		}
+	}
 	GenStateConsumeDoc(&(*pGen),&pClass->sDoc);
 	if( GenStateConsumeAttrs(&(*pGen),&pClass->aAttrs) == SXERR_ABORT ){
 		return SXERR_ABORT;
@@ -9450,6 +9697,14 @@ static sxi32 GenStateCompileClassEx(ph7_gen_state *pGen,sxi32 iFlags,
 			SyBlob sResolved;
 			SyString sBaseName;
 			sxu32 nRefLine;
+			if( iFlags & PH7_CLASS_ENUM ){
+				/* php parse-fatals here (enums have no inheritance) */
+				rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,
+					"Enum %z cannot extend a class",&pClass->sName);
+				if( rc == SXERR_ABORT ){
+					return SXERR_ABORT;
+				}
+			}
 			pGen->pIn++; /* Advance past 'extends' */
 			nRefLine = (pGen->pIn < pGen->pEnd) ? pGen->pIn->nLine : nLine;
 			SyBlobInit(&sResolved,&pGen->pVm->sAllocator);
@@ -9480,7 +9735,15 @@ static sxi32 GenStateCompileClassEx(ph7_gen_state *pGen,sxi32 iFlags,
 					return SXERR_ABORT;
 				}
 			}else{
-				if( pBase->iFlags & PH7_CLASS_FINAL ){
+				if( pBase->iFlags & PH7_CLASS_ENUM ){
+					rc = PH7_GenCompileError(pGen,E_ERROR,nLine,
+						"Class %z cannot extend enum %z",pName,&pBase->sName);
+					if( rc == SXERR_ABORT ){
+						SyBlobRelease(&sResolved);
+						return SXERR_ABORT;
+					}
+					pBase = 0; /* Never inherit from an enum */
+				}else if( pBase->iFlags & PH7_CLASS_FINAL ){
 					rc = PH7_GenCompileError(pGen,E_ERROR,nLine,
 						"Class '%z' may not inherit from final class '%z'",pName,&pBase->sName);
 					if( rc == SXERR_ABORT ){
@@ -9490,6 +9753,9 @@ static sxi32 GenStateCompileClassEx(ph7_gen_state *pGen,sxi32 iFlags,
 				}
 			}
 			SyBlobRelease(&sResolved);
+			if( iFlags & PH7_CLASS_ENUM ){
+				pBase = 0; /* Error already reported: enums have no base class */
+			}
 		}
 		if (pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_KEYWORD) && SX_PTR_TO_INT(pGen->pIn->pUserData) == PH7_TKWRD_IMPLEMENTS ){
 			ph7_class *pInterface;
@@ -9651,6 +9917,17 @@ static sxi32 GenStateCompileClassEx(ph7_gen_state *pGen,sxi32 iFlags,
 		if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_KEYWORD) ){
 			/* Extract the current keyword */
 			nKwrd = SX_PTR_TO_INT(pGen->pIn->pUserData);
+			if( nKwrd == PH7_TKWRD_CASE && (pClass->iFlags & PH7_CLASS_ENUM) ){
+				/* Enum case declaration: `case NAME [= value];` */
+				rc = GenStateCompileEnumCase(&(*pGen),pClass);
+				if( rc != SXRET_OK ){
+					if( rc == SXERR_ABORT ){
+						return SXERR_ABORT;
+					}
+					goto done;
+				}
+				continue;
+			}
 			if( nKwrd == PH7_TKWRD_USE ){
 				/* Trait use: use TraitA, TraitB [{ ... }]; */
 				TraitUseEntry sUse;
@@ -10157,6 +10434,16 @@ static sxi32 GenStateCompileClassEx(ph7_gen_state *pGen,sxi32 iFlags,
 			SySetRelease(&pUse->aTraits);
 		}
 	}
+	if( pClass->iFlags & PH7_CLASS_ENUM ){
+		/* Enum validation + name/value props + cases()/from()/tryFrom() synthesis.
+		 * Runs after trait application so trait-imported properties are caught. */
+		rc = GenStateEnumFinalize(&(*pGen),pClass,nLine);
+		if( rc == SXERR_ABORT ){
+			SySetRelease(&aUseEntries);
+			SySetRelease(&aInterfaces);
+			return SXERR_ABORT;
+		}
+	}
 	/* Install the class */
 	rc = PH7_VmInstallClass(pGen->pVm,pClass);
 	if( rc == SXRET_OK ){
@@ -10172,6 +10459,26 @@ static sxi32 GenStateCompileClassEx(ph7_gen_state *pGen,sxi32 iFlags,
 			rc = PH7_ClassImplement(pClass,apInterface[n]);
 			if( rc != SXRET_OK ){
 				break;
+			}
+		}
+		/* Auto-implement UnitEnum (and BackedEnum for backed enums) — php 8.1:
+		 * every enum satisfies `instanceof UnitEnum` implicitly. */
+		if( rc == SXRET_OK && (pClass->iFlags & PH7_CLASS_ENUM) ){
+			ph7_class *pIntf = PH7_VmExtractClass(pGen->pVm,"UnitEnum",sizeof("UnitEnum")-1,FALSE,0);
+			while( pIntf && (pIntf->iFlags & PH7_CLASS_INTERFACE) == 0 ){
+				pIntf = pIntf->pNextName;
+			}
+			if( pIntf ){
+				PH7_ClassImplement(pClass,pIntf);
+			}
+			if( pClass->nEnumBacking != 0 ){
+				pIntf = PH7_VmExtractClass(pGen->pVm,"BackedEnum",sizeof("BackedEnum")-1,FALSE,0);
+				while( pIntf && (pIntf->iFlags & PH7_CLASS_INTERFACE) == 0 ){
+					pIntf = pIntf->pNextName;
+				}
+				if( pIntf ){
+					PH7_ClassImplement(pClass,pIntf);
+				}
 			}
 		}
 		/* Auto-implement Stringable when class declares __toString (PHP 8.0+).
@@ -10709,6 +11016,30 @@ static sxi32 PH7_CompileClass(ph7_gen_state *pGen)
 	sxi32 rc;
 	rc = GenStateCompileClass(&(*pGen),0);
 	return rc;
+}
+/*
+ * Return TRUE if the token stream starts an enum declaration (PHP 8.1):
+ * the context-sensitive identifier `enum` (not a reserved word — it stays
+ * valid as a function/constant name, like `readonly`) directly followed by
+ * an identifier. `enum(...)`/`enum;`/`$enum` all keep their expression
+ * meaning; `enum Name` can never start a valid expression.
+ */
+static int GenStateStartsEnumDecl(SyToken *pIn,SyToken *pEnd)
+{
+	return (pIn->nType & PH7_TK_ID)
+		&& pIn->sData.nByte == sizeof("enum")-1
+		&& SyStrnicmp(pIn->sData.zString,"enum",sizeof("enum")-1) == 0
+		&& &pIn[1] < pEnd && (pIn[1].nType & PH7_TK_ID);
+}
+/*
+ * Compile an enum declaration (PHP 8.1). An enum is a final class carrying
+ * PH7_CLASS_ENUM: `case` members become lazily-materialized singleton
+ * constants, cases()/from()/tryFrom() are synthesized, and UnitEnum/BackedEnum
+ * are implemented implicitly (GenStateCompileClassEx handles the specifics).
+ */
+static sxi32 PH7_CompileEnum(ph7_gen_state *pGen)
+{
+	return GenStateCompileClass(&(*pGen),PH7_CLASS_ENUM|PH7_CLASS_FINAL);
 }
 /*
  * Exception handling.
@@ -13103,6 +13434,10 @@ static sxi32 GenStateCompileChunk(
 				 * here rather than the keyword-only dispatcher because `readonly`
 				 * is a context-sensitive ID and combos need a full-run scan. */
 				xCons = PH7_CompileClassModifiers;
+			}else if( GenStateStartsEnumDecl(pGen->pIn,pGen->pEnd) ){
+				/* `enum Name …` (PHP 8.1) — `enum` is a context-sensitive ID,
+				 * so it is detected here rather than the keyword dispatcher. */
+				xCons = PH7_CompileEnum;
 			}else if( pGen->pIn->nType & PH7_TK_KEYWORD ){
 				sxu32 nKeyword = (sxu32)SX_PTR_TO_INT(pGen->pIn->pUserData);
 				/* Try to extract a language construct handler */

--- a/src/ph7/constant.c
+++ b/src/ph7/constant.c
@@ -1890,6 +1890,15 @@ static void PH7_JSON_ERROR_UTF8_Const(ph7_value *pVal,void *pUserData)
 	ph7_value_int(pVal,JSON_ERROR_UTF8);
 }
 /*
+ * JSON_ERROR_NON_BACKED_ENUM.
+ *   Expand the value of JSON_ERROR_NON_BACKED_ENUM defined in ph7Int.h (php 8.1).
+ */
+static void PH7_JSON_ERROR_NON_BACKED_ENUM_Const(ph7_value *pVal,void *pUserData)
+{
+	SXUNUSED(pUserData); /* cc warning */
+	ph7_value_int(pVal,JSON_ERROR_NON_BACKED_ENUM);
+}
+/*
  * static
  *  Expand the name of the current class. 'static' otherwise.
  */
@@ -2279,6 +2288,7 @@ static const ph7_builtin_constant aBuiltIn[] = {
 	{"JSON_ERROR_CTRL_CHAR", PH7_JSON_ERROR_CTRL_CHAR_Const},
 	{"JSON_ERROR_SYNTAX",    PH7_JSON_ERROR_SYNTAX_Const},
 	{"JSON_ERROR_UTF8",      PH7_JSON_ERROR_UTF8_Const},
+	{"JSON_ERROR_NON_BACKED_ENUM", PH7_JSON_ERROR_NON_BACKED_ENUM_Const},
 	{"static",               PH7_static_Const       },
 	{"self",                 PH7_self_Const         },
 	{"__CLASS__",            PH7_self_Const         },

--- a/src/ph7/memobj.c
+++ b/src/ph7/memobj.c
@@ -1645,6 +1645,27 @@ PH7_PRIVATE sxi32 PH7_MemObjDump(
 	for( i = 0 ; i < nTab ; i++ ){
 		SyBlobAppend(&(*pOut)," ",sizeof(char));
 	}
+	if( ShowType && (pObj->iFlags & (MEMOBJ_OBJ|MEMOBJ_NULL)) == MEMOBJ_OBJ ){
+		/* php 8.1: var_dump of an enum case prints `enum(S::A)` — no body */
+		ph7_class_instance *pInst = (ph7_class_instance *)pObj->x.pOther;
+		if( pInst->pClass->iFlags & PH7_CLASS_ENUM ){
+			ph7_value *pName = PH7_EnumCaseNameValue(pInst);
+			if( isRef ){
+				SyBlobAppend(&(*pOut),"&",sizeof(char));
+			}
+			SyBlobFormat(&(*pOut),"enum(%z::",&pInst->pClass->sName);
+			if( pName && SyBlobLength(&pName->sBlob) > 0 ){
+				SyBlobAppend(&(*pOut),SyBlobData(&pName->sBlob),SyBlobLength(&pName->sBlob));
+			}
+			SyBlobAppend(&(*pOut),")",sizeof(char));
+#ifdef __WINNT__
+			SyBlobAppend(&(*pOut),"\r\n",sizeof("\r\n")-1);
+#else
+			SyBlobAppend(&(*pOut),"\n",sizeof(char));
+#endif
+			return SXRET_OK;
+		}
+	}
 	if( ShowType ){
 		if( isRef ){
 			SyBlobAppend(&(*pOut),"&",sizeof(char));

--- a/src/ph7/oo.c
+++ b/src/ph7/oo.c
@@ -36,6 +36,7 @@ PH7_PRIVATE ph7_class * PH7_NewRawClass(ph7_vm *pVm,const SyString *pName,sxu32 
 	SySetInit(&pClass->aInterface,&pVm->sAllocator,sizeof(ph7_class *));
 	SySetInit(&pClass->aTrait,&pVm->sAllocator,sizeof(ph7_class *));
 	SySetInit(&pClass->aAttrs,&pVm->sAllocator,sizeof(ph7_attribute));
+	SySetInit(&pClass->aEnumCases,&pVm->sAllocator,sizeof(ph7_class_attr *));
 	pClass->nLine = nLine;
 	if( pVm->bCompilingBuiltin ){
 		/* Defined by an embedded builtin chunk: internal, no defining file.
@@ -1342,14 +1343,51 @@ PH7_PRIVATE sxi32 PH7_ClassInstanceCmp(ph7_class_instance *pLeft,ph7_class_insta
  * SXERR_LIMIT(infinite recursion) indicates failure.
  */
 /*
+ * Return the `name` property value of an enum case instance (the case name),
+ * or 0 when unavailable. Shared by the var_dump/var_export/json/serialize
+ * renderers, which all print enum cases as Class::CaseName forms.
+ */
+PH7_PRIVATE ph7_value * PH7_EnumCaseNameValue(ph7_class_instance *pThis)
+{
+	SyHashEntry *pEntry;
+	if( (pThis->pClass->iFlags & PH7_CLASS_ENUM) == 0 ){
+		return 0;
+	}
+	pEntry = SyHashGet(&pThis->hAttr,(const void *)"name",sizeof("name")-1);
+	if( pEntry == 0 ){
+		return 0;
+	}
+	return PH7_ClassInstanceExtractAttrValue(pThis,(VmClassAttr *)pEntry->pUserData);
+}
+/*
+ * Return the `value` property value (the backing value) of an enum case
+ * instance, or 0 when unavailable (pure enums have none).
+ */
+PH7_PRIVATE ph7_value * PH7_EnumCaseBackingValueOf(ph7_class_instance *pThis)
+{
+	SyHashEntry *pEntry;
+	if( (pThis->pClass->iFlags & PH7_CLASS_ENUM) == 0 ){
+		return 0;
+	}
+	pEntry = SyHashGet(&pThis->hAttr,(const void *)"value",sizeof("value")-1);
+	if( pEntry == 0 ){
+		return 0;
+	}
+	return PH7_ClassInstanceExtractAttrValue(pThis,(VmClassAttr *)pEntry->pUserData);
+}
+/*
  * Emit a class-instance dump header plus its trailing newline. For var_dump
  * (ShowType) it completes the "object(" prefix the caller already emitted as
  *   ClassName)#<id> (<count>) {
  * for print_r it emits the legacy PHL  Object(ClassName) {  (count/id unused).
+ * Enum cases print php's `ClassName Enum {` print_r header (var_dump never
+ * reaches here for enums — PH7_MemObjDump prints `enum(S::A)` directly).
  */
 static void DumpClassInstanceHeader(SyBlob *pOut,ph7_class *pClass,sxu32 nObjId,int ShowType,sxu32 nCount)
 {
-	if( !ShowType ){
+	if( !ShowType && (pClass->iFlags & PH7_CLASS_ENUM) != 0 ){
+		SyBlobFormat(&(*pOut),"%z Enum {",&pClass->sName);
+	}else if( !ShowType ){
 		SyBlobAppend(&(*pOut),"Object(",sizeof("Object(")-1);
 		SyBlobFormat(&(*pOut),"%z) {",&pClass->sName);
 	}else{

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -857,6 +857,11 @@ struct ph7_class
 	sxu32 nEndLine;       /* Line of the class body's closing brace (Reflection getEndLine) */
 	SyString sDoc;        /* Doc-comment preceding the declaration (duplicated; empty = none) */
 	SySet aAttrs;         /* Declared #[...] attributes (ph7_attribute records) */
+	sxu32 nEnumBacking;   /* Enum backing type: 0 = pure/not an enum, MEMOBJ_INT or MEMOBJ_STRING */
+	SySet aEnumCases;     /* Enum cases (ph7_class_attr *) in declaration order. Case singletons
+	                       * materialize lazily and INDIVIDUALLY on first access (php 8.1: a broken
+	                       * sibling case does not poison a valid one); an unmaterialized case has
+	                       * nIdx == SXU32_HIGH. */
 };
 /* Class configuration flags */
 #define PH7_CLASS_FINAL       0x001 /* Class is final [cannot be extended] */
@@ -868,6 +873,7 @@ struct ph7_class
 #define PH7_CLASS_INTERNAL    0x040 /* Class was defined while compiling a builtin chunk (embedded PHP
                                      * library). Reflection reports it as internal: isInternal() true,
                                      * getFileName() false. */
+#define PH7_CLASS_ENUM        0x080 /* Class is an enum (PHP 8.1). Also carries PH7_CLASS_FINAL. */
 /* Class attribute/methods/constants protection levels */
 #define PH7_CLASS_PROT_PUBLIC     1 /* public */
 #define PH7_CLASS_PROT_PROTECTED  2 /* protected */
@@ -904,7 +910,13 @@ struct ph7_class_attr
 #define PH7_CLASS_ATTR_DYNAMIC      0x100  /* Runtime-added (dynamic) property: the ph7_class_attr is
                                             * instance-owned (synthesized, not class-declared) and must
                                             * be freed when the instance is released. */
-/* next free bit: 0x200 */
+#define PH7_CLASS_ATTR_ENUMCASE     0x200  /* Enum case: a class constant whose value is the lazily
+                                            * materialized case singleton (aByteCode holds the BACKING
+                                            * value expression for backed enums; empty when pure). */
+#define PH7_CLASS_ATTR_EVALING      0x400  /* Transient: this constant's initializer is being evaluated
+                                            * (on-demand, VmClassConstEvalOnDemand). Re-entry means a
+                                            * self-referencing constant — php's catchable Error. */
+/* next free bit: 0x800 */
 /*
  * Each class method is parsed out and stored in an instance of the following
  * structure.
@@ -1212,6 +1224,17 @@ struct ph7_vm
 	                             * (vm_builtin_magic_call), which consumes this + the class +
 	                             * the original name. Holds a reference; NULL for __callStatic. */
 	ph7_class *pMagicCallClass; /* Pending __call/__callStatic declaring class */
+	ph7_class *pConstEvalClass; /* Transient: class whose constant/property initializer bytecode is
+	                             * being evaluated (VmLocalExec has no method frame, so self::/parent::
+	                             * inside an initializer resolve through this fallback — consulted by
+	                             * PH7_VmPeekDeclaringClass/PH7_VmPeekTopClass when no frame matches). */
+	sxi32 nConstEvalDepth;      /* Nesting depth of constant/enum-case initializer evaluations. A
+	                             * cycle detected at an inner level (pConstCycleAttr) is thrown only
+	                             * when depth returns to 0 — a throw INSIDE an initializer mini-exec
+	                             * cannot be routed to a user catch (pre-existing engine restriction),
+	                             * so the outermost, opcode-level evaluation raises it instead. */
+	ph7_class_attr *pConstCycleAttr;  /* Self-referencing constant detected during evaluation */
+	ph7_class *pConstCycleClass;      /* ...and the class it belongs to (for the Error message) */
 	SyBlob sMagicCallName;      /* Pending original method name (stable copy) */
 	sxi32 nBoundaryRc;          /* C-boundary parked throw status (0 / PH7_EXCEPTION / PH7_ABORT).
 	                             * Set by VmBoundaryPark when a PHP callee invoked from a C site
@@ -1725,7 +1748,8 @@ enum json_err_code{
 	JSON_ERROR_STATE_MISMATCH, /* Occurs with underflow or with the modes mismatch.  */
 	JSON_ERROR_CTRL_CHAR, /* Control character error, possibly incorrectly encoded.  */
 	JSON_ERROR_SYNTAX,    /* Syntax error. */
-	JSON_ERROR_UTF8       /* Malformed UTF-8 characters */
+	JSON_ERROR_UTF8,      /* Malformed UTF-8 characters */
+	JSON_ERROR_NON_BACKED_ENUM = 11 /* Non-backed enum given to json_encode (php 8.1 value) */
 };
 /* The following constants can be combined to form options for json_encode(). */
 #define	JSON_HEX_TAG           0x01  /* All < and > are converted to \u003C and \u003E. */
@@ -1862,6 +1886,7 @@ PH7_PRIVATE sxi32 PH7_VmRefObjRemove(ph7_vm *pVm,sxu32 nIdx,SyHashEntry *pEntry,
 PH7_PRIVATE sxi32 PH7_VmRefObjInstall(ph7_vm *pVm,sxu32 nIdx,SyHashEntry *pEntry,ph7_hashmap_node *pMapEntry,sxi32 iFlags);
 PH7_PRIVATE sxi32 PH7_VmPushFilePath(ph7_vm *pVm,const char *zPath,int nLen,sxu8 bMain,sxi32 *pNew);
 PH7_PRIVATE ph7_class * PH7_VmExtractClass(ph7_vm *pVm,const char *zName,sxu32 nByte,sxi32 iLoadable,sxi32 iNest);
+PH7_PRIVATE sxi32 PH7_VmMaterializeClassConst(ph7_vm *pVm,ph7_class *pClass,ph7_class_attr *pAttr);
 PH7_PRIVATE ph7_class * PH7_VmTriggerAutoload(ph7_vm *pVm,const char *zName,sxu32 nByte,sxi32 iLoadable);
 PH7_PRIVATE sxi32 PH7_VmRegisterConstant(ph7_vm *pVm,const SyString *pName,ProcConstant xExpand,void *pUserData);
 PH7_PRIVATE sxi32 PH7_VmRegisterConstantEx(ph7_vm *pVm,const SyString *pName,ProcConstant xExpand,
@@ -2238,6 +2263,8 @@ PH7_PRIVATE sxi32 PH7_ClassInstanceDump(SyBlob *pOut,ph7_class_instance *pThis,i
 PH7_PRIVATE sxi32 PH7_ClassInstanceCallMagicMethod(ph7_vm *pVm,ph7_class *pClass,ph7_class_instance *pThis,const char *zMethod,
 	sxu32 nByte,const SyString *pAttrName,ph7_value *pResult);
 PH7_PRIVATE ph7_value * PH7_ClassInstanceExtractAttrValue(ph7_class_instance *pThis,VmClassAttr *pAttr);
+PH7_PRIVATE ph7_value * PH7_EnumCaseNameValue(ph7_class_instance *pThis);
+PH7_PRIVATE ph7_value * PH7_EnumCaseBackingValueOf(ph7_class_instance *pThis);
 PH7_PRIVATE sxi32 PH7_ClassInstanceToHashmap(ph7_class_instance *pThis,ph7_hashmap *pMap);
 PH7_PRIVATE sxi32 PH7_ClassInstanceWalk(ph7_class_instance *pThis,
 	int (*xWalk)(const char *,ph7_value *,void *),void *pUserData);

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -522,6 +522,7 @@ static const struct VmBuiltinArity {
 	/* Class/reflection family */
 	{ "class_alias",               2, 1 },
 	{ "class_exists",              1, 1 },
+	{ "enum_exists",               1, 1 },
 	{ "get_class_methods",         1, 0 },
 	{ "get_class_vars",            1, 0 },
 	{ "get_object_vars",           1, 0 },
@@ -1394,6 +1395,8 @@ static ph7_vm_func * VmOverload(
 /* Forward declaration */
 /* VmLocalExec and VmErrorFormat forward declarations removed - now PH7_PRIVATE in ph7int.h */
 static sxi32 VmEnforceConstantType(ph7_vm *pVm,ph7_class *pClass,ph7_class_attr *pAttr,ph7_value *pValue);
+static void VmBoundaryPark(ph7_vm *pVm,sxi32 rc);
+static sxi32 VmConstCycleThrow(ph7_vm *pVm);
 /*
  * Mount a compiled class into the freshly created vitual machine so that
  * it can be instanciated from the executed PHP script.
@@ -1420,8 +1423,28 @@ static sxi32 VmMountUserClassAttrs(
 	while( (pEntry = SyHashGetNextEntry(&pClass->hAttr)) != 0 ){
 		/* Extract the current attribute */
 		pAttr = (ph7_class_attr *)pEntry->pUserData;
-		if( pAttr->iFlags & (PH7_CLASS_ATTR_CONSTANT|PH7_CLASS_ATTR_STATIC) ){
+		if( (pAttr->iFlags & PH7_CLASS_ATTR_CONSTANT)
+		 && ((pAttr->iFlags & PH7_CLASS_ATTR_TYPED) == 0
+			|| (pAttr->iFlags & PH7_CLASS_ATTR_ENUMCASE) != 0) ){
+			/* Untyped class constants and enum cases are evaluated LAZILY, on
+			 * first access (VmClassConstEvalOnDemand / VmEnumMaterializeCase),
+			 * matching php. Eager evaluation here ran BEFORE execution for
+			 * top-level classes (PH7_VmMakeReady), so an initializer error
+			 * (self-reference, enum backing mismatch) could never reach a
+			 * user catch, and initializers referencing constants of a class
+			 * mounted later in hash order silently read NULL. TYPED constants
+			 * stay eager: php validates them at DECLARATION time ("Cannot use
+			 * %s as value for class constant" fatal without any access). */
+			continue;
+		}
+		if( pAttr->iFlags & (PH7_CLASS_ATTR_STATIC|PH7_CLASS_ATTR_CONSTANT) ){
 			ph7_value *pMemObj;
+			if( pAttr->nIdx != SXU32_HIGH ){
+				/* Already materialized (an attr shared with an earlier-mounted
+				 * class). PH7_VmReset invalidates every nIdx before its
+				 * re-mount pass, so VM reuse still re-evaluates. */
+				continue;
+			}
 			/* Reserve a memory object for this constant/static attribute */
 			pMemObj = PH7_ReserveMemObj(&(*pVm));
 			if( pMemObj == 0 ){
@@ -1432,8 +1455,29 @@ static sxi32 VmMountUserClassAttrs(
 				return SXERR_MEM;
 			}
 			if( SySetUsed(&pAttr->aByteCode) > 0 ){
-				/* Initialize attribute default value (any complex expression) */
-				VmLocalExec(&(*pVm),&pAttr->aByteCode,pMemObj,FALSE);
+				/* Initialize attribute default value (any complex expression).
+				 * pConstEvalClass lets self::/parent:: in the initializer
+				 * resolve (VmLocalExec runs without a method frame). */
+				ph7_class *pSaveCtx = pVm->pConstEvalClass;
+				sxi32 rcExec;
+				pVm->pConstEvalClass = pAttr->pDeclClass ? pAttr->pDeclClass : pClass;
+				pAttr->iFlags |= PH7_CLASS_ATTR_EVALING; /* cycle guard, shared with the on-demand path */
+				pVm->nConstEvalDepth++;
+				rcExec = VmLocalExec(&(*pVm),&pAttr->aByteCode,pMemObj,FALSE);
+				pVm->nConstEvalDepth--;
+				pAttr->iFlags &= ~PH7_CLASS_ATTR_EVALING;
+				pVm->pConstEvalClass = pSaveCtx;
+				if( rcExec == PH7_EXCEPTION || rcExec == PH7_ABORT ){
+					/* The initializer raised (self-referencing constant, or a
+					 * throwing enum-case reference): park it for the fetch-point
+					 * router — user classes mount mid-execution, so the throw
+					 * lands catchably at the declaration site. */
+					VmBoundaryPark(&(*pVm),rcExec);
+				}else if( pVm->pConstCycleAttr && pVm->nConstEvalDepth == 0 ){
+					/* A nested evaluation detected a self-referencing constant:
+					 * raise it at this, the outermost level. */
+					VmBoundaryPark(&(*pVm),VmConstCycleThrow(&(*pVm)));
+				}
 				/* Typed class constant (PHP 8.3): enforce the computed value
 				 * against the declared type. A mismatch is a non-catchable
 				 * fatal, raised here at definition time (matching PHP). */
@@ -1559,8 +1603,13 @@ PH7_PRIVATE sxi32 PH7_VmCreateClassInstanceFrame(
 			pVmAttr->iState = 0;
 			pVmAttr->pOwner = pClass;
 			if( SySetUsed(&pAttr->aByteCode) > 0 ){
-				/* Initialize attribute default value (any complex expression) */
+				/* Initialize attribute default value (any complex expression).
+				 * pConstEvalClass: self::CONST in a property default resolves
+				 * against the declaring class (no method frame here). */
+				ph7_class *pSaveCtx = pVm->pConstEvalClass;
+				pVm->pConstEvalClass = pAttr->pDeclClass ? pAttr->pDeclClass : pClass;
 				VmLocalExec(&(*pVm),&pAttr->aByteCode,pMemObj,FALSE);
+				pVm->pConstEvalClass = pSaveCtx;
 			}else if( pAttr->iFlags & PH7_CLASS_ATTR_TYPED ){
 				/* Typed property without a default: mark uninitialized. Reading
 				 * it before the first write is an Error in PHP 7.4+. */
@@ -2442,6 +2491,10 @@ PH7_PRIVATE sxi32 PH7_VmInit(
 	pVm->pResumeInstr = 0;
 	pVm->iResumeStackDepth = 0;
 	pVm->nBoundaryRc = 0;
+	pVm->pConstEvalClass = 0;
+	pVm->nConstEvalDepth = 0;
+	pVm->pConstCycleAttr = 0;
+	pVm->pConstCycleClass = 0;
 	SySetReset(&pVm->aMagicGuard);
 	if( pVm->pMagicSetThis ){
 		PH7_ClassInstanceUnref(pVm->pMagicSetThis);
@@ -3058,6 +3111,7 @@ static const struct VmBuiltinSig {
 	{ "chunk_split", "string $string, int $length = 76, string $separator = ?", "string" },
 	{ "class_alias", "string $class, string $alias, bool $autoload = true", "bool" },
 	{ "class_exists", "string $class, bool $autoload = true", "bool" },
+	{ "enum_exists", "string $enum, bool $autoload = true", "bool" },
 	{ "closedir", "$dir_handle = NULL", "void" },
 	{ "compact", "$var_name, ...$var_names = ?", "array" },
 	{ "constant", "string $name", "mixed" },
@@ -3833,6 +3887,10 @@ PH7_PRIVATE sxi32 PH7_VmReset(ph7_vm *pVm)
 	pVm->pResumeInstr = 0;
 	pVm->iResumeStackDepth = 0;
 	pVm->nBoundaryRc = 0;
+	pVm->pConstEvalClass = 0;
+	pVm->nConstEvalDepth = 0;
+	pVm->pConstCycleAttr = 0;
+	pVm->pConstCycleClass = 0;
 	SySetReset(&pVm->aMagicGuard);
 	if( pVm->pMagicSetThis ){
 		PH7_ClassInstanceUnref(pVm->pMagicSetThis);
@@ -3880,9 +3938,27 @@ PH7_PRIVATE sxi32 PH7_VmReset(ph7_vm *pVm)
 			return rc;
 		}
 	}
-	/* (10) Re-mount the static/const attribute slots of every class. */
+	/* (10) Re-mount the static/const attribute slots of every class. First
+	 * invalidate every const/static slot index across ALL classes: the object
+	 * pool was truncated, so the old indexes are stale, and the mount loop
+	 * (plus the on-demand constant evaluator it can trigger) skips attributes
+	 * whose nIdx is already set. Enum case singletons re-materialize lazily. */
 	{
 		SyHashEntry *pEntry;
+		SyHashResetLoopCursor(&pVm->hClass);
+		while( (pEntry = SyHashGetNextEntry(&pVm->hClass)) != 0 ){
+			ph7_class *pClass = (ph7_class *)pEntry->pUserData;
+			ph7_class_attr *pAttr;
+			SyHashEntry *pAttrEntry;
+			SyHashResetLoopCursor(&pClass->hAttr);
+			while( (pAttrEntry = SyHashGetNextEntry(&pClass->hAttr)) != 0 ){
+				pAttr = (ph7_class_attr *)pAttrEntry->pUserData;
+				if( pAttr->iFlags & (PH7_CLASS_ATTR_CONSTANT|PH7_CLASS_ATTR_STATIC) ){
+					pAttr->nIdx = SXU32_HIGH;
+					pAttr->iFlags &= ~PH7_CLASS_ATTR_EVALING;
+				}
+			}
+		}
 		SyHashResetLoopCursor(&pVm->hClass);
 		while( (pEntry = SyHashGetNextEntry(&pVm->hClass)) != 0 ){
 			sxi32 rc = VmMountUserClassAttrs(&(*pVm),(ph7_class *)pEntry->pUserData);
@@ -5127,6 +5203,339 @@ static sxi32 VmThrowFixedError(ph7_vm *pVm, const char *zClass, const char *zMsg
 	SyBlobInit(&sMsg, &pVm->sAllocator);
 	SyBlobAppend(&sMsg, zMsg, SyStrlen(zMsg));
 	return VmThrowBuiltinError(pVm, zClass, SyStrlen(zClass), &sMsg);
+}
+/*
+ * Enum case singletons (PHP 8.1).
+ *
+ * Each `case` of an enum is a class constant (PH7_CLASS_ATTR_ENUMCASE) whose
+ * slot holds THE singleton instance of the enum class for that case; strict
+ * `===` between two accesses is then the ordinary instance-pointer identity.
+ * Materialization is lazy and all-at-once on first access, matching php: the
+ * backing-value type check and the duplicate-value check only fire when a
+ * case (or cases()/from()/tryFrom()) is first touched.
+ */
+/* Write [pSrcVal] into the instance property [zProp] of [pObj], clearing the
+ * readonly write-once latch so later user writes raise php's "Cannot modify
+ * readonly property" through the normal store path. */
+static void VmEnumSetInstanceProp(ph7_vm *pVm,ph7_class_instance *pObj,
+	const char *zProp,sxu32 nProp,ph7_value *pSrcVal)
+{
+	SyHashEntry *pEntry = SyHashGet(&pObj->hAttr,(const void *)zProp,nProp);
+	VmClassAttr *pVmAttr;
+	ph7_value *pSlot;
+	if( pEntry == 0 ){
+		return;
+	}
+	pVmAttr = (VmClassAttr *)pEntry->pUserData;
+	pSlot = (ph7_value *)SySetAt(&pVm->aMemObj,pVmAttr->nIdx);
+	if( pSlot == 0 ){
+		return;
+	}
+	PH7_MemObjStore(pSrcVal,pSlot);
+	pVmAttr->iState &= ~VM_CLASS_ATTR_UNINIT;
+}
+/* Return the backing value (the `value` property) of an already-materialized
+ * enum case, or 0 when unavailable (pure enum / not yet materialized). */
+static ph7_value * VmEnumCaseBackingValue(ph7_vm *pVm,ph7_class_attr *pCase)
+{
+	ph7_value *pSlot = (ph7_value *)SySetAt(&pVm->aMemObj,pCase->nIdx);
+	ph7_class_instance *pObj;
+	SyHashEntry *pEntry;
+	if( pSlot == 0 || (pSlot->iFlags & MEMOBJ_OBJ) == 0 ){
+		return 0;
+	}
+	pObj = (ph7_class_instance *)pSlot->x.pOther;
+	pEntry = SyHashGet(&pObj->hAttr,"value",sizeof("value")-1);
+	if( pEntry == 0 ){
+		return 0;
+	}
+	return (ph7_value *)SySetAt(&pVm->aMemObj,((VmClassAttr *)pEntry->pUserData)->nIdx);
+}
+/*
+ * Raise the pending self-referencing-constant Error recorded by an inner
+ * initializer evaluation (pConstCycleAttr). Called only at nConstEvalDepth 0 —
+ * a throw inside an initializer mini-exec cannot be routed to a user catch
+ * (pre-existing engine restriction), so the outermost, opcode-level evaluation
+ * raises it. Returns the throw status to park/route.
+ */
+static sxi32 VmConstCycleThrow(ph7_vm *pVm)
+{
+	SyBlob sMsg;
+	ph7_class_attr *pAttr = pVm->pConstCycleAttr;
+	ph7_class *pOwner = pVm->pConstCycleClass;
+	pVm->pConstCycleAttr = 0;
+	pVm->pConstCycleClass = 0;
+	SyBlobInit(&sMsg,&pVm->sAllocator);
+	SyBlobFormat(&sMsg,"Cannot declare self-referencing constant %z::%z",
+		pOwner ? &pOwner->sName : &pAttr->sName,&pAttr->sName);
+	return VmThrowBuiltinError(pVm,"Error",sizeof("Error")-1,&sMsg);
+}
+/*
+ * Materialize ONE case singleton of an enum class. php 8.1 semantics: cases
+ * materialize lazily and individually on first access — the backing-value
+ * type check fires per case, and the duplicate-value check compares only
+ * against cases that have already materialized (a broken sibling case does
+ * not poison a valid one). Returns SXRET_OK, or the PH7_EXCEPTION/PH7_ABORT
+ * of a thrown catchable error — TypeError (backing type mismatch) or Error
+ * (duplicate value / self-reference) — which the caller routes
+ * (VmBoundaryPark at an opcode site, direct return from a builtin thunk).
+ */
+static sxi32 VmEnumMaterializeCase(ph7_vm *pVm,ph7_class *pClass,ph7_class_attr *pCase)
+{
+	ph7_class_attr **apCase;
+	ph7_class_instance *pObj;
+	ph7_value *pSlot;
+	ph7_value sBacking,sPropVal;
+	sxu32 i;
+	if( pCase->nIdx != SXU32_HIGH ){
+		return SXRET_OK;
+	}
+	if( pCase->iFlags & PH7_CLASS_ATTR_EVALING ){
+		/* `case A = self::A->value` — record the cycle; the outermost
+		 * evaluation raises it (see VmConstCycleThrow). */
+		if( pVm->pConstCycleAttr == 0 ){
+			pVm->pConstCycleAttr = pCase;
+			pVm->pConstCycleClass = pClass;
+		}
+		return SXRET_OK;
+	}
+	PH7_MemObjInit(pVm,&sBacking);
+	if( pClass->nEnumBacking != 0 ){
+		if( SySetUsed(&pCase->aByteCode) > 0 ){
+			/* pConstEvalClass: `case A = self::OFF + 1` resolves self:: */
+			ph7_class *pSaveCtx = pVm->pConstEvalClass;
+			sxi32 rcExec;
+			pVm->pConstEvalClass = pClass;
+			pCase->iFlags |= PH7_CLASS_ATTR_EVALING;
+			pVm->nConstEvalDepth++;
+			rcExec = VmLocalExec(&(*pVm),&pCase->aByteCode,&sBacking,FALSE);
+			pVm->nConstEvalDepth--;
+			pCase->iFlags &= ~PH7_CLASS_ATTR_EVALING;
+			pVm->pConstEvalClass = pSaveCtx;
+			if( rcExec == PH7_EXCEPTION || rcExec == PH7_ABORT ){
+				/* The backing expression raised: abandon materialization and
+				 * hand the status to the caller to park/route. */
+				PH7_MemObjRelease(&sBacking);
+				return rcExec;
+			}
+			if( pVm->pConstCycleAttr && pVm->nConstEvalDepth == 0 ){
+				PH7_MemObjRelease(&sBacking);
+				return VmConstCycleThrow(&(*pVm));
+			}
+		}
+		if( (sBacking.iFlags & pClass->nEnumBacking) == 0 ){
+			/* php: TypeError, checked lazily at first case access */
+			SyBlob sMsg;
+			const char *zGiven = ph7_type_name(&sBacking);
+			PH7_MemObjRelease(&sBacking);
+			SyBlobInit(&sMsg,&pVm->sAllocator);
+			SyBlobFormat(&sMsg,"Enum case type %s does not match enum backing type %s",
+				zGiven,(pClass->nEnumBacking == MEMOBJ_INT) ? "int" : "string");
+			return VmThrowBuiltinError(pVm,"TypeError",sizeof("TypeError")-1,&sMsg);
+		}
+		if( pClass->nEnumBacking == MEMOBJ_INT ){
+			/* Normalize a whole-real (PHL flags them MEMOBJ_REAL|MEMOBJ_INT,
+			 * the typed-constant leniency) to a genuine int. */
+			PH7_MemObjToInteger(&sBacking);
+		}else{
+			PH7_MemObjToString(&sBacking);
+		}
+		/* php: two cases sharing one backing value are an Error — compared
+		 * against already-materialized cases only (php registers values as
+		 * each case evaluates). */
+		apCase = (ph7_class_attr **)SySetBasePtr(&pClass->aEnumCases);
+		for( i = 0 ; i < SySetUsed(&pClass->aEnumCases) ; i++ ){
+			ph7_value *pPrev;
+			int bDup = 0;
+			if( apCase[i] == pCase ){
+				continue;
+			}
+			pPrev = VmEnumCaseBackingValue(&(*pVm),apCase[i]);
+			if( pPrev ){
+				if( pClass->nEnumBacking == MEMOBJ_INT ){
+					bDup = (pPrev->x.iVal == sBacking.x.iVal);
+				}else{
+					bDup = SyBlobLength(&pPrev->sBlob) == SyBlobLength(&sBacking.sBlob)
+						&& SyMemcmp(SyBlobData(&pPrev->sBlob),SyBlobData(&sBacking.sBlob),
+							SyBlobLength(&sBacking.sBlob)) == 0;
+				}
+			}
+			if( bDup ){
+				/* php prints the two cases in DECLARATION order regardless of
+				 * which one is being evaluated. */
+				ph7_class_attr *pFirst = apCase[i], *pSecond = pCase;
+				SyBlob sMsg;
+				sxu32 j;
+				for( j = 0 ; j < SySetUsed(&pClass->aEnumCases) ; j++ ){
+					if( apCase[j] == pCase ){ break; }
+				}
+				if( j < i ){
+					pFirst = pCase;
+					pSecond = apCase[i];
+				}
+				PH7_MemObjRelease(&sBacking);
+				SyBlobInit(&sMsg,&pVm->sAllocator);
+				SyBlobFormat(&sMsg,"Duplicate value in enum %z for cases %z and %z",
+					&pClass->sName,&pFirst->sName,&pSecond->sName);
+				return VmThrowBuiltinError(pVm,"Error",sizeof("Error")-1,&sMsg);
+			}
+		}
+	}
+	/* Create the singleton and fill its readonly props */
+	pObj = PH7_NewClassInstance(&(*pVm),pClass);
+	if( pObj == 0 ){
+		PH7_MemObjRelease(&sBacking);
+		VmErrorFormat(&(*pVm),PH7_CTX_ERR,
+			"Cannot create enum case %z::%z due to a memory failure",
+			&pClass->sName,&pCase->sName);
+		return PH7_ABORT;
+	}
+	PH7_MemObjInitFromString(pVm,&sPropVal,&pCase->sName);
+	VmEnumSetInstanceProp(&(*pVm),pObj,"name",sizeof("name")-1,&sPropVal);
+	PH7_MemObjRelease(&sPropVal);
+	if( pClass->nEnumBacking != 0 ){
+		VmEnumSetInstanceProp(&(*pVm),pObj,"value",sizeof("value")-1,&sBacking);
+	}
+	PH7_MemObjRelease(&sBacking);
+	/* Park the singleton in the case's constant slot. The slot takes over
+	 * the instance's initial iRef=1 (synthesized-object invariant). */
+	pSlot = PH7_ReserveMemObj(&(*pVm));
+	if( pSlot == 0 ){
+		PH7_ClassInstanceUnref(pObj);
+		VmErrorFormat(&(*pVm),PH7_CTX_ERR,
+			"Cannot reserve a memory object for enum case %z::%z",
+			&pClass->sName,&pCase->sName);
+		return PH7_ABORT;
+	}
+	pSlot->x.pOther = pObj;
+	MemObjSetType(pSlot,MEMOBJ_OBJ);
+	PH7_VmRefObjInstall(&(*pVm),pSlot->nIdx,0,0,VM_REF_IDX_KEEP);
+	pCase->nIdx = pSlot->nIdx;
+	return SXRET_OK;
+}
+/*
+ * Materialize EVERY case singleton of [pClass], in declaration order — the
+ * cases()/from()/tryFrom() entry point (php equally evaluates all cases
+ * there, so a broken case surfaces its error at the same point).
+ */
+static sxi32 VmEnumMaterialize(ph7_vm *pVm,ph7_class *pClass)
+{
+	ph7_class_attr **apCase;
+	sxu32 n;
+	if( (pClass->iFlags & PH7_CLASS_ENUM) == 0 ){
+		return SXRET_OK;
+	}
+	apCase = (ph7_class_attr **)SySetBasePtr(&pClass->aEnumCases);
+	for( n = 0 ; n < SySetUsed(&pClass->aEnumCases) ; n++ ){
+		sxi32 rc = VmEnumMaterializeCase(&(*pVm),pClass,apCase[n]);
+		if( rc != SXRET_OK ){
+			return rc;
+		}
+	}
+	return SXRET_OK;
+}
+/*
+ * Resolve [pName] (a string ph7_value holding an enum FQN) to its enum class,
+ * or 0 when the name does not name an enum.
+ */
+static ph7_class * VmExtractEnumClass(ph7_vm *pVm,ph7_value *pName)
+{
+	ph7_class *pClass;
+	if( (pName->iFlags & MEMOBJ_STRING) == 0 || SyBlobLength(&pName->sBlob) < 1 ){
+		return 0;
+	}
+	pClass = PH7_VmExtractClass(&(*pVm),(const char *)SyBlobData(&pName->sBlob),
+		SyBlobLength(&pName->sBlob),FALSE,0);
+	while( pClass && (pClass->iFlags & PH7_CLASS_ENUM) == 0 ){
+		pClass = pClass->pNextName;
+	}
+	return pClass;
+}
+/*
+ * Evaluate a class constant's initializer on demand.
+ *
+ * Constant slots are normally filled eagerly at class mount, but a constant
+ * whose initializer references ANOTHER not-yet-mounted constant (same class —
+ * `const B = self::A + 1` — or a class mounted later in hash order) reaches
+ * OP_MEMBER with nIdx still unset; before this helper the load silently
+ * produced NULL (a mount-order-dependent silent wrong answer, surfaced by the
+ * enum work, 13 Jul 2026). Evaluates the initializer now — with
+ * pConstEvalClass set so self::/parent:: resolve — memoizes the slot, and
+ * leaves the mount loop's later visit to skip it (nIdx already set).
+ * A re-entrant evaluation of the SAME constant is php's catchable
+ * "Cannot declare self-referencing constant" Error.
+ */
+static sxi32 VmClassConstEvalOnDemand(ph7_vm *pVm,ph7_class *pClass,ph7_class_attr *pAttr)
+{
+	ph7_value *pMemObj;
+	if( pAttr->nIdx != SXU32_HIGH
+		|| (pAttr->iFlags & PH7_CLASS_ATTR_CONSTANT) == 0
+		|| (pAttr->iFlags & PH7_CLASS_ATTR_ENUMCASE) != 0 ){
+		return SXRET_OK;
+	}
+	if( pAttr->iFlags & PH7_CLASS_ATTR_EVALING ){
+		/* Cycle: record it for the OUTERMOST evaluation to raise
+		 * (VmConstCycleThrow) — a throw at this inner level would be lost
+		 * inside the initializer mini-exec. Loads NULL benignly here. */
+		if( pVm->pConstCycleAttr == 0 ){
+			pVm->pConstCycleAttr = pAttr;
+			pVm->pConstCycleClass = pAttr->pDeclClass ? pAttr->pDeclClass : pClass;
+		}
+		return SXRET_OK;
+	}
+	pMemObj = PH7_ReserveMemObj(&(*pVm));
+	if( pMemObj == 0 ){
+		return SXERR_MEM;
+	}
+	if( SySetUsed(&pAttr->aByteCode) > 0 ){
+		ph7_class *pSaveCtx = pVm->pConstEvalClass;
+		sxi32 rcExec;
+		pAttr->iFlags |= PH7_CLASS_ATTR_EVALING;
+		pVm->pConstEvalClass = pAttr->pDeclClass ? pAttr->pDeclClass : pClass;
+		pVm->nConstEvalDepth++;
+		rcExec = VmLocalExec(&(*pVm),&pAttr->aByteCode,pMemObj,FALSE);
+		pVm->nConstEvalDepth--;
+		pVm->pConstEvalClass = pSaveCtx;
+		pAttr->iFlags &= ~PH7_CLASS_ATTR_EVALING;
+		/* Memoize before any throw so re-access doesn't loop. */
+		pAttr->nIdx = pMemObj->nIdx;
+		PH7_VmRefObjInstall(&(*pVm),pMemObj->nIdx,0,0,VM_REF_IDX_KEEP);
+		if( rcExec == PH7_EXCEPTION || rcExec == PH7_ABORT ){
+			/* The initializer raised: hand the status to the caller to
+			 * park/route. */
+			return rcExec;
+		}
+		if( pVm->pConstCycleAttr && pVm->nConstEvalDepth == 0 ){
+			/* A nested evaluation detected a self-referencing constant:
+			 * raise it here, at opcode level, where it routes to a catch. */
+			return VmConstCycleThrow(&(*pVm));
+		}
+		if( pAttr->iFlags & PH7_CLASS_ATTR_TYPED ){
+			sxi32 rcType = VmEnforceConstantType(&(*pVm),pClass,pAttr,pMemObj);
+			if( rcType != SXRET_OK ){
+				return rcType;
+			}
+		}
+		return SXRET_OK;
+	}
+	pAttr->nIdx = pMemObj->nIdx;
+	PH7_VmRefObjInstall(&(*pVm),pMemObj->nIdx,0,0,VM_REF_IDX_KEEP);
+	return SXRET_OK;
+}
+/*
+ * Public seam for the constant-slot readers outside vm.c (reflection,
+ * get_class_vars): class constants evaluate lazily, so a listing-style read
+ * must materialize the slot first. Returns SXRET_OK or a throw status.
+ */
+PH7_PRIVATE sxi32 PH7_VmMaterializeClassConst(ph7_vm *pVm,ph7_class *pClass,ph7_class_attr *pAttr)
+{
+	if( pAttr->nIdx != SXU32_HIGH || (pAttr->iFlags & PH7_CLASS_ATTR_CONSTANT) == 0 ){
+		return SXRET_OK;
+	}
+	if( pAttr->iFlags & PH7_CLASS_ATTR_ENUMCASE ){
+		return VmEnumMaterializeCase(&(*pVm),pClass,pAttr);
+	}
+	return VmClassConstEvalOnDemand(&(*pVm),pClass,pAttr);
 }
 /*
  * Throw php's catchable Error for an append (`$a[] = v`) whose saturated
@@ -13280,6 +13689,35 @@ case PH7_OP_MEMBER: {
 											}
 										}
 									}
+									if( pAttr->nIdx == SXU32_HIGH ){
+										/* Unmaterialized slot. Enum case: first access
+										 * materializes ALL the singletons. Plain constant: its
+										 * initializer hasn't run yet (mount-order-dependent
+										 * cross-constant reference) — evaluate on demand. A
+										 * raised TypeError/Error (backing mismatch, duplicate
+										 * value, self-reference) parks on the boundary rail;
+										 * the op completes benignly with NULL and the
+										 * fetch-point router lands the throw. */
+										sxi32 rcEnum;
+										if( pAttr->iFlags & PH7_CLASS_ATTR_ENUMCASE ){
+											/* php: a DIRECT static access evaluates every case
+											 * of the enum (whole-class constant update) — a
+											 * broken sibling case throws here too. A reference
+											 * from inside another constant's initializer
+											 * (nConstEvalDepth > 0) evaluates only the
+											 * requested case. */
+											if( pVm->nConstEvalDepth > 0 ){
+												rcEnum = VmEnumMaterializeCase(&(*pVm),pClass,pAttr);
+											}else{
+												rcEnum = VmEnumMaterialize(&(*pVm),pClass);
+											}
+										}else{
+											rcEnum = VmClassConstEvalOnDemand(&(*pVm),pClass,pAttr);
+										}
+										if( rcEnum != SXRET_OK ){
+											VmBoundaryPark(&(*pVm),rcEnum);
+										}
+									}
 									/* Load the desired attribute */
 									pValue = (ph7_value *)SySetAt(&pVm->aMemObj,pAttr->nIdx);
 									if( pValue ){
@@ -13369,6 +13807,19 @@ case PH7_OP_NEW: {
 			VmPopOperand(&pTos,nCtorArgs);
 		}
 		goto Abort;
+	}else if( pClass->iFlags & PH7_CLASS_ENUM ){
+		/* php 8.1: enums cannot be instantiated — a catchable Error, raised
+		 * BEFORE any construction (no instance, no __destruct). */
+		SyBlob sErrMsg;
+		SyBlobInit(&sErrMsg,&pVm->sAllocator);
+		SyBlobFormat(&sErrMsg,"Cannot instantiate enum %z",&pClass->sName);
+		VmBoundaryPark(&(*pVm),VmThrowBuiltinError(&(*pVm),"Error",sizeof("Error")-1,&sErrMsg));
+		if( nCtorArgs > 0 ){
+			VmPopOperand(&pTos,nCtorArgs);
+		}
+		PH7_MemObjRelease(pTos);
+		pTos->nIdx = SXU32_HIGH;
+		break;
 	}else{
 		ph7_class_method *pCons;
 		/* Check if a constructor is available — BEFORE instantiation: a
@@ -13508,6 +13959,28 @@ case PH7_OP_CLONE: {
 	}
 	/* Point to the source */
 	pSrc = (ph7_class_instance *)pTos->x.pOther;
+	/* Enum cases are not cloneable — php's catchable Error (the singleton
+	 * identity would break). */
+	if( pSrc->pClass->iFlags & PH7_CLASS_ENUM ){
+		SyBlob sMsg;
+		SyBlobInit(&sMsg,&pVm->sAllocator);
+		SyBlobFormat(&sMsg,"Trying to clone an uncloneable object of class %z",
+			&pSrc->pClass->sName);
+		rc = VmThrowBuiltinError(pVm,"Error",sizeof("Error")-1,&sMsg);
+		PH7_MemObjRelease(pTos);
+		pTos->nIdx = SXU32_HIGH;
+		if( rc == PH7_ABORT ){
+			goto Abort;
+		}
+		{
+			sxi32 iRp;
+			if( VmRecordedResume(pVm,&iRp,sState.pEntryFrame,aInstr) ){
+				pc = iRp;
+				break;
+			}
+		}
+		goto Exception;
+	}
 	/* Generator and Fiber objects are not cloneable (matches PHP) */
 	if( pSrc->pClass == pVm->pGeneratorClass || pSrc->pClass == pVm->pFiberClass ){
 		VmErrorFormat(&(*pVm),PH7_CTX_ERR,
@@ -18722,8 +19195,9 @@ PH7_PRIVATE ph7_class * PH7_VmPeekTopClass(ph7_vm *pVm)
 	SySet *pSet = &pVm->aSelf;
 	ph7_class **apClass;
 	if( SySetUsed(pSet) <= 0 ){
-		/* Empty stack,return NULL */
-		return 0;
+		/* Empty stack: fall back to the initializer-eval class (see
+		 * pConstEvalClass) so static:: degrades to self:: there. */
+		return pVm->pConstEvalClass;
 	}
 	/* Peek the last entry */
 	apClass = (ph7_class **)SySetBasePtr(pSet);
@@ -18764,8 +19238,9 @@ PH7_PRIVATE ph7_class * PH7_VmPeekDeclaringClass(ph7_vm *pVm)
 			return (ph7_class *)pVmFunc->pUserData;
 		}
 	}
-
-	return 0;
+	/* No method frame: a constant/property initializer evaluated via
+	 * VmLocalExec resolves self:: against the class being initialized. */
+	return pVm->pConstEvalClass;
 }
 
 /* Class/OOP builtin functions moved to vm_builtin_class.c */
@@ -19435,6 +19910,126 @@ static int vm_builtin_define(ph7_context *pCtx,int nArg,ph7_value **apArg)
  * Return
  *  Constant value or NULL if not defined.
  */
+/*
+ * Enum method thunks (PHP 8.1). Every enum's synthesized cases()/from()/
+ * tryFrom() methods (GenStateCompileEnumMethods, compile.c) forward here with
+ * the enum's FQN as a literal first argument — the same forwarder pattern the
+ * Generator/Fiber/Reflection builtins use.
+ */
+/* array __phl_enum_cases(string $enumFqn) — declaration-order case list */
+static int vm_builtin_enum_cases(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	ph7_vm *pVm = pCtx->pVm;
+	ph7_class_attr **apCase;
+	ph7_class *pClass;
+	ph7_value *pArray;
+	sxu32 n;
+	sxi32 rc;
+	if( nArg < 1 || (pClass = VmExtractEnumClass(pVm,apArg[0])) == 0 ){
+		ph7_result_null(pCtx);
+		return SXRET_OK;
+	}
+	rc = VmEnumMaterialize(pVm,pClass);
+	if( rc != SXRET_OK ){
+		return rc;
+	}
+	pArray = ph7_context_new_array(pCtx);
+	if( pArray == 0 ){
+		ph7_result_null(pCtx);
+		return SXRET_OK;
+	}
+	apCase = (ph7_class_attr **)SySetBasePtr(&pClass->aEnumCases);
+	for( n = 0 ; n < SySetUsed(&pClass->aEnumCases) ; n++ ){
+		ph7_value *pSlot = (ph7_value *)SySetAt(&pVm->aMemObj,apCase[n]->nIdx);
+		if( pSlot ){
+			ph7_array_add_elem(pArray,0,pSlot); /* Copies; the object ref is retained */
+		}
+	}
+	ph7_result_value(pCtx,pArray);
+	return SXRET_OK;
+}
+/* Shared scan for from()/tryFrom(): return the slot of the case whose backing
+ * value equals *pNeedle (already coerced to the backing type by the synthesized
+ * method's signature), or 0 on miss. */
+static ph7_value * VmEnumFindCaseByValue(ph7_vm *pVm,ph7_class *pClass,ph7_value *pNeedle)
+{
+	ph7_class_attr **apCase = (ph7_class_attr **)SySetBasePtr(&pClass->aEnumCases);
+	sxu32 n;
+	for( n = 0 ; n < SySetUsed(&pClass->aEnumCases) ; n++ ){
+		ph7_value *pVal = VmEnumCaseBackingValue(pVm,apCase[n]);
+		int bMatch = 0;
+		if( pVal ){
+			if( pClass->nEnumBacking == MEMOBJ_INT ){
+				bMatch = (pNeedle->iFlags & MEMOBJ_INT) && pVal->x.iVal == pNeedle->x.iVal;
+			}else{
+				bMatch = (pNeedle->iFlags & MEMOBJ_STRING)
+					&& SyBlobLength(&pVal->sBlob) == SyBlobLength(&pNeedle->sBlob)
+					&& SyMemcmp(SyBlobData(&pVal->sBlob),SyBlobData(&pNeedle->sBlob),
+						SyBlobLength(&pNeedle->sBlob)) == 0;
+			}
+		}
+		if( bMatch ){
+			return (ph7_value *)SySetAt(&pVm->aMemObj,apCase[n]->nIdx);
+		}
+	}
+	return 0;
+}
+/* static from(int|string $value) / static tryFrom(int|string $value) */
+static int VmEnumFromCommon(ph7_context *pCtx,int nArg,ph7_value **apArg,int bTry)
+{
+	ph7_vm *pVm = pCtx->pVm;
+	ph7_class *pClass;
+	ph7_value *pFound;
+	sxi32 rc;
+	if( nArg < 2 || (pClass = VmExtractEnumClass(pVm,apArg[0])) == 0 ){
+		ph7_result_null(pCtx);
+		return SXRET_OK;
+	}
+	rc = VmEnumMaterialize(pVm,pClass);
+	if( rc != SXRET_OK ){
+		return rc;
+	}
+	pFound = VmEnumFindCaseByValue(pVm,pClass,apArg[1]);
+	if( pFound ){
+		ph7_result_value(pCtx,pFound);
+		return SXRET_OK;
+	}
+	if( bTry ){
+		ph7_result_null(pCtx);
+		return SXRET_OK;
+	}
+	if( pClass->nEnumBacking == MEMOBJ_INT ){
+		char zVal[32];
+		SyBufferFormat(zVal,sizeof(zVal),"%qd",ph7_value_to_int64(apArg[1]));
+		return PH7_VmThrowException(pCtx,"ValueError",
+			"%s is not a valid backing value for enum %z",zVal,&pClass->sName);
+	}
+	return PH7_VmThrowException(pCtx,"ValueError",
+		"\"%.*s\" is not a valid backing value for enum %z",
+		(int)SyBlobLength(&apArg[1]->sBlob),(const char *)SyBlobData(&apArg[1]->sBlob),
+		&pClass->sName);
+}
+static int vm_builtin_enum_from(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	return VmEnumFromCommon(pCtx,nArg,apArg,FALSE);
+}
+static int vm_builtin_enum_tryfrom(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	return VmEnumFromCommon(pCtx,nArg,apArg,TRUE);
+}
+/*
+ * bool enum_exists(string $enum, bool $autoload = true)
+ *  TRUE only for a declared enum (PHP 8.1); a plain class/interface is FALSE.
+ */
+static int vm_builtin_enum_exists(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	ph7_class *pClass = 0;
+	if( nArg > 0 ){
+		pClass = VmExtractEnumClass(pCtx->pVm,apArg[0]);
+	}
+	ph7_result_bool(pCtx,pClass != 0);
+	return SXRET_OK;
+}
 static int vm_builtin_constant(ph7_context *pCtx,int nArg,ph7_value **apArg)
 {
 	SyHashEntry *pEntry;
@@ -19472,6 +20067,20 @@ static int vm_builtin_constant(ph7_context *pCtx,int nArg,ph7_value **apArg)
 			if( iSep + 2 < nLen ){
 				ph7_class_attr *pAttr = PH7_ClassExtractAttribute(pClass,
 					&zName[iSep+2],(sxu32)(nLen - iSep - 2));
+				if( pAttr && pAttr->nIdx == SXU32_HIGH ){
+					/* Unmaterialized: enum case → materialize the singletons
+					 * (all of them: constant("S::A") is a direct access, like
+					 * OP_MEMBER); plain constant → run its initializer. */
+					sxi32 rcEnum;
+					if( pAttr->iFlags & PH7_CLASS_ATTR_ENUMCASE ){
+						rcEnum = VmEnumMaterialize(pCtx->pVm,pClass);
+					}else{
+						rcEnum = VmClassConstEvalOnDemand(pCtx->pVm,pClass,pAttr);
+					}
+					if( rcEnum != SXRET_OK ){
+						return rcEnum;
+					}
+				}
 				if( pAttr && (pAttr->iFlags & PH7_CLASS_ATTR_CONSTANT) ){
 					ph7_value *pValue = (ph7_value *)SySetAt(&pCtx->pVm->aMemObj,pAttr->nIdx);
 					if( pValue ){
@@ -20483,7 +21092,16 @@ static void VmExportValue(SyBlob *pOut, ph7_value *pVal, int nIndent, int depth)
 		}
 	}else if( ph7_value_is_object(pVal) ){
 		ph7_class_instance *pThis = (ph7_class_instance *)pVal->x.pOther;
-		if( pThis->iFlags & VM_INSTANCE_DUMPING ){
+		if( pThis->pClass->iFlags & PH7_CLASS_ENUM ){
+			/* php 8.1: an enum case exports as `\S::A` */
+			ph7_value *pName = PH7_EnumCaseNameValue(pThis);
+			SyBlobAppend(pOut,"\\",1);
+			SyBlobAppend(pOut,pThis->pClass->sName.zString,pThis->pClass->sName.nByte);
+			SyBlobAppend(pOut,"::",2);
+			if( pName && SyBlobLength(&pName->sBlob) > 0 ){
+				SyBlobAppend(pOut,SyBlobData(&pName->sBlob),SyBlobLength(&pName->sBlob));
+			}
+		}else if( pThis->iFlags & VM_INSTANCE_DUMPING ){
 			SyBlobAppend(pOut,"NULL",4); /* circular reference -> NULL, like PHP */
 		}else{
 			SyString *pClassName = &pThis->pClass->sName;
@@ -23533,6 +24151,10 @@ static int vm_builtin_magic_call(ph7_context *pCtx,int nArg,ph7_value **apArg)
 }
 static const ph7_builtin_func aVmFunc[] = {
 	{ "__phl_magic_call", vm_builtin_magic_call },
+	{ "__phl_enum_cases",   vm_builtin_enum_cases },
+	{ "__phl_enum_from",    vm_builtin_enum_from },
+	{ "__phl_enum_tryfrom", vm_builtin_enum_tryfrom },
+	{ "enum_exists",        vm_builtin_enum_exists },
 	{ "func_num_args"  , vm_builtin_func_num_args },
 	{ "func_get_arg"   , vm_builtin_func_get_arg  },
 	{ "func_get_args"  , vm_builtin_func_get_args },

--- a/src/ph7/vm_builtin_class.c
+++ b/src/ph7/vm_builtin_class.c
@@ -599,6 +599,11 @@ PH7_PRIVATE int PH7_VmClassMemberAccess(
 			pCallerScope = pFrame->pBoundScope;
 		}else if( pVmFunc && (pVmFunc->iFlags & VM_FUNC_CLASS_METHOD) ){
 			pCallerScope = (ph7_class *)pVmFunc->pUserData;
+		}else if( pVm->pConstEvalClass ){
+			/* Constant/property initializer bytecode runs without a method
+			 * frame; its scope is the class being initialized (php: a private
+			 * constant is reachable from its own class's initializers). */
+			pCallerScope = pVm->pConstEvalClass;
 		}else{
 			goto dis; /* Not in a class scope: access is forbidden */
 		}
@@ -686,7 +691,8 @@ PH7_PRIVATE int vm_builtin_get_class_vars(ph7_context *pCtx,int nArg,ph7_value *
 			SyString *pAttrName = &pAttr->sName;
 			ph7_value *pValue = 0;
 			if( pAttr->iFlags & (PH7_CLASS_ATTR_CONSTANT|PH7_CLASS_ATTR_STATIC) ){
-				/* Extract static attribute value which is always computed */
+				/* Static slots are computed at mount; constants lazily */
+				PH7_VmMaterializeClassConst(pCtx->pVm,pClass,pAttr);
 				pValue = (ph7_value *)SySetAt(&pCtx->pVm->aMemObj,pAttr->nIdx);
 			}else{
 				if( SySetUsed(&pAttr->aByteCode) > 0 ){

--- a/src/ph7/vm_builtin_reflection.c
+++ b/src/ph7/vm_builtin_reflection.c
@@ -264,6 +264,30 @@ static int vm_builtin_reflect_class_info(ph7_context *pCtx, int nArg, ph7_value 
 	ReflectMapAddBool(pCtx, pInfo, "abstract", (pClass->iFlags & PH7_CLASS_ABSTRACT) != 0);
 	ReflectMapAddBool(pCtx, pInfo, "final", (pClass->iFlags & PH7_CLASS_FINAL) != 0);
 	ReflectMapAddBool(pCtx, pInfo, "readonly", (pClass->iFlags & PH7_CLASS_READONLY) != 0);
+	ReflectMapAddBool(pCtx, pInfo, "enum", (pClass->iFlags & PH7_CLASS_ENUM) != 0);
+	if( pClass->nEnumBacking == MEMOBJ_INT ){
+		ReflectMapAddStr(pCtx, pInfo, "enumbacking", "int", (int)sizeof("int")-1);
+	}else if( pClass->nEnumBacking == MEMOBJ_STRING ){
+		ReflectMapAddStr(pCtx, pInfo, "enumbacking", "string", (int)sizeof("string")-1);
+	}else{
+		ReflectMapAddStr(pCtx, pInfo, "enumbacking", "", 0);
+	}
+	{
+		/* Enum case names in declaration order (empty list for non-enums) */
+		ph7_value *pCases = ph7_context_new_array(pCtx);
+		if( pCases ){
+			ph7_class_attr **apCase = (ph7_class_attr **)SySetBasePtr(&pClass->aEnumCases);
+			sxu32 nCase;
+			for( nCase = 0 ; nCase < SySetUsed(&pClass->aEnumCases) ; nCase++ ){
+				ph7_value *pNm = ph7_context_new_scalar(pCtx);
+				if( pNm ){
+					ph7_value_string(pNm,apCase[nCase]->sName.zString,(int)apCase[nCase]->sName.nByte);
+					ph7_array_add_elem(pCases,0,pNm);
+				}
+			}
+			ph7_array_add_strkey_elem(pInfo,"cases",pCases);
+		}
+	}
 	if( pClass->pBase ){
 		ReflectMapAddStr(pCtx, pInfo, "parent", SyStringData(&pClass->pBase->sName),
 			(int)SyStringLength(&pClass->pBase->sName));
@@ -378,6 +402,7 @@ static int vm_builtin_reflect_class_info(ph7_context *pCtx, int nArg, ph7_value 
 				}
 				if( pAttr->iFlags & PH7_CLASS_ATTR_CONSTANT ){
 					ReflectMapAddBool(pCtx, pMeta, "final", (pAttr->iFlags & PH7_CLASS_ATTR_FINAL) != 0);
+					ReflectMapAddBool(pCtx, pMeta, "enumcase", (pAttr->iFlags & PH7_CLASS_ATTR_ENUMCASE) != 0);
 					ReflectMapAddDyn(pCtx, pConsts, &pAttr->sName, pMeta);
 				}else{
 					ReflectMapAddBool(pCtx, pMeta, "static", (pAttr->iFlags & PH7_CLASS_ATTR_STATIC) != 0);
@@ -485,7 +510,12 @@ static int vm_builtin_reflect_const_value(ph7_context *pCtx, int nArg, ph7_value
 		ph7_result_null(pCtx);
 		return PH7_OK;
 	}
-	/* Constant slots are evaluated when the class is mounted */
+	/* Constant slots are evaluated lazily on first access */
+	if( PH7_VmMaterializeClassConst(pCtx->pVm,pClass,pAttr) != SXRET_OK ){
+		/* Initializer raised: the throw is in flight; report null here */
+		ph7_result_null(pCtx);
+		return PH7_OK;
+	}
 	pValue = (ph7_value *)SySetAt(&pCtx->pVm->aMemObj, pAttr->nIdx);
 	if( pValue ){
 		ph7_result_value(pCtx, pValue);
@@ -1716,7 +1746,7 @@ static const char zReflectLib1[] =
 " public function isAbstract(){ $i = $this->__rinfo(); return $i['abstract']; }"
 " public function isFinal(){ $i = $this->__rinfo(); return $i['final']; }"
 " public function isReadOnly(){ $i = $this->__rinfo(); return $i['readonly']; }"
-" public function isEnum(){ return false; }"
+" public function isEnum(){ $i = $this->__rinfo(); return $i['enum']; }"
 " public function isAnonymous(){ return strpos($this->name,'class@anonymous') === 0; }"
 " public function getModifiers(){"
 "  $i = $this->__rinfo();"
@@ -1829,7 +1859,7 @@ static const char zReflectLib1[] =
 " public function getDocComment(){ $i = $this->__rinfo(); return $i['doc']; }"
 " public function isInstantiable(){"
 "  $i = $this->__rinfo();"
-"  if($i['interface'] || $i['trait'] || $i['abstract']){ return false; }"
+"  if($i['interface'] || $i['trait'] || $i['abstract'] || $i['enum']){ return false; }"
 "  if($i['ctorvis'] !== 0 && $i['ctorvis'] !== 1){ return false; }"
 "  return true;"
 " }"
@@ -2589,7 +2619,7 @@ static const char zReflectLib3[] =
 " public function isProtected(){ $m = $this->__rcmeta(); return $m['vis'] === 2; }"
 " public function isPrivate(){ $m = $this->__rcmeta(); return $m['vis'] === 3; }"
 " public function isFinal(){ $m = $this->__rcmeta(); return $m['final']; }"
-" public function isEnumCase(){ return false; }"
+" public function isEnumCase(){ $m = $this->__rcmeta(); return $m['enumcase']; }"
 " public function isDeprecated(){ $m = $this->__rcmeta(); return __reflect_has_deprecated($m['attrs']); }"
 " public function hasType(){ $m = $this->__rcmeta(); return $m['typed']; }"
 " public function getType(){ $m = $this->__rcmeta(); return $m['typed'] ? __reflect_make_type($m['typetext']) : null; }"
@@ -2841,23 +2871,55 @@ static const char zReflectLib6[] =
 "  if($info === null){"
 "   throw new ReflectionException('Class \"'.$objectOrClass.'\" does not exist');"
 "  }"
-"  throw new ReflectionException('Class \"'.$info['name'].'\" is not an enum');"
+"  if(!$info['enum']){"
+"   throw new ReflectionException('Class \"'.$info['name'].'\" is not an enum');"
+"  }"
+"  parent::__construct($objectOrClass);"
 " }"
-" public function hasCase($name){ return false; }"
-" public function getCase($name){ throw new ReflectionException('Case '.$name.' does not exist'); }"
-" public function getCases(){ return array(); }"
-" public function isBacked(){ return false; }"
-" public function getBackingType(){ return null; }"
+" public function hasCase($name){"
+"  $i = $this->__rinfo();"
+"  return in_array($name, $i['cases'], true);"
+" }"
+" public function getCase($name){"
+"  if(!$this->hasCase($name)){"
+"   throw new ReflectionException('Case '.$this->name.'::'.$name.' does not exist');"
+"  }"
+"  if($this->isBacked()){ return new ReflectionEnumBackedCase($this->name, $name); }"
+"  return new ReflectionEnumUnitCase($this->name, $name);"
+" }"
+" public function getCases(){"
+"  $i = $this->__rinfo();"
+"  $out = array();"
+"  foreach($i['cases'] as $c){"
+"   $out[] = $this->isBacked()"
+"    ? new ReflectionEnumBackedCase($this->name, $c)"
+"    : new ReflectionEnumUnitCase($this->name, $c);"
+"  }"
+"  return $out;"
+" }"
+" public function isBacked(){ $i = $this->__rinfo(); return $i['enumbacking'] !== ''; }"
+" public function getBackingType(){"
+"  $i = $this->__rinfo();"
+"  if($i['enumbacking'] === ''){ return null; }"
+"  return __reflect_make_type($i['enumbacking']);"
+" }"
 "}"
 "class ReflectionEnumUnitCase extends ReflectionClassConstant {"
 " public function __construct($class, $constant){"
 "  parent::__construct($class, $constant);"
-"  throw new ReflectionException('Class \"'.$this->class.'\" is not an enum');"
+"  $ci = __reflect_class_info($class);"
+"  if(!$ci['enum']){"
+"   throw new ReflectionException('Class \"'.$this->class.'\" is not an enum');"
+"  }"
+"  $m = $this->__rcmeta();"
+"  if(!$m['enumcase']){"
+"   throw new ReflectionException('Constant '.$this->class.'::'.$constant.' is not a case');"
+"  }"
 " }"
-" public function getEnum(){ return null; }"
+" public function getEnum(){ return new ReflectionEnum($this->class); }"
 "}"
 "class ReflectionEnumBackedCase extends ReflectionEnumUnitCase {"
-" public function getBackingValue(){ return null; }"
+" public function getBackingValue(){ return $this->getValue()->value; }"
 "}"
 "final class ReflectionReference {"
 " protected $__id = '';"

--- a/src/ph7/vm_json.c
+++ b/src/ph7/vm_json.c
@@ -27,6 +27,8 @@ struct json_private_data
 	int nRecCount;     /* Recursion count */
 	int exc;           /* True if a jsonSerialize() callback threw an exception */
 	int oom;           /* True if a result append ran out of memory (raises a fatal) */
+	int fail;          /* True if the value is unencodable (php 8.1: a non-backed
+	                    * enum case) — json_encode returns FALSE */
 };
 /*
  * Emit into the JSON result, flagging OOM on the shared data and bailing out
@@ -214,10 +216,25 @@ static sxi32 VmJsonEncode(
 			ph7_vm *pVm = pIn->pVm;
 			ph7_class_method *pMethod = 0;
 			/* If the object implements JsonSerializable, encode the value
-			 * returned by jsonSerialize() instead of its public properties. */
+			 * returned by jsonSerialize() instead of its public properties.
+			 * An enum implementing it explicitly also takes this path (php). */
 			if( pVm->pJsonSerializableClass
 				&& PH7_VmInstanceOf(pThis->pClass,pVm->pJsonSerializableClass) ){
 				pMethod = PH7_ClassExtractMethod(pThis->pClass,"jsonSerialize",sizeof("jsonSerialize")-1);
+			}
+			if( pMethod == 0 && (pThis->pClass->iFlags & PH7_CLASS_ENUM) != 0 ){
+				/* php 8.1: a BACKED enum case encodes as its backing value; a
+				 * pure enum case has no default serialization — json_encode
+				 * returns false. */
+				ph7_value *pBacking = PH7_EnumCaseBackingValueOf(pThis);
+				if( pBacking ){
+					pData->nRecCount++;
+					VmJsonEncode(pBacking,pData);
+					pData->nRecCount--;
+				}else{
+					pData->fail = 1;
+				}
+				return PH7_OK;
 			}
 			if( pMethod ){
 				ph7_value sResult;
@@ -360,10 +377,12 @@ PH7_PRIVATE int vm_builtin_json_encode(ph7_context *pCtx,int nArg,ph7_value **ap
 	sJson.iFlags = 0;
 	sJson.exc = 0;
 	sJson.oom = 0;
+	sJson.fail = 0;
 	if( nArg > 1 && ph7_value_is_int(apArg[1]) ){
 		/* Extract option flags */
 		sJson.iFlags = ph7_value_to_int(apArg[1]);
 	}
+	pCtx->pVm->json_rc = JSON_ERROR_NONE;
 	/* Perform the encoding operation */
 	rc = VmJsonEncode(apArg[0],&sJson);
 	if( sJson.oom ){
@@ -374,6 +393,13 @@ PH7_PRIVATE int vm_builtin_json_encode(ph7_context *pCtx,int nArg,ph7_value **ap
 	if( rc == PH7_EXCEPTION || sJson.exc ){
 		/* A jsonSerialize() callback threw — propagate so the exception unwinds */
 		return PH7_EXCEPTION;
+	}
+	if( sJson.fail ){
+		/* Unencodable value (php 8.1: non-backed enum case): the whole encode
+		 * fails — discard whatever was emitted and return FALSE. */
+		pCtx->pVm->json_rc = JSON_ERROR_NON_BACKED_ENUM;
+		ph7_result_bool(pCtx,0);
+		return PH7_OK;
 	}
 	/* All done */
 	return PH7_OK;
@@ -433,6 +459,9 @@ PH7_PRIVATE int vm_builtin_json_last_error_msg(ph7_context *pCtx,int nArg,ph7_va
 		break;
 	case JSON_ERROR_UTF8:
 		zMsg = "Malformed UTF-8 characters, possibly incorrectly encoded";
+		break;
+	case JSON_ERROR_NON_BACKED_ENUM:
+		zMsg = "Non-backed enums have no default serialization";
 		break;
 	default:
 		zMsg = "Unknown error";

--- a/src/ph7/vm_serialize.c
+++ b/src/ph7/vm_serialize.c
@@ -223,6 +223,20 @@ static sxi32 VmSerializeObject(ph7_value *pIn, serialize_data *pData)
 		pData->exc = 1;
 		return PH7_EXCEPTION;
 	}
+	/* Enum cases serialize as php 8.1's E: tag — E:<len>:"Class:CASE"; — so
+	 * unserialize restores THE case singleton, preserving `===` identity. */
+	if( pThis->pClass->iFlags & PH7_CLASS_ENUM ){
+		ph7_value *pName = PH7_EnumCaseNameValue(pThis);
+		sxu32 nName = pName ? SyBlobLength(&pName->sBlob) : 0;
+		SyBlobFormat(pData->pOut,"E:%u:\"",(unsigned)(pClassName->nByte + 1 + nName));
+		SyBlobAppend(pData->pOut,pClassName->zString,pClassName->nByte);
+		SyBlobAppend(pData->pOut,":",1);
+		if( nName > 0 ){
+			SyBlobAppend(pData->pOut,SyBlobData(&pName->sBlob),nName);
+		}
+		SyBlobAppend(pData->pOut,"\";",2);
+		return SXRET_OK;
+	}
 	SyBlobInit(&sBody,&pVm->sAllocator);
 	pSave = pData->pOut;
 	pData->pOut = &sBody;     /* recursion appends to the body blob */
@@ -526,6 +540,43 @@ fail:
 	ph7_context_release_value(ud->pCtx,pObjVal);
 	return 0;
 }
+/* Parse E:<len>:"Class:CASE"; into the enum case SINGLETON (php 8.1). */
+static ph7_value * VmUnserializeEnumCase(unserialize_data *ud)
+{
+	sxu32 nLen, nCls, i;
+	const char *zBody;
+	ph7_class *pClass;
+	ph7_class_attr *pAttr;
+	ph7_value *pSlot, *pOut;
+	if( !VmUnExpect(ud,'E') || !VmUnExpect(ud,':') ){ return 0; }
+	if( !VmUnParseUInt(ud,&nLen) ){ return 0; }
+	if( !VmUnExpect(ud,':') || !VmUnExpect(ud,'"') ){ return 0; }
+	if( nLen > (sxu32)(ud->zEnd - ud->zCur) ){ return 0; }
+	zBody = ud->zCur; ud->zCur += nLen;
+	if( !VmUnExpect(ud,'"') || !VmUnExpect(ud,';') ){ return 0; }
+	/* Split "Class:CASE" at the LAST ':' (class names never contain ':') */
+	nCls = 0;
+	for( i = nLen ; i > 0 ; i-- ){
+		if( zBody[i-1] == ':' ){ nCls = i - 1; break; }
+	}
+	if( nCls == 0 || nCls + 1 >= nLen ){ return 0; }
+	pClass = PH7_VmExtractClass(ud->pVm,zBody,nCls,FALSE,0);
+	while( pClass && (pClass->iFlags & PH7_CLASS_ENUM) == 0 ){
+		pClass = pClass->pNextName;
+	}
+	if( pClass == 0 ){ return 0; }
+	pAttr = PH7_ClassExtractAttribute(pClass,&zBody[nCls+1],nLen - nCls - 1);
+	if( pAttr == 0 || (pAttr->iFlags & PH7_CLASS_ATTR_ENUMCASE) == 0 ){ return 0; }
+	if( PH7_VmMaterializeClassConst(ud->pVm,pClass,pAttr) != SXRET_OK ){
+		ud->exc = 1;
+		return 0;
+	}
+	pSlot = (ph7_value *)SySetAt(&ud->pVm->aMemObj,pAttr->nIdx);
+	if( pSlot == 0 ){ return 0; }
+	pOut = ph7_context_new_scalar(ud->pCtx);
+	if( pOut ){ PH7_MemObjStore(pSlot,pOut); } /* retains the singleton */
+	return pOut;
+}
 static ph7_value * VmUnserializeValue(unserialize_data *ud)
 {
 	ph7_value *pOut;
@@ -593,6 +644,8 @@ static ph7_value * VmUnserializeValue(unserialize_data *ud)
 		return VmUnserializeArray(ud);
 	case 'O':
 		return VmUnserializeObject(ud);
+	case 'E':
+		return VmUnserializeEnumCase(ud);
 	default:
 		/* r:/R: back-references and anything else are unsupported */
 		return 0;

--- a/tests/ph7/001-smoke/oo/class_const_lazy_eval.phpt
+++ b/tests/ph7/001-smoke/oo/class_const_lazy_eval.phpt
@@ -1,0 +1,52 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Class constants: initializers referencing other constants (self::/parent::/cross-class), lazily evaluated
+--FILE--
+<?php
+class CclBase {
+    const A = 5;
+    const B = self::A + 1;
+    private const SECRET = 3;
+    const FROM_SECRET = self::SECRET * 2; // own-class private access is in scope
+    public $p = self::A + 10;
+}
+class CclChild extends CclBase {
+    const C = parent::B * 2;
+}
+class CclForward {
+    const X = CclLater::Y + 1; // cross-class reference, target declared later
+}
+class CclLater { const Y = 41; }
+interface CclIface { const V = 9; }
+class CclImpl implements CclIface { const W = self::V + 1; }
+
+echo CclBase::B, "\n";
+echo CclBase::FROM_SECRET, "\n";
+echo CclChild::C, "\n";
+echo CclForward::X, "\n";
+echo CclImpl::W, "\n";
+$o = new CclBase();
+echo $o->p, "\n";
+class CclSelfRef { const LOOP = self::LOOP; }
+try {
+    echo CclSelfRef::LOOP;
+} catch (Error $e) {
+    // php words the reference as written ("self::LOOP"), PHL as resolved
+    // ("CclSelfRef::LOOP") — assert the shared core.
+    echo get_class($e), ": ",
+        str_contains($e->getMessage(), "self-referencing constant") ? "self-ref" : "?", "\n";
+}
+?>
+--EXPECT--
+6
+6
+12
+42
+10
+15
+Error: self-ref
+--CLEAN--
+<?php
+unset($o);

--- a/tests/ph7/001-smoke/oo/enum_basics.phpt
+++ b/tests/ph7/001-smoke/oo/enum_basics.phpt
@@ -1,0 +1,89 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Enums (PHP 8.1): cases, name/value, identity, cases()/from()/tryFrom, interfaces, traits, json, serialize
+--FILE--
+<?php
+interface EnbHasLabel { const PREFIX = "card"; public function label(): string; }
+trait EnbNamer { public function tag(): string { return "tag:" . $this->name; } }
+enum EnbSuit: string implements EnbHasLabel {
+    use EnbNamer;
+    const Wild = self::Spades;
+    case Hearts = "H";
+    case Spades = "S";
+    public function label(): string { return self::PREFIX . ":" . $this->value; }
+    public static function first(): EnbSuit { return self::cases()[0]; }
+}
+enum EnbPure { case Alpha; case Beta; }
+enum EnbInt: int { const OFF = 10; case Lo = self::OFF + 1; case Hi = 20; }
+
+echo EnbSuit::Hearts->name, " ", EnbSuit::Hearts->value, "\n";
+echo EnbSuit::Hearts === EnbSuit::Hearts ? "same" : "diff", "\n";
+echo EnbSuit::Hearts === EnbSuit::Spades ? "same" : "diff", "\n";
+echo EnbSuit::Hearts instanceof UnitEnum ? "unit" : "-", " ",
+     EnbSuit::Hearts instanceof BackedEnum ? "backed" : "-", " ",
+     EnbSuit::Hearts instanceof EnbSuit ? "self" : "-", " ",
+     EnbSuit::Hearts instanceof EnbHasLabel ? "iface" : "-", "\n";
+echo EnbPure::Alpha instanceof BackedEnum ? "backed" : "notbacked", "\n";
+echo count(EnbSuit::cases()), " ", implode(",", array_map(fn($c) => $c->name, EnbSuit::cases())), "\n";
+echo EnbSuit::from("S")->name, " ", EnbSuit::tryFrom("X") === null ? "null" : "?", "\n";
+echo EnbInt::from("11")->name, "\n"; // weak-mode coercion at from()
+echo match(EnbSuit::Spades) { EnbSuit::Hearts => "h", EnbSuit::Spades => "s" }, "\n";
+echo EnbSuit::Hearts->label(), " ", EnbSuit::Spades->tag(), "\n";
+echo EnbSuit::Wild === EnbSuit::Spades ? "wild=spades" : "?", "\n";
+echo EnbSuit::first()->name, "\n";
+echo EnbInt::Lo->value, " ", EnbInt::Hi->value, "\n";
+echo get_class(EnbSuit::Hearts), " ", gettype(EnbSuit::Hearts), "\n";
+echo enum_exists("EnbSuit") ? "y" : "n", enum_exists("EnbHasLabel") ? "y" : "n", enum_exists("Missing8") ? "y" : "n", "\n";
+echo constant("EnbSuit::Hearts")->value, "\n";
+function enb_pick(EnbSuit $s = EnbSuit::Spades): string { return $s->name; }
+echo enb_pick(), " ", enb_pick(EnbSuit::Hearts), "\n";
+class EnbHolder { const DEF = EnbPure::Beta; }
+echo EnbHolder::DEF->name, "\n";
+$fcc = EnbSuit::from(...);
+echo $fcc("H")->name, "\n";
+echo json_encode(EnbSuit::Hearts), " ", json_encode([EnbInt::Lo, EnbInt::Hi]), "\n";
+echo json_encode(EnbPure::Alpha) === false ? "jsonfail" : "?", "\n";
+echo serialize(EnbSuit::Hearts), "\n";
+echo unserialize(serialize(EnbSuit::Hearts)) === EnbSuit::Hearts ? "roundtrip" : "?", "\n";
+echo var_export(EnbPure::Alpha, true), "\n";
+$o = EnbSuit::Hearts;
+echo isset($o->name) ? "n1" : "-", isset($o->value) ? "v1" : "-", isset($o->nope) ? "x1" : "-", "\n";
+$vars = get_object_vars($o);
+echo $vars["name"], $vars["value"], "\n";
+echo property_exists($o, "name") ? "pe" : "-", "\n";
+echo in_array(EnbPure::Beta, EnbPure::cases(), true) ? "inarr" : "-", "\n";
+?>
+--EXPECT--
+Hearts H
+same
+diff
+unit backed self iface
+notbacked
+2 Hearts,Spades
+Spades null
+Lo
+s
+card:H tag:Spades
+wild=spades
+Hearts
+11 20
+EnbSuit object
+ynn
+H
+Spades Hearts
+Beta
+Hearts
+"H" [11,20]
+jsonfail
+E:14:"EnbSuit:Hearts";
+roundtrip
+\EnbPure::Alpha
+n1v1-
+HeartsH
+pe
+inarr
+--CLEAN--
+<?php
+unset($o, $vars, $fcc);

--- a/tests/ph7/001-smoke/oo/enum_errors.phpt
+++ b/tests/ph7/001-smoke/oo/enum_errors.phpt
@@ -1,0 +1,42 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Enums (PHP 8.1): catchable runtime errors — new/clone/from/tryFrom/readonly/dup-value/type-mismatch
+--FILE--
+<?php
+enum EneColor: string { case Red = "r"; case Blue = "b"; }
+enum EnePure { case One; }
+enum EneDup: int { case A = 1; case B = 1; }
+enum EneBad: int { case Broken = "zzz"; case Fine = 5; }
+class EneRef { const FINE = EneBad::Fine; } // constant-expression reference: evaluates ONLY that case
+
+function ene_try(callable $f): void {
+    try { $f(); echo "no-throw\n"; }
+    catch (Throwable $e) { echo get_class($e), ": ", $e->getMessage(), "\n"; }
+}
+ene_try(fn() => new EneColor());
+ene_try(fn() => clone EneColor::Red);
+ene_try(fn() => EneColor::from("nope"));
+ene_try(fn() => EneColor::tryFrom(4)); // weak mode coerces int 4 to "4": a miss, null, no throw
+ene_try(function() { $o = EneColor::Red; $o->name = "X"; });
+ene_try(fn() => EneDup::B); // direct access evaluates every case: duplicate detected
+ene_try(fn() => EneBad::Broken);
+echo EneRef::FINE->name, "\n"; // ...but the constant-expression path reaches the valid sibling
+echo EneColor::tryFrom("nope") === null ? "trynull" : "?", "\n";
+echo EnePure::One->name, "\n";
+?>
+--EXPECT--
+Error: Cannot instantiate enum EneColor
+Error: Trying to clone an uncloneable object of class EneColor
+ValueError: "nope" is not a valid backing value for enum EneColor
+no-throw
+Error: Cannot modify readonly property EneColor::$name
+Error: Duplicate value in enum EneDup for cases A and B
+TypeError: Enum case type string does not match enum backing type int
+Fine
+trynull
+One
+--CLEAN--
+<?php
+unset($o);

--- a/tests/ph7/001-smoke/oo/enum_reflection.phpt
+++ b/tests/ph7/001-smoke/oo/enum_reflection.phpt
@@ -1,0 +1,56 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Enum reflection (PHP 8.1): isEnum, ReflectionEnum cases/backing, ReflectionEnumUnitCase/BackedCase
+--FILE--
+<?php
+enum EnrSuit: string { case Hearts = "H"; case Spades = "S"; const Wild = "W"; }
+enum EnrPure { case Solo; }
+
+$rc = new ReflectionClass("EnrSuit");
+echo $rc->isEnum() ? "enum" : "-", " ", $rc->isFinal() ? "final" : "-", " ",
+     $rc->isInstantiable() ? "inst" : "noinst", "\n";
+echo (new ReflectionClass("stdClass"))->isEnum() ? "enum" : "notenum", "\n";
+
+$re = new ReflectionEnum("EnrSuit");
+echo $re->getName(), " ", $re->isBacked() ? "backed" : "pure", " ", (string)$re->getBackingType(), "\n";
+echo $re->hasCase("Hearts") ? "has" : "-", $re->hasCase("Wild") ? "?" : "nowild", "\n";
+foreach ($re->getCases() as $c) {
+    echo get_class($c), " ", $c->getName(), " ", $c->getBackingValue(),
+         " ", $c->getValue() === EnrSuit::from($c->getBackingValue()) ? "sing" : "?", "\n";
+}
+$case = $re->getCase("Spades");
+echo $case->isEnumCase() ? "case" : "-", " ", $case->getEnum()->getName(), "\n";
+echo (new ReflectionClassConstant("EnrSuit", "Wild"))->isEnumCase() ? "?" : "notcase", "\n";
+
+$rp = new ReflectionEnum("EnrPure");
+echo $rp->isBacked() ? "?" : "pure", " ", $rp->getBackingType() === null ? "nulltype" : "?", "\n";
+echo get_class($rp->getCases()[0]), "\n";
+echo $rp->getCases()[0]->getValue() === EnrPure::Solo ? "solo" : "?", "\n";
+
+try { new ReflectionEnum("stdClass"); }
+catch (ReflectionException $e) { echo "ex1: ", $e->getMessage(), "\n"; }
+try { new ReflectionEnumUnitCase("EnrSuit", "Wild"); }
+catch (ReflectionException $e) { echo "ex2: ", $e->getMessage(), "\n"; }
+try { $re->getCase("Missing"); }
+catch (ReflectionException $e) { echo "ex3: ", $e->getMessage(), "\n"; }
+?>
+--EXPECT--
+enum final noinst
+notenum
+EnrSuit backed string
+hasnowild
+ReflectionEnumBackedCase Hearts H sing
+ReflectionEnumBackedCase Spades S sing
+case EnrSuit
+notcase
+pure nulltype
+ReflectionEnumUnitCase
+solo
+ex1: Class "stdClass" is not an enum
+ex2: Constant EnrSuit::Wild is not a case
+ex3: Case EnrSuit::Missing does not exist
+--CLEAN--
+<?php
+unset($rc, $re, $rp, $case, $c);

--- a/tests/ph7/002-integration/oo/enum_backing_type_invalid.phpt
+++ b/tests/ph7/002-integration/oo/enum_backing_type_invalid.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Enum backing type must be int or string (compile fatal)
+--FILE--
+<?php
+enum EnumFloatBacked: float { case A = 1.5; }
+echo "unreached\n";
+?>
+--EXPECTF--
+%AEnum backing type must be int or string, float given%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/enum_case_value_rules.phpt
+++ b/tests/ph7/002-integration/oo/enum_case_value_rules.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A case of a non-backed enum must not have a value (compile fatal)
+--FILE--
+<?php
+enum EnumPureWithValue { case A = 5; }
+echo "unreached\n";
+?>
+--EXPECTF--
+%ACase A of non-backed enum EnumPureWithValue must not have a value%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/enum_no_extend.phpt
+++ b/tests/ph7/002-integration/oo/enum_no_extend.phpt
@@ -1,0 +1,15 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A class cannot extend an enum (compile fatal)
+--FILE--
+<?php
+enum EnumSealed { case A; }
+class EnumSubclass extends EnumSealed {}
+echo "unreached\n";
+?>
+--EXPECTF--
+%AClass EnumSubclass cannot extend enum EnumSealed%A
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/oo/enum_no_properties.phpt
+++ b/tests/ph7/002-integration/oo/enum_no_properties.phpt
@@ -1,0 +1,14 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Enums cannot declare properties (compile fatal)
+--FILE--
+<?php
+enum EnumNoProps { case A; public $x = 1; }
+echo "unreached\n";
+?>
+--EXPECTF--
+%AEnum EnumNoProps cannot include properties%A
+--CLEAN--
+<?php


### PR DESCRIPTION
Enums parse via a context-sensitive `enum` identifier into final classes whose `case` members are class constants (PH7_CLASS_ATTR_ENUMCASE) holding the backing expression; case singletons materialize lazily and per-case (php's constant-expression semantics) or whole-class on direct static access, giving `===` identity via the shared constant slot. cases()/ from()/tryFrom() are synthesized PHP forwarders over __phl_enum_* thunks; readonly $name/$value, UnitEnum/BackedEnum auto-implement, traits/consts/ interfaces/attributes/namespaces all supported. new/clone/extends/ properties/banned magic methods are rejected with php's messages; enum_exists(), serialize E: tags (singleton-restoring unserialize), json_encode (backed value / false + JSON_ERROR_NON_BACKED_ENUM), enum(S::A) var_dump, \S::A var_export, and the ReflectionEnum family (isEnum/isEnumCase/getCases/getBackingType/UnitCase/BackedCase) are wired.

Fixed en route: class-constant initializers referencing other constants were mount-order-dependent silent NULLs (const B = self::A + 1 read 1, php 6) — untyped constants now evaluate on first access, self::/parent:: resolve inside initializer bytecode via a transient eval-class context (own-class private constants included), and self-referencing constants throw php's catchable Error from the outermost evaluation.
