### PR TITLE
Parse static closures and fix $this binding

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -2249,11 +2249,18 @@ PH7_PRIVATE sxi32 PH7_CompileAnnonFunc(ph7_gen_state *pGen,sxi32 iCompileFlag)
 						      */
 	SyString sName;
 	sxu32 nKwLine;
+	sxi32 iFlags = 0;
 	sxu32 nLen;
 	sxi32 rc;
 	SXUNUSED(iCompileFlag); /* cc warning */
 
 	nKwLine = pGen->pIn->nLine; /* Line of the 'function' keyword (Reflection getStartLine) */
+	if( (pGen->pIn->nType & PH7_TK_KEYWORD)
+		&& SX_PTR_TO_INT(pGen->pIn->pUserData) == PH7_TKWRD_STATIC ){
+		/* Static closure: no $this auto-capture, bind refused */
+		iFlags |= VM_FUNC_STATIC_CL;
+		pGen->pIn++; /* Jump the 'static' keyword */
+	}
 	pGen->pIn++; /* Jump the 'function' keyword */
 	if( pGen->pIn->nType & (PH7_TK_ID|PH7_TK_KEYWORD) ){
 		pGen->pIn++;
@@ -2266,7 +2273,7 @@ PH7_PRIVATE sxi32 PH7_CompileAnnonFunc(ph7_gen_state *pGen,sxi32 iCompileFlag)
 	}
 	SyStringInitFromBuf(&sName,zName,nLen);
 	/* Compile the lambda body */
-	rc = GenStateCompileFunc(&(*pGen),&sName,0,TRUE,&pAnnonFunc);
+	rc = GenStateCompileFunc(&(*pGen),&sName,iFlags,TRUE,&pAnnonFunc);
 	if( rc == SXERR_ABORT ){
 		return SXERR_ABORT;
 	}
@@ -2635,6 +2642,7 @@ PH7_PRIVATE sxi32 PH7_CompileArrowFunc(ph7_gen_state *pGen,sxi32 iCompileFlag)
 	if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_KEYWORD)
 		&& SX_PTR_TO_INT(pGen->pIn->pUserData) == PH7_TKWRD_STATIC ){
 		bStatic = 1;
+		iFlags |= VM_FUNC_STATIC_CL;
 		pGen->pIn++;
 	}
 	/* 'fn' keyword (guaranteed by ExprExtractNode's dispatch) */
@@ -5270,6 +5278,20 @@ static sxi32 PH7_CompileStatic(ph7_gen_state *pGen)
 	char *zDup;
 	sxu32 nLine;
 	sxi32 rc;
+	/* `static function () {}` / `static fn () =>` at statement position is an
+	 * EXPRESSION statement (a bare static closure), not a static-variable
+	 * declaration — hand it to the expression compiler (php accepts it). */
+	if( &pGen->pIn[1] < pGen->pEnd && (pGen->pIn[1].nType & PH7_TK_KEYWORD)
+	 && (SX_PTR_TO_INT(pGen->pIn[1].pUserData) == PH7_TKWRD_FUNCTION
+	  || SX_PTR_TO_INT(pGen->pIn[1].pUserData) == PH7_TKWRD_FN) ){
+		rc = PH7_CompileExpr(&(*pGen),0,0);
+		if( rc == SXERR_ABORT ){
+			return SXERR_ABORT;
+		}else if( rc != SXERR_EMPTY ){
+			PH7_VmEmitInstr(pGen->pVm,PH7_OP_POP,1,0,0,0);
+		}
+		return SXRET_OK;
+	}
 	/* Jump the static keyword */
 	nLine = pGen->pIn->nLine;
 	pGen->pIn++;
@@ -7484,21 +7506,6 @@ static sxi32 GenStateCompileFunc(
 						pGen->pIn++;
 					}
 				}
-				if( !got_this ){
-					/* Make the $this variable [Current processed Object (class instance)]
-					 * available to the closure environment.
-					 */
-					SyZero(&sEnv,sizeof(ph7_vm_func_closure_env));
-					sEnv.iFlags = VM_FUNC_ARG_IGNORE; /* Do not install if NULL */
-					sEnv.nIdx = SXU32_HIGH;
-					PH7_MemObjInit(pGen->pVm,&sEnv.sValue);
-					SyStringInitFromBuf(&sEnv.sName,"this",sizeof("this")-1);
-					SySetPut(&pFunc->aClosureEnv,(const void *)&sEnv);
-				}
-				if( SySetUsed(&pFunc->aClosureEnv) > 0 ){
-					/* Mark as closure */
-					pFunc->iFlags |= VM_FUNC_CLOSURE;
-				}
 				/* php 7.1+: the return type follows the use clause —
 				 * `function (...) use (...) : int {`. Gated on the colon:
 				 * GenStateParseReturnType resets the type fields at entry,
@@ -7512,6 +7519,25 @@ static sxi32 GenStateCompileFunc(
 						return SXERR_SYNTAX;
 					}
 				}
+		}
+		if( !got_this && (iFlags & VM_FUNC_STATIC_CL) == 0 ){
+			/* Make the $this variable [Current processed Object (class instance)]
+			 * available to the closure environment — for EVERY non-static
+			 * anonymous function, use list or not (php binds $this to any
+			 * closure declared in a method; pre-fix only `use (...)` closures
+			 * captured it). Flagged VM_FUNC_ARG_IGNORE so the null capture of
+			 * a global-scope closure is silently dropped at install. A static
+			 * closure never binds $this (php). */
+			SyZero(&sEnv,sizeof(ph7_vm_func_closure_env));
+			sEnv.iFlags = VM_FUNC_ARG_IGNORE; /* Do not install if NULL */
+			sEnv.nIdx = SXU32_HIGH;
+			PH7_MemObjInit(pGen->pVm,&sEnv.sValue);
+			SyStringInitFromBuf(&sEnv.sName,"this",sizeof("this")-1);
+			SySetPut(&pFunc->aClosureEnv,(const void *)&sEnv);
+		}
+		if( SySetUsed(&pFunc->aClosureEnv) > 0 ){
+			/* Mark as closure */
+			pFunc->iFlags |= VM_FUNC_CLOSURE;
 		}
 	}
 	/* Compile the body */

--- a/src/ph7/parse.c
+++ b/src/ph7/parse.c
@@ -1085,8 +1085,11 @@ static sxi32 ExprExtractNode(ph7_gen_state *pGen,ph7_expr_node **ppNode,int iLas
 				 PH7_TK_LPAREN|PH7_TK_OCB|PH7_TK_OSB,
 				 PH7_TK_RPAREN|PH7_TK_CCB|PH7_TK_CSB,&pCur);
 			 pNode->xCode = PH7_CompileYield;
-		 }else if( nKeyword == PH7_TKWRD_FUNCTION ){
-			 /* Annonymous function */
+		 }else if( nKeyword == PH7_TKWRD_FUNCTION
+			|| ( nKeyword == PH7_TKWRD_STATIC && &pCur[1] < pGen->pEnd
+				 && (pCur[1].nType & PH7_TK_KEYWORD)
+				 && SX_PTR_TO_INT(pCur[1].pUserData) == PH7_TKWRD_FUNCTION ) ){
+			 /* Annonymous function: function (...) {...} or static function (...) {...} */
 			  if( &pCur[1] >= pGen->pEnd ){
 				 /* Assume a literal */
 				ExprAssembleLiteral(&pCur,pGen->pEnd);

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -764,7 +764,9 @@ struct ph7_vm_func_closure_env
 #define VM_FUNC_INTERNAL     0x2000 /* Function was defined while compiling a builtin chunk
                                      * (embedded PHP library). Reflection reports it as internal:
                                      * isInternal() true, getFileName() false. */
-/* next free bit: 0x4000 */
+#define VM_FUNC_STATIC_CL    0x4000 /* Static closure/arrow fn (`static function () {}` /
+                                     * `static fn () =>`): no $this auto-capture, bind refused. */
+/* next free bit: 0x8000 */
 /*
  * Each user defined function is parsed out and stored in an instance
  * of the following structure.

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -9911,6 +9911,15 @@ case PH7_OP_LOAD_CLOSURE:{
 		pClosure->sReturnClass = pFunc->sReturnClass;
 		pClosure->aReturnUnion = pFunc->aReturnUnion;
 		pClosure->sReturnTypeName = pFunc->sReturnTypeName;
+		pClosure->bStrictTypes = pFunc->bStrictTypes;
+		pClosure->nMaxStack = pFunc->nMaxStack;
+		/* Reflection descriptor fields (getDocComment/getAttributes/getStartLine/
+		 * getEndLine/getFileName read the INSTANTIATED copy via $__fn) */
+		pClosure->aAttrs = pFunc->aAttrs;
+		pClosure->sDoc = pFunc->sDoc;
+		pClosure->sFile = pFunc->sFile;
+		pClosure->nLine = pFunc->nLine;
+		pClosure->nEndLine = pFunc->nEndLine;
 		SyStringInitFromBuf(&pClosure->sName,zName,mLen);
 		/* Register the closure */
 		PH7_VmInstallUserFunction(pVm,pClosure,0);
@@ -14786,6 +14795,10 @@ case PH7_OP_CALL: {
 			pThis = pVm->pClosureThis;
 			pVm->pClosureThis = 0;
 			bClosureThis = 1;
+		}
+		if( pVm->pClosureScope ){
+			/* May ride alongside a bound $this, or stand alone for a
+			 * scope-only rebind (`bindTo(null, Scope::class)`). */
 			pClosureScope = pVm->pClosureScope;
 			pVm->pClosureScope = 0;
 		}
@@ -15145,9 +15158,10 @@ case PH7_OP_CALL: {
 			PH7_MemObjRelease(pTos);
 			break;
 		}
-		if( bClosureThis && pClosureScope ){
-			/* Bound plain closure with an explicit scope: private/protected access inside the body
-			 * resolves against it (Closure::bindTo($o, Scope::class) / call($o)). */
+		if( pClosureScope ){
+			/* Plain closure with an explicit scope — bound (bindTo($o, Scope::class) /
+			 * call($o)) or scope-only (bindTo(null, Scope::class)): private/protected
+			 * access inside the body resolves against it. */
 			pFrame->pBoundScope = pClosureScope;
 		}
 		/* Stamp the ACTUAL call arity for func_num_args()/func_get_args() (band
@@ -15845,6 +15859,13 @@ case PH7_OP_CALL: {
 				pEnv = &aEnv[iEnv];
 				if( (pEnv->iFlags & VM_FUNC_ARG_IGNORE) && (pEnv->sValue.iFlags & MEMOBJ_NULL) ){
 					/* Do not install null value */
+					continue;
+				}
+				if( bClosureThis && SyStringLength(&pEnv->sName) == sizeof("this")-1
+				 && SyMemcmp(SyStringData(&pEnv->sName),"this",sizeof("this")-1) == 0 ){
+					/* The Closure instance carries an explicit bound $this
+					 * (bindTo/bind/call): it wins over the creation-time
+					 * captured $this, php-exact. */
 					continue;
 				}
 				if( (pEnv->iFlags & VM_FUNC_ARG_BY_REF) && pEnv->nIdx != SXU32_HIGH ){
@@ -17127,6 +17148,27 @@ static sxi32 VmClosureUnwrap(ph7_vm *pVm, ph7_value *pVal, ph7_value *pOut)
 					PH7_MemObjStringAppend(pOut, SyBlobData(&pFn->sBlob), SyBlobLength(&pFn->sBlob));
 					return SXRET_OK;
 				}
+			}else{
+				/* Scope-only rebind of a PLAIN closure (`bindTo(null, Scope::class)`):
+				 * $__fn names a function, not a static method of the scope class, so
+				 * the [scope, method] array callable below would fail method
+				 * resolution. Dispatch the plain $__fn string and carry the scope for
+				 * private/protected visibility (pClosureThis stays unset — no $this).
+				 * A static-method FCC ($__fn really is a method of the scope class)
+				 * falls through to the array-callable path. */
+				ph7_class *pScopeClass = PH7_VmExtractClass(pVm,
+					(const char *)SyBlobData(&pScope->sBlob), SyBlobLength(&pScope->sBlob), FALSE, 0);
+				if( pScopeClass == 0
+				 || PH7_ClassExtractMethod(pScopeClass,
+						(const char *)SyBlobData(&pFn->sBlob), SyBlobLength(&pFn->sBlob)) == 0 ){
+					if( pScopeClass
+					 && SyHashGet(&pVm->hFunction, (const void *)SyBlobData(&pFn->sBlob),
+							SyBlobLength(&pFn->sBlob)) != 0 ){
+						pVm->pClosureScope = pScopeClass;
+					}
+					PH7_MemObjStringAppend(pOut, SyBlobData(&pFn->sBlob), SyBlobLength(&pFn->sBlob));
+					return SXRET_OK;
+				}
 			}
 			pMap = PH7_NewHashmap(&(*pVm), 0, 0);
 			if( pMap == 0 ){
@@ -17455,6 +17497,22 @@ static int vm_builtin_Closure_bindTo(ph7_context *pCtx, int nArg, ph7_value **ap
 		return PH7_VmThrowException(pCtx, "TypeError",
 			"Closure::bindTo(): Argument #1 ($newThis) must be of type ?object");
 	}
+	if( pNewThis ){
+		/* php refuses to bind an instance to a static closure: warning + null */
+		SyString sAttr;
+		ph7_value *pFn;
+		SyStringInitFromBuf(&sAttr, "__fn", 4);
+		pFn = PH7_ClassInstanceFetchAttr(pClosure, &sAttr);
+		if( pFn && (pFn->iFlags & MEMOBJ_STRING) && SyBlobLength(&pFn->sBlob) > 0 ){
+			SyHashEntry *pEntry = SyHashGet(&pVm->hFunction, SyBlobData(&pFn->sBlob), SyBlobLength(&pFn->sBlob));
+			if( pEntry && (((ph7_vm_func *)pEntry->pUserData)->iFlags & VM_FUNC_STATIC_CL) ){
+				PH7_VmThrowError(pVm,0,PH7_CTX_WARNING,
+					"Cannot bind an instance to a static closure, this will be an error in PHP 9");
+				ph7_result_null(pCtx);
+				return PH7_OK;
+			}
+		}
+	}
 	if( VmClosureResolveScope((nArg > 2) ? apArg[2] : 0, &sScope) ){
 		pScopePtr = &sScope;
 	}
@@ -17609,8 +17667,29 @@ static ph7_vm_func * VmFiberResolveCallable(ph7_context *pCtx, ph7_class_instanc
 			}
 			PH7_MemObjRelease(&sName);
 			if( pEntry ){
+				/* A BOUND closure parked its $this in the pClosureThis transient
+				 * (VmClosureUnwrap): consume it as the fiber's $this — it wins over
+				 * the creation-time env capture (VmFiberSetupFrame's skip). *ppThis
+				 * is a borrow (the closure's $__this attr keeps the object alive
+				 * through $__callable), so drop the parked ref. The scope transient
+				 * is cleared alongside: fiber bodies don't model pBoundScope
+				 * visibility (recorded residual), and a stale transient would
+				 * poison the next OP_CALL's frame. */
+				if( pVm->pClosureThis ){
+					*ppThis = pVm->pClosureThis;
+					PH7_ClassInstanceUnref(pVm->pClosureThis);
+					pVm->pClosureThis = 0;
+				}
+				pVm->pClosureScope = 0;
 				return (ph7_vm_func *)pEntry->pUserData;
 			}
+			if( pVm->pClosureThis ){
+				/* Failed resolution: drop the parked transient so it neither leaks
+				 * nor poisons the next call. */
+				PH7_ClassInstanceUnref(pVm->pClosureThis);
+				pVm->pClosureThis = 0;
+			}
+			pVm->pClosureScope = 0;
 			PH7_VmThrowException(pCtx, "FiberError", "Fiber callable closure could not be resolved");
 			return 0;
 		}
@@ -17881,6 +17960,12 @@ static sxi32 VmFiberSetupFrame(ph7_vm *pVm, ph7_exec_ctx *pExecCtx,
 		for( iEnv = 0; iEnv < SySetUsed(&pFunc->aClosureEnv); ++iEnv ){
 			pEnv = &aEnv[iEnv];
 			if( (pEnv->iFlags & VM_FUNC_ARG_IGNORE) && (pEnv->sValue.iFlags & MEMOBJ_NULL) ){
+				continue;
+			}
+			if( pClosureThis && SyStringLength(&pEnv->sName) == sizeof("this")-1
+			 && SyMemcmp(SyStringData(&pEnv->sName),"this",sizeof("this")-1) == 0 ){
+				/* An explicit bound $this (bindTo/bind/call) wins over the
+				 * creation-time captured $this, php-exact (mirrors OP_CALL). */
 				continue;
 			}
 			if( (pEnv->iFlags & VM_FUNC_ARG_BY_REF) && pEnv->nIdx != SXU32_HIGH ){
@@ -19659,8 +19744,10 @@ PH7_PRIVATE sxi32 PH7_VmCallUserFunctionWithMap(
 			if( pVm->pClosureThis ){
 				PH7_ClassInstanceUnref(pVm->pClosureThis);
 				pVm->pClosureThis = 0;
-				pVm->pClosureScope = 0;
 			}
+			/* The scope transient can stand alone (scope-only rebind); it holds no
+			 * owned reference — just clear it if the dispatch didn't consume it. */
+			pVm->pClosureScope = 0;
 			PH7_MemObjRelease(&sCallable);
 			return rcClo;
 		}

--- a/src/ph7/vm_builtin_reflection.c
+++ b/src/ph7/vm_builtin_reflection.c
@@ -1029,6 +1029,7 @@ static void ReflectFillFuncCommon(ph7_context *pCtx, ph7_value *pInfo, ph7_vm_fu
 	ReflectMapAddStr(pCtx, pInfo, "name", SyStringData(&pFunc->sName), (int)SyStringLength(&pFunc->sName));
 	ReflectMapAddBool(pCtx, pInfo, "internal", (pFunc->iFlags & VM_FUNC_INTERNAL) != 0);
 	ReflectMapAddBool(pCtx, pInfo, "closure", bAnon);
+	ReflectMapAddBool(pCtx, pInfo, "fstatic", (pFunc->iFlags & VM_FUNC_STATIC_CL) != 0);
 	ReflectMapAddBool(pCtx, pInfo, "byref", (pFunc->iFlags & VM_FUNC_REF_RETURN) != 0);
 	ReflectMapAddBool(pCtx, pInfo, "generator", (pFunc->iFlags & VM_FUNC_GENERATOR) != 0);
 	ReflectMapAddBool(pCtx, pInfo, "strict", pFunc->bStrictTypes != 0);
@@ -1147,6 +1148,7 @@ static int vm_builtin_reflect_func_info(ph7_context *pCtx, int nArg, ph7_value *
 		ReflectMapAddStr(pCtx, pInfo, "name", SyStringData(&pHost->sName), (int)SyStringLength(&pHost->sName));
 		ReflectMapAddBool(pCtx, pInfo, "internal", 1);
 		ReflectMapAddBool(pCtx, pInfo, "closure", 0);
+		ReflectMapAddBool(pCtx, pInfo, "fstatic", 0);
 		ReflectMapAddBool(pCtx, pInfo, "byref", 0);
 		ReflectMapAddBool(pCtx, pInfo, "generator", 0);
 		ReflectMapAddBool(pCtx, pInfo, "strict", 0);
@@ -2096,7 +2098,7 @@ static const char zReflectLib2[] =
 " public function isInternal(){ $i = $this->__rfinfo(); return $i['internal']; }"
 " public function isUserDefined(){ return !$this->isInternal(); }"
 " public function isDeprecated(){ $i = $this->__rfinfo(); return __reflect_has_deprecated($i['attrs']); }"
-" public function isStatic(){ return false; }"
+" public function isStatic(){ $i = $this->__rfinfo(); return $i['fstatic']; }"
 " public function getFileName(){ $i = $this->__rfinfo(); return $i['file']; }"
 " public function getStartLine(){"
 "  $i = $this->__rfinfo();"

--- a/tests/ph7/001-smoke/static_closures_this_binding.phpt
+++ b/tests/ph7/001-smoke/static_closures_this_binding.phpt
@@ -1,0 +1,79 @@
+--TEST--
+static function(){} closures, auto-$this capture without use(), and bound-$this precedence
+--FILE--
+<?php
+// static closure expression parses and calls
+$sctA = static function () { return 7; };
+echo $sctA(), "\n";
+// static closure with a by-ref use list
+$sctN = 1;
+$sctB = static function () use (&$sctN) { return ++$sctN; };
+echo $sctB(), $sctN, "\n";
+// bare statement-position static closure is accepted (useless but valid)
+static function () {};
+static fn() => 1;
+echo "stmt-ok", "\n";
+// a no-use closure made in a method binds $this
+class SctHolder {
+    public $v = 7;
+    function mk() { return function () { return $this->v; }; }
+    function mkStatic() { return static function () { return isset($this) ? "y" : "n"; }; }
+}
+$sctO = new SctHolder();
+$sctF = $sctO->mk();
+echo $sctF(), "\n";
+// a static closure made in a method has no $this
+$sctS = $sctO->mkStatic();
+echo $sctS(), "\n";
+// global-scope closure has no $this either way
+$sctP = function () { return isset($this) ? "y" : "n"; };
+echo $sctP(), "\n";
+// isStatic() reflection
+echo (int) (new ReflectionFunction($sctA))->isStatic(),
+     (int) (new ReflectionFunction($sctF))->isStatic(),
+     (int) (new ReflectionFunction(static fn() => 1))->isStatic(), "\n";
+// binding an instance to a static closure is refused (warning swallowed for parity:
+// php fires the handler regardless of error_reporting, PHL gates on it — cover both)
+set_error_handler(function () { return true; });
+error_reporting(0);
+$sctR = Closure::bind($sctA, new SctHolder());
+restore_error_handler();
+error_reporting(E_ALL);
+echo $sctR === null ? "null" : "bound", "\n";
+// bindTo(null, scope) keeps the closure callable and grants scope visibility
+class SctPriv { private static $sec = 42; }
+$sctC = function () { return SctPriv::$sec ?? "no"; };
+$sctD = $sctC->bindTo(null, SctPriv::class);
+echo $sctD(), "\n";
+// an explicit bound $this wins over the creation-time captured $this
+class SctOther { public $v = 6; }
+$sctE = Closure::bind($sctF, new SctOther(), SctOther::class);
+echo $sctE(), $sctF(), "\n";
+// ... including through generator and fiber dispatch
+class SctGen {
+    public $v = 4;
+    function mk() { return function () { yield $this->v; }; }
+}
+$sctG = (new SctGen())->mk();
+$sctH = Closure::bind($sctG, new SctOther(), SctOther::class);
+foreach ($sctH() as $x) { echo $x; }
+foreach ($sctG() as $x) { echo $x; }
+echo "\n";
+$sctFibC = (new SctHolder())->mk();
+$sctFibB = Closure::bind($sctFibC, new SctOther(), SctOther::class);
+$sctFib = new Fiber(function () use ($sctFibB, $sctFibC) { echo $sctFibB(), $sctFibC(); });
+$sctFib->start();
+echo "\n";
+--EXPECT--
+7
+22
+stmt-ok
+7
+n
+n
+101
+null
+42
+67
+64
+67


### PR DESCRIPTION
Four cascading pre-existing bugs surfaced by the by-ref-capture probes:

1. `static function () {}` was a compile error in both expression and statement position (`static fn` worked). The expression dispatcher now routes STATIC+FUNCTION to the anonymous-function branch and PH7_CompileStatic hands statement-position static closures to the expression compiler. The new VM_FUNC_STATIC_CL flag (also set by static arrow fns) suppresses $this capture, makes Closure::bind(new C) on a static closure warn and return null like php, and surfaces through ReflectionFunction::isStatic() (reflection ledger 13).

2. A closure with no use() list never captured $this: the auto-capture env entry was nested inside the use-list parse, so a method-made `function () { return $this->v; }` dispatched with null $this. The IGNORE-flagged $this entry now attaches to every non-static anonymous function, and the OP_LOAD_CLOSURE instantiation copy gained the reflection descriptor fields it silently dropped (sDoc, aAttrs, sFile, nLine, nEndLine, bStrictTypes, nMaxStack).

3. An explicit bound $this (bind/bindTo/call) was overwritten by the creation-time captured $this at env install; both install sites now let the instance binding win. The fiber path additionally never consumed the parked bound-$this transient (lost binding + stale-$this poisoning of the next call); VmFiberResolveCallable now consumes or clears it on every exit.

4. bindTo(null, Scope::class) built a bogus [Scope, "[closure_N]"] array callable and the call silently returned null; the unwrap now dispatches the plain function name with pBoundScope visibility, and the scope transient is consumed independently of the $this transient.

Byte-verified vs php 8.5.7; cross-engine test
static_closures_this_binding.phpt; test-compat green; docker ASan+UBSan clean; tiny build ok.
