### PR TITLE
Bind closure use (&$x) captures by reference

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -2324,6 +2324,7 @@ static sxi32 GenStateArrowAddCapture(
 	}
 	SyZero(&sEnv,sizeof(ph7_vm_func_closure_env));
 	sEnv.iFlags = 0;
+	sEnv.nIdx = SXU32_HIGH;
 	PH7_MemObjInit(pGen->pVm,&sEnv.sValue);
 	SyStringInitFromBuf(&sEnv.sName,zDup,nByte);
 	SySetPut(&pFunc->aClosureEnv,(const void *)&sEnv);
@@ -2760,6 +2761,7 @@ PH7_PRIVATE sxi32 PH7_CompileArrowFunc(ph7_gen_state *pGen,sxi32 iCompileFlag)
 		}
 		SyZero(&sEnv,sizeof(ph7_vm_func_closure_env));
 		sEnv.iFlags = VM_FUNC_ARG_IGNORE;
+		sEnv.nIdx = SXU32_HIGH;
 		PH7_MemObjInit(pGen->pVm,&sEnv.sValue);
 		SyStringInitFromBuf(&sEnv.sName,zThisDup,sizeof("this")-1);
 		SySetPut(&pFunc->aClosureEnv,(const void *)&sEnv);
@@ -7431,10 +7433,8 @@ static sxi32 GenStateCompileFunc(
 					}
 					nLineLocal = pGen->pIn->nLine;
 					if( pGen->pIn->nType & PH7_TK_AMPER ){
-						/* Pass by reference,record that */
-						PH7_GenCompileError(pGen,E_WARNING,nLineLocal,
-							"Closure: Pass by reference is disabled in the current release of the PH7 engine,PH7 is switching to pass by value"
-							);
+						/* Capture by reference: OP_LOAD_CLOSURE binds the env entry
+						 * to the variable's memory slot instead of copying its value. */
 						iFlagsLocal = VM_FUNC_ARG_BY_REF;
 						pGen->pIn++;
 					}
@@ -7464,6 +7464,7 @@ static sxi32 GenStateCompileFunc(
 							/* Zero the structure */
 							SyZero(&sEnv,sizeof(ph7_vm_func_closure_env));
 							sEnv.iFlags = iFlagsLocal;
+							sEnv.nIdx = SXU32_HIGH;
 							PH7_MemObjInit(pGen->pVm,&sEnv.sValue);
 							SyStringInitFromBuf(&sEnv.sName,zDup,pNameLocal->nByte);
 							if( !got_this && pNameLocal->nByte == sizeof("this")-1 &&
@@ -7489,6 +7490,7 @@ static sxi32 GenStateCompileFunc(
 					 */
 					SyZero(&sEnv,sizeof(ph7_vm_func_closure_env));
 					sEnv.iFlags = VM_FUNC_ARG_IGNORE; /* Do not install if NULL */
+					sEnv.nIdx = SXU32_HIGH;
 					PH7_MemObjInit(pGen->pVm,&sEnv.sValue);
 					SyStringInitFromBuf(&sEnv.sName,"this",sizeof("this")-1);
 					SySetPut(&pFunc->aClosureEnv,(const void *)&sEnv);

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -1030,6 +1030,41 @@ static void VmLeaveFrame(ph7_vm *pVm)
 	}
 }
 /*
+ * Pin a memory-object slot past its owning frame: remove it from whichever
+ * active frame's local-teardown set records it (walking the parent chain
+ * covers by-ref argument aliases whose slot belongs to a caller), and flag
+ * its reference record VM_REF_IDX_KEEP so unset() cannot recycle the index.
+ * Used for by-reference closure captures (`use (&$x)`), whose slot must stay
+ * alive as long as the closure itself: the slot then lives until VM reset —
+ * php frees it by refcount, PHL trades that for a script-lifetime pin.
+ */
+static VmRefObj * VmRefObjExtract(ph7_vm *pVm,sxu32 nObjIdx);
+static void VmPinMemObjSlot(ph7_vm *pVm,sxu32 nIdx)
+{
+	VmFrame *pFrame;
+	VmRefObj *pRef;
+	for( pFrame = pVm->pFrame ; pFrame ; pFrame = pFrame->pParent ){
+		VmSlot *aSlot = (VmSlot *)SySetBasePtr(&pFrame->sLocal);
+		sxu32 n;
+		for( n = 0 ; n < SySetUsed(&pFrame->sLocal) ; ++n ){
+			if( aSlot[n].nIdx == nIdx ){
+				/* Swap-remove: teardown order over sLocal is immaterial */
+				aSlot[n] = aSlot[SySetUsed(&pFrame->sLocal)-1];
+				(void)SySetPop(&pFrame->sLocal);
+				pFrame = 0; /* Slot owned by exactly one frame */
+				break;
+			}
+		}
+		if( pFrame == 0 ){
+			break;
+		}
+	}
+	pRef = VmRefObjExtract(&(*pVm),nIdx);
+	if( pRef ){
+		pRef->iFlags |= VM_REF_IDX_KEEP;
+	}
+}
+/*
  * Skip exception frames to reach the nearest non-exception frame.
  * Exception frames are transparent wrappers pushed by try/catch and
  * should be skipped when looking for the real execution context.
@@ -9889,17 +9924,27 @@ case PH7_OP_LOAD_CLOSURE:{
 			sEnv.iFlags = pEnv->iFlags;
 			sEnv.nIdx = SXU32_HIGH;
 			PH7_MemObjInit(pVm,&sEnv.sValue);
-			if( sEnv.iFlags & VM_FUNC_ARG_BY_REF ){
-				/* Pass by reference */
-				PH7_VmThrowError(pVm,0,PH7_CTX_WARNING,
-					"Closure: Pass by reference is disabled in the current release of the PH7 engine,PH7 is switching to pass by value"
-					);
-			}
-			/* Standard pass by value */
-			pValue = VmExtractMemObj(pVm,&sEnv.sName,FALSE,FALSE);
-			if( pValue ){
-				/* Copy imported value */
-				PH7_MemObjStore(pValue,&sEnv.sValue);
+			if( (sEnv.iFlags & (VM_FUNC_ARG_BY_REF|VM_FUNC_ARG_IGNORE)) == VM_FUNC_ARG_BY_REF
+			 && !(SyStringLength(&sEnv.sName) == sizeof("this")-1
+				&& SyMemcmp(SyStringData(&sEnv.sName),"this",sizeof("this")-1) == 0) ){
+				/* Capture by reference: bind the env entry to the variable's
+				 * memory slot — creating a fresh null variable when missing,
+				 * as php does (`use (&$f)` before $f is assigned) — and pin
+				 * the slot past the creating frame's teardown so the closure
+				 * can outlive its birth scope. The call-time env install
+				 * aliases the name to this slot instead of copying a value. */
+				pValue = VmExtractMemObj(pVm,&sEnv.sName,FALSE,TRUE);
+				if( pValue ){
+					sEnv.nIdx = pValue->nIdx;
+					VmPinMemObjSlot(pVm,pValue->nIdx);
+				}
+			}else{
+				/* Standard pass by value */
+				pValue = VmExtractMemObj(pVm,&sEnv.sName,FALSE,FALSE);
+				if( pValue ){
+					/* Copy imported value */
+					PH7_MemObjStore(pValue,&sEnv.sValue);
+				}
 			}
 			/* Insert the imported variable */
 			SySetPut(&pClosure->aClosureEnv,(const void *)&sEnv);
@@ -15802,6 +15847,15 @@ case PH7_OP_CALL: {
 					/* Do not install null value */
 					continue;
 				}
+				if( (pEnv->iFlags & VM_FUNC_ARG_BY_REF) && pEnv->nIdx != SXU32_HIGH ){
+					/* Captured by reference: link the name to the shared slot
+					 * (no copy), mirroring the by-ref argument install above. */
+					if( SyHashGet(&pFrame->hVar,SyStringData(&pEnv->sName),SyStringLength(&pEnv->sName)) == 0 ){
+						SyHashInsert(&pFrame->hVar,SyStringData(&pEnv->sName),
+							SyStringLength(&pEnv->sName),SX_INT_TO_PTR(pEnv->nIdx));
+					}
+					continue;
+				}
 				pValue = VmExtractMemObj(pVm,&pEnv->sName,FALSE,TRUE);
 				if( pValue == 0 ){
 					continue;
@@ -17827,6 +17881,15 @@ static sxi32 VmFiberSetupFrame(ph7_vm *pVm, ph7_exec_ctx *pExecCtx,
 		for( iEnv = 0; iEnv < SySetUsed(&pFunc->aClosureEnv); ++iEnv ){
 			pEnv = &aEnv[iEnv];
 			if( (pEnv->iFlags & VM_FUNC_ARG_IGNORE) && (pEnv->sValue.iFlags & MEMOBJ_NULL) ){
+				continue;
+			}
+			if( (pEnv->iFlags & VM_FUNC_ARG_BY_REF) && pEnv->nIdx != SXU32_HIGH ){
+				/* Captured by reference: link the name to the shared slot
+				 * (no copy), mirroring the OP_CALL env install. */
+				if( SyHashGet(&pExecCtx->pFrame->hVar,SyStringData(&pEnv->sName),SyStringLength(&pEnv->sName)) == 0 ){
+					SyHashInsert(&pExecCtx->pFrame->hVar,SyStringData(&pEnv->sName),
+						SyStringLength(&pEnv->sName),SX_INT_TO_PTR(pEnv->nIdx));
+				}
 				continue;
 			}
 			pValue = VmExtractMemObj(pVm, &pEnv->sName, FALSE, TRUE);

--- a/src/ph7/vm_builtin_reflection.c
+++ b/src/ph7/vm_builtin_reflection.c
@@ -1238,6 +1238,12 @@ static int vm_builtin_reflect_func_info(ph7_context *pCtx, int nArg, ph7_value *
 				 && SyMemcmp(SyStringData(&aEnv[n].sName), "this", sizeof("this")-1) == 0 ){
 					continue;
 				}
+				if( (aEnv[n].iFlags & VM_FUNC_ARG_BY_REF) && aEnv[n].nIdx != SXU32_HIGH ){
+					/* Captured by reference: report the slot's live value */
+					ph7_value *pLive = (ph7_value *)SySetAt(&pCtx->pVm->aMemObj, aEnv[n].nIdx);
+					ReflectMapAddDyn(pCtx, pUsed, &aEnv[n].sName, pLive ? pLive : &aEnv[n].sValue);
+					continue;
+				}
 				ReflectMapAddDyn(pCtx, pUsed, &aEnv[n].sName, &aEnv[n].sValue);
 			}
 			ph7_array_add_strkey_elem(pInfo, "used", pUsed);

--- a/tests/ph7/001-smoke/closure_byref_capture.phpt
+++ b/tests/ph7/001-smoke/closure_byref_capture.phpt
@@ -1,0 +1,144 @@
+--TEST--
+Closure by-reference capture use (&$x): recursion idiom, write-through, lifetime, generators, fibers
+--FILE--
+<?php
+// Canonical recursion idiom
+$cbrFact = function ($n) use (&$cbrFact) { return $n <= 1 ? 1 : $n * $cbrFact($n - 1); };
+echo $cbrFact(5), "\n";
+// Writes inside the closure are visible outside, and vice versa
+$cbrX = 1;
+$cbrInc = function () use (&$cbrX) { $cbrX++; };
+$cbrInc(); $cbrInc();
+echo $cbrX, "\n";
+$cbrY = 1;
+$cbrGet = function () use (&$cbrY) { return $cbrY; };
+$cbrY = 5;
+echo $cbrGet(), "\n";
+// By-value capture still snapshots
+$cbrZ = 1;
+$cbrSnap = function () use ($cbrZ) { return $cbrZ; };
+$cbrZ = 9;
+echo $cbrSnap(), "\n";
+// Closure outlives its creating frame
+function cbrMkCounter() { $c = 0; return function () use (&$c) { return ++$c; }; }
+$cbrF = cbrMkCounter();
+$cbrG = cbrMkCounter();
+echo $cbrF(), $cbrF(), $cbrF(), $cbrG(), "\n";
+// Mixed by-ref and by-value in one use list
+$cbrA = 1; $cbrB = 2; $cbrC = 3;
+$cbrMix = function () use (&$cbrA, $cbrB, &$cbrC) { $cbrA += 10; $cbrC += 100; return "$cbrA|$cbrB|$cbrC"; };
+echo $cbrMix(), ";", $cbrA, ",", $cbrB, ",", $cbrC, "\n";
+// Two closures share one variable
+$cbrN = 0;
+$cbrBump = function () use (&$cbrN) { $cbrN++; };
+$cbrRead = function () use (&$cbrN) { return $cbrN; };
+$cbrBump(); $cbrBump(); $cbrBump();
+echo $cbrRead(), "\n";
+// Capture of a not-yet-defined variable auto-vivifies null, assignable through the closure
+$cbrSet = function ($v) use (&$cbrLate) { $cbrLate = $v; };
+$cbrSet(42);
+echo $cbrLate, "\n";
+// Mutual recursion through two by-ref captures
+$cbrEven = null; $cbrOdd = null;
+$cbrEven = function ($n) use (&$cbrOdd) { return $n == 0 ? true : $cbrOdd($n - 1); };
+$cbrOdd = function ($n) use (&$cbrEven) { return $n == 0 ? false : $cbrEven($n - 1); };
+echo $cbrEven(10) ? "T" : "F", $cbrOdd(7) ? "T" : "F", "\n";
+// Array captured by reference
+$cbrArr = [1, 2];
+$cbrPush = function ($v) use (&$cbrArr) { $cbrArr[] = $v; };
+$cbrPush(3); $cbrPush(4);
+echo implode(",", $cbrArr), "\n";
+// Nested closures chaining the same reference
+$cbrW = 5;
+$cbrOuter = function () use (&$cbrW) {
+    $cbrInner = function () use (&$cbrW) { $cbrW *= 2; };
+    $cbrInner();
+    return $cbrW;
+};
+echo $cbrOuter(), ",", $cbrW, "\n";
+// Closures created in a loop share the loop variable; by-value snapshots per-iteration
+$cbrFns = [];
+for ($cbrI = 0; $cbrI < 3; $cbrI++) { $cbrFns[] = function () use (&$cbrI) { return $cbrI; }; }
+echo $cbrFns[0](), $cbrFns[1](), $cbrFns[2](), "\n";
+$cbrFns = [];
+for ($cbrI = 0; $cbrI < 3; $cbrI++) { $cbrFns[] = function () use ($cbrI) { return $cbrI; }; }
+echo $cbrFns[0](), $cbrFns[1](), $cbrFns[2](), "\n";
+// $this and by-ref capture coexist in a method-made closure
+class CbrHolder {
+    public $v = 5;
+    function make() {
+        $cnt = 0;
+        return function () use (&$cnt) { $cnt++; return $this->v + $cnt; };
+    }
+}
+$cbrH = new CbrHolder();
+$cbrM = $cbrH->make();
+echo $cbrM(), $cbrM(), "\n";
+// Closure::bind keeps the by-ref binding live
+class CbrPriv { private $p = 10; }
+$cbrK = 1;
+$cbrCl = function () use (&$cbrK) { return $this->p + $cbrK; };
+$cbrBound = Closure::bind($cbrCl, new CbrPriv(), CbrPriv::class);
+$cbrK = 2;
+echo $cbrBound(), "\n";
+// Builtin callback dispatch writes through
+$cbrTotal = 0;
+array_map(function ($x) use (&$cbrTotal) { $cbrTotal += $x; }, [1, 2, 3, 4]);
+echo $cbrTotal, "\n";
+$cbrSum = 0;
+$cbrAdd = function ($v) use (&$cbrSum) { $cbrSum += $v; };
+call_user_func($cbrAdd, 5);
+call_user_func_array($cbrAdd, [7]);
+echo $cbrSum, "\n";
+// Generator closure observes live updates to the shared variable
+$cbrT = 0;
+$cbrGen = function () use (&$cbrT) { while ($cbrT < 3) { yield $cbrT; } };
+foreach ($cbrGen() as $v) { $cbrT++; echo $v; }
+echo "|", $cbrT, "\n";
+// Fiber closure writes through across suspend/resume
+$cbrFs = 0;
+$cbrFib = new Fiber(function () use (&$cbrFs) { $cbrFs = 11; Fiber::suspend(); $cbrFs = 22; });
+$cbrFib->start();
+echo $cbrFs, ",";
+$cbrFib->resume();
+echo $cbrFs, "\n";
+// By-ref parameter chained into a by-ref capture (slot owned by the caller)
+function cbrWrap(&$y) { return function () use (&$y) { return ++$y; }; }
+$cbrZz = 1;
+$cbrQ = cbrWrap($cbrZz);
+echo $cbrQ(), $cbrQ(), ",", $cbrZz, "\n";
+// Independent instantiations do not share state
+function cbrMkPair() { $n = 0; return [function () use (&$n) { return ++$n; }, function () use (&$n) { return $n * 10; }]; }
+[$cbrI1, $cbrT1] = cbrMkPair();
+[$cbrI2, $cbrT2] = cbrMkPair();
+$cbrI1(); $cbrI1();
+echo $cbrT1(), ",", $cbrT2(), "\n";
+// ReflectionFunction::getClosureUsedVariables reports the live value
+$cbrRv = 5;
+$cbrRc = function () use (&$cbrRv) {};
+$cbrRv = 8;
+$cbrUsed = (new ReflectionFunction($cbrRc))->getClosureUsedVariables();
+echo $cbrUsed["cbrRv"], "\n";
+--EXPECT--
+120
+3
+5
+1
+1231
+11|2|103;11,2,103
+3
+42
+TT
+1,2,3,4
+10,10
+333
+012
+67
+12
+10
+12
+012|3
+11,22
+23,3
+20,0
+8


### PR DESCRIPTION
A by-ref use entry previously warned and silently bound by value, breaking php's canonical recursion idiom $f = function () use (&$f) {...}. The env struct's documented-but-dead nIdx field now carries the captured variable's memory-slot index: OP_LOAD_CLOSURE resolves the variable in the creating frame (auto-vivifying null like php) and pins the slot past that frame's teardown (VmPinMemObjSlot: removed from the owner frame's sLocal set, walked up the parent chain for by-ref-argument aliases, plus VM_REF_IDX_KEEP so unset() can never recycle the index), and both closure-env install sites (OP_CALL and VmFiberSetupFrame) alias the name to the shared slot like the by-ref argument install instead of copying a value.

ReflectionFunction::getClosureUsedVariables() reports the live slot value for by-ref entries. Closure::bind/bindTo/call inherit the binding since the env lives on the per-instantiation VM function. Compile-side env templates initialize nIdx to SXU32_HIGH (SyZero left 0, a valid slot index).

Byte-verified vs php 8.5.7: recursion + mutual recursion, write-through both directions, closures outliving their creator, loop/nested/method captures, generator and fiber closures, callback dispatch, 20k-closure stress, and slot-recycling churn probes. Cross-engine test closure_byref_capture.phpt; test-compat green; docker ASan+UBSan clean; tiny build ok.
