### PR TITLE
Run property hooks in RMW, ??= and walks

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -7886,7 +7886,16 @@ static int GenStateInitHasNewExpr(ph7_gen_state *pGen)
 			}
 			continue;
 		}
-		if( p->nType & (PH7_TK_LPAREN|PH7_TK_OSB|PH7_TK_OCB) ){
+		if( p->nType & PH7_TK_OCB ){
+			if( iDepth == 0 ){
+				/* A depth-0 '{' can only open a PHP 8.4 property-hook list
+				 * (`public T $x = default { get …; }`): the default expression
+				 * ends here. A `new` inside a hook BODY runs at access time and
+				 * is legal — don't scan into it. */
+				break;
+			}
+			iDepth++;
+		}else if( p->nType & (PH7_TK_LPAREN|PH7_TK_OSB) ){
 			iDepth++;
 		}else if( p->nType & (PH7_TK_RPAREN|PH7_TK_CSB|PH7_TK_CCB) ){
 			if( iDepth > 0 ){
@@ -12824,6 +12833,16 @@ static sxi32 GenStateEmitExprCode(
 					|| pNode->pOp->iOp == EXPR_OP_NULLSAFE_ARROW
 					|| pNode->pOp->iOp == EXPR_OP_DC) ){
 				iLeftFlags &= ~EXPR_FLAG_MEMBER_WRITE;
+			}
+			/* `++`/`--` mutate their operand in place — the operand is a write
+			 * lvalue exactly like a compound assign's (`$o->m[0]++` must tag the
+			 * member base PH7_MEMBER_WRITE the way `$o->m[0] += 1` does: hooked
+			 * properties throw php's Indirect-modification Error, missing ones
+			 * auto-vivify). The prec-18 site below handles the assign family;
+			 * `++`/`--` are unary, their operand is pLeft. */
+			if( pNode->pOp
+				&& (pNode->pOp->iVmOp == PH7_OP_INCR || pNode->pOp->iVmOp == PH7_OP_DECR) ){
+				iLeftFlags |= EXPR_FLAG_LOAD_IDX_STORE | EXPR_FLAG_MEMBER_WRITE;
 			}
 			rc = GenStateEmitExprCode(&(*pGen),pNode->pLeft,iLeftFlags);
 		}

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1155,6 +1155,52 @@ struct VmMagicGuard
 	sxu32 nNameHash;  /* property-name hash (SyBinHash) */
 	sxu8 cKind;       /* accessor kind: 'g' = __get */
 };
+/* Pending property write-back entry (PHP 8.4 hooks + magic ??=): a LIFO of
+ * these (ph7_vm.aHookRmw) carries every write whose dispatch is deferred past
+ * OP_MEMBER to a later opcode:
+ *   VM_HOOK_PEND_RMW        — read-modify-write on a hooked property: OP_MEMBER
+ *                             dispatched the get hook (or read the raw backing
+ *                             store when set-only) into a fresh SCRATCH memobj
+ *                             slot; the modify op (++/--/compound-assign)
+ *                             mutates the scratch and its tail consumes the
+ *                             entry (matched by kind + scratch index) to
+ *                             dispatch the set hook with the computed value.
+ *   VM_HOOK_PEND_COAL_HOOK  — `$o->p ??= v` on a hooked property: the entry is
+ *                             consumed by the OP_NULLC_STORE at nPc (matched by
+ *                             owner + pc) to dispatch the set hook.
+ *   VM_HOOK_PEND_COAL_MAGIC — `$o->p ??= v` on a missing property whose class
+ *                             declares __set: consumed the same way, dispatching
+ *                             __set(sName, value).
+ * The armed window is [nJmpPc, nPc]: an owner fetch outside it means the
+ * statement was abandoned (a routed throw) or the ??= short-circuit jump was
+ * taken — the entry is dropped, no set dispatch (php: the throw/skip discards
+ * the write). LIFO order makes nested arms (a ??= RHS containing further
+ * hooked stores or coalesce-assigns, a recursive re-entry through a cast
+ * inside a modify op) nest correctly. Each entry owns one instance reference;
+ * MAGIC entries own their name blob. */
+#define VM_HOOK_PEND_RMW         0
+#define VM_HOOK_PEND_COAL_HOOK   1
+#define VM_HOOK_PEND_COAL_MAGIC  2
+typedef struct VmHookRmw VmHookRmw;
+struct VmHookRmw
+{
+	sxu8 iKind;                 /* VM_HOOK_PEND_* */
+	ph7_class_instance *pThis;  /* receiver (owns one reference while pending) */
+	ph7_class_attr *pAttr;      /* hooked property (hook kinds; 0 for MAGIC) */
+	sxu32 nBackIdx;             /* BACKING slot index (for `set => expr` stores) */
+	sxu32 nScratchIdx;          /* RMW: scratch slot the modify op operates on;
+	                             * SXU32_HIGH for the coalesce kinds */
+	SyBlob sName;               /* COAL_MAGIC: property name copy (entry-owned) */
+	void *pOwnerStack;          /* arming activation's operand-stack base (identity;
+	                             * a nested exec — even a recursive one over the same
+	                             * bytecode — has a different base, so it never drops
+	                             * an enclosing activation's pending entry) */
+	void *pInstrs;              /* arming activation's bytecode array */
+	sxu32 nJmpPc;               /* first pc of the armed window (RMW: == nPc;
+	                             * coalesce: the OP_NULLC_JMP right after the arm) */
+	sxu32 nPc;                  /* pc of the consuming op (RMW: the modify op;
+	                             * coalesce: the OP_NULLC_STORE) */
+};
 struct ph7_vm
 {
 	SyMemBackend sAllocator;	/* Memory backend */
@@ -1244,6 +1290,8 @@ struct ph7_vm
 	                             * reference while armed. */
 	ph7_class_attr *pHookSetAttr; /* Pending hook-set property (declared attr; name + flags) */
 	sxu32 nHookSetIdx;          /* Pending hook-set BACKING slot index (for `set => expr`) */
+	SySet aHookRmw;             /* Pending property-hook read-modify-write write-backs (LIFO;
+	                             * VmHookRmw entries — see the struct above ph7_vm). */
 	ph7_class_instance *pMagicCallThis; /* Pending __call receiver (band A #3b): OP_MEMBER hit a
 	                             * missing method on a class declaring __call/__callStatic and
 	                             * redirected the callee to the hidden packing trampoline
@@ -2289,6 +2337,7 @@ PH7_PRIVATE sxi32 PH7_ClassInstanceDump(SyBlob *pOut,ph7_class_instance *pThis,i
 PH7_PRIVATE sxi32 PH7_ClassInstanceCallMagicMethod(ph7_vm *pVm,ph7_class *pClass,ph7_class_instance *pThis,const char *zMethod,
 	sxu32 nByte,const SyString *pAttrName,ph7_value *pResult);
 PH7_PRIVATE ph7_value * PH7_ClassInstanceExtractAttrValue(ph7_class_instance *pThis,VmClassAttr *pAttr);
+PH7_PRIVATE sxi32 PH7_VmHookGetAttrValue(ph7_class_instance *pThis,VmClassAttr *pVmAttr,ph7_value *pOut);
 PH7_PRIVATE ph7_value * PH7_EnumCaseNameValue(ph7_class_instance *pThis);
 PH7_PRIVATE ph7_value * PH7_EnumCaseBackingValueOf(ph7_class_instance *pThis);
 PH7_PRIVATE sxi32 PH7_ClassInstanceToHashmap(ph7_class_instance *pThis,ph7_hashmap *pMap);

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -2515,6 +2515,7 @@ PH7_PRIVATE sxi32 PH7_VmInit(
 	pVm->pHookSetThis = 0;
 	pVm->pHookSetAttr = 0;
 	pVm->nHookSetIdx = SXU32_HIGH;
+	SySetInit(&pVm->aHookRmw,&pVm->sAllocator,sizeof(VmHookRmw));
 	pVm->pMagicCallThis = 0;
 	pVm->pMagicCallClass = 0;
 	SyBlobInit(&pVm->sMagicCallName,&pVm->sAllocator);
@@ -4103,6 +4104,18 @@ PH7_PRIVATE sxi32 PH7_VmReset(ph7_vm *pVm)
 	pVm->pConstCycleAttr = 0;
 	pVm->pConstCycleClass = 0;
 	SySetReset(&pVm->aMagicGuard);
+	{
+		/* Drop any pending write-back entries (each owns one instance ref;
+		 * MAGIC entries own a name blob; scratch slots die with aMemObj) */
+		VmHookRmw *aRmw = (VmHookRmw *)SySetBasePtr(&pVm->aHookRmw);
+		sxu32 nRmw = SySetUsed(&pVm->aHookRmw);
+		sxu32 iRmw;
+		for( iRmw = 0 ; iRmw < nRmw ; ++iRmw ){
+			SyBlobRelease(&aRmw[iRmw].sName);
+			PH7_ClassInstanceUnref(aRmw[iRmw].pThis);
+		}
+		SySetReset(&pVm->aHookRmw);
+	}
 	if( pVm->pMagicSetThis ){
 		PH7_ClassInstanceUnref(pVm->pMagicSetThis);
 		pVm->pMagicSetThis = 0;
@@ -8108,9 +8121,16 @@ static int VmMemberCtxIsLookup(sxi32 iP2)
  */
 static int VmMagicGuardHeld(ph7_vm *pVm,void *pThis,const SyString *pName,sxu8 cKind)
 {
-	VmMagicGuard *aG = (VmMagicGuard *)SySetBasePtr(&pVm->aMagicGuard);
-	sxu32 nHash = SyBinHash((const void *)pName->zString,pName->nByte);
+	VmMagicGuard *aG;
+	sxu32 nHash;
 	sxu32 n;
+	if( SySetUsed(&pVm->aMagicGuard) == 0 ){
+		/* Common case (no accessor in flight): skip the name hash entirely —
+		 * every hooked-property access consults the guard, often twice. */
+		return FALSE;
+	}
+	aG = (VmMagicGuard *)SySetBasePtr(&pVm->aMagicGuard);
+	nHash = SyBinHash((const void *)pName->zString,pName->nByte);
 	for( n = 0; n < SySetUsed(&pVm->aMagicGuard); ++n ){
 		if( aG[n].pThis == pThis && aG[n].nNameHash == nHash && aG[n].cKind == cKind ){
 			return TRUE;
@@ -8154,6 +8174,216 @@ static int VmMemberNextIsWrite(const VmInstr *pNext)
 			return 1;
 		default:
 			return 0;
+	}
+}
+/*
+ * Whether execution is currently INSIDE one of pName's own hook bodies on this
+ * instance. php's rule: within ANY hook of property x (get or set alike),
+ * `$this->x` addresses the raw backing store for BOTH reads and writes — so
+ * every hook-dispatch decision checks both guard kinds, not just its own.
+ */
+static int VmHookGuardHeld(ph7_vm *pVm,void *pThis,const SyString *pName)
+{
+	return VmMagicGuardHeld(pVm,pThis,pName,'G') || VmMagicGuardHeld(pVm,pThis,pName,'S');
+}
+/*
+ * Dispatch the SET side of a hooked-property write: php's read-only Error when
+ * the property has no set hook, the asymmetric set-visibility check (php checks
+ * it before the hook runs), then __phl_hook_set_NAME with pValue; a
+ * `set => expr` hook's return value is stored into the BACKING slot through the
+ * ordinary typed enforcement. Errors park on the boundary rail (the caller's
+ * opcode completes benignly; the fetch-point router lands them). Shared by the
+ * plain-store consume (OP_STORE), the coalesce-assign consume (OP_NULLC_STORE)
+ * and the read-modify-write write-back (VmHookRmwConsume). Does NOT release the
+ * caller's reference on pHThis. Returns PH7_ABORT only for the enforcement's
+ * abort path; SXRET_OK otherwise.
+ */
+static sxi32 VmHookSetDispatch(ph7_vm *pVm,ph7_class_instance *pHThis,ph7_class_attr *pHAttr,sxu32 nBackIdx,ph7_value *pValue)
+{
+	char zHName[384];
+	sxu32 nHName;
+	ph7_class_method *pSetHook;
+	if( (pHAttr->iFlags & PH7_CLASS_ATTR_HOOK_SET) == 0 ){
+		/* get-only hooked property: php's read-only Error */
+		SyBlob sErrMsg;
+		SyBlobInit(&sErrMsg,&pVm->sAllocator);
+		SyBlobFormat(&sErrMsg,"Property %z::$%z is read-only",
+			&pHThis->pClass->sName,&pHAttr->sName);
+		VmBoundaryPark(&(*pVm),VmThrowBuiltinError(&(*pVm),"Error",sizeof("Error")-1,&sErrMsg));
+		return SXRET_OK;
+	}
+	if( pHAttr->iFlags & (PH7_CLASS_ATTR_PRIVATE_SET|PH7_CLASS_ATTR_PROTECTED_SET) ){
+		/* Asymmetric set-visibility is checked BEFORE the hook dispatches (php) */
+		sxi32 rcVis = VmCheckSetVisibility(&(*pVm),pHThis->pClass,pHAttr);
+		if( rcVis != SXRET_OK ){
+			VmBoundaryPark(&(*pVm),rcVis);
+			return SXRET_OK;
+		}
+	}
+	nHName = SyBufferFormat(zHName,sizeof(zHName),"__phl_hook_set_%z",&pHAttr->sName);
+	pSetHook = PH7_ClassExtractMethod(pHThis->pClass,zHName,nHName);
+	if( pSetHook ){
+		ph7_value sHookRet;
+		ph7_value *apHArg[1];
+		apHArg[0] = pValue;
+		PH7_MemObjInit(pVm,&sHookRet);
+		VmMagicGuardPush(pVm,(void *)pHThis,&pHAttr->sName,'S');
+		PH7_VmCallClassMethod(&(*pVm),pHThis,pSetHook,&sHookRet,1,apHArg);
+		VmMagicGuardPop(pVm);
+		if( (pSetHook->sFunc.iFlags & VM_FUNC_HOOK_SET_EXPR)
+		 && nBackIdx != SXU32_HIGH && pVm->nBoundaryRc == 0 ){
+			sxi32 rcH = VmEnforcePropertyTypeOnStore(&(*pVm),nBackIdx,&sHookRet,0);
+			if( rcH == SXRET_OK ){
+				ph7_value *pBack = (ph7_value *)SySetAt(&pVm->aMemObj,nBackIdx);
+				if( pBack ){
+					PH7_MemObjStore(&sHookRet,pBack);
+				}
+			}else if( rcH == PH7_ABORT ){
+				PH7_MemObjRelease(&sHookRet);
+				return PH7_ABORT;
+			}
+			/* PH7_EXCEPTION: the TypeError was routed/parked by the enforcement —
+			 * the store is skipped, execution lands at the fetch point like any
+			 * parked throw. */
+		}
+		PH7_MemObjRelease(&sHookRet);
+	}
+	return SXRET_OK;
+}
+/*
+ * Consume the top pending hook-RMW entry if it targets slot nIdx — called from
+ * the tail of every read-modify-write opcode (++/--/compound-assign) with the
+ * slot it just wrote. A non-matching top (an ordinary variable RMW running
+ * inside a nested exec while an outer write-back is pending) is left alone.
+ * On match: copy the computed value out of the scratch slot, return the slot
+ * to the free pool, and dispatch the set side (VmHookSetDispatch) — unless a
+ * throw parked during the modify op, which wins (php: the exception discards
+ * the write). Returns SXERR_NOTFOUND when nothing was consumed, PH7_ABORT to
+ * propagate the enforcement abort, SXRET_OK otherwise.
+ */
+/*
+ * Hook-aware attribute read for the C-side object walks — foreach over an
+ * object, get_object_vars(), json_encode(), var_export(): php dispatches the
+ * GET hook on these surfaces, while var_dump / (array) / print_r / serialize
+ * read the raw backing store. Fills pOut (an initialized ph7_value the caller
+ * owns) with the hook's return value and returns SXRET_OK — or the call's
+ * PH7_EXCEPTION/PH7_ABORT when the hook threw (also parked on the boundary
+ * rail like any C-boundary callee). Returns SXERR_NOTFOUND when the property
+ * has no get hook (or execution is inside one of its own hook bodies): the
+ * caller reads the raw slot then.
+ */
+PH7_PRIVATE sxi32 PH7_VmHookGetAttrValue(ph7_class_instance *pThis,VmClassAttr *pVmAttr,ph7_value *pOut)
+{
+	ph7_vm *pVm = pThis->pVm;
+	char zHName[384];
+	sxu32 nHName;
+	ph7_class_method *pGetHook;
+	sxi32 rc;
+	if( (pVmAttr->pAttr->iFlags & PH7_CLASS_ATTR_HOOK_GET) == 0
+	 || VmHookGuardHeld(pVm,(void *)pThis,&pVmAttr->pAttr->sName)
+	 || pVm->nBoundaryRc != 0 ){
+		/* The boundary-rc gate keeps a C-side walk (get_object_vars/var_export/
+		 * foreach) from running FURTHER hooks after one already threw — php
+		 * aborts the whole builtin at the first throw; the walk falls back to
+		 * raw values whose output the routed throw then discards. */
+		return SXERR_NOTFOUND;
+	}
+	nHName = SyBufferFormat(zHName,sizeof(zHName),"__phl_hook_get_%z",&pVmAttr->pAttr->sName);
+	pGetHook = PH7_ClassExtractMethod(pThis->pClass,zHName,nHName);
+	if( pGetHook == 0 ){
+		return SXERR_NOTFOUND;
+	}
+	VmMagicGuardPush(pVm,(void *)pThis,&pVmAttr->pAttr->sName,'G');
+	rc = PH7_VmCallClassMethod(&(*pVm),pThis,pGetHook,pOut,0,0);
+	VmMagicGuardPop(pVm);
+	return rc;
+}
+/*
+ * Release a hook-RMW SCRATCH slot: drop its contents and return the index to
+ * the free pool. Scratch slots come from PH7_ReserveMemObj and are never
+ * ref-linked, so this bypasses PH7_VmUnsetMemObj's VmRefObj bookkeeping.
+ */
+static void VmHookRmwFreeScratch(ph7_vm *pVm,sxu32 nIdx)
+{
+	ph7_value *pScr = (ph7_value *)SySetAt(&pVm->aMemObj,nIdx);
+	VmSlot sFree;
+	if( pScr ){
+		PH7_MemObjRelease(pScr);
+	}
+	sFree.nIdx = nIdx;
+	sFree.pUserData = 0;
+	SySetPut(&pVm->aFreeObj,(const void *)&sFree);
+}
+/*
+ * Drop the top pending write-back entry without dispatching its set side: the
+ * arming statement was abandoned by a throw, or a ??= short-circuit jump
+ * skipped its assign (php: the throw/skip discards the write). Releases the
+ * scratch slot (RMW kind), the name blob (MAGIC kind) and the entry's
+ * instance reference.
+ */
+static void VmHookRmwDropTop(ph7_vm *pVm)
+{
+	VmHookRmw *pEnt = (VmHookRmw *)SySetPeek(&pVm->aHookRmw);
+	if( pEnt == 0 ){
+		return;
+	}
+	if( pEnt->nScratchIdx != SXU32_HIGH ){
+		VmHookRmwFreeScratch(&(*pVm),pEnt->nScratchIdx);
+	}
+	SyBlobRelease(&pEnt->sName);
+	PH7_ClassInstanceUnref(pEnt->pThis);
+	(void)SySetPop(&pVm->aHookRmw);
+}
+static sxi32 VmHookRmwConsume(ph7_vm *pVm,sxu32 nIdx)
+{
+	VmHookRmw sEnt;
+	VmHookRmw *pEnt;
+	ph7_value *pScr;
+	ph7_value sVal;
+	sxi32 rc = SXRET_OK;
+	pEnt = (VmHookRmw *)SySetPeek(&pVm->aHookRmw);
+	if( pEnt == 0 || pEnt->iKind != VM_HOOK_PEND_RMW || pEnt->nScratchIdx != nIdx ){
+		return SXERR_NOTFOUND;
+	}
+	sEnt = *pEnt;
+	(void)SySetPop(&pVm->aHookRmw);
+	/* Copy the computed value out of the scratch slot, then free the slot
+	 * (the set dispatch below may reserve slots — nothing may read the
+	 * scratch index past this point). */
+	PH7_MemObjInit(pVm,&sVal);
+	pScr = (ph7_value *)SySetAt(&pVm->aMemObj,sEnt.nScratchIdx);
+	if( pScr ){
+		PH7_MemObjStore(pScr,&sVal);
+	}
+	VmHookRmwFreeScratch(&(*pVm),sEnt.nScratchIdx);
+	sVal.nIdx = SXU32_HIGH;
+	if( pVm->nBoundaryRc == 0 ){
+		rc = VmHookSetDispatch(&(*pVm),sEnt.pThis,sEnt.pAttr,sEnt.nBackIdx,&sVal);
+	}
+	PH7_MemObjRelease(&sVal);
+	PH7_ClassInstanceUnref(sEnt.pThis);
+	return rc;
+}
+/*
+ * Dispatch __set($name, $value) on pSetThis — the shared consume for a pending
+ * magic-set: OP_STORE's plain-store transient and OP_NULLC_STORE's coalesce
+ * entry both funnel here. The guard makes a same-name write inside __set fall
+ * through to creation, like php. Does NOT release the caller's reference.
+ */
+static void VmMagicSetDispatch(ph7_vm *pVm,ph7_class_instance *pSetThis,const SyString *pName,ph7_value *pValue)
+{
+	ph7_class_method *pSetMeth = PH7_ClassExtractMethod(pSetThis->pClass,"__set",sizeof("__set")-1);
+	if( pSetMeth ){
+		ph7_value sNameVal;
+		ph7_value *apSetArg[2];
+		PH7_MemObjInitFromString(pVm,&sNameVal,pName);
+		sNameVal.nIdx = SXU32_HIGH;
+		apSetArg[0] = &sNameVal;
+		apSetArg[1] = pValue;
+		VmMagicGuardPush(pVm,(void *)pSetThis,pName,'s');
+		PH7_VmCallClassMethod(&(*pVm),pSetThis,pSetMeth,0,2,apSetArg);
+		VmMagicGuardPop(pVm);
+		PH7_MemObjRelease(&sNameVal);
 	}
 }
 /*
@@ -8840,6 +9070,25 @@ static sxi32 VmByteCodeExecBody(
 		sxi32 _rcR = VmCheckReadonlyMutate(&(*pVm),(nIdxArg)); \
 		PH7_DISPATCH_ENFORCE_RC(_rcR) \
 	}
+/*
+ * Hook-RMW write-back for the tail of every read-modify-write opcode: if the
+ * top pending VmHookRmw entry targets the slot this op just wrote (a SCRATCH
+ * slot armed by the preceding OP_MEMBER on a hooked property), dispatch the
+ * property's set hook with the computed value. pResArg (may be 0) is the
+ * op's surviving stack result whose nIdx still points at the freed scratch
+ * slot — sanitize it to a pure temp so no later op treats it as an lvalue.
+ * Must be used inside a case of the main switch.
+ */
+#define PH7_HOOK_RMW_WRITEBACK(nIdxArg, pResArg) \
+	if( SySetUsed(&pVm->aHookRmw) > 0 ){ \
+		sxi32 _rcHk = VmHookRmwConsume(&(*pVm),(nIdxArg)); \
+		if( _rcHk == PH7_ABORT ){ \
+			goto Abort; \
+		} \
+		if( _rcHk == SXRET_OK && (pResArg) != 0 ){ \
+			((ph7_value *)(pResArg))->nIdx = SXU32_HIGH; \
+		} \
+	}
 	/* Generator::throw() inject-at-yield: when this invocation is a resumed generator/fiber
 	 * body carrying a pending injected exception, raise it HERE — once, before the dispatch
 	 * loop (pc is already at the resume point) — so the existing OP_THROW route
@@ -8952,39 +9201,61 @@ VmLoopFetch:
 		 * the abandoned mid-expression operands to the catching try's base), or
 		 * propagate out of this exec. Checked at the fetch point, so a swallowed
 		 * throw outlives at most the C remainder of ONE opcode instead of
-		 * silently resuming the surrounding PHP code with a bogus value. */
-		if( pVm->nBoundaryRc != 0 ){
-			sxi32 rcBr = pVm->nBoundaryRc;
-			pVm->nBoundaryRc = 0;
-			if( rcBr == PH7_ABORT ){
-				goto Abort;
-			}
-			if( pVm->pInlineInstr == (void *)aInstr ){
-				/* Caught by an inline try (generator body) THIS exec owns: drain
-				 * and land (pre-fetch path: pc is used directly, no trailing ++). */
-				while( (sxi32)(pTos - pStack) > pVm->iInlineDrain ){
-					PH7_MemObjRelease(pTos);
-					pTos--;
+		 * silently resuming the surrounding PHP code with a bogus value.
+		 * The pending write-back sweep shares this one guard so the hot
+		 * no-hooks path pays a single predicted branch per fetch. */
+		if( pVm->nBoundaryRc != 0 || SySetUsed(&pVm->aHookRmw) > 0 ){
+			if( pVm->nBoundaryRc != 0 ){
+				sxi32 rcBr = pVm->nBoundaryRc;
+				pVm->nBoundaryRc = 0;
+				if( rcBr == PH7_ABORT ){
+					goto Abort;
 				}
-				pc = (sxi32)pVm->iInlinePc;
-				pVm->pInlineInstr = 0;
-			}else{
-				sxi32 iBrPc;
-				if( VmRecordedResume(pVm,&iBrPc,sState.pEntryFrame,aInstr) ){
-					/* Caught in place by a try THIS exec owns: drain the abandoned
-					 * operands to the catching try's base and land at its pad
-					 * (iBrPc is landing-1 for the dispatcher's trailing pc++;
-					 * pre-fetch here, so +1 lands on the pad itself). */
-					while( (sxi32)(pTos - pStack) > pVm->iResumeStackDepth ){
+				if( pVm->pInlineInstr == (void *)aInstr ){
+					/* Caught by an inline try (generator body) THIS exec owns: drain
+					 * and land (pre-fetch path: pc is used directly, no trailing ++). */
+					while( (sxi32)(pTos - pStack) > pVm->iInlineDrain ){
 						PH7_MemObjRelease(pTos);
 						pTos--;
 					}
-					pc = iBrPc + 1;
+					pc = (sxi32)pVm->iInlinePc;
+					pVm->pInlineInstr = 0;
 				}else{
-					/* Caught by an outer exec (or uncaught-with-report pending):
-					 * unwind out of this exec; the owner's macros/router land it. */
-					goto Exception;
+					sxi32 iBrPc;
+					if( VmRecordedResume(pVm,&iBrPc,sState.pEntryFrame,aInstr) ){
+						/* Caught in place by a try THIS exec owns: drain the abandoned
+						 * operands to the catching try's base and land at its pad
+						 * (iBrPc is landing-1 for the dispatcher's trailing pc++;
+						 * pre-fetch here, so +1 lands on the pad itself). */
+						while( (sxi32)(pTos - pStack) > pVm->iResumeStackDepth ){
+							PH7_MemObjRelease(pTos);
+							pTos--;
+						}
+						pc = iBrPc + 1;
+					}else{
+						/* Caught by an outer exec (or uncaught-with-report pending):
+						 * unwind out of this exec; the owner's macros/router land it. */
+						goto Exception;
+					}
 				}
+			}
+			/* Stale write-back sweep: a pending entry whose OWNING activation is
+			 * fetching any pc outside its armed window [nJmpPc, nPc] is dead — for
+			 * an RMW entry (window = the modify op alone) a routed throw abandoned
+			 * the arming statement mid-flight; for a ??= entry either a throw
+			 * abandoned the RHS or the short-circuit jump landed past the
+			 * OP_NULLC_STORE (the assign is skipped). Drop it — no set dispatch
+			 * (php: the throw/skip discards the write). A nested exec (even a
+			 * recursive one over the same bytecode) has a different operand-stack
+			 * base and leaves enclosing entries alone; entries below a live top
+			 * are reached as the drops expose them. */
+			while( SySetUsed(&pVm->aHookRmw) > 0 ){
+				VmHookRmw *pTopRmw = (VmHookRmw *)SySetPeek(&pVm->aHookRmw);
+				if( pTopRmw->pOwnerStack != (void *)pStack || pTopRmw->pInstrs != (void *)aInstr
+				 || ((sxu32)pc >= pTopRmw->nJmpPc && (sxu32)pc <= pTopRmw->nPc) ){
+					break; /* not ours, or legitimately in flight */
+				}
+				VmHookRmwDropTop(&(*pVm));
 			}
 		}
 		/* Fetch the instruction to execute */
@@ -10008,6 +10279,31 @@ case PH7_OP_LOAD_IDX: {
 		if( pTos->nIdx != SXU32_HIGH ){
 			ph7_value *pObj;
 			if( (pObj = (ph7_value *)SySetAt(&pVm->aMemObj,pTos->nIdx)) != 0 ){
+				/* php 8 write-context auto-vivify rules: NULL converts to array
+				 * silently; FALSE converts with the 8.1 deprecation; any other
+				 * scalar base — int/float/true/resource — is php's catchable
+				 * "Cannot use a scalar value as an array" Error and the variable
+				 * stays untouched (pre-fix the base was silently CONVERTED,
+				 * corrupting e.g. `$i = 5; $i[0]++` into array(0 => 6); string
+				 * bases were intercepted by the string-offset paths above). */
+				if( (pObj->iFlags & (MEMOBJ_INT|MEMOBJ_REAL|MEMOBJ_RES)) != 0
+				 || ((pObj->iFlags & MEMOBJ_BOOL) != 0 && pObj->x.iVal != 0) ){
+					SyBlob sErrMsg;
+					SyBlobInit(&sErrMsg,&pVm->sAllocator);
+					SyBlobAppend(&sErrMsg,"Cannot use a scalar value as an array",
+						sizeof("Cannot use a scalar value as an array")-1);
+					VmBoundaryPark(&(*pVm),VmThrowBuiltinError(&(*pVm),"Error",sizeof("Error")-1,&sErrMsg));
+					if( pIdx ){
+						PH7_MemObjRelease(pIdx);
+					}
+					PH7_MemObjRelease(pTos);
+					pTos->nIdx = SXU32_HIGH;
+					break;
+				}
+				if( (pObj->iFlags & MEMOBJ_BOOL) != 0 ){
+					VmErrorFormat(&(*pVm),8192 /* E_DEPRECATED */,
+						"Automatic conversion of false to array is deprecated");
+				}
 				PH7_MemObjToHashmap(pObj);
 				PH7_MemObjLoad(pObj,pTos);
 			}
@@ -10312,23 +10608,10 @@ case PH7_OP_STORE: {
 			 * the stack as the assignment expression's result — php's semantics
 			 * (no property is created; a throw rides the boundary rail). */
 			ph7_class_instance *pSetThis = pVm->pMagicSetThis;
-			ph7_class_method *pSetMeth;
 			SyString sSetName;
 			pVm->pMagicSetThis = 0;
 			SyStringInitFromBuf(&sSetName,SyBlobData(&pVm->sMagicSetName),SyBlobLength(&pVm->sMagicSetName));
-			pSetMeth = PH7_ClassExtractMethod(pSetThis->pClass,"__set",sizeof("__set")-1);
-			if( pSetMeth ){
-				ph7_value sNameVal;
-				ph7_value *apSetArg[2];
-				PH7_MemObjInitFromString(pVm,&sNameVal,&sSetName);
-				sNameVal.nIdx = SXU32_HIGH;
-				apSetArg[0] = &sNameVal;
-				apSetArg[1] = pTos;
-				VmMagicGuardPush(pVm,(void *)pSetThis,&sSetName,'s');
-				PH7_VmCallClassMethod(&(*pVm),pSetThis,pSetMeth,0,2,apSetArg);
-				VmMagicGuardPop(pVm);
-				PH7_MemObjRelease(&sNameVal);
-			}
+			VmMagicSetDispatch(&(*pVm),pSetThis,&sSetName,pTos);
 			PH7_ClassInstanceUnref(pSetThis);
 			SyBlobReset(&pVm->sMagicSetName);
 			break;
@@ -10343,62 +10626,15 @@ case PH7_OP_STORE: {
 			ph7_class_instance *pHThis = pVm->pHookSetThis;
 			ph7_class_attr *pHAttr = pVm->pHookSetAttr;
 			sxu32 nBackIdx = pVm->nHookSetIdx;
+			sxi32 rcHs;
 			pVm->pHookSetThis = 0;
 			pVm->pHookSetAttr = 0;
 			pVm->nHookSetIdx = SXU32_HIGH;
-			if( (pHAttr->iFlags & PH7_CLASS_ATTR_HOOK_SET) == 0 ){
-				/* get-only hooked property: php's read-only Error */
-				SyBlob sErrMsg;
-				SyBlobInit(&sErrMsg,&pVm->sAllocator);
-				SyBlobFormat(&sErrMsg,"Property %z::$%z is read-only",
-					&pHThis->pClass->sName,&pHAttr->sName);
-				VmBoundaryPark(&(*pVm),VmThrowBuiltinError(&(*pVm),"Error",sizeof("Error")-1,&sErrMsg));
-				PH7_ClassInstanceUnref(pHThis);
-				break;
-			}
-			if( pHAttr->iFlags & (PH7_CLASS_ATTR_PRIVATE_SET|PH7_CLASS_ATTR_PROTECTED_SET) ){
-				/* Asymmetric set-visibility is checked BEFORE the hook dispatches (php) */
-				sxi32 rcVis = VmCheckSetVisibility(&(*pVm),pHThis->pClass,pHAttr);
-				if( rcVis != SXRET_OK ){
-					VmBoundaryPark(&(*pVm),rcVis);
-					PH7_ClassInstanceUnref(pHThis);
-					break;
-				}
-			}
-			{
-				char zHName[384];
-				sxu32 nHName = SyBufferFormat(zHName,sizeof(zHName),
-					"__phl_hook_set_%z",&pHAttr->sName);
-				ph7_class_method *pSetHook = PH7_ClassExtractMethod(pHThis->pClass,zHName,nHName);
-				if( pSetHook ){
-					ph7_value sHookRet;
-					ph7_value *apHArg[1];
-					apHArg[0] = pTos;
-					PH7_MemObjInit(pVm,&sHookRet);
-					VmMagicGuardPush(pVm,(void *)pHThis,&pHAttr->sName,'S');
-					PH7_VmCallClassMethod(&(*pVm),pHThis,pSetHook,&sHookRet,1,apHArg);
-					VmMagicGuardPop(pVm);
-					if( (pSetHook->sFunc.iFlags & VM_FUNC_HOOK_SET_EXPR)
-					 && nBackIdx != SXU32_HIGH && pVm->nBoundaryRc == 0 ){
-						sxi32 rcH = VmEnforcePropertyTypeOnStore(&(*pVm),nBackIdx,&sHookRet,0);
-						if( rcH == SXRET_OK ){
-							ph7_value *pBack = (ph7_value *)SySetAt(&pVm->aMemObj,nBackIdx);
-							if( pBack ){
-								PH7_MemObjStore(&sHookRet,pBack);
-							}
-						}else if( rcH == PH7_ABORT ){
-							PH7_MemObjRelease(&sHookRet);
-							PH7_ClassInstanceUnref(pHThis);
-							goto Abort;
-						}
-						/* PH7_EXCEPTION: the TypeError was routed/parked by the
-						 * enforcement — the store is skipped, execution lands at
-						 * the fetch point like any parked throw. */
-					}
-					PH7_MemObjRelease(&sHookRet);
-				}
-			}
+			rcHs = VmHookSetDispatch(&(*pVm),pHThis,pHAttr,nBackIdx,pTos);
 			PH7_ClassInstanceUnref(pHThis);
+			if( rcHs == PH7_ABORT ){
+				goto Abort;
+			}
 			break;
 		}
 		if( nIdx == SXU32_HIGH ){
@@ -10716,6 +10952,30 @@ case PH7_OP_INCR:
 	 * type (it bypasses the store path), so enforce before the type guard below
 	 * — which otherwise skips object/array/resource operands. */
 	PH7_ENFORCE_READONLY_MUTATE(pTos->nIdx);
+	/* A hooked property whose get hook returned an array/object/resource:
+	 * php's TypeError, raised BEFORE any set dispatch (the type guard below
+	 * would skip the mutation and the tail write-back would otherwise call
+	 * the set hook with the unchanged value). */
+	if( (pTos->iFlags & (MEMOBJ_HASHMAP|MEMOBJ_OBJ|MEMOBJ_RES)) != 0
+	 && SySetUsed(&pVm->aHookRmw) > 0 ){
+		VmHookRmw *pTopInc = (VmHookRmw *)SySetPeek(&pVm->aHookRmw);
+		if( pTopInc->iKind == VM_HOOK_PEND_RMW && pTopInc->nScratchIdx == pTos->nIdx ){
+			SyBlob sErrMsg;
+			SyBlobInit(&sErrMsg,&pVm->sAllocator);
+			if( pTos->iFlags & MEMOBJ_HASHMAP ){
+				SyBlobAppend(&sErrMsg,"Cannot increment array",sizeof("Cannot increment array")-1);
+			}else if( pTos->iFlags & MEMOBJ_OBJ ){
+				SyBlobFormat(&sErrMsg,"Cannot increment %z",
+					&((ph7_class_instance *)pTos->x.pOther)->pClass->sName);
+			}else{
+				SyBlobAppend(&sErrMsg,"Cannot increment resource",sizeof("Cannot increment resource")-1);
+			}
+			VmBoundaryPark(&(*pVm),VmThrowBuiltinError(&(*pVm),"TypeError",sizeof("TypeError")-1,&sErrMsg));
+			VmHookRmwDropTop(&(*pVm));
+			pTos->nIdx = SXU32_HIGH;
+			break;
+		}
+	}
 	if( (pTos->iFlags & (MEMOBJ_HASHMAP|MEMOBJ_OBJ|MEMOBJ_RES)) == 0 ){
 		if( pTos->nIdx != SXU32_HIGH ){
 			ph7_value *pObj;
@@ -10808,6 +11068,7 @@ case PH7_OP_INCR:
 			}
 		}
 	}
+	PH7_HOOK_RMW_WRITEBACK(pTos->nIdx,pTos);
 	break;
 /*
  * DECR: P1 * *
@@ -10827,6 +11088,29 @@ case PH7_OP_DECR:
 	 * — which otherwise skips null/object/array/resource operands (e.g. a readonly
 	 * property currently holding null). */
 	PH7_ENFORCE_READONLY_MUTATE(pTos->nIdx);
+	/* A hooked property whose get hook returned an array/object/resource:
+	 * php's TypeError, raised BEFORE any set dispatch (null stays excluded —
+	 * `--` on null is php's no-op and its write-back still dispatches set). */
+	if( (pTos->iFlags & (MEMOBJ_HASHMAP|MEMOBJ_OBJ|MEMOBJ_RES)) != 0
+	 && SySetUsed(&pVm->aHookRmw) > 0 ){
+		VmHookRmw *pTopDec = (VmHookRmw *)SySetPeek(&pVm->aHookRmw);
+		if( pTopDec->iKind == VM_HOOK_PEND_RMW && pTopDec->nScratchIdx == pTos->nIdx ){
+			SyBlob sErrMsg;
+			SyBlobInit(&sErrMsg,&pVm->sAllocator);
+			if( pTos->iFlags & MEMOBJ_HASHMAP ){
+				SyBlobAppend(&sErrMsg,"Cannot decrement array",sizeof("Cannot decrement array")-1);
+			}else if( pTos->iFlags & MEMOBJ_OBJ ){
+				SyBlobFormat(&sErrMsg,"Cannot decrement %z",
+					&((ph7_class_instance *)pTos->x.pOther)->pClass->sName);
+			}else{
+				SyBlobAppend(&sErrMsg,"Cannot decrement resource",sizeof("Cannot decrement resource")-1);
+			}
+			VmBoundaryPark(&(*pVm),VmThrowBuiltinError(&(*pVm),"TypeError",sizeof("TypeError")-1,&sErrMsg));
+			VmHookRmwDropTop(&(*pVm));
+			pTos->nIdx = SXU32_HIGH;
+			break;
+		}
+	}
 	/* NULL stays excluded: PHP leaves `--` on null untouched (no-op). */
 	if( (pTos->iFlags & (MEMOBJ_HASHMAP|MEMOBJ_OBJ|MEMOBJ_RES|MEMOBJ_NULL)) == 0 ){
 		if( pTos->nIdx != SXU32_HIGH ){
@@ -10912,6 +11196,7 @@ case PH7_OP_DECR:
 			}
 		}
 	}
+	PH7_HOOK_RMW_WRITEBACK(pTos->nIdx,pTos);
 	break;
 /*
  * UMINUS: * * *
@@ -11070,6 +11355,7 @@ case PH7_OP_MUL_STORE: {
 			PH7_MemObjStore(pNos,pObj);
 		}
 	}
+	PH7_HOOK_RMW_WRITEBACK(pTos->nIdx,0);
 	VmPopOperand(&pTos,1);
 	break;
 				 }
@@ -11192,6 +11478,7 @@ case PH7_OP_POW_STORE: {
 			PH7_MemObjStore(pNos,pObj);
 		}
 	}
+	PH7_HOOK_RMW_WRITEBACK(pTos->nIdx,0);
 	VmPopOperand(&pTos,1);
 	break;
 				 }
@@ -11246,6 +11533,7 @@ case PH7_OP_ADD_STORE:{
 		PH7_ENFORCE_TYPED_STORE(nIdx,pTos);
 		PH7_MemObjStore(pTos,pObj);
 	}
+	PH7_HOOK_RMW_WRITEBACK(nIdx,0);
 	/* Ticket 1433-35: Perform a stack dup */
 	PH7_MemObjStore(pTos,pNos);
 	VmPopOperand(&pTos,1);
@@ -11359,6 +11647,7 @@ case PH7_OP_SUB_STORE: {
 		PH7_ENFORCE_TYPED_STORE(pTos->nIdx,pNos);
 		PH7_MemObjStore(pNos,pObj);
 	}
+	PH7_HOOK_RMW_WRITEBACK(pTos->nIdx,0);
 	VmPopOperand(&pTos,1);
 	break;
 				 }
@@ -11461,6 +11750,7 @@ case PH7_OP_MOD_STORE: {
 		PH7_ENFORCE_TYPED_STORE(pTos->nIdx,pNos);
 		PH7_MemObjStore(pNos,pObj);
 	}
+	PH7_HOOK_RMW_WRITEBACK(pTos->nIdx,0);
 	VmPopOperand(&pTos,1);
 	break;
 				}
@@ -11552,6 +11842,7 @@ case PH7_OP_DIV_STORE:{
 		PH7_ENFORCE_TYPED_STORE(pTos->nIdx,pNos);
 		PH7_MemObjStore(pNos,pObj);
 	}
+	PH7_HOOK_RMW_WRITEBACK(pTos->nIdx,0);
 	VmPopOperand(&pTos,1);
 	break;
 				}
@@ -11665,6 +11956,7 @@ case PH7_OP_BXOR_STORE:{
 		PH7_ENFORCE_TYPED_STORE(pTos->nIdx,pNos);
 		PH7_MemObjStore(pNos,pObj);
 	}
+	PH7_HOOK_RMW_WRITEBACK(pTos->nIdx,0);
 	VmPopOperand(&pTos,1);
 	break;
 				 }
@@ -11762,6 +12054,7 @@ case PH7_OP_SHR_STORE: {
 		PH7_ENFORCE_TYPED_STORE(pTos->nIdx,pNos);
 		PH7_MemObjStore(pNos,pObj);
 	}
+	PH7_HOOK_RMW_WRITEBACK(pTos->nIdx,0);
 	VmPopOperand(&pTos,1);
 	break;
 				 }
@@ -11867,6 +12160,9 @@ case PH7_OP_CAT_STORE:{
 		if( (pInstr+1)->iOp != PH7_OP_POP ){
 			PH7_MemObjStore(pObj,pNos);
 		}
+		/* A hooked lvalue's scratch slot was appended in place — dispatch the
+		 * set side now (the consume reads the computed value from the slot). */
+		PH7_HOOK_RMW_WRITEBACK(nIdx,0);
 		pNos->nIdx = SXU32_HIGH;
 		VmPopOperand(&pTos,1);
 		break;
@@ -11892,6 +12188,7 @@ case PH7_OP_CAT_STORE:{
 		PH7_ENFORCE_TYPED_STORE(pTos->nIdx,pTos);
 		PH7_MemObjStore(pTos,pObj);
 	}
+	PH7_HOOK_RMW_WRITEBACK(pTos->nIdx,0);
 	PH7_MemObjStore(pTos,pNos);
 	VmPopOperand(&pTos,1);
 	break;
@@ -11982,7 +12279,10 @@ case PH7_OP_NULLC_JMP: {
 	}
 #endif
 	if( (pTos->iFlags & MEMOBJ_NULL) == 0 ){
-		pc = pInstr->iP2 - 1; /* Jump (will be incremented by the loop) */
+		pc = pInstr->iP2 - 1; /* Jump (will be incremented by the loop) —
+		 * a pending ??= write-back entry armed by the preceding OP_MEMBER is
+		 * dropped by the fetch-point sweep (the landing pc is past its
+		 * OP_NULLC_STORE window): the skipped assign never dispatches. */
 	}
 	break;
 }
@@ -12023,6 +12323,40 @@ case PH7_OP_NULLC_STORE: {
 		goto Abort;
 	}
 #endif
+	if( SySetUsed(&pVm->aHookRmw) > 0 ){
+		/* `$o->p ??= v` whose test value was null: the OP_MEMBER pushed a
+		 * COAL entry targeting exactly THIS store (owner + pc identity — a
+		 * stale entry from an abandoned statement can never match, and nested
+		 * arms in the RHS were consumed/dropped above this one). Dispatch the
+		 * set hook (COAL_HOOK) or __set (COAL_MAGIC — the band A #3b ??=
+		 * residual: pre-fix the assign bypassed __set through the normal slot
+		 * path). The RHS stays as the expression result. */
+		VmHookRmw *pTop = (VmHookRmw *)SySetPeek(&pVm->aHookRmw);
+		if( pTop->pOwnerStack == (void *)pStack && pTop->pInstrs == (void *)aInstr
+		 && pTop->nPc == (sxu32)pc
+		 && (pTop->iKind == VM_HOOK_PEND_COAL_HOOK || pTop->iKind == VM_HOOK_PEND_COAL_MAGIC) ){
+			VmHookRmw sPend = *pTop;
+			(void)SySetPop(&pVm->aHookRmw);
+			if( sPend.iKind == VM_HOOK_PEND_COAL_HOOK ){
+				sxi32 rcHs = VmHookSetDispatch(&(*pVm),sPend.pThis,sPend.pAttr,sPend.nBackIdx,pTos);
+				if( rcHs == PH7_ABORT ){
+					SyBlobRelease(&sPend.sName);
+					PH7_ClassInstanceUnref(sPend.pThis);
+					goto Abort;
+				}
+			}else{
+				SyString sSetName;
+				SyStringInitFromBuf(&sSetName,SyBlobData(&sPend.sName),SyBlobLength(&sPend.sName));
+				VmMagicSetDispatch(&(*pVm),sPend.pThis,&sSetName,pTos);
+			}
+			SyBlobRelease(&sPend.sName);
+			PH7_ClassInstanceUnref(sPend.pThis);
+			PH7_MemObjStore(pTos,pNos);
+			pNos->nIdx = SXU32_HIGH;
+			VmPopOperand(&pTos,1);
+			break;
+		}
+	}
 	/* ArrayAccess null-coalesce-assign target: the preceding LOAD_IDX iP2=3
 	 * armed pVm with the (object, key) on a missing key. Dispatch to
 	 * offsetSet instead of writing through the synthetic pNos->nIdx. */
@@ -13368,6 +13702,58 @@ case PH7_OP_FOREACH_STEP: {
 					MemObjSetType(pKey,MEMOBJ_STRING);
 				}
 			}
+			if( (pVmAttr->pAttr->iFlags & (PH7_CLASS_ATTR_HOOK_GET|PH7_CLASS_ATTR_HOOK_SET))
+			 && (pStep->iFlags & PH7_4EACH_STEP_REF)
+			 && !VmHookGuardHeld(pVm,(void *)pThis,&pVmAttr->pAttr->sName) ){
+				/* php: a hooked property (virtual or backed) cannot be iterated
+				 * by reference — catchable Error. Tear the step down like the
+				 * exhausted-iteration path (break the by-ref binding, unlink,
+				 * free, drop the instance retain) so nothing leaks and a
+				 * re-entered foreach starts fresh; the fetch-point router lands
+				 * the parked throw right after this op. Inside the property's
+				 * own hook body the guard keeps raw semantics (no Error). */
+				SyBlob sErrMsg;
+				SyBlobInit(&sErrMsg,&pVm->sAllocator);
+				SyBlobFormat(&sErrMsg,"Cannot create reference to property %z::$%z",
+					&pThis->pClass->sName,&pVmAttr->pAttr->sName);
+				VmBoundaryPark(&(*pVm),VmThrowBuiltinError(&(*pVm),"Error",sizeof("Error")-1,&sErrMsg));
+				SyHashDeleteEntry(&pFrameLocal->hVar,SyStringData(&pInfo->sValue),SyStringLength(&pInfo->sValue),0);
+				VmForeachStepUnlink(pInfo,pStep);
+				SyMemBackendPoolFree(&pVm->sAllocator,pStep);
+				PH7_ClassInstanceUnref(pThis);
+				break;
+			}
+			if( (pStep->iFlags & PH7_4EACH_STEP_REF) == 0
+			 && (pVmAttr->pAttr->iFlags & PH7_CLASS_ATTR_HOOK_GET) != 0 ){
+				/* PHP 8.4 property hooks: object iteration reads through the
+				 * get hook (virtual properties included; the flag gate keeps
+				 * hook-free classes on the raw zero-copy path below). The
+				 * object step walks hAttr with the hash's single EMBEDDED
+				 * cursor — save/restore it around the dispatch so a hook that
+				 * re-enters an hAttr walk on this instance (get_object_vars,
+				 * json_encode of $this) can't truncate THIS iteration. A hook
+				 * that unset()s the property the saved cursor points at stays
+				 * a recorded hazard (php's own semantics there are murky). */
+				ph7_value sHookVal;
+				sxi32 rcHk;
+				SyHashEntry_Pr *pSavedCur = pThis->hAttr.pCurrent;
+				PH7_MemObjInit(pVm,&sHookVal);
+				rcHk = PH7_VmHookGetAttrValue(pThis,pVmAttr,&sHookVal);
+				pThis->hAttr.pCurrent = pSavedCur;
+				if( rcHk != SXERR_NOTFOUND ){
+					if( rcHk == SXRET_OK ){
+						pValue = VmExtractMemObj(&(*pVm),&pInfo->sValue,FALSE,TRUE);
+						if( pValue ){
+							PH7_MemObjStore(&sHookVal,pValue);
+						}
+					}
+					/* a throw parked on the boundary rail: the fetch-point
+					 * router lands it right after this op */
+					PH7_MemObjRelease(&sHookVal);
+					break;
+				}
+				PH7_MemObjRelease(&sHookVal);
+			}
 			/* Extract attribute value */
 			pAttrValue = PH7_ClassInstanceExtractAttrValue(pThis,pVmAttr);
 			if( pAttrValue ){
@@ -13557,6 +13943,7 @@ case PH7_OP_MEMBER: {
 							 * stdClass and #[AllowDynamicProperties]); a readonly
 							 * class raises php's catchable Error instead. */
 							ph7_class_method *pSetMagic = 0;
+							ph7_class_method *pCoalIsset = 0, *pCoalGet = 0, *pCoalSet = 0;
 							int bPlainStore = (pNext->iOp == PH7_OP_STORE && pNext->iP2 != 0);
 							if( bPlainStore ){
 								pSetMagic = PH7_ClassExtractMethod(pClass,"__set",sizeof("__set")-1);
@@ -13568,14 +13955,89 @@ case PH7_OP_MEMBER: {
 								SyBlobAppend(&pVm->sMagicSetName,(const void *)sName.zString,sName.nByte);
 								/* pObjAttr stays NULL; the miss path below stays silent. */
 							}else if( !bPlainStore && pInstr->iP2 == PH7_MEMBER_WRITE
+							 && pNext->iOp == PH7_OP_NULLC_JMP
+							 && ((pCoalIsset = PH7_ClassExtractMethod(pClass,"__isset",sizeof("__isset")-1)) != 0
+							  || (pCoalGet = PH7_ClassExtractMethod(pClass,"__get",sizeof("__get")-1)) != 0
+							  || (pCoalSet = PH7_ClassExtractMethod(pClass,"__set",sizeof("__set")-1)) != 0) ){
+								/* `$o->p ??= v` on a missing property with magic accessors:
+								 * php consults __isset first when declared — false means
+								 * assign directly through __set with NO __get call (the
+								 * test value stays null); true (or no __isset) means __get
+								 * provides the test value. A COAL_MAGIC entry is pushed
+								 * for the OP_NULLC_STORE at the jump target; the
+								 * fetch-point sweep drops it when the short-circuit jump
+								 * skips the assign or a throw abandons the RHS. Without
+								 * __set the assign side keeps the pre-existing loud
+								 * "Cannot perform assignment" path (php would create a
+								 * dynamic property there — recorded residual). Note the
+								 * condition's short-circuit assignment chain: a hit on an
+								 * earlier method leaves the later pointers unresolved, so
+								 * re-resolve the leftovers here (each is one hash probe,
+								 * only on this ??=-miss path). */
+								ph7_value sTest;
+								int bMiss = 0; /* __isset said false: skip __get, test value stays null */
+								if( pCoalIsset != 0 ){
+									pCoalGet = PH7_ClassExtractMethod(pClass,"__get",sizeof("__get")-1);
+								}
+								if( pCoalIsset != 0 || pCoalGet != 0 ){
+									pCoalSet = PH7_ClassExtractMethod(pClass,"__set",sizeof("__set")-1);
+								}
+								PH7_MemObjInit(pVm,&sTest);
+								if( pCoalIsset && !VmMagicGuardHeld(pVm,(void *)pThis,&sName,'i') ){
+									ph7_value sIssetRet;
+									PH7_MemObjInit(pVm,&sIssetRet);
+									VmMagicGuardPush(pVm,(void *)pThis,&sName,'i');
+									PH7_ClassInstanceCallMagicMethod(&(*pVm),pClass,pThis,"__isset",sizeof("__isset")-1,&sName,&sIssetRet);
+									VmMagicGuardPop(pVm);
+									PH7_MemObjToBool(&sIssetRet);
+									bMiss = sIssetRet.x.iVal == 0;
+									PH7_MemObjRelease(&sIssetRet);
+								}
+								if( !bMiss && pCoalGet && !VmMagicGuardHeld(pVm,(void *)pThis,&sName,'g') ){
+									VmMagicGuardPush(pVm,(void *)pThis,&sName,'g');
+									PH7_ClassInstanceCallMagicMethod(&(*pVm),pClass,pThis,"__get",sizeof("__get")-1,&sName,&sTest);
+									VmMagicGuardPop(pVm);
+								}
+								if( pCoalSet && !VmMagicGuardHeld(pVm,(void *)pThis,&sName,'s')
+								 && pVm->nBoundaryRc == 0 ){
+									VmHookRmw sPend;
+									sPend.iKind = VM_HOOK_PEND_COAL_MAGIC;
+									sPend.pThis = pThis;
+									sPend.pAttr = 0;
+									sPend.nBackIdx = SXU32_HIGH;
+									sPend.nScratchIdx = SXU32_HIGH;
+									SyBlobInit(&sPend.sName,&pVm->sAllocator);
+									SyBlobAppend(&sPend.sName,(const void *)sName.zString,sName.nByte);
+									sPend.pOwnerStack = (void *)pStack;
+									sPend.pInstrs = (void *)aInstr;
+									sPend.nJmpPc = (sxu32)(pc + 1);        /* the OP_NULLC_JMP */
+									sPend.nPc = (sxu32)(pNext->iP2 - 1);   /* the OP_NULLC_STORE */
+									pThis->iRef++;
+									SySetPut(&pVm->aHookRmw,(const void *)&sPend);
+								}
+								/* Pop the attribute name; the test value becomes the
+								 * expression slot (a temp, not an lvalue). */
+								VmPopOperand(&pTos,1);
+								pThis->iRef++;
+								PH7_MemObjRelease(pTos);
+								PH7_MemObjStore(&sTest,pTos);
+								pTos->nIdx = SXU32_HIGH;
+								PH7_MemObjRelease(&sTest);
+								PH7_ClassInstanceUnref(pThis);
+								break;
+							}else if( !bPlainStore && pInstr->iP2 == PH7_MEMBER_WRITE
+							 && !VmMemberNextIsWrite(pNext)
 							 && PH7_ClassExtractMethod(pClass,"__get",sizeof("__get")-1) ){
-								/* `$o->p ??= v` / subscript-write base on a class with
-								 * __get: php reads through the magic layer (the ??= then
-								 * skips its assign on a non-null value; a subscript write
-								 * lands on the temp and is lost, like php's
-								 * indirect-modification case). A PLAIN store (bPlainStore
-								 * — the compiler tags those PH7_MEMBER_WRITE too) is NOT
-								 * this case: it falls through to dynamic creation.
+								/* Subscript-write base on a class with __get: php reads
+								 * through the magic layer (the write lands on the temp and
+								 * is lost, like php's indirect-modification case). A PLAIN
+								 * store (bPlainStore — the compiler tags those
+								 * PH7_MEMBER_WRITE too) is NOT this case: it falls through
+								 * to dynamic creation. A direct ++/--/compound-assign
+								 * (VmMemberNextIsWrite — the compiler now tags those
+								 * PH7_MEMBER_WRITE as well) is NOT this case either: it
+								 * falls through to dynamic creation like before (the
+								 * recorded RMW-vivifies-instead-of-__get residual, §7).
 								 * Leave the miss path — the read gate below dispatches
 								 * __get. */
 							}else if( pThis->pClass->iFlags & PH7_CLASS_READONLY ){
@@ -13701,19 +14163,32 @@ case PH7_OP_MEMBER: {
 					ph7_value *pValue = 0; /* cc warning */
 					/* Check attribute access */
 					if( PH7_VmClassMemberAccess(&(*pVm),pClass,&pObjAttr->pAttr->sName,pObjAttr->pAttr->iProtection,FALSE) ){
-						if( pObjAttr->pAttr->iFlags & (PH7_CLASS_ATTR_HOOK_GET|PH7_CLASS_ATTR_HOOK_SET) ){
-							/* PHP 8.4 property hooks: route reads and plain writes through
-							 * the synthesized hook methods. A held guard means we are
-							 * INSIDE this property's hook body — fall through to the raw
-							 * backing slot (php: hooks see the backing store). */
+						if( (pObjAttr->pAttr->iFlags & (PH7_CLASS_ATTR_HOOK_GET|PH7_CLASS_ATTR_HOOK_SET))
+						 && !VmHookGuardHeld(pVm,(void *)pThis,&sName) ){
+							/* PHP 8.4 property hooks: route reads, writes, and the
+							 * read-modify-write forms through the synthesized hook
+							 * methods. A held guard (either kind) means we are INSIDE
+							 * one of this property's own hook bodies — fall through to
+							 * the raw backing slot for BOTH directions (php: `$this->x`
+							 * within any of x's hooks addresses the backing store). */
 							VmInstr *pNextH = pInstr + 1;
 							int bPlainStore = (pNextH->iOp == PH7_OP_STORE && pNextH->iP2 != 0);
-							int bOtherWrite = (pInstr->iP2 == PH7_MEMBER_WRITE)
-								|| (!bPlainStore && VmMemberNextIsWrite(pNextH));
-							if( bPlainStore && !VmMagicGuardHeld(pVm,(void *)pThis,&sName,'S') ){
+							int bCoalesceW = pInstr->iP2 == PH7_MEMBER_WRITE
+								&& pNextH->iOp == PH7_OP_NULLC_JMP;
+							/* ++/--/compound-assign: the modify op FOLLOWS the member
+							 * directly (the compiler tags compound-assign members
+							 * PH7_MEMBER_WRITE too, so classify by the next op, not iP2;
+							 * the !bPlainStore term is load-bearing — VmMemberNextIsWrite
+							 * returns 1 for a member OP_STORE too) */
+							int bRmwNext = !bPlainStore && VmMemberNextIsWrite(pNextH);
+							int bSubscriptW = !bPlainStore && !bCoalesceW && !bRmwNext
+								&& pInstr->iP2 == PH7_MEMBER_WRITE;
+							if( bPlainStore ){
 								/* Arm the pending hook-set for the following OP_STORE — it
 								 * dispatches the set hook, or throws the read-only Error
-								 * when the property only has a get hook. */
+								 * when the property only has a get hook. (The scalar
+								 * transient is safe here: its window is exactly one
+								 * instruction, MEMBER -> STORE, nothing runs in between.) */
 								pThis->iRef++;
 								pVm->pHookSetThis = pThis;
 								pVm->pHookSetAttr = pObjAttr->pAttr;
@@ -13722,22 +14197,26 @@ case PH7_OP_MEMBER: {
 								PH7_ClassInstanceUnref(pThis);
 								break;
 							}
-							if( VmMemberCtxIsLookup(pInstr->iP2)
-							 && (pObjAttr->pAttr->iFlags & PH7_CLASS_ATTR_HOOK_GET)
-							 && !VmMagicGuardHeld(pVm,(void *)pThis,&sName,'G') ){
+							if( bSubscriptW ){
+								/* Subscript write base ($o->m[] = v, $o->m[$k] = v):
+								 * php's catchable Error, with or without a set hook
+								 * (only a by-ref `&get` hook would allow it — a loud
+								 * compile error in PHL). The op completes benignly with
+								 * a null temp; the fetch-point router lands the throw. */
+								SyBlob sErrMsg;
+								SyBlobInit(&sErrMsg,&pVm->sAllocator);
+								SyBlobFormat(&sErrMsg,"Indirect modification of %z::$%z is not allowed",
+									&pThis->pClass->sName,&pObjAttr->pAttr->sName);
+								VmBoundaryPark(&(*pVm),VmThrowBuiltinError(&(*pVm),"Error",sizeof("Error")-1,&sErrMsg));
+								PH7_ClassInstanceUnref(pThis);
+								break;
+							}
+							if( VmMemberCtxIsLookup(pInstr->iP2) ){
 								/* isset()/empty() on a hooked property calls the get hook
 								 * (php): isset is "get() !== null", empty tests the value. */
-								char zHName[384];
-								sxu32 nHName = SyBufferFormat(zHName,sizeof(zHName),
-									"__phl_hook_get_%z",&pObjAttr->pAttr->sName);
-								ph7_class_method *pGetHook =
-									PH7_ClassExtractMethod(pThis->pClass,zHName,nHName);
-								if( pGetHook ){
-									ph7_value sHookRet;
-									PH7_MemObjInit(pVm,&sHookRet);
-									VmMagicGuardPush(pVm,(void *)pThis,&sName,'G');
-									PH7_VmCallClassMethod(&(*pVm),pThis,pGetHook,&sHookRet,0,0);
-									VmMagicGuardPop(pVm);
+								ph7_value sHookRet;
+								PH7_MemObjInit(pVm,&sHookRet);
+								if( PH7_VmHookGetAttrValue(pThis,pObjAttr,&sHookRet) != SXERR_NOTFOUND ){
 									if( pInstr->iP2 == PH7_MEMBER_ISSET ){
 										pTos->x.iVal = (sHookRet.iFlags & MEMOBJ_NULL) == 0;
 										MemObjSetType(pTos,MEMOBJ_BOOL);
@@ -13750,37 +14229,102 @@ case PH7_OP_MEMBER: {
 									PH7_ClassInstanceUnref(pThis);
 									break;
 								}
+								PH7_MemObjRelease(&sHookRet);
 							}
-							if( !bPlainStore && !bOtherWrite && !VmMemberCtxIsLookup(pInstr->iP2)
-							 && (pObjAttr->pAttr->iFlags & PH7_CLASS_ATTR_HOOK_GET)
-							 && !VmMagicGuardHeld(pVm,(void *)pThis,&sName,'G') ){
+							if( !bCoalesceW && !bRmwNext && !VmMemberCtxIsLookup(pInstr->iP2) ){
 								/* Read: dispatch __phl_hook_get_NAME (inheritance-aware) */
-								char zHName[384];
-								sxu32 nHName = SyBufferFormat(zHName,sizeof(zHName),
-									"__phl_hook_get_%z",&pObjAttr->pAttr->sName);
-								ph7_class_method *pGetHook =
-									PH7_ClassExtractMethod(pThis->pClass,zHName,nHName);
-								if( pGetHook ){
-									ph7_value sHookRet;
-									PH7_MemObjInit(pVm,&sHookRet);
-									VmMagicGuardPush(pVm,(void *)pThis,&sName,'G');
-									PH7_VmCallClassMethod(&(*pVm),pThis,pGetHook,&sHookRet,0,0);
-									VmMagicGuardPop(pVm);
+								ph7_value sHookRet;
+								PH7_MemObjInit(pVm,&sHookRet);
+								if( PH7_VmHookGetAttrValue(pThis,pObjAttr,&sHookRet) != SXERR_NOTFOUND ){
 									PH7_MemObjStore(&sHookRet,pTos);
 									pTos->nIdx = SXU32_HIGH;
 									PH7_MemObjRelease(&sHookRet);
 									PH7_ClassInstanceUnref(pThis);
 									break;
 								}
+								PH7_MemObjRelease(&sHookRet);
 							}
-							if( bOtherWrite && !VmMagicGuardHeld(pVm,(void *)pThis,&sName,'S')
-							 && !VmMagicGuardHeld(pVm,(void *)pThis,&sName,'G') ){
-								/* Read-modify-write (`++`, `.=`, subscript writes…) on a
-								 * hooked property: not yet modeled — LOUD, never a silent
-								 * hook bypass (recorded residual; the raw slot is used). */
-								VmErrorFormat(&(*pVm),PH7_CTX_WARNING,
-									"Read-modify-write on hooked property %z::$%z bypasses its hooks (not yet supported)",
-									&pClass->sName,&pObjAttr->pAttr->sName);
+							if( bCoalesceW || bRmwNext ){
+								/* `$o->x ??= v` (bCoalesceW) and the read-modify-write
+								 * forms `$o->x++`, `$o->x .= v`, … (bRmwNext): php reads
+								 * through the get hook (raw backing when the property is
+								 * set-only) and writes through the set hook.
+								 *   - ??=: the test value goes on the stack and a
+								 *     COAL_HOOK entry is pushed for the OP_NULLC_STORE
+								 *     at the jump target; the fetch-point sweep drops it
+								 *     when the short-circuit jump skips the assign or a
+								 *     throw abandons the RHS (the entry is NOT a scalar
+								 *     transient — nested stores/coalesces in the RHS
+								 *     stack their own entries above it).
+								 *   - RMW: the value goes into a fresh SCRATCH slot the
+								 *     modify op mutates in place; the entry makes the
+								 *     op's tail dispatch the set side with the computed
+								 *     value (PH7_HOOK_RMW_WRITEBACK). */
+								ph7_value sCur;
+								sxi32 rcCur;
+								PH7_MemObjInit(pVm,&sCur);
+								rcCur = PH7_VmHookGetAttrValue(pThis,pObjAttr,&sCur);
+								if( rcCur == SXERR_NOTFOUND ){
+									/* set-only hook (or guard edge): the read side is the
+									 * raw backing store (php) */
+									ph7_value *pBack = (ph7_value *)SySetAt(&pVm->aMemObj,pObjAttr->nIdx);
+									if( pBack ){
+										PH7_MemObjStore(pBack,&sCur);
+									}
+								}else if( pVm->nBoundaryRc != 0 ){
+									/* the get hook threw: leave the null temp; the
+									 * fetch-point router lands the parked throw —
+									 * nothing is armed. */
+									PH7_MemObjRelease(&sCur);
+									PH7_ClassInstanceUnref(pThis);
+									break;
+								}
+								if( bCoalesceW ){
+									VmHookRmw sPend;
+									PH7_MemObjStore(&sCur,pTos);
+									pTos->nIdx = SXU32_HIGH;
+									PH7_MemObjRelease(&sCur);
+									sPend.iKind = VM_HOOK_PEND_COAL_HOOK;
+									sPend.pThis = pThis;
+									sPend.pAttr = pObjAttr->pAttr;
+									sPend.nBackIdx = pObjAttr->nIdx;
+									sPend.nScratchIdx = SXU32_HIGH;
+									SyBlobInit(&sPend.sName,&pVm->sAllocator);
+									sPend.pOwnerStack = (void *)pStack;
+									sPend.pInstrs = (void *)aInstr;
+									sPend.nJmpPc = (sxu32)(pc + 1);            /* the OP_NULLC_JMP */
+									sPend.nPc = (sxu32)(pNextH->iP2 - 1);      /* the OP_NULLC_STORE */
+									pThis->iRef++;
+									SySetPut(&pVm->aHookRmw,(const void *)&sPend);
+									PH7_ClassInstanceUnref(pThis);
+									break;
+								}
+								{
+									ph7_value *pScr = PH7_ReserveMemObj(&(*pVm));
+									if( pScr ){
+										VmHookRmw sRmw;
+										PH7_MemObjStore(&sCur,pScr);
+										PH7_MemObjStore(&sCur,pTos);
+										pTos->nIdx = pScr->nIdx;
+										sRmw.iKind = VM_HOOK_PEND_RMW;
+										sRmw.pThis = pThis;
+										sRmw.pAttr = pObjAttr->pAttr;
+										sRmw.nBackIdx = pObjAttr->nIdx;
+										sRmw.nScratchIdx = pScr->nIdx;
+										SyBlobInit(&sRmw.sName,&pVm->sAllocator);
+										sRmw.pOwnerStack = (void *)pStack;
+										sRmw.pInstrs = (void *)aInstr;
+										sRmw.nJmpPc = (sxu32)(pc + 1);  /* the modify op ... */
+										sRmw.nPc = (sxu32)(pc + 1);     /* ... is the whole window */
+										pThis->iRef++;
+										SySetPut(&pVm->aHookRmw,(const void *)&sRmw);
+									}
+									/* OOM: pScr == 0 — leave the null temp (loud allocator
+									 * diagnostics already fired) */
+									PH7_MemObjRelease(&sCur);
+									PH7_ClassInstanceUnref(pThis);
+									break;
+								}
 							}
 						}
 						/* PHP 7.4+: reading an uninitialized typed property is an Error.
@@ -16839,6 +17383,16 @@ Unwind:
 	 * with the pre-stage-2 lossy deep-suspend (stage 4 replaces this).
 	 * At the bottom, VmExecFinalize hands the status to the native caller. */
 	for(;;){
+		if( rc == PH7_ABORT || rc == PH7_EXCEPTION ){
+			/* Drop any pending hook-RMW write-backs this activation armed — its
+			 * statement is abandoned (only the innermost activation at throw time
+			 * can own entries: the armed window spans exactly one instruction, so
+			 * no OP_CALL record ever intervenes). */
+			while( SySetUsed(&pVm->aHookRmw) > 0
+			 && ((VmHookRmw *)SySetPeek(&pVm->aHookRmw))->pOwnerStack == (void *)pStack ){
+				VmHookRmwDropTop(&(*pVm));
+			}
+		}
 		if( pCallTop == 0 ){
 			return VmExecFinalize(&(*pVm),&sState,&aArg,pTos,rc);
 		}
@@ -21774,22 +22328,63 @@ static void VmExportValue(SyBlob *pOut, ph7_value *pVal, int nIndent, int depth)
 		}else{
 			SyString *pClassName = &pThis->pClass->sName;
 			SyHashEntry *pEntry;
+			SySet sNames;
+			SyString *aName;
+			sxu32 iName,nName;
 			pThis->iFlags |= VM_INSTANCE_DUMPING;
 			SyBlobAppend(pOut,"\\",1);
 			SyBlobAppend(pOut,pClassName->zString,pClassName->nByte);
 			SyBlobAppend(pOut,"::__set_state(array(\n",21);
+			/* SNAPSHOT the attribute names first: a PHP 8.4 get hook dispatched
+			 * mid-walk may re-enter an hAttr walk on this instance (the hash has
+			 * a single embedded loop cursor) or unset()/create properties; names
+			 * point into class-owned attr storage and each is re-looked-up. */
+			SySetInit(&sNames,&pThis->pVm->sAllocator,sizeof(SyString));
 			SyHashResetLoopCursor(&pThis->hAttr);
 			while( (pEntry = SyHashGetNextEntry(&pThis->hAttr)) != 0 ){
 				VmClassAttr *pVmAttr = (VmClassAttr *)pEntry->pUserData;
-				SyString *pAName = &pVmAttr->pAttr->sName;
-				ph7_value *pAttrVal;
 				if( pVmAttr->pAttr->iFlags & (PH7_CLASS_ATTR_STATIC|PH7_CLASS_ATTR_CONSTANT) ){ continue; }
+				SySetPut(&sNames,(const void *)&pVmAttr->pAttr->sName);
+			}
+			aName = (SyString *)SySetBasePtr(&sNames);
+			nName = SySetUsed(&sNames);
+			for( iName = 0 ; iName < nName ; ++iName ){
+				SyString *pAName = &aName[iName];
+				VmClassAttr *pVmAttr;
+				ph7_value *pAttrVal;
+				pEntry = SyHashGet(&pThis->hAttr,(const void *)pAName->zString,pAName->nByte);
+				if( pEntry == 0 ){ continue; } /* unset by an earlier hook */
+				pVmAttr = (VmClassAttr *)pEntry->pUserData;
 				VmExportIndent(pOut,nIndent+3); /* object property lines sit one deeper than arrays */
 				VmExportQuoted(pOut,pAName->zString,(int)pAName->nByte);
+				/* PHP 8.4 property hooks: var_export() reads through the get hook
+				 * (every visibility — php exports private hooked values too). A
+				 * throwing hook parks on the boundary rail; the helper's boundary
+				 * gate keeps LATER hooks from running (the raw values the tail of
+				 * the export falls back to are discarded when the throw routes). */
+				{
+					ph7_value sHookVal;
+					sxi32 rcHk;
+					PH7_MemObjInit(pThis->pVm,&sHookVal);
+					rcHk = PH7_VmHookGetAttrValue(pThis,pVmAttr,&sHookVal);
+					if( rcHk == SXRET_OK ){
+						VmExportEntryValue(pOut,&sHookVal,nIndent,depth);
+						PH7_MemObjRelease(&sHookVal);
+						continue;
+					}
+					PH7_MemObjRelease(&sHookVal);
+					if( rcHk != SXERR_NOTFOUND ){
+						/* the hook threw (parked on the boundary rail): NULL
+						 * placeholder keeps the output well-formed */
+						SyBlobAppend(pOut," => NULL,\n",10);
+						continue;
+					}
+				}
 				pAttrVal = PH7_ClassInstanceExtractAttrValue(pThis,pVmAttr);
 				if( pAttrVal ){ VmExportEntryValue(pOut,pAttrVal,nIndent,depth); }
 				else { SyBlobAppend(pOut," => NULL,\n",10); }
 			}
+			SySetRelease(&sNames);
 			VmExportIndent(pOut,nIndent);
 			SyBlobAppend(pOut,"))",2);
 			pThis->iFlags &= ~VM_INSTANCE_DUMPING;

--- a/src/ph7/vm_builtin_class.c
+++ b/src/ph7/vm_builtin_class.c
@@ -753,29 +753,70 @@ PH7_PRIVATE int vm_builtin_get_object_vars(ph7_context *pCtx,int nArg,ph7_value 
 		ph7_result_null(pCtx);
 		return PH7_OK;
 	}
-	/* Fill the array with the defined attribute visible from the current scope */
-	SyHashResetLoopCursor(&pThis->hAttr);
-	while((pEntry = SyHashGetNextEntry(&pThis->hAttr)) != 0 ){
-		VmClassAttr *pVmAttr = (VmClassAttr *)pEntry->pUserData;
-		SyString *pAttrName;
-		if( pVmAttr->pAttr->iFlags & (PH7_CLASS_ATTR_STATIC|PH7_CLASS_ATTR_CONSTANT) ){
-			/* Only non-static/constant attributes are extracted */
-			continue;
-		}
-		pAttrName = &pVmAttr->pAttr->sName;
-		/* Check if the access is allowed */
-		if( PH7_VmClassMemberAccess(pCtx->pVm,pThis->pClass,pAttrName,pVmAttr->pAttr->iProtection,FALSE) ){
-			ph7_value *pValue = 0;
-			/* Extract attribute */
-			pValue = PH7_ClassInstanceExtractAttrValue(pThis,pVmAttr);
-			if( pValue ){
-				/* Insert attribute name in the array */
-				ph7_value_string(pName,pAttrName->zString,pAttrName->nByte);
-				ph7_array_add_elem(pArray,pName,pValue); /* Will make it's own copy */
+	/* Fill the array with the defined attribute visible from the current scope.
+	 * SNAPSHOT the attribute names first: a PHP 8.4 get hook dispatched mid-walk
+	 * runs user code that may re-enter an hAttr walk on this instance (resetting
+	 * the hash's single embedded loop cursor) or unset()/create properties. The
+	 * names point into CLASS-owned attr storage (they outlive instance mutation);
+	 * each is re-looked-up before use so an entry unset by an earlier hook is
+	 * skipped instead of read after free. */
+	{
+		SySet sNames;
+		SyString *aName;
+		sxu32 iName,nName;
+		SySetInit(&sNames,&pCtx->pVm->sAllocator,sizeof(SyString));
+		SyHashResetLoopCursor(&pThis->hAttr);
+		while((pEntry = SyHashGetNextEntry(&pThis->hAttr)) != 0 ){
+			VmClassAttr *pVmAttr = (VmClassAttr *)pEntry->pUserData;
+			if( pVmAttr->pAttr->iFlags & (PH7_CLASS_ATTR_STATIC|PH7_CLASS_ATTR_CONSTANT) ){
+				/* Only non-static/constant attributes are extracted */
+				continue;
 			}
-			/* Reset the cursor */
-			ph7_value_reset_string_cursor(pName);
+			SySetPut(&sNames,(const void *)&pVmAttr->pAttr->sName);
 		}
+		aName = (SyString *)SySetBasePtr(&sNames);
+		nName = SySetUsed(&sNames);
+		for( iName = 0 ; iName < nName ; ++iName ){
+			SyString *pAttrName = &aName[iName];
+			VmClassAttr *pVmAttr;
+			pEntry = SyHashGet(&pThis->hAttr,(const void *)pAttrName->zString,pAttrName->nByte);
+			if( pEntry == 0 ){
+				continue; /* unset by an earlier hook */
+			}
+			pVmAttr = (VmClassAttr *)pEntry->pUserData;
+			/* Check if the access is allowed */
+			if( PH7_VmClassMemberAccess(pCtx->pVm,pThis->pClass,pAttrName,pVmAttr->pAttr->iProtection,FALSE) ){
+				ph7_value *pValue = 0;
+				ph7_value sHookVal;
+				sxi32 rcHk;
+				/* PHP 8.4 property hooks: get_object_vars() reads through the get
+				 * hook (virtual properties included); raw slot otherwise. */
+				PH7_MemObjInit(pCtx->pVm,&sHookVal);
+				rcHk = PH7_VmHookGetAttrValue(pThis,pVmAttr,&sHookVal);
+				if( rcHk == SXRET_OK ){
+					pValue = &sHookVal;
+				}else if( rcHk == SXERR_NOTFOUND ){
+					/* Extract attribute */
+					pValue = PH7_ClassInstanceExtractAttrValue(pThis,pVmAttr);
+				}else{
+					/* the hook threw — parked on the boundary rail; php aborts the
+					 * whole builtin at the first throw (the helper's boundary gate
+					 * keeps LATER hooks from running; raw values it falls back to
+					 * are discarded when the throw routes) */
+					PH7_MemObjRelease(&sHookVal);
+					break;
+				}
+				if( pValue ){
+					/* Insert attribute name in the array */
+					ph7_value_string(pName,pAttrName->zString,pAttrName->nByte);
+					ph7_array_add_elem(pArray,pName,pValue); /* Will make it's own copy */
+				}
+				PH7_MemObjRelease(&sHookVal);
+				/* Reset the cursor */
+				ph7_value_reset_string_cursor(pName);
+			}
+		}
+		SySetRelease(&sNames);
 	}
 	/* Return the created array */
 	ph7_result_value(pCtx,pArray);

--- a/src/ph7/vm_json.c
+++ b/src/ph7/vm_json.c
@@ -259,15 +259,77 @@ static sxi32 VmJsonEncode(
 					return PH7_OK;
 				}
 			}else{
-				/* Encode the class instance */
+				SyHashEntry *pAttrEntry;
+				SySet sNames;
+				SyString *aName;
+				sxu32 iName,nName;
+				/* Encode the class instance: php serializes only PUBLIC
+				 * non-static properties, reading through a PHP 8.4 get hook
+				 * when one is declared (virtual properties included). The
+				 * names are SNAPSHOTTED first — a hook dispatched mid-walk may
+				 * re-enter an hAttr walk on this instance (the hash has a
+				 * single embedded loop cursor) or unset()/create properties;
+				 * names point into class-owned attr storage and each is
+				 * re-looked-up before use. */
 				pData->isFirst = 1;
 				/* Append the curly braces */
 				JSON_EMIT(pData,ph7_result_string(pCtx,"{",(int)sizeof(char)));
-				/* Iterate throw class attribute */
-				ph7_object_walk(pIn,VmJsonObjectEncode,pData);
-				if( pData->oom ){
-					return PH7_OK;
+				SySetInit(&sNames,&pVm->sAllocator,sizeof(SyString));
+				SyHashResetLoopCursor(&pThis->hAttr);
+				while( (pAttrEntry = SyHashGetNextEntry(&pThis->hAttr)) != 0 ){
+					VmClassAttr *pVmAttr = (VmClassAttr *)pAttrEntry->pUserData;
+					if( (pVmAttr->pAttr->iFlags & (PH7_CLASS_ATTR_STATIC|PH7_CLASS_ATTR_CONSTANT))
+					 || pVmAttr->pAttr->iProtection != PH7_CLASS_PROT_PUBLIC ){
+						continue;
+					}
+					SySetPut(&sNames,(const void *)&pVmAttr->pAttr->sName);
 				}
+				aName = (SyString *)SySetBasePtr(&sNames);
+				nName = SySetUsed(&sNames);
+				for( iName = 0 ; iName < nName ; ++iName ){
+					VmClassAttr *pVmAttr;
+					ph7_value *pAttrVal = 0;
+					ph7_value sHookVal;
+					sxi32 rcHk;
+					pAttrEntry = SyHashGet(&pThis->hAttr,(const void *)aName[iName].zString,aName[iName].nByte);
+					if( pAttrEntry == 0 ){
+						continue; /* unset by an earlier hook */
+					}
+					pVmAttr = (VmClassAttr *)pAttrEntry->pUserData;
+					PH7_MemObjInit(pVm,&sHookVal);
+					rcHk = PH7_VmHookGetAttrValue(pThis,pVmAttr,&sHookVal);
+					if( rcHk == SXRET_OK ){
+						pAttrVal = &sHookVal;
+					}else if( rcHk == SXERR_NOTFOUND ){
+						/* Encode a COPY: the encoder casts scalars in place
+						 * (ph7_value_to_string), which must not corrupt the
+						 * live attribute slot. */
+						ph7_value *pRaw = PH7_ClassInstanceExtractAttrValue(pThis,pVmAttr);
+						if( pRaw ){
+							PH7_MemObjStore(pRaw,&sHookVal);
+							pAttrVal = &sHookVal;
+						}
+					}else{
+						/* the get hook threw — propagate like jsonSerialize() */
+						PH7_MemObjRelease(&sHookVal);
+						SySetRelease(&sNames);
+						pData->exc = 1;
+						return PH7_EXCEPTION;
+					}
+					if( pAttrVal ){
+						VmJsonObjectEncode(SyStringData(&pVmAttr->pAttr->sName),pAttrVal,pData);
+					}
+					PH7_MemObjRelease(&sHookVal);
+					if( pData->exc ){
+						SySetRelease(&sNames);
+						return PH7_EXCEPTION; /* a nested jsonSerialize()/hook threw */
+					}
+					if( pData->oom ){
+						SySetRelease(&sNames);
+						return PH7_OK;
+					}
+				}
+				SySetRelease(&sNames);
 				/* Append the closing curly braces  */
 				JSON_EMIT(pData,ph7_result_string(pCtx,"}",(int)sizeof(char)));
 			}

--- a/tests/ph7/001-smoke/function/preg_match/preg_match_subscript_nested.phpt
+++ b/tests/ph7/001-smoke/function/preg_match/preg_match_subscript_nested.phpt
@@ -13,8 +13,8 @@ echo $a['x']['y'][0] . "\n";
 echo $a['x']['y'][1] . "\n";
 var_export($b['x']['y']); echo "\n"; // shared copy untouched (still 0, not an array)
 // deeper, fully auto-vivified
-preg_match('/(\w+)/', 'Hi', $c['p']['q']['r']);
-echo $c['p']['q']['r'][0] . "\n";
+preg_match('/(\w+)/', 'Hi', $pmsnC['p']['q']['r']);
+echo $pmsnC['p']['q']['r'][0] . "\n";
 ?>
 --EXPECT--
 1

--- a/tests/ph7/001-smoke/property_hooks_coalesce_pending.phpt
+++ b/tests/ph7/001-smoke/property_hooks_coalesce_pending.phpt
@@ -1,0 +1,86 @@
+--TEST--
+Property hooks / magic ??= pending-set robustness: nested coalesces, throws in the RHS, scalar-as-array errors, increment type errors
+--FILE--
+<?php
+// an inner ??= in the RHS must not disturb the outer pending set
+class HcA {
+    public ?int $p = null {
+        get => $this->p;
+        set { echo "SET"; $this->p = $value; }
+    }
+}
+function hcF() { $y = 1; $y ??= 2; return 7; }
+$hcA = new HcA();
+$hcA->p ??= hcF();
+echo "|", $hcA->p, "\n";
+// a throw in the RHS discards the pending set; a later unrelated store is unaffected
+class HcD { public $x = 0; }
+function hcThrower() { throw new Exception("t"); }
+$hcB = new HcA();
+$hcD = new HcD();
+try { $hcB->p ??= hcThrower(); } catch (Exception $e) { echo "caught|"; }
+$hcD->x = 1;
+echo "d=", $hcD->x, " p=", var_export($hcB->p, true), "\n";
+// nested hooked coalesce assigns inner-then-outer
+class HcN {
+    public ?int $p = null { get => $this->p; set { echo "P(", $value, ")"; $this->p = $value; } }
+    public ?int $q = null { get => $this->q; set { echo "Q(", $value, ")"; $this->q = $value; } }
+}
+$hcN = new HcN();
+$hcN->p ??= ($hcN->q ??= 3);
+echo "|p=", $hcN->p, " q=", $hcN->q, "\n";
+// a member store inside the RHS must not consume the outer pending set
+class HcH {
+    public $store = null;
+    public ?int $x = null { get => $this->x; set { echo "HOOK(", $value, ")"; $this->store = $value; $this->x = $value; } }
+    public int $plain = 0;
+}
+class HcW { public $v = 0; }
+$hcH = new HcH();
+$hcW = new HcW();
+function hcG() { global $hcW; $hcW->v = 123; return 5; }
+$hcH->x ??= hcG();
+echo "|w=", $hcW->v, " store=", $hcH->store, "\n";
+// magic ??= with a throwing RHS: __set never runs, later stores unaffected
+class HcM {
+    private $d = [];
+    public function __get($n) { echo "G"; return $this->d[$n] ?? null; }
+    public function __set($n, $v) { echo "S"; $this->d[$n] = $v; }
+}
+$hcM = new HcM();
+try { $hcM->p ??= hcThrower(); } catch (Exception $e) { echo "caught|"; }
+$hcD->x = 2;
+echo "d=", $hcD->x, "\n";
+// scalar bases refuse subscript writes (php 8): int/float/true error, null/false convert
+$hcI = 5;
+try { $hcI[0]++; } catch (Error $e) { echo $e->getMessage(), "; "; }
+var_export($hcI); echo "\n";
+$hcJ = 1.5;
+try { $hcJ[0][0] = "x"; } catch (Error $e) { echo $e->getMessage(), "; "; }
+var_export($hcJ); echo "\n";
+$hcK = true;
+try { $hcK[2] ??= 9; } catch (Error $e) { echo $e->getMessage(), "; "; }
+var_export($hcK); echo "\n";
+$hcL = null;
+$hcL[0][1] = "ok";
+echo $hcL[0][1], "\n";
+// ++/-- on an array-valued hooked property: php's TypeError, set hook never runs
+class HcArr {
+    public array $m = [] { get => $this->m; set { echo "SETM"; $this->m = $value; } }
+}
+$hcArr = new HcArr();
+try { $hcArr->m++; } catch (TypeError $e) { echo $e->getMessage(), "\n"; }
+try { $hcArr->m--; } catch (TypeError $e) { echo $e->getMessage(), "\n"; }
+?>
+--EXPECT--
+SET|7
+caught|d=1 p=NULL
+Q(3)P(3)|p=3 q=3
+HOOK(5)|w=123 store=5
+Gcaught|d=2
+Cannot use a scalar value as an array; 5
+Cannot use a scalar value as an array; 1.5
+Cannot use a scalar value as an array; true
+ok
+Cannot increment array
+Cannot decrement array

--- a/tests/ph7/001-smoke/property_hooks_rmw_iteration.phpt
+++ b/tests/ph7/001-smoke/property_hooks_rmw_iteration.phpt
@@ -1,0 +1,156 @@
+--TEST--
+Property hooks (PHP 8.4) slice 2: read-modify-write dispatch, ??=, subscript errors, iteration/get_object_vars/json/var_export get-dispatch
+--FILE--
+<?php
+// ++ / -- / compound assigns dispatch get then set
+class HrA {
+    public int $x = 1 {
+        get => $this->x * 10;
+        set { $this->x = $value + 1; }
+    }
+}
+$hrA = new HrA();
+$hrA->x++;
+echo $hrA->x, "\n";                       // get(1)=10, ++ -> 11, set(11) -> 12, get -> 120
+$hrB = new HrA();
+echo "post=", $hrB->x++, " mid=", $hrB->x, "\n";
+$hrC = new HrA();
+echo "pre=", ++$hrC->x, "\n";
+$hrD = new HrA();
+$hrRes = ($hrD->x += 5);
+echo "r=", $hrRes, " final=", $hrD->x, "\n";
+// .= via get/set
+class HrS {
+    public string $s = "a" {
+        get => strtoupper($this->s);
+        set { $this->s = $value . "!"; }
+    }
+}
+$hrS = new HrS();
+$hrS->s .= "b";
+echo $hrS->s, "\n";                       // get "A", ."b" -> "Ab", set -> backing "Ab!", get -> "AB!"
+// RMW on a get-only hook: get runs, then php's read-only Error
+class HrG { public int $g { get { echo "G"; return 5; } } }
+$hrG = new HrG();
+try { $hrG->g++; } catch (Error $e) { echo "|", $e->getMessage(), "\n"; }
+// RMW on a set-only hook reads the raw backing store
+class HrO { public int $o = 1 { set { $this->o = $value * 100; } } }
+$hrO = new HrO();
+$hrO->o++;
+echo $hrO->o, "\n";
+// subscript writes and subscript RMW: php's Indirect-modification Error
+class HrM { public array $m = [1] { get => $this->m; set { $this->m = $value; } } }
+$hrM = new HrM();
+try { $hrM->m[] = 9; } catch (Error $e) { echo $e->getMessage(), "\n"; }
+try { $hrM->m[0]++; } catch (Error $e) { echo $e->getMessage(), "\n"; }
+// ??= dispatches get for the test and set for the assign
+class HrN {
+    public ?int $n = null {
+        get => $this->n;
+        set { $this->n = $value + 1; }
+    }
+}
+$hrN = new HrN();
+$hrN->n ??= 5;
+echo $hrN->n, "\n";
+$hrN2 = new HrN();
+$hrN2->n = 0;      // set(0) -> backing 1
+$hrN2->n ??= 7;    // get -> 1, non-null: assign skipped
+echo $hrN2->n, "\n";
+// a throw during the modify op discards the write (set hook never runs)
+class HrT { function __toString(): string { throw new Exception("boom"); } }
+class HrU {
+    public string $u = "a" {
+        get => strtoupper($this->u);
+        set { echo "SET"; $this->u = $value; }
+    }
+}
+$hrU = new HrU();
+try { $hrU->u .= new HrT(); } catch (Exception $e) { echo "caught "; }
+echo $hrU->u, "\n";
+// inside a hook body $this->prop is raw for BOTH directions
+class HrX {
+    public int $c = 1 {
+        get { $this->c = 99; return $this->c; }   // raw write, raw read
+        set { $this->c = $value + 1; }
+    }
+}
+$hrX = new HrX();
+echo $hrX->c, "\n";
+class HrY {
+    public int $d = 1 {
+        get => $this->d * 10;
+        set { $this->d = $value + $this->d; }     // raw read inside set
+    }
+}
+$hrY = new HrY();
+$hrY->d = 5;
+echo $hrY->d, "\n";
+// `new` is allowed inside hook bodies of a property WITH a default
+class HrV { public int $vv = 9; }
+class HrW { public int $w = 1 { get { $o = new HrV(); return $this->w + $o->vv; } } }
+echo (new HrW())->w, "\n";
+// iteration surfaces dispatch get (virtual props included); by-ref foreach errors
+class HrI {
+    public int $virt { get => 42; }
+    public int $backed = 1 { get => $this->backed * 10; set { $this->backed = $value + 1; } }
+    public int $plain = 7;
+    private int $priv = 5 { get => $this->priv * 2; }
+}
+$hrI = new HrI();
+foreach ($hrI as $k => $v) { echo $k, "=", $v, ";"; }
+echo "\n";
+echo json_encode(get_object_vars($hrI)), "\n";
+echo json_encode($hrI), "\n";
+var_export($hrI);
+echo "\n";
+try { foreach ($hrI as $k => &$v) {} } catch (Error $e) { echo $e->getMessage(), "\n"; }
+// get_object_vars from inside the class sees private hooked values through get
+class HrP {
+    public int $v { get => 7; }
+    private int $q = 3 { get => $this->q * 5; }
+    function all(): array { return get_object_vars($this); }
+}
+echo json_encode((new HrP())->all()), "\n";
+// magic ??= : __isset consulted first, then __set (no __get on a miss)
+class HrQ {
+    private $d = [];
+    public function __isset($n) { echo "I"; return isset($this->d[$n]); }
+    public function __get($n) { echo "G"; return $this->d[$n] ?? null; }
+    public function __set($n, $v) { echo "S"; $this->d[$n] = $v; }
+}
+$hrQ = new HrQ();
+$hrQ->p ??= 5;
+echo "|", $hrQ->p, "\n";
+$hrQ->p ??= 9;
+echo "|", $hrQ->p, "\n";
+?>
+--EXPECT--
+120
+post=10 mid=120
+pre=11
+r=15 final=160
+AB!
+G|Property HrG::$g is read-only
+200
+Indirect modification of HrM::$m is not allowed
+Indirect modification of HrM::$m is not allowed
+6
+1
+caught A
+99
+60
+10
+virt=42;backed=10;plain=7;
+{"virt":42,"backed":10,"plain":7}
+{"virt":42,"backed":10,"plain":7}
+\HrI::__set_state(array(
+   'virt' => 42,
+   'backed' => 10,
+   'plain' => 7,
+   'priv' => 10,
+))
+Cannot create reference to property HrI::$virt
+{"v":7,"q":15}
+IS|G5
+IG|G5


### PR DESCRIPTION
Read-modify-write forms ($o->x++, --, every compound assign) on hooked properties now dispatch get -> modify -> set with php-exact expression results and error ordering: OP_MEMBER reads through the get hook (raw backing when set-only) into a fresh scratch slot the modify op mutates in place, and the op's tail consumes a pending write-back entry to dispatch the set side (read-only Error on get-only properties AFTER get runs, asymmetric set-visibility checked before the hook, set => expr returns stored through typed enforcement). Subscript writes and subscript RMW on hooked properties throw php's catchable "Indirect modification of C::$m is not allowed"; ++/-- whose get hook returned an array/object throws php's "Cannot increment/decrement ..." TypeError before any set dispatch. `??=` dispatches get for the null test and set for the assign — the same wiring implements php's full magic contract (__isset consulted first, false -> __set with no __get), closing the band A #3 magic ??= residual.

Pending write-backs live on one owner-identified LIFO (VmHookRmw: RMW / COAL_HOOK / COAL_MAGIC kinds) with an armed pc-window; a fetch-point sweep (fused into the boundary-rc branch, so the hot path pays a single check) drops entries whose statement was abandoned by a throw or skipped by the ??= short-circuit. This survives adversarial shapes a scalar transient cannot: throws mid-RHS, nested hooked coalesces, member stores and unrelated ??= inside the RHS, recursive re-entry through casts inside the modify op.

Object iteration, get_object_vars(), json_encode(), and var_export() read hooked properties through get (virtual properties included; var_dump/(array)/print_r/serialize stay raw like php); by-ref foreach over a hooked property throws php's "Cannot create reference to property C::$x" with full step teardown. The C-side walks snapshot attribute names (and foreach saves/restores the shared hAttr cursor) so a hook that re-enters a walk or mutates the instance cannot truncate or corrupt the outer iteration — php 8.5 itself stack- overflows there; a throwing hook stops the walk instead of running later hooks.

Fixed en route: $this->x inside ANY of x's own hook bodies is now raw for BOTH directions (the guard was kind-specific: stores inside get dispatched set, reads inside set dispatched get); `new` inside a hook body of a property with a default no longer trips the property-default new-scan (it stops at the depth-0 hook-list brace); json_encode leaked private/protected properties (php encodes public only); LOAD_IDX write-mode now implements php 8's vivify rules — null converts, false converts with the 8.1 deprecation, int/float/true scalars throw the catchable "Cannot use a scalar value as an array" Error with the base untouched — fixing pre-existing silent corruption of $i[0][1]=v and $i[0]??=v and keeping the compiler's new ++/-- write-lvalue tag (needed for $o->m[0]++ hook errors and $a[5]++ vivify parity) from extending it; VmMagicGuardHeld early-outs before hashing when no accessor is in flight.

Byte-verified against php 8.5.7; cross-engine tests property_hooks_rmw_iteration.phpt + property_hooks_coalesce_pending.phpt; test-compat green under both engines; docker ASan+UBSan clean over smoke/integration/deep; MODE=tiny builds.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
