### PR TITLE
Resolve new self()/static() and scope closures

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -1926,6 +1926,7 @@ static void VmReleaseExecCtx(ph7_vm *pVm, ph7_exec_ctx *pCtx);
 static ph7_generator * VmGeneratorExtractCtx(ph7_vm *pVm, ph7_value *pGenObj);
 static int VmValueIsClosure(ph7_vm *pVm, ph7_value *pVal);
 static sxi32 VmClosureUnwrap(ph7_vm *pVm, ph7_value *pVal, ph7_value *pOut);
+static ph7_class * VmFccResolveScope(ph7_vm *pVm, ph7_value *pTarget);
 static ph7_class_instance * VmCreateClosure(ph7_vm *pVm, const SyString *pName,
 	ph7_class_instance *pBoundThis, const SyString *pScope);
 static ph7_class * VmFccResolveScope(ph7_vm *pVm, ph7_value *pTarget);
@@ -9913,6 +9914,12 @@ case PH7_OP_LOAD_CLOSURE:{
 		pClosure->sReturnTypeName = pFunc->sReturnTypeName;
 		pClosure->bStrictTypes = pFunc->bStrictTypes;
 		pClosure->nMaxStack = pFunc->nMaxStack;
+		if( pClosure->pUserData == 0 ){
+			/* Stamp the creation-site class scope (see PH7_VmPeekDeclaringClass):
+			 * a closure made in a method — or in another closure, whose own stamp
+			 * the peek reads — resolves self::/parent:: against it like php. */
+			pClosure->pUserData = (void *)PH7_VmPeekDeclaringClass(pVm);
+		}
 		/* Reflection descriptor fields (getDocComment/getAttributes/getStartLine/
 		 * getEndLine/getFileName read the INSTANTIATED copy via $__fn) */
 		pClosure->aAttrs = pFunc->aAttrs;
@@ -13842,9 +13849,31 @@ case PH7_OP_NEW: {
 	VmCallArgMap *pEffNewMap = VmEffCallArgMap(pVm,pInstr,pArg,
 		nCtorArgs > 0 ? (sxu32)nCtorArgs : 0,&sEffNewMap);
 	if( (pTos->iFlags & MEMOBJ_STRING) && SyBlobLength(&pTos->sBlob) > 0 ){
-		/* Try to extract the desired class */
-		pClass = PH7_VmExtractClass(&(*pVm),(const char *)SyBlobData(&pTos->sBlob),
-			SyBlobLength(&pTos->sBlob),TRUE /* Only loadable class but not 'interface' or 'abstract' class*/,0);
+		const char *zCls = (const char *)SyBlobData(&pTos->sBlob);
+		sxu32 nCls = SyBlobLength(&pTos->sBlob);
+		if( (nCls == sizeof("self")-1 && SyMemcmp(zCls,"self",sizeof("self")-1) == 0)
+		 || (nCls == sizeof("static")-1 && SyMemcmp(zCls,"static",sizeof("static")-1) == 0)
+		 || (nCls == sizeof("parent")-1 && SyMemcmp(zCls,"parent",sizeof("parent")-1) == 0) ){
+			/* new self() / new static() / new parent(): resolve against the live
+			 * class context (LSB for static), sharing the FCC resolver. */
+			pClass = VmFccResolveScope(&(*pVm),pTos);
+			if( pClass && (pClass->iFlags & (PH7_CLASS_INTERFACE|PH7_CLASS_ABSTRACT)) ){
+				/* Not new-able (the named path's iLoadable extract excludes these
+				 * before it ever gets here): php's wording, with the RESOLVED name. */
+				VmErrorFormat(&(*pVm),PH7_CTX_ERR,"Cannot instantiate %s %z",
+					(pClass->iFlags & PH7_CLASS_INTERFACE) ? "interface" : "abstract class",
+					&pClass->sName);
+				PH7_MemObjRelease(pTos);
+				if( nCtorArgs > 0 ){
+					VmPopOperand(&pTos,nCtorArgs);
+				}
+				goto Abort;
+			}
+		}else{
+			/* Try to extract the desired class */
+			pClass = PH7_VmExtractClass(&(*pVm),zCls,nCls,
+				TRUE /* Only loadable class but not 'interface' or 'abstract' class*/,0);
+		}
 	}else if( pTos->iFlags & MEMOBJ_OBJ ){
 		/* Take the base class from the loaded instance */
 		pClass = ((ph7_class_instance *)pTos->x.pOther)->pClass;
@@ -19380,9 +19409,21 @@ PH7_PRIVATE ph7_class * PH7_VmPeekDeclaringClass(ph7_vm *pVm)
 
 	/* Check if we're in a method context */
 	if( pFrame->pParent ){
+		if( pFrame->pBoundScope ){
+			/* Closure::bind/bindTo/call scope override: it REPLACES the closure's
+			 * class scope (php), so self::/parent:: resolve against it. */
+			return pFrame->pBoundScope;
+		}
 		pVmFunc = (ph7_vm_func *)pFrame->pUserData;
 		if( pVmFunc && (pVmFunc->iFlags & VM_FUNC_CLASS_METHOD) ){
 			/* Return the declaring class */
+			return (ph7_class *)pVmFunc->pUserData;
+		}
+		if( pVmFunc && (pVmFunc->iFlags & VM_FUNC_CLOSURE) && pVmFunc->pUserData ){
+			/* A closure inherits the class scope of its creation site: OP_LOAD_CLOSURE
+			 * stamps the then-declaring class into the instantiated copy's pUserData
+			 * (0 for global-scope closures — methods own the field the same way), so
+			 * self::/parent::/new self() inside a closure body resolve like php. */
 			return (ph7_class *)pVmFunc->pUserData;
 		}
 	}

--- a/tests/ph7/001-smoke/new_self_static_parent.phpt
+++ b/tests/ph7/001-smoke/new_self_static_parent.phpt
@@ -1,0 +1,75 @@
+--TEST--
+new self() / new static() / new parent() with LSB, plus closure class-scope inheritance
+--FILE--
+<?php
+class NspA {
+    static function mkSelf() { return new self(); }
+    static function mkStatic() { return new static(); }
+    function dupSelf() { return new self(); }
+    function dupStatic() { return new static(); }
+}
+class NspB extends NspA {}
+echo get_class(NspA::mkSelf()), get_class(NspA::mkStatic()), "\n";
+echo get_class(NspB::mkSelf()), get_class(NspB::mkStatic()), "\n";
+$nspB = new NspB();
+echo get_class($nspB->dupSelf()), get_class($nspB->dupStatic()), "\n";
+// parent, with constructor arguments
+class NspP { public $v; function __construct($v = 0) { $this->v = $v; } }
+class NspC extends NspP {
+    static function mk($v) { return new parent($v); }
+}
+$nspP = NspC::mk(5);
+echo get_class($nspP), $nspP->v, "\n";
+// constructor args and spread flow through static
+class NspD {
+    public $a; public $b;
+    function __construct($a, $b) { $this->a = $a; $this->b = $b; }
+    static function of($a, $b) { return new static($a, $b); }
+}
+class NspE extends NspD {}
+$nspE = NspE::of(1, 2);
+echo get_class($nspE), $nspE->a, $nspE->b, "\n";
+class NspF {
+    public $s;
+    function __construct(...$xs) { $this->s = implode(",", $xs); }
+    static function all(array $xs) { return new static(...$xs); }
+}
+echo NspF::all([7, 8, 9])->s, "\n";
+// method chain on new self()
+class NspG { function m() { return "chain"; } static function go() { return new self()->m(); } }
+echo NspG::go(), "\n";
+// static in a trait method resolves to the using class
+trait NspT { static function make() { return new static(); } }
+class NspH { use NspT; }
+echo get_class(NspH::make()), "\n";
+// new static() from an abstract base instantiates the called subclass
+abstract class NspQ { static function mk() { return new static(); } }
+class NspR extends NspQ {}
+echo get_class(NspR::mk()), "\n";
+// closures inherit the class scope of their creation site
+class NspI {
+    const X = 9;
+    function viaClosure() { $f = function () { return [get_class(new self()), self::X]; }; return $f(); }
+}
+[$nspCls, $nspConst] = (new NspI())->viaClosure();
+echo $nspCls, $nspConst, "\n";
+// a bind() scope override replaces the closure's class scope
+class NspS { const T = "s1"; }
+$nspF2 = function () { return self::T; };
+$nspG2 = Closure::bind($nspF2, null, NspS::class);
+echo $nspG2(), "\n";
+// instanceof round trip
+echo NspB::mkStatic() instanceof NspB ? "T" : "F", NspB::mkSelf() instanceof NspB ? "T" : "F", "\n";
+--EXPECT--
+NspANspA
+NspANspB
+NspANspB
+NspP5
+NspE12
+7,8,9
+chain
+NspH
+NspR
+NspI9
+s1
+TF


### PR DESCRIPTION
All three keywords previously raised "Class 'self' is not defined" at runtime: the compiler passes them through as literal class-name strings and OP_NEW only knew explicit names. OP_NEW now routes the three keywords through the shared FCC resolver (VmFccResolveScope): self resolves to the declaring class (trait-aware), static to the late-static-binding top class, parent to the declaring class's base. Constructor arguments, named args and spread flow through unchanged, and the new C()->m() chain form works on the keywords, lifting that recorded residual. A keyword resolving to an interface or abstract class aborts with php's "Cannot instantiate abstract class X" wording instead of the misleading undefined-class text.

Probing new self() inside closures exposed a wider pre-existing gap: closures never inherited their creation site's class scope, so self::CONST, parent:: and new self() failed in every closure body. OP_LOAD_CLOSURE now stamps the creation-time declaring class into the instantiated copy's free pUserData field (the same field methods use), and PH7_VmPeekDeclaringClass reads it for closure frames - preferring pFrame->pBoundScope so a Closure::bind scope override replaces the stamped scope like php. Nested closures propagate the stamp.

Byte-verified vs php 8.5.7; cross-engine test new_self_static_parent.phpt; test-compat green; docker ASan+UBSan clean; tiny build ok.
