### PR TITLE
Capture attributes on expressions and consts

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -2248,6 +2248,8 @@ PH7_PRIVATE sxi32 PH7_CompileAnnonFunc(ph7_gen_state *pGen,sxi32 iCompileFlag)
 							  * one thread is allowed to compile the script.
 						      */
 	SyString sName;
+	SyToken *pTokKw = pGen->pIn; /* Attribute-sidecar key: `$f = #[A] function…` trivia
+	                              * is keyed to this ['static'] 'function' token */
 	sxu32 nKwLine;
 	sxi32 iFlags = 0;
 	sxu32 nLen;
@@ -2279,6 +2281,11 @@ PH7_PRIVATE sxi32 PH7_CompileAnnonFunc(ph7_gen_state *pGen,sxi32 iCompileFlag)
 	}
 	if( pAnnonFunc ){
 		pAnnonFunc->nLine = nKwLine;
+		/* Expression-position attributes (`$f = #[A] function () {}`): the trivia
+		 * sidecar keys them to the closure's first keyword token. */
+		if( GenStateCollectParamAttrs(&(*pGen),pTokKw,&pAnnonFunc->aAttrs) == SXERR_ABORT ){
+			return SXERR_ABORT;
+		}
 	}
 	/* Every anonymous function is a Closure object in PHP, so emit OP_LOAD_CLOSURE for
 	 * both real closures (per-instantiation captured env) and plain lambdas (no captures);
@@ -2629,6 +2636,7 @@ PH7_PRIVATE sxi32 PH7_CompileArrowFunc(ph7_gen_state *pGen,sxi32 iCompileFlag)
 	char zName[512];
 	static int iCnt = 1;
 	char *zDup;
+	SyToken *pTokKw;
 	sxu32 nLen;
 	sxu32 nLine;
 	sxi32 iFlags = 0;
@@ -2638,6 +2646,8 @@ PH7_PRIVATE sxi32 PH7_CompileArrowFunc(ph7_gen_state *pGen,sxi32 iCompileFlag)
 	SXUNUSED(iCompileFlag); /* cc warning */
 
 	nLine = pGen->pIn->nLine;
+	/* Attribute-sidecar key: `#[A] [static] fn` trivia is keyed to this token */
+	pTokKw = pGen->pIn;
 	/* Optional 'static' prefix */
 	if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_KEYWORD)
 		&& SX_PTR_TO_INT(pGen->pIn->pUserData) == PH7_TKWRD_STATIC ){
@@ -2699,6 +2709,10 @@ PH7_PRIVATE sxi32 PH7_CompileArrowFunc(ph7_gen_state *pGen,sxi32 iCompileFlag)
 	PH7_VmInitFuncState(pGen->pVm,pFunc,zDup,nLen,iFlags,0);
 	/* Reflection getStartLine(): line of the ['static'] 'fn' keyword */
 	pFunc->nLine = nLine;
+	/* Expression-position attributes (`$f = #[A] fn () => …`) */
+	if( GenStateCollectParamAttrs(&(*pGen),pTokKw,&pFunc->aAttrs) == SXERR_ABORT ){
+		return SXERR_ABORT;
+	}
 	/* Collect function arguments */
 	if( pGen->pIn < pSigEnd ){
 		rc = GenStateCollectFuncArgs(pFunc,&(*pGen),pSigEnd,0,0);
@@ -3569,6 +3583,19 @@ static sxi32 PH7_CompileConstant(ph7_gen_state *pGen)
 		SyStringInitFromBuf(&sFQNStr,(const char *)SyBlobData(&sFQN),SyBlobLength(&sFQN));
 		rc = PH7_VmRegisterConstantEx(pGen->pVm,&sFQNStr,PH7_VmExpandConstantValue,pConsCode,
 			(SyString *)SySetPeek(&pGen->pVm->aFiles),nLineLocal,1);
+		if( rc == SXRET_OK && SySetUsed(&pGen->aPendingAttrs) > 0 ){
+			/* php 8.5: attributes on `const` statements — attach the pending
+			 * groups to the registered constant record for Reflection. */
+			SyHashEntry *pCEntry = SyHashGet(&pGen->pVm->hConstant,
+				SyBlobData(&sFQN),SyBlobLength(&sFQN));
+			if( pCEntry ){
+				ph7_constant *pRegCons = (ph7_constant *)pCEntry->pUserData;
+				if( GenStateConsumeAttrs(&(*pGen),&pRegCons->aAttrs) == SXERR_ABORT ){
+					SyBlobRelease(&sFQN);
+					return SXERR_ABORT;
+				}
+			}
+		}
 		SyBlobRelease(&sFQN);
 	}
 	if( rc != SXRET_OK ){
@@ -10582,6 +10609,8 @@ PH7_PRIVATE sxi32 PH7_CompileAnnonClass(ph7_gen_state *pGen,sxi32 iCompileFlag)
 	static int iCnt = 1;     /* Single-threaded compile: no locking needed */
 	SyString sName;
 	SyToken *pArgStart,*pArgEnd;
+	SyToken *pTokKw = pGen->pIn; /* Attribute-sidecar key: `new #[A] class` trivia
+	                              * is keyed to this 'class' token */
 	ph7_value *pObj;
 	sxu32 nLine = pGen->pIn->nLine;
 	sxu32 nIdx,nLen;
@@ -10600,6 +10629,14 @@ PH7_PRIVATE sxi32 PH7_CompileAnnonClass(ph7_gen_state *pGen,sxi32 iCompileFlag)
 	rc = GenStateCompileClassEx(pGen,0,&sName,&pArgStart,&pArgEnd);
 	if( rc != SXRET_OK ){
 		return rc;
+	}
+	{
+		/* Expression-position attributes (`new #[A] class {…}`) */
+		ph7_class *pAnonClass = PH7_VmExtractClass(pGen->pVm,zName,nLen,FALSE,0);
+		if( pAnonClass
+		 && GenStateCollectParamAttrs(&(*pGen),pTokKw,&pAnonClass->aAttrs) == SXERR_ABORT ){
+			return SXERR_ABORT;
+		}
 	}
 	/* Emit the instantiation. OP_NEW expects the class name on the stack top
 	 * with the constructor arguments beneath it, so push the args first. */
@@ -13436,6 +13473,36 @@ static sxi32 GenStateCompileChunk(
 		}
 		/* Bind a directly-preceding docblock to this statement */
 		GenStateSetPendingDoc(&(*pGen));
+		if( SySetUsed(&pGen->aPendingAttrs) > 0 ){
+			/* php: a statement-position attribute group must be followed by a
+			 * declaration (function/class-like/const) — `#[A] $x = 1;` is a
+			 * parse error, never a silent discard. `static`/`fn`/`function`
+			 * cover bare closure-expression statements; `readonly`/`enum` are
+			 * context-sensitive IDs handled by the modified-class/enum scans. */
+			int bAttrTarget = 0;
+			if( GenStateStartsModifiedClass(pGen->pIn,pGen->pEnd)
+			 || GenStateStartsEnumDecl(pGen->pIn,pGen->pEnd) ){
+				bAttrTarget = 1;
+			}else if( pGen->pIn->nType & PH7_TK_KEYWORD ){
+				sxu32 nKw = (sxu32)SX_PTR_TO_INT(pGen->pIn->pUserData);
+				if( nKw == PH7_TKWRD_FUNCTION || nKw == PH7_TKWRD_CLASS
+				 || nKw == PH7_TKWRD_INTERFACE || nKw == PH7_TKWRD_TRAIT
+				 || nKw == PH7_TKWRD_ABSTRACT || nKw == PH7_TKWRD_FINAL
+				 || nKw == PH7_TKWRD_CONST || nKw == PH7_TKWRD_STATIC
+				 || nKw == PH7_TKWRD_FN ){
+					bAttrTarget = 1;
+				}
+			}
+			if( !bAttrTarget ){
+				rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,
+					"syntax error, unexpected token \"%z\" after attribute group; expecting a declaration",
+					&pGen->pIn->sData);
+				if( rc == SXERR_ABORT ){
+					break;
+				}
+				SySetReset(&pGen->aPendingAttrs);
+			}
+		}
 		/* Peek to detect a top-level `declare` so the strict_types lock
 		 * below doesn't fire before the directive has a chance to run. */
 		if( pGen->pIn->nType & PH7_TK_KEYWORD ){

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -193,6 +193,8 @@ struct ph7_constant
 	sxu32 nLine;           /* Declaration line for `const`; 0 for define()/engine */
 	sxu8 bUserDefined;     /* 1 when created by user code (const / define()):
 	                        * Reflection isInternal()/getFileName() input */
+	SySet aAttrs;          /* Declared #[...] attributes (ph7_attribute records) —
+	                        * php 8.5 attributes on `const` statements */
 };
 typedef struct ph7_aux_data ph7_aux_data;
 /*

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -231,6 +231,7 @@ PH7_PRIVATE sxi32 PH7_VmRegisterConstantEx(
 		}
 		pCons->nLine = nLine;
 		pCons->bUserDefined = (sxu8)(bUser ? 1 : 0);
+		SySetReset(&pCons->aAttrs); /* redefinition drops the old attributes */
 		return SXRET_OK;
 	}
 	/* Allocate a new constant instance */
@@ -254,6 +255,7 @@ PH7_PRIVATE sxi32 PH7_VmRegisterConstantEx(
 	SyStringInitFromBuf(&pCons->sName,zDupName,pName->nByte);
 	pCons->xExpand = xExpand;
 	pCons->pUserData = pUserData;
+	SySetInit(&pCons->aAttrs,&pVm->sAllocator,sizeof(ph7_attribute));
 	rc = SyHashInsert(&pVm->hConstant,(const void *)zDupName,SyStringLength(&pCons->sName),pCons);
 	if( rc != SXRET_OK ){
 		SyMemBackendFree(&pVm->sAllocator,zDupName);
@@ -3638,6 +3640,20 @@ static void VmThrowUserDeprecatedFmt(ph7_vm *pVm,const char *zFmt,...)
  * pDeclClass names the method's declaring class (0 for plain functions).
  */
 /*
+ * Expand a global constant's value, emitting the php 8.5 #[\Deprecated]
+ * E_USER_DEPRECATED notice first when the constant carries attributes
+ * (`Constant GD is deprecated since 1.2` — every access re-warns).
+ */
+static void VmDeprecatedAttrNoticeSubject(ph7_vm *pVm,SySet *pAttrs,
+	const char *zKind,const SyString *pQual,const SyString *pName);
+static void VmExpandConstantWithNotice(ph7_vm *pVm,ph7_constant *pCons,ph7_value *pOut)
+{
+	if( SySetUsed(&pCons->aAttrs) > 0 ){
+		VmDeprecatedAttrNoticeSubject(pVm,&pCons->aAttrs,"Constant",0,&pCons->sName);
+	}
+	pCons->xExpand(pOut,pCons->pUserData);
+}
+/*
  * Scan a declared-attribute set for #[\Deprecated]; when found, evaluate its
  * message:/since: arguments (positional #0 = message, #1 = since) into the
  * caller's values and return TRUE. The base subject text ("Function f()",
@@ -3709,6 +3725,31 @@ static void VmDeprecatedEmit(ph7_vm *pVm,SyBlob *pOut,
 	}
 	VmThrowUserDeprecatedFmt(pVm,"%.*s",(int)SyBlobLength(pOut),(const char *)SyBlobData(pOut));
 }
+/*
+ * Generic #[\Deprecated] notice for a named subject:
+ * "<Kind> [Qual::]Name is deprecated[ since X][, message]".
+ */
+static void VmDeprecatedAttrNoticeSubject(ph7_vm *pVm,SySet *pAttrs,
+	const char *zKind,const SyString *pQual,const SyString *pName)
+{
+	ph7_value sMsg,sSince;
+	SyBlob sOut;
+	int bMsg,bSince;
+	PH7_MemObjInit(pVm,&sMsg);
+	PH7_MemObjInit(pVm,&sSince);
+	if( VmDeprecatedAttrExtract(pVm,pAttrs,&sMsg,&bMsg,&sSince,&bSince) ){
+		SyBlobInit(&sOut,&pVm->sAllocator);
+		if( pQual ){
+			SyBlobFormat(&sOut,"%s %z::%z is deprecated",zKind,pQual,pName);
+		}else{
+			SyBlobFormat(&sOut,"%s %z is deprecated",zKind,pName);
+		}
+		VmDeprecatedEmit(pVm,&sOut,&sMsg,bMsg,&sSince,bSince);
+		SyBlobRelease(&sOut);
+	}
+	PH7_MemObjRelease(&sMsg);
+	PH7_MemObjRelease(&sSince);
+}
 static void VmDeprecatedAttrNotice(ph7_vm *pVm,ph7_vm_func *pFunc,ph7_class *pDeclClass)
 {
 	ph7_value sMsg,sSince;
@@ -3735,21 +3776,9 @@ static void VmDeprecatedAttrNotice(ph7_vm *pVm,ph7_vm_func *pFunc,ph7_class *pDe
  */
 static void VmDeprecatedConstNotice(ph7_vm *pVm,ph7_class *pClass,ph7_class_attr *pMember)
 {
-	ph7_value sMsg,sSince;
-	SyBlob sOut;
-	int bMsg,bSince;
-	PH7_MemObjInit(pVm,&sMsg);
-	PH7_MemObjInit(pVm,&sSince);
-	if( VmDeprecatedAttrExtract(pVm,&pMember->aAttrs,&sMsg,&bMsg,&sSince,&bSince) ){
-		SyBlobInit(&sOut,&pVm->sAllocator);
-		SyBlobFormat(&sOut,"%s %z::%z is deprecated",
-			(pMember->iFlags & PH7_CLASS_ATTR_ENUMCASE) ? "Enum case" : "Constant",
-			&pClass->sName,&pMember->sName);
-		VmDeprecatedEmit(pVm,&sOut,&sMsg,bMsg,&sSince,bSince);
-		SyBlobRelease(&sOut);
-	}
-	PH7_MemObjRelease(&sMsg);
-	PH7_MemObjRelease(&sSince);
+	VmDeprecatedAttrNoticeSubject(pVm,&pMember->aAttrs,
+		(pMember->iFlags & PH7_CLASS_ATTR_ENUMCASE) ? "Enum case" : "Constant",
+		&pClass->sName,&pMember->sName);
 }
 PH7_PRIVATE sxi32 PH7_VmMakeReady(
 	ph7_vm *pVm /* Target VM */
@@ -9387,7 +9416,7 @@ case PH7_OP_LOADC: {
 						ph7_constant *pCons = (ph7_constant *)pEntry->pUserData;
 						MemObjSetType(pTos,MEMOBJ_NULL);
 						SyBlobReset(&pTos->sBlob);
-						pCons->xExpand(pTos,pCons->pUserData);
+						VmExpandConstantWithNotice(&(*pVm),pCons,pTos);
 						pTos->nIdx = SXU32_HIGH;
 						break;
 					}
@@ -9402,7 +9431,7 @@ case PH7_OP_LOADC: {
 				MemObjSetType(pTos,MEMOBJ_NULL);
 				SyBlobReset(&pTos->sBlob);
 				/* Invoke the callback and deal with the expanded value */
-				pCons->xExpand(pTos,pCons->pUserData);
+				VmExpandConstantWithNotice(&(*pVm),pCons,pTos);
 				/* Mark as constant */
 				pTos->nIdx = SXU32_HIGH;
 				break;
@@ -9430,7 +9459,7 @@ case PH7_OP_LOADC: {
 						ph7_constant *pCons = (ph7_constant *)pEntry->pUserData;
 						MemObjSetType(pTos,MEMOBJ_NULL);
 						SyBlobReset(&pTos->sBlob);
-						pCons->xExpand(pTos,pCons->pUserData);
+						VmExpandConstantWithNotice(&(*pVm),pCons,pTos);
 						pTos->nIdx = SXU32_HIGH;
 						break;
 					}
@@ -20498,6 +20527,10 @@ static int vm_builtin_constant(ph7_context *pCtx,int nArg,ph7_value **apArg)
 				if( pAttr && (pAttr->iFlags & PH7_CLASS_ATTR_CONSTANT) ){
 					ph7_value *pValue = (ph7_value *)SySetAt(&pCtx->pVm->aMemObj,pAttr->nIdx);
 					if( pValue ){
+						if( SySetUsed(&pAttr->aAttrs) > 0 ){
+							/* #[\Deprecated] warns through constant() too (php) */
+							VmDeprecatedConstNotice(pCtx->pVm,pClass,pAttr);
+						}
 						ph7_result_value(pCtx,pValue);
 						return SXRET_OK;
 					}
@@ -20517,8 +20550,9 @@ static int vm_builtin_constant(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	PH7_MemObjInit(pCtx->pVm,&sVal);
 	/* Point to the structure that describe the constant */
 	pCons = (ph7_constant *)SyHashEntryGetUserData(pEntry);
-	/* Extract constant value by calling it's associated callback */
-	pCons->xExpand(&sVal,pCons->pUserData);
+	/* Extract constant value by calling it's associated callback
+	 * (emits the #[\Deprecated] notice first when attributed, php) */
+	VmExpandConstantWithNotice(pCtx->pVm,pCons,&sVal);
 	/* Return that value */
 	ph7_result_value(pCtx,&sVal);
 	/* Cleanup */

--- a/src/ph7/vm_builtin_reflection.c
+++ b/src/ph7/vm_builtin_reflection.c
@@ -1588,6 +1588,7 @@ static int vm_builtin_reflect_const_info(ph7_context *pCtx, int nArg, ph7_value 
 		ReflectMapAddBool(pCtx, pInfo, "file", 0);
 	}
 	ReflectMapAddInt(pCtx, pInfo, "line", (sxi64)pCons->nLine);
+	ReflectMapAddAttrs(pCtx, pInfo, &pCons->aAttrs);
 	ph7_result_value(pCtx, pInfo);
 	return PH7_OK;
 }
@@ -1657,6 +1658,14 @@ static int vm_builtin_reflect_attr_args(ph7_context *pCtx, int nArg, ph7_value *
 		ph7_vm_func_arg *pParam = pFunc
 			? (ph7_vm_func_arg *)SySetAt(&pFunc->aArgs, (sxu32)ph7_value_to_int(apArg[3])) : 0;
 		if( pParam ){ pAttrs = &pParam->aAttrs; }
+	}else if( nKind == 5 && SyMemcmp(zKind, "const", 5) == 0 ){
+		/* Global constant (php 8.5 attributes on `const` statements) */
+		const char *zCName;
+		int nCName;
+		SyHashEntry *pCEntry;
+		zCName = ph7_value_to_string(apArg[1], &nCName);
+		pCEntry = nCName > 0 ? SyHashGet(&pVm->hConstant, (const void *)zCName, (sxu32)nCName) : 0;
+		if( pCEntry ){ pAttrs = &((ph7_constant *)pCEntry->pUserData)->aAttrs; }
 	}
 	if( pAttrs == 0 || (pAttrRec = (ph7_attribute *)SySetAt(pAttrs, nAttrIdx)) == 0
 	 || (pOut = ph7_context_new_array(pCtx)) == 0 ){
@@ -2834,7 +2843,11 @@ static const char zReflectLib6[] =
 "  $i = __reflect_const_info($this->name);"
 "  return $i['internal'] ? 'Core' : false;"
 " }"
-" public function getAttributes($name = null, $flags = 0){ return array(); }"
+" public function getAttributes($name = null, $flags = 0){"
+"  $i = __reflect_const_info($this->name);"
+"  if($i === null){ return array(); }"
+"  return __reflect_build_attrs($i['attrs'], array('const', $this->name, null, 0), 64, $name, $flags);"
+" }"
 " public function __toString(){"
 "  return 'Constant [ '.$this->name.' ]'.\"\\n\";"
 " }"

--- a/tests/ph7/001-smoke/attribute_expression_and_const_capture.phpt
+++ b/tests/ph7/001-smoke/attribute_expression_and_const_capture.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Attribute capture on closures/arrow-fns/anonymous classes in expressions and on const statements
+--FILE--
+<?php
+set_error_handler(function ($no, $msg) { echo "[", $no, "] ", $msg, "\n"; return true; });
+#[Attribute] class AecMark { function __construct(public string $v = "d", public int $n = 0) {} }
+// closure expression
+$aecC1 = #[AecMark("x", 5)] function () { return 1; };
+$aecAt = (new ReflectionFunction($aecC1))->getAttributes();
+echo count($aecAt), $aecAt[0]->getName(), $aecAt[0]->newInstance()->v, $aecAt[0]->newInstance()->n, "\n";
+// arrow-fn expression
+$aecC2 = #[AecMark] fn() => 2;
+echo count((new ReflectionFunction($aecC2))->getAttributes()), "\n";
+// anonymous-class expression
+$aecO = new #[AecMark("k")] class { public $z = 3; };
+$aecCat = (new ReflectionClass($aecO))->getAttributes();
+echo count($aecCat), $aecCat[0]->newInstance()->v, "\n";
+// attributes on a global const statement (php 8.5) + ReflectionConstant
+#[AecMark("c")] const AEC_C = 41;
+$aecR = new ReflectionConstant("AEC_C");
+$aecGat = $aecR->getAttributes();
+echo count($aecGat), $aecGat[0]->getName(), $aecGat[0]->newInstance()->v, AEC_C, "\n";
+// #[\Deprecated] on a global const warns on access and through constant()
+#[\Deprecated(since: "1.2")] const AEC_D = 42;
+echo AEC_D, "\n";
+echo constant("AEC_D"), "\n";
+// ... and a deprecated class constant through constant()
+class AecK { #[\Deprecated] const KK = 43; }
+echo constant("AecK::KK"), "\n";
+restore_error_handler();
+--EXPECT--
+1AecMarkx5
+1
+1k
+1AecMarkc41
+[16384] Constant AEC_D is deprecated since 1.2
+42
+[16384] Constant AEC_D is deprecated since 1.2
+42
+[16384] Constant AecK::KK is deprecated
+43


### PR DESCRIPTION
Attributes on closures ($f = #[A] function () {}), arrow fns, and anonymous-class expressions (new #[A] class {}) were silently dropped: the statement-boundary pending list never sees mid-expression groups. The trivia sidecar already keys every #[...] group to the token it precedes, so the three expression compilers now collect their entry keyword token's groups via GenStateCollectParamAttrs (the parameter mechanism), giving full getAttributes()/newInstance() round-trips.

const statements (php 8.5) store attributes on the new ph7_constant.aAttrs: PH7_CompileConstant consumes the pending groups into the registered record, __reflect_const_info exports them, a new 'const' kind in __reflect_attr_args evaluates arguments lazily, and ReflectionConstant::getAttributes() replaces its stub. #[\Deprecated] on a global const now warns on every access (VmExpandConstantWithNotice wraps the three OP_LOADC expansion sites and constant()'s global arm), and constant('C::K') emits the class-constant notice too. The generic notice builder was refactored out (VmDeprecatedAttrNoticeSubject).

A statement-position attribute group followed by a non-declaration (#[A] $x = 1;) is now a compile error like php's parse error instead of a silent discard.

Byte-verified vs php 8.5.7; cross-engine test
attribute_expression_and_const_capture.phpt; test-compat green; docker ASan+UBSan clean; tiny build ok.
