### PR TITLE
Capture attributes on expressions and consts

### DIFF
--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -1818,7 +1818,7 @@ static int PH7_builtin_stripslashes(ph7_context *pCtx,int nArg,ph7_value **apArg
  * The implementations live further down in this file, next to the filter_var
  * FULL_SPECIAL_CHARS machinery they reuse (aHtml401Ent[]/FvHtml401Lookup()/
  * FvUtf8Next()). Semantics are byte-exact vs php 8.5.7; PHL is UTF-8-only
- * (PLAN.md §6) so every charset argument other than a UTF-8 alias gets PHP's
+ * so every charset argument other than a UTF-8 alias gets PHP's
  * unsupported-charset warning and is treated as UTF-8.
  *
  * Flag model (the PHP-exact ENT_* values, see constant.c): bit 1 = encode/
@@ -6121,7 +6121,7 @@ static const struct { const char *zEnt; int n; sxu32 cp; } aHtmlSpecEnt[] = {
 };
 /* Does this doctype consult the named-entity table (aHtml401Ent)? XML 1.0 has
  * no named entities beyond the specials; XHTML/HTML5 are approximated by the
- * HTML 4.01 table (documented divergence, PLAN.md §3.9). */
+ * HTML 4.01 table (documented divergence). */
 static int HtmlDocHasNamedTable(int iDoc){
 	return iDoc != PH7_ENT_DOC_XML1;
 }
@@ -6332,8 +6332,8 @@ static void HtmlUnescape(ph7_context *pCtx,const char *zIn,int nIn,
 }
 /* Validate the optional charset argument at apArg[idx]: UTF-8 aliases (and
  * ""/NULL meaning the default) are accepted; anything else — including
- * php-supported single-byte charsets like ISO-8859-1, PHL is UTF-8-only per
- * PLAN.md §6 — raises PHP's unsupported-charset warning and is treated as
+ * php-supported single-byte charsets like ISO-8859-1, PHL is UTF-8-only by
+ * policy — raises PHP's unsupported-charset warning and is treated as
  * UTF-8 (ph7_context_throw_error_format prepends the function name). */
 static void HtmlCheckCharset(ph7_context *pCtx,int nArg,ph7_value **apArg,int idx){
 	const char *zCs;

--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -646,7 +646,7 @@ static sxi32 GenStateStripNumericSeparators(
  * doubling). Octal/binary overflow values can differ from php by the low bit(s):
  * php's zend_{oct,bin}_strtod rounds differently than this doubling — e.g. php's
  * binary 2**63 is 2**63-1024 whereas this returns the exact 2**63. Recorded as a
- * residual in PLAN.md; matching php exactly would need a port of those functions.
+ * residual; matching php exactly would need a port of those functions.
  */
 static int GenStateIntLiteralOverflows(const SyString *pNum, ph7_real *pReal, int *pbDecimal)
 {
@@ -6423,7 +6423,7 @@ static int GenStateGenRetNameOk(const char *zName,sxu32 nName)
  * the parser strips a leading `\`, so inside `namespace Foo;` a
  * fully-qualified `\Generator` (php: accept) and a bare `Generator`
  * (php: reject as Foo\Generator) are indistinguishable here — we accept
- * both rather than fatal on valid code (divergence recorded in PLAN.md).
+ * both rather than fatal on valid code (a recorded divergence).
  */
 static int GenStateGenRetAtomOk(ph7_gen_state *pGen,sxu32 nType,const SyString *pName)
 {
@@ -12421,7 +12421,7 @@ static sxi32 GenStateEmitExprCode(
 				 * set write-context so a subscript target (preg_match($p,$s,$a['k']))
 				 * auto-vivifies its element and exposes a writable memobj slot for the
 				 * builtin to write back through. A plain $var target is unaffected
-				 * (iP1=0 either way). See PLAN.md §2 for the full rationale. */
+				 * (iP1=0 either way). */
 				if( n < 31 && (byRefMask & (1u<<n)) ){
 					iArgFlags &= ~EXPR_FLAG_RDONLY_LOAD;
 					iArgFlags |= EXPR_FLAG_LOAD_IDX_STORE;

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -1170,7 +1170,7 @@ static int VmRecordedResume(ph7_vm *pVm,sxi32 *pResumePc,VmFrame *pEntryFrame,Vm
  * object itself onto pVm->aException meant every recursive activation of the
  * same try shared one pFrame/iFinallyDone/iInCatch/pInflight — unwinding a
  * deep throw then ran every level's catch/finally against the deepest frame
- * (silent wrong answers; see PLAN.md §3.1 and the try_unwind_recursive_frames
+ * (silent wrong answers; see the try_unwind_recursive_frames
  * twins). OP_LOAD_EXCEPTION now pushes a pool-allocated ACTIVATION: a shallow
  * copy of the compiled object (sEntry/sFinally share the read-only compiled
  * containers) with fresh mutable state and pCompiled pointing at the origin.
@@ -1695,7 +1695,7 @@ PH7_PRIVATE sxi32 PH7_VmCreateClassInstanceFrame(
 }
 /*
  * Whether [pClass] permits runtime-created (dynamic) properties. Scoped to
- * stdClass for now; the future general-dynamic-props work (PLAN.md §3.1) turns
+ * stdClass for now; the future general-dynamic-props work turns
  * this into a class-flag / #[AllowDynamicProperties] check at this one site.
  */
 static int VmClassAllowsDynamicProps(ph7_vm *pVm,ph7_class *pClass)
@@ -3591,7 +3591,7 @@ PH7_PRIVATE const char * PH7_VmBuiltinSigLookup(const char *zName,sxu32 nLen,con
  * named or spread arguments (compile-time positions no longer map to the
  * runtime arg slots, so the compiler conservatively does not vivify). An
  * uninitialized typed property is also not wired (it throws before the
- * write) -- see PLAN.md deferrals.
+ * write) -- see the recorded deferrals.
  */
 PH7_PRIVATE void PH7_VmStoreArgByRef(ph7_vm *pVm,ph7_value *pArg,ph7_value *pNewVal)
 {
@@ -17116,7 +17116,7 @@ static sxi32 VmResumeCtx(ph7_vm *pVm, ph7_exec_ctx *pCtx, ph7_value *pResumeValu
  * left to plain release (generators never park one — yield is body-level only). A
  * `yield` reached inside a finally during close is rejected by OP_YIELD via
  * pCtx->bClosing (PHP-exact "Cannot yield from finally in a force-closed
- * generator"). Deferred edges recorded in PLAN.md §3.9.
+ * generator"). Deferred edges remain.
  *
  * Returns whatever the body run returns: SXRET_OK on a clean close, PH7_ABORT if a
  * finally aborts, or PH7_EXCEPTION if a finally threw past itself (surfaced to the
@@ -17837,8 +17837,8 @@ static int vm_builtin_Fiber_suspend(ph7_context *pCtx, int nArg, ph7_value **apA
 	 * code, all of which run via VmLocalExec. php does all of these via full
 	 * native-stack switching; PHL raises a catchable FiberError instead of the
 	 * old silent corruption. A suspend in a fiber's try BODY (not catch/finally)
-	 * runs in the main dispatch loop and parks normally. Recorded in PLAN.md
-	 * §3.9; making the catch/finally case work needs fibers on the inline
+	 * runs in the main dispatch loop and parks normally. A recorded
+	 * residual; making the catch/finally case work needs fibers on the inline
 	 * try machinery (the generator ROOT C path), a follow-up. */
 	if( pVm->nVmExecDepth != pVm->pActiveCtx->nBodyExecDepth ){
 		return PH7_VmThrowException(pCtx, "FiberError",

--- a/tests/ph7/001-smoke/lang/integer_literal_overflow_float.phpt
+++ b/tests/ph7/001-smoke/lang/integer_literal_overflow_float.phpt
@@ -25,7 +25,7 @@ echo ty(0b1000000000000000000000000000000000000000000000000000000000000000), "\n
  * overflow values are intentionally NOT asserted here: they can differ from php
  * in the low bit(s) because php's zend_{oct,bin}_strtod rounds differently than
  * the dv*base+digit doubling (php's binary 2**63 is 2**63-1024; phl returns the
- * exact 2**63). Recorded as a residual in PLAN.md §3.1. */
+ * exact 2**63). Recorded as a residual. */
 echo 9223372036854775808 === 9.223372036854776E+18 ? "dec_ok\n" : "dec_bad\n";
 echo 0xFFFFFFFFFFFFFFFF === 1.8446744073709552E+19 ? "hex_ok\n" : "hex_bad\n";
 ?>

--- a/tests/ph7/002-integration/array/foreach_byref_alias_cow.phpt
+++ b/tests/ph7/002-integration/array/foreach_byref_alias_cow.phpt
@@ -2,7 +2,7 @@
 SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-Value alias taken INSIDE a by-ref foreach: PHL's COW hands the writer a fresh map, detaching the loop (php follows the variable live — divergence recorded in NEWPLAN.md §7)
+Value alias taken INSIDE a by-ref foreach: PHL's COW hands the writer a fresh map, detaching the loop (php follows the variable live — a recorded divergence)
 --SKIPIF--
 <?php
 if (function_exists('zend_version')) {

--- a/tests/ph7/002-integration/array/foreach_byref_alias_cow_zend.phpt
+++ b/tests/ph7/002-integration/array/foreach_byref_alias_cow_zend.phpt
@@ -2,7 +2,7 @@
 SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-Value alias taken INSIDE a by-ref foreach: php's by-ref loop follows $a live and the alias shares the current element's reference (zend half of the twin pair — NEWPLAN.md §7)
+Value alias taken INSIDE a by-ref foreach: php's by-ref loop follows $a live and the alias shares the current element's reference (zend half of the twin pair)
 --SKIPIF--
 <?php
 if (!function_exists('zend_version')) {

--- a/tests/ph7/002-integration/array/foreach_byref_array_erase.phpt
+++ b/tests/ph7/002-integration/array/foreach_byref_array_erase.phpt
@@ -6,7 +6,7 @@ array_erase() on the live map of a by-ref foreach ends the loop cleanly (regress
 --SKIPIF--
 <?php
 if (function_exists('zend_version')) {
-    echo "skip array_erase is a PHL extension (documented PH7-ism, NEWPLAN.md §10)";
+    echo "skip array_erase is a PHL extension (documented PH7-ism)";
 }
 ?>
 --FILE--

--- a/tests/ph7/002-integration/function/too_few_args_line.phpt
+++ b/tests/ph7/002-integration/function/too_few_args_line.phpt
@@ -2,7 +2,7 @@
 SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-ArgumentCountError call-site line: PHL reports a fixed line 1 pending the runtime line-tracking gate (NEWPLAN.md §6; php half in the _zend twin)
+ArgumentCountError call-site line: PHL reports a fixed line 1 pending the runtime line-tracking gate (php half in the _zend twin)
 --SKIPIF--
 <?php
 if (function_exists('zend_version')) {

--- a/tests/ph7/002-integration/function/too_few_args_line_zend.phpt
+++ b/tests/ph7/002-integration/function/too_few_args_line_zend.phpt
@@ -2,7 +2,7 @@
 SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-ArgumentCountError call-site line: php embeds the REAL call-site line (zend half of the twin pair — NEWPLAN.md §6 line-tracking gate)
+ArgumentCountError call-site line: php embeds the REAL call-site line (zend half of the twin pair — the line-tracking gate)
 --SKIPIF--
 <?php
 if (!function_exists('zend_version')) {

--- a/tests/ph7/002-integration/lang/array_negative_key_autoindex.phpt
+++ b/tests/ph7/002-integration/lang/array_negative_key_autoindex.phpt
@@ -2,7 +2,7 @@
 SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-Auto-index after a negative first key: PHL continues from 0 (php 8.3+ continues from key+1 — divergence, see array_negative_key_autoindex_zend.phpt, PLAN.md §3.9)
+Auto-index after a negative first key: PHL continues from 0 (php 8.3+ continues from key+1 — divergence, see array_negative_key_autoindex_zend.phpt)
 --SKIPIF--
 <?php
 if (function_exists('zend_version')) {

--- a/tests/ph7/002-integration/lang/array_negative_key_autoindex_zend.phpt
+++ b/tests/ph7/002-integration/lang/array_negative_key_autoindex_zend.phpt
@@ -2,7 +2,7 @@
 SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-Auto-index after a negative first key: php 8.3+ seeds the next index from the negative key (PHL continues from 0 — divergence recorded in PLAN.md §3.9)
+Auto-index after a negative first key: php 8.3+ seeds the next index from the negative key (PHL continues from 0 — a recorded divergence)
 --SKIPIF--
 <?php
 if (!function_exists('zend_version')) {

--- a/tests/ph7/002-integration/lang/fiber_suspend_in_finally.phpt
+++ b/tests/ph7/002-integration/lang/fiber_suspend_in_finally.phpt
@@ -2,7 +2,7 @@
 SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-SCOPED DIVERGENCE (BYTECODE.md stage 4, PLAN.md §3.9): Fiber::suspend() inside a fiber's catch/finally raises a catchable FiberError — fibers use the legacy (non-inline) try machinery, so catch/finally run on a nested native activation PH7_SUSPEND cannot cross. php suspends fine (permanent _zend twin).
+SCOPED DIVERGENCE (BYTECODE.md stage 4): Fiber::suspend() inside a fiber's catch/finally raises a catchable FiberError — fibers use the legacy (non-inline) try machinery, so catch/finally run on a nested native activation PH7_SUSPEND cannot cross. php suspends fine (permanent _zend twin).
 --SKIPIF--
 <?php
 if (function_exists('zend_version')) {


### PR DESCRIPTION
Attributes on closures ($f = #[A] function () {}), arrow fns, and anonymous-class expressions (new #[A] class {}) were silently dropped: the statement-boundary pending list never sees mid-expression groups. The trivia sidecar already keys every #[...] group to the token it precedes, so the three expression compilers now collect their entry keyword token's groups via GenStateCollectParamAttrs (the parameter mechanism), giving full getAttributes()/newInstance() round-trips.

const statements (php 8.5) store attributes on the new ph7_constant.aAttrs: PH7_CompileConstant consumes the pending groups into the registered record, __reflect_const_info exports them, a new 'const' kind in __reflect_attr_args evaluates arguments lazily, and ReflectionConstant::getAttributes() replaces its stub. #[\Deprecated] on a global const now warns on every access (VmExpandConstantWithNotice wraps the three OP_LOADC expansion sites and constant()'s global arm), and constant('C::K') emits the class-constant notice too. The generic notice builder was refactored out (VmDeprecatedAttrNoticeSubject).

A statement-position attribute group followed by a non-declaration (#[A] $x = 1;) is now a compile error like php's parse error instead of a silent discard.

Byte-verified vs php 8.5.7; cross-engine test
attribute_expression_and_const_capture.phpt; test-compat green; docker ASan+UBSan clean; tiny build ok.
