### PR TITLE
Implement PHP 8.4 asymmetric property visibility

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -2217,6 +2217,8 @@ PH7_PRIVATE sxi32 PH7_CompileShortList(ph7_gen_state *pGen,sxi32 iCompileFlag)
 static sxi32 GenStateCompileFunc(ph7_gen_state *pGen,SyString *pName,sxi32 iFlags,int bHandleClosure,ph7_vm_func **ppFunc);
 static int GenStateIsReservedConstant(SyString *pName);
 static int GenStateIsReadonly(SyToken *pTok);
+static sxi32 GenStatePeekSetVisibility(SyToken *pTok,SyToken *pEnd,int *pnTok);
+static sxi32 GenStateSetVisFlag(sxi32 nKw);
 static sxi32 GenStateValidateMemberType(ph7_gen_state *pGen,ph7_class *pClass,const SyString *pMemberName,
 	sxu32 nType,const SyString *pTypeClass,const SyString *pTypeText,SySet *pUnionAlts,const char *zErrFmt,sxu32 nLine);
 static void GenStateBuildFQN(ph7_gen_state *pGen,const SyString *pName,SyBlob *pOut);
@@ -6143,11 +6145,24 @@ static sxi32 GenStateCollectFuncArgs(ph7_vm_func *pFunc,ph7_gen_state *pGen,SyTo
 		{
 			int bReadonly = 0, bVisSeen = 0;
 			sxi32 iVis = PH7_CLASS_PROT_PUBLIC;
+			sxi32 iSetVisFlag = 0;
+			int nSetTok;
+			sxi32 nSetVis;
 			if( pIn < pEnd && GenStateIsReadonly(pIn) ){
 				bReadonly = 1;
 				pIn++;
 			}
-			if( pIn < pEnd && (pIn->nType & PH7_TK_KEYWORD) ){
+			nSetVis = GenStatePeekSetVisibility(pIn,pEnd,&nSetTok);
+			if( nSetVis ){
+				/* Leading `private(set)` etc: promoted with a public read side */
+				iSetVisFlag = GenStateSetVisFlag(nSetVis);
+				bVisSeen = 1;
+				pIn += nSetTok;
+				if( pIn < pEnd && GenStateIsReadonly(pIn) ){
+					bReadonly = 1;
+					pIn++;
+				}
+			}else if( pIn < pEnd && (pIn->nType & PH7_TK_KEYWORD) ){
 				sxu32 nKw = (sxu32)SX_PTR_TO_INT(pIn->pUserData);
 				if( nKw == PH7_TKWRD_PUBLIC || nKw == PH7_TKWRD_PROTECTED || nKw == PH7_TKWRD_PRIVATE ){
 					bVisSeen = 1;
@@ -6155,11 +6170,22 @@ static sxi32 GenStateCollectFuncArgs(ph7_vm_func *pFunc,ph7_gen_state *pGen,SyTo
 						: (nKw == PH7_TKWRD_PROTECTED) ? PH7_CLASS_PROT_PROTECTED
 						: PH7_CLASS_PROT_PUBLIC;
 					pIn++;
+					nSetVis = GenStatePeekSetVisibility(pIn,pEnd,&nSetTok);
+					if( nSetVis ){
+						/* `public private(set) T $x` promoted form */
+						iSetVisFlag = GenStateSetVisFlag(nSetVis);
+						pIn += nSetTok;
+					}
 					if( pIn < pEnd && GenStateIsReadonly(pIn) ){
 						bReadonly = 1;
 						pIn++;
 					}
 				}
+			}
+			if( iSetVisFlag == PH7_CLASS_ATTR_PRIVATE_SET ){
+				sArg.iFlags |= VM_FUNC_ARG_PRIV_SET;
+			}else if( iSetVisFlag == PH7_CLASS_ATTR_PROTECTED_SET ){
+				sArg.iFlags |= VM_FUNC_ARG_PROT_SET;
 			}
 			if( bVisSeen || bReadonly ){
 				if( !bCtorCtx ){
@@ -8335,6 +8361,41 @@ static int GenStateIsReadonly(SyToken *pTok)
 		&& pTok->sData.nByte == sizeof("readonly")-1
 		&& SyStrnicmp(pTok->sData.zString,"readonly",sizeof("readonly")-1) == 0;
 }
+/*
+ * Detect an asymmetric set-visibility modifier `public(set)` / `protected(set)`
+ * / `private(set)` (PHP 8.4) starting at pTok. Returns the visibility keyword id
+ * (PH7_TKWRD_*) and sets *pnTok to the 4 tokens consumed, or 0 when not present
+ * (a bare visibility keyword is NOT a set-modifier; the '(' 'set' ')' run is).
+ */
+static sxi32 GenStatePeekSetVisibility(SyToken *pTok,SyToken *pEnd,int *pnTok)
+{
+	*pnTok = 0;
+	if( &pTok[3] < pEnd
+	 && (pTok->nType & PH7_TK_KEYWORD)
+	 && (pTok[1].nType & PH7_TK_LPAREN)
+	 && (pTok[2].nType & (PH7_TK_ID|PH7_TK_KEYWORD))
+	 && pTok[2].sData.nByte == sizeof("set")-1
+	 && SyStrnicmp(pTok[2].sData.zString,"set",sizeof("set")-1) == 0
+	 && (pTok[3].nType & PH7_TK_RPAREN) ){
+		sxi32 nKw = SX_PTR_TO_INT(pTok->pUserData);
+		if( nKw == PH7_TKWRD_PUBLIC || nKw == PH7_TKWRD_PRIVATE || nKw == PH7_TKWRD_PROTECTED ){
+			*pnTok = 4;
+			return nKw;
+		}
+	}
+	return 0;
+}
+/* Map a set-visibility keyword to its PH7_CLASS_ATTR_* flag. */
+static sxi32 GenStateSetVisFlag(sxi32 nKw)
+{
+	if( nKw == PH7_TKWRD_PRIVATE ){
+		return PH7_CLASS_ATTR_PRIVATE_SET;
+	}
+	if( nKw == PH7_TKWRD_PROTECTED ){
+		return PH7_CLASS_ATTR_PROTECTED_SET;
+	}
+	return PH7_CLASS_ATTR_PUBLIC_SET;
+}
 static sxi32 GenStateCompileClassAttr(ph7_gen_state *pGen,sxi32 iProtection,sxi32 iFlags,ph7_class *pClass)
 {
 	sxu32 nLine = pGen->pIn->nLine;
@@ -8405,6 +8466,26 @@ loop:
 			return SXERR_ABORT;
 		}
 		goto Synchronize;
+	}
+	/* Asymmetric-visibility rules (PHP 8.4): the property must be typed, and
+	 * the read visibility must not be narrower than the set visibility. */
+	if( iFlags & (PH7_CLASS_ATTR_PRIVATE_SET|PH7_CLASS_ATTR_PROTECTED_SET|PH7_CLASS_ATTR_PUBLIC_SET) ){
+		const char *zAvErr = 0;
+		sxi32 iSetLevel = (iFlags & PH7_CLASS_ATTR_PRIVATE_SET) ? PH7_CLASS_PROT_PRIVATE
+			: (iFlags & PH7_CLASS_ATTR_PROTECTED_SET) ? PH7_CLASS_PROT_PROTECTED
+			: PH7_CLASS_PROT_PUBLIC;
+		if( (iTypeFlags & PH7_CLASS_ATTR_TYPED) == 0 ){
+			zAvErr = "Property with asymmetric visibility %z::$%z must have type";
+		}else if( iProtection > iSetLevel ){
+			zAvErr = "Visibility of property %z::$%z must not be weaker than set visibility";
+		}
+		if( zAvErr ){
+			rc = PH7_GenCompileError(pGen,E_ERROR,nLine,zAvErr,&pClass->sName,pName);
+			if( rc == SXERR_ABORT ){
+				return SXERR_ABORT;
+			}
+			goto Synchronize;
+		}
 	}
 	/* readonly property rules (PHP 8.1): cannot be static, must be typed, and
 	 * cannot carry a default value. PHP-exact diagnostics. */
@@ -8735,6 +8816,20 @@ static sxi32 GenStateCompileClassMethod(
 					goto Synchronize;
 				}
 				iAttrFlags |= PH7_CLASS_ATTR_READONLY;
+			}
+			if( pArg->iFlags & (VM_FUNC_ARG_PRIV_SET|VM_FUNC_ARG_PROT_SET) ){
+				/* Asymmetric set-visibility on a promoted property (PHP 8.4) */
+				if( (iAttrFlags & PH7_CLASS_ATTR_TYPED) == 0 ){
+					rc = PH7_GenCompileError(pGen,E_ERROR,nLine,
+						"Property with asymmetric visibility %z::$%z must have type",
+						&pClass->sName,&pArg->sName);
+					if( rc == SXERR_ABORT ){
+						return SXERR_ABORT;
+					}
+					goto Synchronize;
+				}
+				iAttrFlags |= (pArg->iFlags & VM_FUNC_ARG_PRIV_SET)
+					? PH7_CLASS_ATTR_PRIVATE_SET : PH7_CLASS_ATTR_PROTECTED_SET;
 			}
 			pAttr = PH7_NewClassAttr(pGen->pVm,&pArg->sName,nLine,pArg->iPromoteVis,iAttrFlags);
 			if( pAttr == 0 ){
@@ -10046,9 +10141,26 @@ static sxi32 GenStateCompileClassEx(ph7_gen_state *pGen,sxi32 iFlags,
 				continue;
 			}
 			if( nKwrd == PH7_TKWRD_PUBLIC || nKwrd == PH7_TKWRD_PRIVATE || nKwrd == PH7_TKWRD_PROTECTED ){
-				iProtection = nKwrd;
-				pGen->pIn++; /* Jump the visibility token */
-				/* Optional `readonly` after the visibility: `public readonly int $x`. */
+				int nSetTok;
+				sxi32 nSetVis = GenStatePeekSetVisibility(pGen->pIn,pGen->pEnd,&nSetTok);
+				if( nSetVis ){
+					/* Leading `private(set)`/`protected(set)` with no read
+					 * visibility: the read side defaults to public (php 8.4). */
+					iAttrflags |= GenStateSetVisFlag(nSetVis);
+					pGen->pIn += nSetTok;
+				}else{
+					iProtection = nKwrd;
+					pGen->pIn++; /* Jump the visibility token */
+					/* Optional asymmetric set-visibility after the read
+					 * visibility: `public private(set) int $x`. */
+					nSetVis = GenStatePeekSetVisibility(pGen->pIn,pGen->pEnd,&nSetTok);
+					if( nSetVis ){
+						iAttrflags |= GenStateSetVisFlag(nSetVis);
+						pGen->pIn += nSetTok;
+					}
+				}
+				/* Optional `readonly` after the visibility: `public readonly int $x`,
+				 * `public private(set) readonly int $x`. */
 				if( pGen->pIn < pGen->pEnd && GenStateIsReadonly(pGen->pIn) ){
 					iAttrflags |= PH7_CLASS_ATTR_READONLY;
 					pGen->pIn++; /* Jump the 'readonly' modifier */
@@ -10104,11 +10216,24 @@ static sxi32 GenStateCompileClassEx(ph7_gen_state *pGen,sxi32 iFlags,
 					iAttrflags |= PH7_CLASS_ATTR_STATIC;
 					pGen->pIn++; /* Jump the static keyword */
 					if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_KEYWORD) ){
-						/* Extract the keyword */
-						nKwrd = SX_PTR_TO_INT(pGen->pIn->pUserData);
-						if( nKwrd == PH7_TKWRD_PUBLIC || nKwrd == PH7_TKWRD_PRIVATE || nKwrd == PH7_TKWRD_PROTECTED ){
-							iProtection = nKwrd;
-							pGen->pIn++; /* Jump the visibility token */
+						int nSetTok;
+						sxi32 nSetVis = GenStatePeekSetVisibility(pGen->pIn,pGen->pEnd,&nSetTok);
+						if( nSetVis ){
+							/* `static private(set) int $x` — read side stays public */
+							iAttrflags |= GenStateSetVisFlag(nSetVis);
+							pGen->pIn += nSetTok;
+						}else{
+							/* Extract the keyword */
+							nKwrd = SX_PTR_TO_INT(pGen->pIn->pUserData);
+							if( nKwrd == PH7_TKWRD_PUBLIC || nKwrd == PH7_TKWRD_PRIVATE || nKwrd == PH7_TKWRD_PROTECTED ){
+								iProtection = nKwrd;
+								pGen->pIn++; /* Jump the visibility token */
+								nSetVis = GenStatePeekSetVisibility(pGen->pIn,pGen->pEnd,&nSetTok);
+								if( nSetVis ){
+									iAttrflags |= GenStateSetVisFlag(nSetVis);
+									pGen->pIn += nSetTok;
+								}
+							}
 						}
 					}
 					/* `readonly` after `static` (an invalid combination): detect it so the

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -768,7 +768,9 @@ struct ph7_vm_func_closure_env
                                      * isInternal() true, getFileName() false. */
 #define VM_FUNC_STATIC_CL    0x4000 /* Static closure/arrow fn (`static function () {}` /
                                      * `static fn () =>`): no $this auto-capture, bind refused. */
-/* next free bit: 0x8000 */
+#define VM_FUNC_ARG_PRIV_SET 0x8000  /* Promoted property is private(set) (PHP 8.4) */
+#define VM_FUNC_ARG_PROT_SET 0x10000 /* Promoted property is protected(set) (PHP 8.4) */
+/* next free bit: 0x20000 */
 /*
  * Each user defined function is parsed out and stored in an instance
  * of the following structure.
@@ -920,7 +922,13 @@ struct ph7_class_attr
 #define PH7_CLASS_ATTR_EVALING      0x400  /* Transient: this constant's initializer is being evaluated
                                             * (on-demand, VmClassConstEvalOnDemand). Re-entry means a
                                             * self-referencing constant — php's catchable Error. */
-/* next free bit: 0x800 */
+#define PH7_CLASS_ATTR_PRIVATE_SET  0x800  /* private(set) asymmetric visibility (PHP 8.4): writes
+                                            * only from the DECLARING class scope (subclasses excluded) */
+#define PH7_CLASS_ATTR_PROTECTED_SET 0x1000 /* protected(set) asymmetric visibility (PHP 8.4): writes
+                                            * from the declaring class or a subclass scope */
+#define PH7_CLASS_ATTR_PUBLIC_SET   0x2000 /* explicit public(set): behaviorally the default, kept
+                                            * for the weaker-than-set check and reflection output */
+/* next free bit: 0x4000 */
 /*
  * Each class method is parsed out and stored in an instance of the following
  * structure.

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -5808,6 +5808,48 @@ static sxi32 VmThrowUninitializedPropertyError(ph7_vm *pVm,ph7_class *pClass,ph7
  * a scope that cannot satisfy the readonly set-scope ("Cannot modify
  * protected(set) readonly property C::$x from {global scope|scope X}").
  */
+/*
+ * Throw the PHP 8.4 Error raised on a write to an asymmetric-visibility
+ * property from a scope its set-visibility excludes:
+ * "Cannot modify private(set) property C::$x from {global scope|scope X}".
+ */
+static sxi32 VmThrowSetVisibilityError(ph7_vm *pVm,ph7_class *pClass,ph7_class_attr *pAttr)
+{
+	ph7_class *pOwner = pAttr->pDeclClass ? pAttr->pDeclClass : pClass;
+	ph7_class *pActive = VmCurrentSelf(pVm);
+	const char *zVis = (pAttr->iFlags & PH7_CLASS_ATTR_PRIVATE_SET) ? "private(set)" : "protected(set)";
+	SyBlob sMsg;
+	SyBlobInit(&sMsg,&pVm->sAllocator);
+	if( pActive ){
+		SyBlobFormat(&sMsg,"Cannot modify %s property %z::$%z from scope %z",
+			zVis,&pOwner->sName,&pAttr->sName,&pActive->sName);
+	}else{
+		SyBlobFormat(&sMsg,"Cannot modify %s property %z::$%z from global scope",
+			zVis,&pOwner->sName,&pAttr->sName);
+	}
+	return VmThrowBuiltinError(pVm,"Error",sizeof("Error")-1,&sMsg);
+}
+/*
+ * Check the PHP 8.4 asymmetric set-visibility of a property write against the
+ * active class scope. private(set): only the DECLARING class scope may write
+ * (subclasses excluded); protected(set): the declaring class or a subclass.
+ * Returns SXRET_OK when allowed, else the throw status.
+ */
+static sxi32 VmCheckSetVisibility(ph7_vm *pVm,ph7_class *pOwner,ph7_class_attr *pAttr)
+{
+	ph7_class *pDecl = pAttr->pDeclClass ? pAttr->pDeclClass : pOwner;
+	ph7_class *pActive = VmCurrentSelf(pVm);
+	int bOk;
+	if( pAttr->iFlags & PH7_CLASS_ATTR_PRIVATE_SET ){
+		bOk = (pActive != 0 && pActive == pDecl);
+	}else{
+		bOk = (pActive != 0 && pDecl != 0 && PH7_VmInstanceOf(pActive,pDecl));
+	}
+	if( !bOk ){
+		return VmThrowSetVisibilityError(pVm,pOwner,pAttr);
+	}
+	return SXRET_OK;
+}
 static sxi32 VmThrowReadonlyError(ph7_vm *pVm,ph7_class *pClass,ph7_class_attr *pAttr,int bModify)
 {
 	ph7_class *pOwner = pAttr->pDeclClass ? pAttr->pDeclClass : pClass;
@@ -5850,6 +5892,11 @@ static sxi32 VmCheckReadonlyMutate(ph7_vm *pVm,sxu32 nIdx)
 	pVmAttr = (VmClassAttr *)pSlot->pUserData;
 	if( pVmAttr->pAttr && (pVmAttr->pAttr->iFlags & PH7_CLASS_ATTR_READONLY) ){
 		return VmThrowReadonlyError(pVm,pVmAttr->pOwner,pVmAttr->pAttr,1);
+	}
+	if( pVmAttr->pAttr
+	 && (pVmAttr->pAttr->iFlags & (PH7_CLASS_ATTR_PRIVATE_SET|PH7_CLASS_ATTR_PROTECTED_SET)) ){
+		/* `++`/`--` is a write: enforce the asymmetric set-visibility (PHP 8.4) */
+		return VmCheckSetVisibility(pVm,pVmAttr->pOwner,pVmAttr->pAttr);
 	}
 	return SXRET_OK;
 }
@@ -6244,20 +6291,28 @@ static sxi32 VmEnforcePropertyTypeOnStore(ph7_vm *pVm,sxu32 nIdx,ph7_value *pVal
 		 * write below — making it the write-once latch (a type-rejected write
 		 * leaves it set, so a later valid initialization still works). */
 		if( !bCloneInit && (pVmAttr->iState & VM_CLASS_ATTR_UNINIT) == 0 ){
-			/* Already initialized: any further write is forbidden, any scope.
+			/* Already initialized: any further write is forbidden, any scope —
+			 * checked BEFORE the set-visibility scope, matching php's order.
 			 * (PHP 8.5 clone($o,[...]) is the sole exception — bCloneInit — which
 			 * re-initializes a readonly property from an allowed scope, so it
 			 * falls through to the set-scope check below.) */
 			return VmThrowReadonlyError(pVm,pVmAttr->pOwner,pAttr,1);
 		}
-		{
-			/* First write (or a clone re-init) must come from within the declaring
-			 * class scope (readonly's set-scope is protected — a subclass may set). */
-			ph7_class *pDecl = pAttr->pDeclClass ? pAttr->pDeclClass : pVmAttr->pOwner;
-			ph7_class *pActive = VmCurrentSelf(pVm);
-			if( pActive == 0 || pDecl == 0 || !PH7_VmInstanceOf(pActive,pDecl) ){
-				return VmThrowReadonlyError(pVm,pVmAttr->pOwner,pAttr,0);
-			}
+	}
+	if( pAttr->iFlags & (PH7_CLASS_ATTR_PRIVATE_SET|PH7_CLASS_ATTR_PROTECTED_SET) ){
+		/* Asymmetric set-visibility (PHP 8.4): EVERY write is scope-checked.
+		 * An explicit set-visibility replaces readonly's implicit protected(set). */
+		sxi32 rcVis = VmCheckSetVisibility(pVm,pVmAttr->pOwner,pAttr);
+		if( rcVis != SXRET_OK ){
+			return rcVis;
+		}
+	}else if( pAttr->iFlags & PH7_CLASS_ATTR_READONLY ){
+		/* First write (or a clone re-init) must come from within the declaring
+		 * class scope (readonly's set-scope is protected — a subclass may set). */
+		ph7_class *pDecl = pAttr->pDeclClass ? pAttr->pDeclClass : pVmAttr->pOwner;
+		ph7_class *pActive = VmCurrentSelf(pVm);
+		if( pActive == 0 || pDecl == 0 || !PH7_VmInstanceOf(pActive,pDecl) ){
+			return VmThrowReadonlyError(pVm,pVmAttr->pOwner,pAttr,0);
 		}
 	}
 	/* Union type: dispatch to the shared coercion helper. Typed properties

--- a/src/ph7/vm_builtin_reflection.c
+++ b/src/ph7/vm_builtin_reflection.c
@@ -407,6 +407,8 @@ static int vm_builtin_reflect_class_info(ph7_context *pCtx, int nArg, ph7_value 
 				}else{
 					ReflectMapAddBool(pCtx, pMeta, "static", (pAttr->iFlags & PH7_CLASS_ATTR_STATIC) != 0);
 					ReflectMapAddBool(pCtx, pMeta, "readonly", (pAttr->iFlags & PH7_CLASS_ATTR_READONLY) != 0);
+					ReflectMapAddBool(pCtx, pMeta, "privset", (pAttr->iFlags & PH7_CLASS_ATTR_PRIVATE_SET) != 0);
+					ReflectMapAddBool(pCtx, pMeta, "protset", (pAttr->iFlags & PH7_CLASS_ATTR_PROTECTED_SET) != 0);
 					ReflectMapAddBool(pCtx, pMeta, "hasdef", SySetUsed(&pAttr->aByteCode) > 0);
 					ReflectMapAddDyn(pCtx, pProps, &pAttr->sName, pMeta);
 				}
@@ -2524,6 +2526,8 @@ static const char zReflectLib3[] =
 " public function isPrivate(){ $m = $this->__rpmeta(); return $m['vis'] === 3; }"
 " public function isStatic(){ $m = $this->__rpmeta(); return $m['static']; }"
 " public function isReadOnly(){ $m = $this->__rpmeta(); return $m['readonly']; }"
+" public function isPrivateSet(){ $m = $this->__rpmeta(); return isset($m['privset']) ? $m['privset'] : false; }"
+" public function isProtectedSet(){ $m = $this->__rpmeta(); return isset($m['protset']) ? $m['protset'] : false; }"
 " public function isDefault(){ $m = $this->__rpmeta(); return !isset($m['dyn']); }"
 " public function isDynamic(){ $m = $this->__rpmeta(); return isset($m['dyn']); }"
 " public function isAbstract(){ return false; }"

--- a/tests/ph7/001-smoke/asymmetric_visibility.phpt
+++ b/tests/ph7/001-smoke/asymmetric_visibility.phpt
@@ -1,0 +1,82 @@
+--TEST--
+Asymmetric visibility (PHP 8.4): private(set)/protected(set) on declared, promoted, and static properties
+--FILE--
+<?php
+class AsvA {
+    public private(set) int $x = 1;
+    function bump() { $this->x++; }
+}
+$asvA = new AsvA();
+echo $asvA->x;
+$asvA->bump();
+echo $asvA->x, "\n";
+try { $asvA->x = 5; } catch (Error $e) { echo get_class($e), ":", $e->getMessage(), "\n"; }
+try { $asvA->x++; } catch (Error $e) { echo $e->getMessage(), "\n"; }
+// protected(set): subclass may write, outside may not
+class AsvB { public protected(set) int $y = 1; function w($v) { $this->y = $v; } }
+class AsvC extends AsvB { function w2($v) { $this->y = $v; } }
+$asvC = new AsvC();
+$asvC->w(5); echo $asvC->y;
+$asvC->w2(9); echo $asvC->y, "\n";
+try { $asvC->y = 2; } catch (Error $e) { echo $e->getMessage(), "\n"; }
+// private(set): even a subclass may not write
+class AsvD extends AsvA { function w3() { $this->x = 7; } }
+$asvD = new AsvD();
+try { $asvD->w3(); } catch (Error $e) { echo $e->getMessage(), "\n"; }
+// standalone private(set) implies a public read side
+class AsvE { private(set) int $z = 3; function set($v) { $this->z = $v; } }
+$asvE = new AsvE();
+echo $asvE->z;
+$asvE->set(4);
+echo $asvE->z, "\n";
+try { $asvE->z = 9; } catch (Error $e) { echo $e->getMessage(), "\n"; }
+// readonly + private(set): a write after init reports the readonly error
+class AsvF { public private(set) readonly int $r; function __construct() { $this->r = 1; } }
+$asvF = new AsvF();
+try { $asvF->r = 2; } catch (Error $e) { echo $e->getMessage(), "\n"; }
+// promoted asymmetric property
+class AsvG {
+    function __construct(public private(set) int $p = 5) {}
+    function inc() { $this->p++; }
+}
+$asvG = new AsvG();
+echo $asvG->p; $asvG->inc(); echo $asvG->p, "\n";
+try { $asvG->p = 8; } catch (Error $e) { echo $e->getMessage(), "\n"; }
+// leading set-visibility on a promoted param
+class AsvH { function __construct(private(set) int $q = 6) {} }
+echo (new AsvH())->q, "\n";
+// explicit public(set) behaves like a plain public property
+class AsvI { public public(set) int $w = 1; }
+$asvI = new AsvI();
+$asvI->w = 5;
+echo $asvI->w, "\n";
+// static property with asymmetric visibility
+class AsvJ { public static private(set) int $s = 1; static function set($v) { self::$s = $v; } }
+echo AsvJ::$s;
+AsvJ::set(3);
+echo AsvJ::$s, "\n";
+try { AsvJ::$s = 9; } catch (Error $e) { echo $e->getMessage(), "\n"; }
+// reflection surface
+$asvP = new ReflectionProperty("AsvA", "x");
+$asvQ = new ReflectionProperty("AsvB", "y");
+$asvR = new ReflectionProperty("AsvI", "w");
+echo (int) $asvP->isPrivateSet(), (int) $asvP->isProtectedSet(),
+     (int) $asvQ->isPrivateSet(), (int) $asvQ->isProtectedSet(),
+     (int) $asvR->isPrivateSet(), (int) $asvR->isProtectedSet(), "\n";
+--EXPECT--
+12
+Error:Cannot modify private(set) property AsvA::$x from global scope
+Cannot modify private(set) property AsvA::$x from global scope
+59
+Cannot modify protected(set) property AsvB::$y from global scope
+Cannot modify private(set) property AsvA::$x from scope AsvD
+34
+Cannot modify private(set) property AsvE::$z from global scope
+Cannot modify readonly property AsvF::$r
+56
+Cannot modify private(set) property AsvG::$p from global scope
+6
+5
+13
+Cannot modify private(set) property AsvJ::$s from global scope
+100100


### PR DESCRIPTION
public private(set) / protected(set) / explicit public(set) on declared, promoted, and static properties (php 8.5 accepts static asym-vis, probe-verified). A leading set-visibility implies a public read side.

Parse: GenStatePeekSetVisibility recognizes the 4-token `vis ( set )` run, wired into the class-body visibility branch, the static-modifier branch, and the constructor-promotion modifier block (readonly on either side). The set visibility is encoded as three new attr flags so inheritance and trait copying ride the existing iFlags plumbing; promoted params carry VM_FUNC_ARG_PRIV_SET/PROT_SET and map to attr flags at materialization. Compile rules with php's exact text: asymmetric properties must have a type, and the read visibility must not be weaker than the set visibility.

Enforce: the typed-slot store path checks scope on every write - private(set) requires the active scope to BE the declaring class (subclasses excluded), protected(set) requires declaring-or-subclass - throwing php's catchable "Cannot modify private(set) property C::$x from {global scope|scope D}". php's check order is preserved: the readonly already-initialized latch fires first, and an explicit set-visibility replaces readonly's implicit protected(set) first-write scope. The ++/-- mutate path enforces the same rule; statics ride the same typed-slot table.

Reflection: ReflectionProperty::isPrivateSet()/isProtectedSet() (php 8.4).

Byte-verified vs php 8.5.7 incl. clone-with-updates interplay; cross-engine test asymmetric_visibility.phpt; test-compat green; docker ASan+UBSan clean; tiny build ok.
