### PR TITLE
Dispatch "Class::method" string callables like php

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -16294,6 +16294,68 @@ SkipFuncBody:
 		}
 		} /* end VmCallArgMap namespace scope */
 		if( pEntry == 0 ){
+			/* php accepts the "Class::method" STATIC-callable string everywhere a
+			 * callable goes ($f = "C::s"; $f(), call_user_func, array_map, …).
+			 * Split on the first "::" and route through the shared array-callable
+			 * machinery ([class-name, method-name]) instead of warning undefined. */
+			sxu32 iSep;
+			int bScoped = 0;
+			for( iSep = 1 ; iSep + 2 < sName.nByte ; ++iSep ){
+				if( sName.zString[iSep] == ':' && sName.zString[iSep+1] == ':' ){
+					bScoped = 1;
+					break;
+				}
+			}
+			if( bScoped ){
+				ph7_hashmap *pCbMap = PH7_NewHashmap(&(*pVm),0,0);
+				if( pCbMap ){
+					ph7_value sCallable,sElem,sResult;
+					sxi32 rcSm;
+					pEffCallMap = VmEffCallArgMap(pVm,pInstr,pArg,
+						nCallArgs > 0 ? (sxu32)nCallArgs : 0,&sEffMap);
+					SySetReset(&aArg);
+					while( pArg < pTos ){
+						SySetPut(&aArg,(const void *)&pArg);
+						pArg++;
+					}
+					PH7_MemObjInit(pVm,&sElem);
+					PH7_MemObjStringAppend(&sElem,sName.zString,iSep);
+					PH7_HashmapInsert(pCbMap,0,&sElem);
+					PH7_MemObjRelease(&sElem);
+					PH7_MemObjInit(pVm,&sElem);
+					PH7_MemObjStringAppend(&sElem,&sName.zString[iSep+2],sName.nByte-(iSep+2));
+					PH7_HashmapInsert(pCbMap,0,&sElem);
+					PH7_MemObjRelease(&sElem);
+					PH7_MemObjInit(pVm,&sCallable);
+					sCallable.x.pOther = pCbMap;
+					MemObjSetType(&sCallable,MEMOBJ_HASHMAP);
+					PH7_MemObjInit(pVm,&sResult);
+					rcSm = PH7_VmCallUserFunctionWithMap(pVm,&sCallable,(int)SySetUsed(&aArg),
+						(ph7_value **)SySetBasePtr(&aArg),&sResult,pEffCallMap);
+					SySetReset(&aArg);
+					PH7_MemObjRelease(&sCallable);
+					if( nCallArgs > 0 ){
+						VmPopOperand(&pTos,nCallArgs);
+					}
+					if( rcSm == PH7_ABORT ){
+						PH7_MemObjRelease(&sResult);
+						goto Abort;
+					}
+					if( rcSm == PH7_EXCEPTION ){
+						sxi32 iResumePc;
+						PH7_MemObjRelease(&sResult);
+						if( VmRecordedResume(pVm,&iResumePc,sState.pEntryFrame,aInstr) ){
+							PH7_MemObjRelease(pTos);
+							pc = iResumePc;
+							break;
+						}
+						goto Exception;
+					}
+					PH7_MemObjStore(&sResult,pTos);
+					PH7_MemObjRelease(&sResult);
+					break;
+				}
+			}
 			/* Call to undefined function */
 			VmErrorFormat(&(*pVm),PH7_CTX_WARNING,"Call to undefined function '%z',NULL will be returned",&sName);
 			/* Consume this call's captured spread runs so they don't leak into a
@@ -19356,6 +19418,18 @@ PH7_PRIVATE int PH7_VmIsCallable(ph7_vm *pVm,ph7_value *pValue,int CallInvoke)
 			SyHashGet(&pVm->hHostFunction,(const void *)zName,(sxu32)nLen) != 0 ){
 				/* Function is callable */
 				res = 1;
+		}else if( nLen > 3 ){
+			/* php's "Class::method" static-callable string */
+			int i;
+			for( i = 1 ; i + 2 < nLen ; ++i ){
+				if( zName[i] == ':' && zName[i+1] == ':' ){
+					ph7_class *pClass = PH7_VmExtractClass(pVm,zName,(sxu32)i,FALSE,0);
+					if( pClass && PH7_ClassExtractMethod(pClass,&zName[i+2],(sxu32)(nLen-(i+2))) ){
+						res = 1;
+					}
+					break;
+				}
+			}
 		}
 	}
 	return res;

--- a/tests/ph7/001-smoke/static_method_string_callable.phpt
+++ b/tests/ph7/001-smoke/static_method_string_callable.phpt
@@ -1,0 +1,29 @@
+--TEST--
+"Class::method" string callables: direct call, call_user_func(_array), array_map, is_callable
+--FILE--
+<?php
+class SmcStr {
+    static function up($s) { return strtoupper($s); }
+    static function add($a, $b) { return $a + $b; }
+}
+$smcF = "SmcStr::up";
+echo $smcF("abc"), "\n";
+echo call_user_func("SmcStr::add", 2, 3), call_user_func_array("SmcStr::add", [4, 5]), "\n";
+echo implode(",", array_map("SmcStr::up", ["a", "b"])), "\n";
+echo is_callable("SmcStr::up") ? "T" : "F",
+     is_callable("SmcStr::nope") ? "T" : "F",
+     is_callable("Nope::up") ? "T" : "F", "\n";
+// inherited static through the subclass name
+class SmcSub extends SmcStr {}
+echo call_user_func("SmcSub::add", 1, 1), "\n";
+// usort comparator as string
+$smcArr = [3, 1, 2];
+usort($smcArr, "SmcStr::add" === "x" ? "strcmp" : function ($a, $b) { return $a <=> $b; });
+echo implode("", $smcArr), "\n";
+--EXPECT--
+ABC
+59
+A,B
+TFF
+2
+123


### PR DESCRIPTION
call_user_func("C::s"), $f = "C::s"; $f(), array_map("C::s", ...) and is_callable("C::s") all failed (undefined-function warning + NULL / false) while php dispatches the static method; only the ["C","s"] array form and the sort-family's internal callback path worked.

OP_CALL's undefined-function branch now detects "::" in the callee name, splits it, and routes the call through the existing array-callable machinery (a two-element [class, method] hashmap dispatched via PH7_VmCallUserFunctionWithMap, with the same ABORT/EXCEPTION routing and spread-run consumption as the array-callable branch). PH7_VmIsCallable's string branch resolves Class::method too, which also fixes the array_map/usort family's up-front callback validation rejecting the string.

Byte-verified vs php 8.5.7; cross-engine test
static_method_string_callable.phpt; test-compat green; docker ASan+UBSan clean; tiny build ok.
