### PR TITLE
Implement PHP 8.4 property hooks (slice 1)

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -2219,6 +2219,7 @@ static int GenStateIsReservedConstant(SyString *pName);
 static int GenStateIsReadonly(SyToken *pTok);
 static sxi32 GenStatePeekSetVisibility(SyToken *pTok,SyToken *pEnd,int *pnTok);
 static sxi32 GenStateSetVisFlag(sxi32 nKw);
+static sxi32 GenStateCompilePropertyHooks(ph7_gen_state *pGen,ph7_class *pClass,ph7_class_attr *pAttr);
 static sxi32 GenStateValidateMemberType(ph7_gen_state *pGen,ph7_class *pClass,const SyString *pMemberName,
 	sxu32 nType,const SyString *pTypeClass,const SyString *pTypeText,SySet *pUnionAlts,const char *zErrFmt,sxu32 nLine);
 static void GenStateBuildFQN(ph7_gen_state *pGen,const SyString *pName,SyBlob *pOut);
@@ -8458,7 +8459,7 @@ loop:
 	pName = &pGen->pIn->sData;
 	/* Advance the stream cursor */
 	pGen->pIn++;
-	if(pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & (PH7_TK_EQUAL/*'='*/|PH7_TK_SEMI/*';'*/|PH7_TK_COMMA/*','*/)) == 0 ){
+	if(pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & (PH7_TK_EQUAL/*'='*/|PH7_TK_SEMI/*';'*/|PH7_TK_COMMA/*','*/|PH7_TK_OCB/*'{' hooks*/)) == 0 ){
 		/* Invalid declaration */
 		rc = PH7_GenCompileError(pGen,E_ERROR,nLine,"Expected '=' or ';' after attribute name '%z'",pName);
 		if( rc == SXERR_ABORT ){
@@ -8560,7 +8561,27 @@ loop:
 	}
 	if( pGen->pIn->nType & PH7_TK_EQUAL /*'='*/ ){
 		SySet *pInstrContainer;
+		SyToken *pSavedDefEnd = pGen->pEnd;
 		pGen->pIn++; /*Jump the equal sign */
+		{
+			/* Delimit the default expression: it ends at the declaration's
+			 * ';'/',' or at a top-level '{' opening a PHP 8.4 hook list
+			 * (`public string $w = "init" { get => …; }`) — the expression
+			 * compiler would otherwise run into the hook tokens. */
+			SyToken *pScan = pGen->pIn;
+			sxi32 iNest = 0;
+			while( pScan < pGen->pEnd ){
+				if( pScan->nType & (PH7_TK_LPAREN|PH7_TK_OSB) ){
+					iNest++;
+				}else if( pScan->nType & (PH7_TK_RPAREN|PH7_TK_CSB) ){
+					iNest--;
+				}else if( iNest <= 0 && (pScan->nType & (PH7_TK_SEMI|PH7_TK_COMMA|PH7_TK_OCB)) ){
+					break;
+				}
+				pScan++;
+			}
+			pGen->pEnd = pScan;
+		}
 		/* Swap bytecode container */
 		pInstrContainer = PH7_VmGetByteCodeContainer(pGen->pVm);
 		PH7_VmSetByteCodeContainer(pGen->pVm,&pAttr->aByteCode);
@@ -8576,12 +8597,27 @@ loop:
 		/* Emit the done instruction */
 		PH7_VmEmitInstr(pGen->pVm,PH7_OP_DONE,1,0,0,0);
 		PH7_VmSetByteCodeContainer(pGen->pVm,pInstrContainer);
+		pGen->pIn = pGen->pEnd;   /* land exactly on the delimiter */
+		pGen->pEnd = pSavedDefEnd;
 	}
 	/* All done,install the attribute */
 	rc = PH7_ClassInstallAttr(pClass,pAttr);
 	if( rc != SXRET_OK ){
 		PH7_GenCompileError(pGen,E_ERROR,nLine,"Fatal, PH7 is running out of memory");
 		return SXERR_ABORT;
+	}
+	if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_OCB /*'{'*/) ){
+		/* PHP 8.4 property hooks: `public [T] $x [= default] { get ...; set ...; }`.
+		 * The list ends the declaration at '}' — no trailing ';', no comma list. */
+		rc = GenStateCompilePropertyHooks(&(*pGen),pClass,pAttr);
+		if( rc == SXERR_ABORT ){
+			return SXERR_ABORT;
+		}
+		if( rc != SXRET_OK ){
+			goto Synchronize;
+		}
+		SySetRelease(&aUnionAlts);
+		return SXRET_OK;
 	}
 	if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_COMMA /*','*/) ){
 		/* Multiple attribute declarations [i.e: public $var1,$var2=5<<1,$var3] */
@@ -8890,6 +8926,164 @@ Synchronize:
 	/* Synchronize with the first semi-colon */
 	while(pGen->pIn < pGen->pEnd && ((pGen->pIn->nType & PH7_TK_SEMI/*';'*/) == 0) ){
 		pGen->pIn++;
+	}
+	return SXERR_CORRUPT;
+}
+/*
+ * Compile a PHP 8.4 property-hook list `{ get ...; set ...; }` following a
+ * property declaration. Each hook body is synthesized into a hidden public
+ * class method (__phl_hook_get_NAME / __phl_hook_set_NAME) so inheritance,
+ * $this binding, and dispatch ride the ordinary method machinery; OP_MEMBER /
+ * OP_STORE route reads and plain writes through them (a per-instance guard
+ * makes $this->NAME inside a hook body address the raw backing slot — php's
+ * rule that hooks see the backing store). `get => expr;` compiles as an
+ * implicit return (the arrow-fn pattern); `set => expr;` compiles the same
+ * and is flagged VM_FUNC_HOOK_SET_EXPR — the dispatcher assigns its return
+ * value to the backing slot. A `set` without a parameter list receives the
+ * implicit `$value` formal.
+ * On entry pGen->pIn sits on '{'; on success it sits just past '}'.
+ */
+static sxi32 GenStateCompilePropertyHooks(ph7_gen_state *pGen,ph7_class *pClass,ph7_class_attr *pAttr)
+{
+	sxu32 nLine = pGen->pIn->nLine;
+	sxi32 rc;
+	pGen->pIn++; /* Jump '{' */
+	while( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_CCB) == 0 ){
+		char zHook[384];
+		SyString sHookName;
+		ph7_class_method *pMeth;
+		int bGet;
+		sxu32 nHLine = pGen->pIn->nLine;
+		if( pGen->pIn->nType & PH7_TK_SEMI ){
+			pGen->pIn++; /* stray ';' between hooks */
+			continue;
+		}
+		if( pGen->pIn->nType & PH7_TK_AMPER ){
+			/* by-reference get hook: not modeled (loud, recorded) */
+			rc = PH7_GenCompileError(pGen,E_ERROR,nHLine,
+				"By-reference property hooks are not supported for %z::$%z",
+				&pClass->sName,&pAttr->sName);
+			if( rc == SXERR_ABORT ){
+				return SXERR_ABORT;
+			}
+			return SXERR_CORRUPT;
+		}
+		if( (pGen->pIn->nType & (PH7_TK_ID|PH7_TK_KEYWORD)) == 0 ){
+			goto HookSyntax;
+		}
+		if( pGen->pIn->sData.nByte == 3
+		 && SyStrnicmp(pGen->pIn->sData.zString,"get",3) == 0 ){
+			bGet = 1;
+		}else if( pGen->pIn->sData.nByte == 3
+		 && SyStrnicmp(pGen->pIn->sData.zString,"set",3) == 0 ){
+			bGet = 0;
+		}else{
+			goto HookSyntax;
+		}
+		pGen->pIn++; /* Jump 'get'/'set' */
+		sHookName.zString = zHook;
+		sHookName.nByte = SyBufferFormat(zHook,sizeof(zHook),"__phl_hook_%s_%z",
+			bGet ? "get" : "set",&pAttr->sName);
+		pMeth = PH7_NewClassMethod(pGen->pVm,pClass,&sHookName,nHLine,
+			PH7_CLASS_PROT_PUBLIC,0,0);
+		if( pMeth == 0 ){
+			PH7_GenCompileError(pGen,E_ERROR,nHLine,"Fatal, PH7 is running out of memory");
+			return SXERR_ABORT;
+		}
+		pMeth->sFunc.nLine = nHLine;
+		if( !bGet ){
+			/* Parameter list: explicit `set(Type $v)` or the implicit `$value` */
+			if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_LPAREN) ){
+				SyToken *pRp = 0;
+				pGen->pIn++;
+				PH7_DelimitNestedTokens(pGen->pIn,pGen->pEnd,PH7_TK_LPAREN,PH7_TK_RPAREN,&pRp);
+				if( pRp >= pGen->pEnd ){
+					goto HookSyntax;
+				}
+				if( pGen->pIn < pRp ){
+					rc = GenStateCollectFuncArgs(&pMeth->sFunc,&(*pGen),pRp,0,0);
+					if( rc == SXERR_ABORT ){
+						return SXERR_ABORT;
+					}
+				}
+				pGen->pIn = &pRp[1];
+			}
+			if( SySetUsed(&pMeth->sFunc.aArgs) < 1 ){
+				/* Implicit $value formal */
+				ph7_vm_func_arg sVArg;
+				char *zVName = SyMemBackendStrDup(&pGen->pVm->sAllocator,"value",sizeof("value")-1);
+				if( zVName == 0 ){
+					PH7_GenCompileError(pGen,E_ERROR,nHLine,"Fatal, PH7 is running out of memory");
+					return SXERR_ABORT;
+				}
+				SyZero(&sVArg,sizeof(ph7_vm_func_arg));
+				SyStringInitFromBuf(&sVArg.sName,zVName,sizeof("value")-1);
+				SySetInit(&sVArg.aByteCode,&pGen->pVm->sAllocator,sizeof(VmInstr));
+				SySetInit(&sVArg.aUnionAlts,&pGen->pVm->sAllocator,sizeof(ph7_type_alt));
+				SySetInit(&sVArg.aAttrs,&pGen->pVm->sAllocator,sizeof(ph7_attribute));
+				SyStringInitFromBuf(&sVArg.sTypeName,0,0);
+				SySetPut(&pMeth->sFunc.aArgs,(const void *)&sVArg);
+			}
+		}
+		if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_OCB) ){
+			/* Block body */
+			rc = GenStateCompileFuncBody(&(*pGen),&pMeth->sFunc);
+			if( rc == SXERR_ABORT ){
+				return SXERR_ABORT;
+			}
+			pMeth->sFunc.nEndLine = pGen->pIn[-1].nLine;
+		}else if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_ARRAY_OP) ){
+			/* `=> expr;` — implicit-return body (the arrow-fn pattern) */
+			GenBlock *pBlock;
+			SySet *pInstrContainer;
+			pGen->pIn++; /* Jump '=>' */
+			rc = GenStateEnterBlock(&(*pGen),GEN_BLOCK_PROTECTED|GEN_BLOCK_FUNC,
+				PH7_VmInstrLength(pGen->pVm),&pMeth->sFunc,&pBlock);
+			if( rc != SXRET_OK ){
+				PH7_GenCompileError(pGen,E_ERROR,nHLine,"PH7 engine is running out-of-memory");
+				return SXERR_ABORT;
+			}
+			pInstrContainer = PH7_VmGetByteCodeContainer(pGen->pVm);
+			PH7_VmSetByteCodeContainer(pGen->pVm,&pMeth->sFunc.aByteCode);
+			rc = PH7_CompileExpr(&(*pGen),EXPR_FLAG_COMMA_STATEMENT,0);
+			PH7_VmEmitInstr(pGen->pVm,PH7_OP_DONE,(rc != SXERR_EMPTY ? 1 : 0),0,0,0);
+			GenStateFixJumps(pGen->pCurrent,PH7_OP_THROW,PH7_VmInstrLength(pGen->pVm));
+			PH7_VmEmitInstr(pGen->pVm,PH7_OP_DONE,0,0,0,0);
+			PH7_VmSetByteCodeContainer(pGen->pVm,pInstrContainer);
+			GenStateLeaveBlock(&(*pGen),0);
+			if( rc == SXERR_ABORT ){
+				return SXERR_ABORT;
+			}
+			pMeth->sFunc.nEndLine = (pGen->pIn < pGen->pEnd) ? pGen->pIn->nLine : nHLine;
+			if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_SEMI) ){
+				pGen->pIn++; /* Jump ';' */
+			}
+			if( !bGet ){
+				/* `set => expr` assigns the expression to the backing store:
+				 * the dispatcher consumes the implicit return value. */
+				pMeth->sFunc.iFlags |= VM_FUNC_HOOK_SET_EXPR;
+			}
+		}else{
+			goto HookSyntax;
+		}
+		rc = PH7_ClassInstallMethod(pClass,pMeth);
+		if( rc != SXRET_OK ){
+			PH7_GenCompileError(pGen,E_ERROR,nHLine,"Fatal, PH7 is running out of memory");
+			return SXERR_ABORT;
+		}
+		pAttr->iFlags |= bGet ? PH7_CLASS_ATTR_HOOK_GET : PH7_CLASS_ATTR_HOOK_SET;
+	}
+	if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_CCB) == 0 ){
+		goto HookSyntax;
+	}
+	pGen->pIn++; /* Jump '}' */
+	return SXRET_OK;
+HookSyntax:
+	rc = PH7_GenCompileError(pGen,E_ERROR,nLine,
+		"Invalid property hook declaration for %z::$%z: expecting 'get' or 'set'",
+		&pClass->sName,&pAttr->sName);
+	if( rc == SXERR_ABORT ){
+		return SXERR_ABORT;
 	}
 	return SXERR_CORRUPT;
 }

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -770,7 +770,9 @@ struct ph7_vm_func_closure_env
                                      * `static fn () =>`): no $this auto-capture, bind refused. */
 #define VM_FUNC_ARG_PRIV_SET 0x8000  /* Promoted property is private(set) (PHP 8.4) */
 #define VM_FUNC_ARG_PROT_SET 0x10000 /* Promoted property is protected(set) (PHP 8.4) */
-/* next free bit: 0x20000 */
+#define VM_FUNC_HOOK_SET_EXPR 0x20000 /* `set => expr` property hook (PHP 8.4): the dispatcher
+                                       * stores the implicit return value into the backing slot */
+/* next free bit: 0x40000 */
 /*
  * Each user defined function is parsed out and stored in an instance
  * of the following structure.
@@ -928,7 +930,11 @@ struct ph7_class_attr
                                             * from the declaring class or a subclass scope */
 #define PH7_CLASS_ATTR_PUBLIC_SET   0x2000 /* explicit public(set): behaviorally the default, kept
                                             * for the weaker-than-set check and reflection output */
-/* next free bit: 0x4000 */
+#define PH7_CLASS_ATTR_HOOK_GET     0x4000 /* property has a `get` hook (PHP 8.4): reads dispatch
+                                            * __phl_hook_get_NAME (guard-bypassed inside hooks) */
+#define PH7_CLASS_ATTR_HOOK_SET     0x8000 /* property has a `set` hook (PHP 8.4): plain writes
+                                            * dispatch __phl_hook_set_NAME */
+/* next free bit: 0x10000 */
 /*
  * Each class method is parsed out and stored in an instance of the following
  * structure.
@@ -1230,6 +1236,14 @@ struct ph7_vm
 	                             * and dispatches __set($name,$value). Holds a reference;
 	                             * one-instruction lifetime by construction. */
 	SyBlob sMagicSetName;       /* Pending __set property name (stable copy) */
+	ph7_class_instance *pHookSetThis; /* Pending property-hook set receiver (PHP 8.4): OP_MEMBER
+	                             * detected a plain store to a hooked property; the following
+	                             * OP_STORE consumes this (with pHookSetAttr/nHookSetIdx) and
+	                             * dispatches __phl_hook_set_NAME — or throws the read-only
+	                             * Error when the property has no set hook. Owns one instance
+	                             * reference while armed. */
+	ph7_class_attr *pHookSetAttr; /* Pending hook-set property (declared attr; name + flags) */
+	sxu32 nHookSetIdx;          /* Pending hook-set BACKING slot index (for `set => expr`) */
 	ph7_class_instance *pMagicCallThis; /* Pending __call receiver (band A #3b): OP_MEMBER hit a
 	                             * missing method on a class declaring __call/__callStatic and
 	                             * redirected the callee to the hidden packing trampoline

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -2512,6 +2512,9 @@ PH7_PRIVATE sxi32 PH7_VmInit(
 	SySetInit(&pVm->aMagicGuard,&pVm->sAllocator,sizeof(VmMagicGuard));
 	pVm->pMagicSetThis = 0;
 	SyBlobInit(&pVm->sMagicSetName,&pVm->sAllocator);
+	pVm->pHookSetThis = 0;
+	pVm->pHookSetAttr = 0;
+	pVm->nHookSetIdx = SXU32_HIGH;
 	pVm->pMagicCallThis = 0;
 	pVm->pMagicCallClass = 0;
 	SyBlobInit(&pVm->sMagicCallName,&pVm->sAllocator);
@@ -2539,6 +2542,12 @@ PH7_PRIVATE sxi32 PH7_VmInit(
 		pVm->pMagicSetThis = 0;
 	}
 	SyBlobRelease(&pVm->sMagicSetName);
+	if( pVm->pHookSetThis ){
+		PH7_ClassInstanceUnref(pVm->pHookSetThis);
+		pVm->pHookSetThis = 0;
+	}
+	pVm->pHookSetAttr = 0;
+	pVm->nHookSetIdx = SXU32_HIGH;
 	if( pVm->pMagicCallThis ){
 		PH7_ClassInstanceUnref(pVm->pMagicCallThis);
 		pVm->pMagicCallThis = 0;
@@ -4099,6 +4108,12 @@ PH7_PRIVATE sxi32 PH7_VmReset(ph7_vm *pVm)
 		pVm->pMagicSetThis = 0;
 	}
 	SyBlobRelease(&pVm->sMagicSetName);
+	if( pVm->pHookSetThis ){
+		PH7_ClassInstanceUnref(pVm->pHookSetThis);
+		pVm->pHookSetThis = 0;
+	}
+	pVm->pHookSetAttr = 0;
+	pVm->nHookSetIdx = SXU32_HIGH;
 	if( pVm->pMagicCallThis ){
 		PH7_ClassInstanceUnref(pVm->pMagicCallThis);
 		pVm->pMagicCallThis = 0;
@@ -10318,6 +10333,74 @@ case PH7_OP_STORE: {
 			SyBlobReset(&pVm->sMagicSetName);
 			break;
 		}
+		if( pVm->pHookSetThis ){
+			/* Pending property-hook set (PHP 8.4): the preceding OP_MEMBER found a
+			 * plain store to a hooked property. Dispatch __phl_hook_set_NAME with
+			 * the rvalue (which stays on the stack as the assignment expression's
+			 * result); a `set => expr` hook's return value is stored into the
+			 * BACKING slot with the ordinary typed enforcement. A property with
+			 * only a get hook is php's catchable "is read-only" Error. */
+			ph7_class_instance *pHThis = pVm->pHookSetThis;
+			ph7_class_attr *pHAttr = pVm->pHookSetAttr;
+			sxu32 nBackIdx = pVm->nHookSetIdx;
+			pVm->pHookSetThis = 0;
+			pVm->pHookSetAttr = 0;
+			pVm->nHookSetIdx = SXU32_HIGH;
+			if( (pHAttr->iFlags & PH7_CLASS_ATTR_HOOK_SET) == 0 ){
+				/* get-only hooked property: php's read-only Error */
+				SyBlob sErrMsg;
+				SyBlobInit(&sErrMsg,&pVm->sAllocator);
+				SyBlobFormat(&sErrMsg,"Property %z::$%z is read-only",
+					&pHThis->pClass->sName,&pHAttr->sName);
+				VmBoundaryPark(&(*pVm),VmThrowBuiltinError(&(*pVm),"Error",sizeof("Error")-1,&sErrMsg));
+				PH7_ClassInstanceUnref(pHThis);
+				break;
+			}
+			if( pHAttr->iFlags & (PH7_CLASS_ATTR_PRIVATE_SET|PH7_CLASS_ATTR_PROTECTED_SET) ){
+				/* Asymmetric set-visibility is checked BEFORE the hook dispatches (php) */
+				sxi32 rcVis = VmCheckSetVisibility(&(*pVm),pHThis->pClass,pHAttr);
+				if( rcVis != SXRET_OK ){
+					VmBoundaryPark(&(*pVm),rcVis);
+					PH7_ClassInstanceUnref(pHThis);
+					break;
+				}
+			}
+			{
+				char zHName[384];
+				sxu32 nHName = SyBufferFormat(zHName,sizeof(zHName),
+					"__phl_hook_set_%z",&pHAttr->sName);
+				ph7_class_method *pSetHook = PH7_ClassExtractMethod(pHThis->pClass,zHName,nHName);
+				if( pSetHook ){
+					ph7_value sHookRet;
+					ph7_value *apHArg[1];
+					apHArg[0] = pTos;
+					PH7_MemObjInit(pVm,&sHookRet);
+					VmMagicGuardPush(pVm,(void *)pHThis,&pHAttr->sName,'S');
+					PH7_VmCallClassMethod(&(*pVm),pHThis,pSetHook,&sHookRet,1,apHArg);
+					VmMagicGuardPop(pVm);
+					if( (pSetHook->sFunc.iFlags & VM_FUNC_HOOK_SET_EXPR)
+					 && nBackIdx != SXU32_HIGH && pVm->nBoundaryRc == 0 ){
+						sxi32 rcH = VmEnforcePropertyTypeOnStore(&(*pVm),nBackIdx,&sHookRet,0);
+						if( rcH == SXRET_OK ){
+							ph7_value *pBack = (ph7_value *)SySetAt(&pVm->aMemObj,nBackIdx);
+							if( pBack ){
+								PH7_MemObjStore(&sHookRet,pBack);
+							}
+						}else if( rcH == PH7_ABORT ){
+							PH7_MemObjRelease(&sHookRet);
+							PH7_ClassInstanceUnref(pHThis);
+							goto Abort;
+						}
+						/* PH7_EXCEPTION: the TypeError was routed/parked by the
+						 * enforcement — the store is skipped, execution lands at
+						 * the fetch point like any parked throw. */
+					}
+					PH7_MemObjRelease(&sHookRet);
+				}
+			}
+			PH7_ClassInstanceUnref(pHThis);
+			break;
+		}
 		if( nIdx == SXU32_HIGH ){
 			PH7_VmThrowError(&(*pVm),0,PH7_CTX_ERR,
 				"Cannot perform assignment on a constant class attribute,PH7 is loading NULL");
@@ -13618,6 +13701,88 @@ case PH7_OP_MEMBER: {
 					ph7_value *pValue = 0; /* cc warning */
 					/* Check attribute access */
 					if( PH7_VmClassMemberAccess(&(*pVm),pClass,&pObjAttr->pAttr->sName,pObjAttr->pAttr->iProtection,FALSE) ){
+						if( pObjAttr->pAttr->iFlags & (PH7_CLASS_ATTR_HOOK_GET|PH7_CLASS_ATTR_HOOK_SET) ){
+							/* PHP 8.4 property hooks: route reads and plain writes through
+							 * the synthesized hook methods. A held guard means we are
+							 * INSIDE this property's hook body — fall through to the raw
+							 * backing slot (php: hooks see the backing store). */
+							VmInstr *pNextH = pInstr + 1;
+							int bPlainStore = (pNextH->iOp == PH7_OP_STORE && pNextH->iP2 != 0);
+							int bOtherWrite = (pInstr->iP2 == PH7_MEMBER_WRITE)
+								|| (!bPlainStore && VmMemberNextIsWrite(pNextH));
+							if( bPlainStore && !VmMagicGuardHeld(pVm,(void *)pThis,&sName,'S') ){
+								/* Arm the pending hook-set for the following OP_STORE — it
+								 * dispatches the set hook, or throws the read-only Error
+								 * when the property only has a get hook. */
+								pThis->iRef++;
+								pVm->pHookSetThis = pThis;
+								pVm->pHookSetAttr = pObjAttr->pAttr;
+								pVm->nHookSetIdx = pObjAttr->nIdx;
+								pTos->nIdx = SXU32_HIGH; /* sentinel slot for OP_STORE */
+								PH7_ClassInstanceUnref(pThis);
+								break;
+							}
+							if( VmMemberCtxIsLookup(pInstr->iP2)
+							 && (pObjAttr->pAttr->iFlags & PH7_CLASS_ATTR_HOOK_GET)
+							 && !VmMagicGuardHeld(pVm,(void *)pThis,&sName,'G') ){
+								/* isset()/empty() on a hooked property calls the get hook
+								 * (php): isset is "get() !== null", empty tests the value. */
+								char zHName[384];
+								sxu32 nHName = SyBufferFormat(zHName,sizeof(zHName),
+									"__phl_hook_get_%z",&pObjAttr->pAttr->sName);
+								ph7_class_method *pGetHook =
+									PH7_ClassExtractMethod(pThis->pClass,zHName,nHName);
+								if( pGetHook ){
+									ph7_value sHookRet;
+									PH7_MemObjInit(pVm,&sHookRet);
+									VmMagicGuardPush(pVm,(void *)pThis,&sName,'G');
+									PH7_VmCallClassMethod(&(*pVm),pThis,pGetHook,&sHookRet,0,0);
+									VmMagicGuardPop(pVm);
+									if( pInstr->iP2 == PH7_MEMBER_ISSET ){
+										pTos->x.iVal = (sHookRet.iFlags & MEMOBJ_NULL) == 0;
+										MemObjSetType(pTos,MEMOBJ_BOOL);
+									}else{
+										/* empty(): hand the value to the truthiness test */
+										PH7_MemObjStore(&sHookRet,pTos);
+									}
+									pTos->nIdx = SXU32_HIGH;
+									PH7_MemObjRelease(&sHookRet);
+									PH7_ClassInstanceUnref(pThis);
+									break;
+								}
+							}
+							if( !bPlainStore && !bOtherWrite && !VmMemberCtxIsLookup(pInstr->iP2)
+							 && (pObjAttr->pAttr->iFlags & PH7_CLASS_ATTR_HOOK_GET)
+							 && !VmMagicGuardHeld(pVm,(void *)pThis,&sName,'G') ){
+								/* Read: dispatch __phl_hook_get_NAME (inheritance-aware) */
+								char zHName[384];
+								sxu32 nHName = SyBufferFormat(zHName,sizeof(zHName),
+									"__phl_hook_get_%z",&pObjAttr->pAttr->sName);
+								ph7_class_method *pGetHook =
+									PH7_ClassExtractMethod(pThis->pClass,zHName,nHName);
+								if( pGetHook ){
+									ph7_value sHookRet;
+									PH7_MemObjInit(pVm,&sHookRet);
+									VmMagicGuardPush(pVm,(void *)pThis,&sName,'G');
+									PH7_VmCallClassMethod(&(*pVm),pThis,pGetHook,&sHookRet,0,0);
+									VmMagicGuardPop(pVm);
+									PH7_MemObjStore(&sHookRet,pTos);
+									pTos->nIdx = SXU32_HIGH;
+									PH7_MemObjRelease(&sHookRet);
+									PH7_ClassInstanceUnref(pThis);
+									break;
+								}
+							}
+							if( bOtherWrite && !VmMagicGuardHeld(pVm,(void *)pThis,&sName,'S')
+							 && !VmMagicGuardHeld(pVm,(void *)pThis,&sName,'G') ){
+								/* Read-modify-write (`++`, `.=`, subscript writes…) on a
+								 * hooked property: not yet modeled — LOUD, never a silent
+								 * hook bypass (recorded residual; the raw slot is used). */
+								VmErrorFormat(&(*pVm),PH7_CTX_WARNING,
+									"Read-modify-write on hooked property %z::$%z bypasses its hooks (not yet supported)",
+									&pClass->sName,&pObjAttr->pAttr->sName);
+							}
+						}
 						/* PHP 7.4+: reading an uninitialized typed property is an Error.
 						 * We can only raise it on a real read, not when the slot is the
 						 * LHS of an assignment — peek at the next instruction to decide.

--- a/tests/ph7/001-smoke/property_hooks_basic.phpt
+++ b/tests/ph7/001-smoke/property_hooks_basic.phpt
@@ -1,0 +1,85 @@
+--TEST--
+Property hooks (PHP 8.4): get/set hooks, backing-store access, defaults, inheritance, errors
+--FILE--
+<?php
+// virtual computed property
+class PhkA {
+    public int $n = 3;
+    public string $virt { get => "V" . $this->n; }
+}
+$phkA = new PhkA();
+echo $phkA->virt, "\n";
+echo isset($phkA->virt) ? "T" : "F", empty($phkA->virt) ? "E" : "N", "\n";
+// backed property with both hooks (block bodies); hooks see the raw backing store
+class PhkB {
+    public string $b { get { return strtoupper($this->b); } set(string $v) { $this->b = trim($v); } }
+}
+$phkB = new PhkB();
+$phkB->b = "  hi  ";
+echo $phkB->b, "|", strlen($phkB->b), "\n";
+// set => expr shorthand assigns to the backing store
+class PhkC { public int $s { set => $value * 2; } }
+$phkC = new PhkC();
+$phkC->s = 4;
+echo $phkC->s, "\n";
+// explicit set(Type $v) writing the backing store
+class PhkD { public int $t { set(int $v) { $this->t = $v + 10; } } }
+$phkD = new PhkD();
+$phkD->t = 4;
+echo $phkD->t, "\n";
+// a get-only property rejects writes with php's catchable Error
+class PhkE { public string $v { get => "x"; } }
+$phkE = new PhkE();
+try { $phkE->v = "y"; } catch (Error $e) { echo get_class($e), ":", $e->getMessage(), "\n"; }
+echo $phkE->v, "\n";
+// children inherit hooks; a child may override them
+class PhkF { public int $h = 0; public int $tw { get => $this->h * 2; set(int $v) { $this->h = $v; } } }
+class PhkG extends PhkF {}
+$phkG = new PhkG();
+$phkG->tw = 21;
+echo $phkG->tw, ",", $phkG->h, "\n";
+class PhkH extends PhkF { public int $tw { get => $this->h * 3; set(int $v) { $this->h = $v; } } }
+$phkH = new PhkH();
+$phkH->tw = 10;
+echo $phkH->tw, ",", (new PhkF())->h, "\n";
+// hooks are ordinary code: call methods, use other properties
+class PhkI {
+    private array $parts = [];
+    public string $joined { get => implode("-", $this->parts); set(string $v) { $this->parts = explode("-", $v); } }
+}
+$phkI = new PhkI();
+$phkI->joined = "a-b-c";
+echo $phkI->joined, "\n";
+// a backing default value coexists with hooks
+class PhkJ { public string $w = "init" { get => "[" . $this->w . "]"; set(string $v) { $this->w = $v; } } }
+$phkJ = new PhkJ();
+echo $phkJ->w, "\n";
+$phkJ->w = "next";
+echo $phkJ->w, "\n";
+// exceptions thrown inside hooks are catchable at the access site
+class PhkK { public int $x { get { throw new RuntimeException("nope"); } } }
+$phkK = new PhkK();
+try { echo $phkK->x; } catch (RuntimeException $e) { echo "caught:", $e->getMessage(), "\n"; }
+class PhkL { public int $age { set(int $v) { if ($v < 0) { throw new InvalidArgumentException("neg"); } $this->age = $v; } } }
+$phkL = new PhkL();
+$phkL->age = 5;
+echo $phkL->age, "\n";
+try { $phkL->age = -1; } catch (InvalidArgumentException $e) { echo "bad:", $e->getMessage(), "\n"; }
+echo $phkL->age, "\n";
+--EXPECT--
+V3
+TN
+HI|2
+8
+14
+Error:Property PhkE::$v is read-only
+x
+42,21
+30,0
+a-b-c
+[init]
+[next]
+caught:nope
+5
+bad:neg
+5


### PR DESCRIPTION
public [T] $x [= default] { get ...; set ...; } - each hook body is synthesized at compile time into a hidden public class method (__phl_hook_get_NAME / __phl_hook_set_NAME), so $this binding, inheritance, and child overrides all ride the ordinary method machinery.

Parse (GenStateCompilePropertyHooks): get/set accept the `=> expr;` shorthand (compiled as an implicit return, the arrow-fn body pattern) or a { ... } block (shared GenStateCompileFuncBody); set takes an explicit (Type $v) parameter (enforced at dispatch like any method arg) or an implicit $value formal; `set => expr` is flagged VM_FUNC_HOOK_SET_EXPR. A backing default coexists with hooks - the property-default initializer now delimits its expression at the first top-level ;/,/{ instead of running into the hook tokens. &get by-ref hooks are a loud compile error.

Dispatch: OP_MEMBER routes reads and isset()/empty() through the get hook (isset is "get() !== null", php); a plain store arms a pending transient that OP_STORE consumes - dispatching the set hook with the rvalue, or throwing php's catchable "Property C::$x is read-only" when only a get hook exists. A `set => expr` hook's return value is stored into the backing slot through the typed-property enforcement, and an asymmetric set-visibility is scope-checked before the hook dispatches (php's order). The existing magic-guard is held around each dispatch, so $this->x inside a hook body addresses the raw backing store - php's rule. Read-modify-write is not yet routed: it warns loudly and uses the raw slot, never a silent bypass (open slice, recorded in the roadmap with the other remainders: iteration get-dispatch, parent::$x::get, reflection surface, virtual-vs-backed strictness).

Byte-verified vs php 8.5.7 (13-scenario paired probe); cross-engine test property_hooks_basic.phpt; test-compat green; docker ASan+UBSan clean; tiny build ok.
