### PR TITLE
Distinguish virtual from backed property hooks

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -8952,10 +8952,41 @@ Synchronize:
  * implicit `$value` formal.
  * On entry pGen->pIn sits on '{'; on success it sits just past '}'.
  */
+/*
+ * Whether any token in [pStart, pEnd) spells `$this->NAME` (this property's own
+ * name; `?->` and `::` member ops count too). php 8.4's virtual-vs-backed rule:
+ * a hooked property is BACKED iff any of its OWN hook bodies references it by
+ * name through $this — otherwise it is VIRTUAL: no backing store, no default
+ * allowed, excluded from the raw object surfaces.
+ */
+static int GenStateHookBodyRefsProp(SyToken *pStart,SyToken *pEnd,const SyString *pName)
+{
+	SyToken *p;
+	for( p = pStart ; p + 3 < pEnd ; p++ ){
+		if( (p->nType & PH7_TK_DOLLAR) == 0 ){
+			continue;
+		}
+		if( (p[1].nType & (PH7_TK_ID|PH7_TK_KEYWORD)) == 0
+		 || p[1].sData.nByte != sizeof("this")-1
+		 || SyMemcmp((const void *)p[1].sData.zString,(const void *)"this",sizeof("this")-1) != 0 ){
+			continue;
+		}
+		if( !GenStateTokenIsMemberOp(&p[2]) ){
+			continue;
+		}
+		if( (p[3].nType & (PH7_TK_ID|PH7_TK_KEYWORD)) != 0
+		 && p[3].sData.nByte == pName->nByte
+		 && SyMemcmp((const void *)p[3].sData.zString,(const void *)pName->zString,pName->nByte) == 0 ){
+			return 1;
+		}
+	}
+	return 0;
+}
 static sxi32 GenStateCompilePropertyHooks(ph7_gen_state *pGen,ph7_class *pClass,ph7_class_attr *pAttr)
 {
 	sxu32 nLine = pGen->pIn->nLine;
 	sxi32 rc;
+	int bRefsSelf = 0;
 	pGen->pIn++; /* Jump '{' */
 	while( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_CCB) == 0 ){
 		char zHook[384];
@@ -9036,16 +9067,22 @@ static sxi32 GenStateCompilePropertyHooks(ph7_gen_state *pGen,ph7_class *pClass,
 		}
 		if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_OCB) ){
 			/* Block body */
+			SyToken *pBodyStart = pGen->pIn;
 			rc = GenStateCompileFuncBody(&(*pGen),&pMeth->sFunc);
 			if( rc == SXERR_ABORT ){
 				return SXERR_ABORT;
 			}
 			pMeth->sFunc.nEndLine = pGen->pIn[-1].nLine;
+			if( !bRefsSelf && GenStateHookBodyRefsProp(pBodyStart,pGen->pIn,&pAttr->sName) ){
+				bRefsSelf = 1;
+			}
 		}else if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_ARRAY_OP) ){
 			/* `=> expr;` — implicit-return body (the arrow-fn pattern) */
 			GenBlock *pBlock;
 			SySet *pInstrContainer;
+			SyToken *pBodyStart;
 			pGen->pIn++; /* Jump '=>' */
+			pBodyStart = pGen->pIn;
 			rc = GenStateEnterBlock(&(*pGen),GEN_BLOCK_PROTECTED|GEN_BLOCK_FUNC,
 				PH7_VmInstrLength(pGen->pVm),&pMeth->sFunc,&pBlock);
 			if( rc != SXRET_OK ){
@@ -9064,13 +9101,19 @@ static sxi32 GenStateCompilePropertyHooks(ph7_gen_state *pGen,ph7_class *pClass,
 				return SXERR_ABORT;
 			}
 			pMeth->sFunc.nEndLine = (pGen->pIn < pGen->pEnd) ? pGen->pIn->nLine : nHLine;
+			if( !bRefsSelf && GenStateHookBodyRefsProp(pBodyStart,pGen->pIn,&pAttr->sName) ){
+				bRefsSelf = 1;
+			}
 			if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_SEMI) ){
 				pGen->pIn++; /* Jump ';' */
 			}
 			if( !bGet ){
 				/* `set => expr` assigns the expression to the backing store:
-				 * the dispatcher consumes the implicit return value. */
+				 * the dispatcher consumes the implicit return value — which
+				 * also makes the property BACKED (php: the shorthand is sugar
+				 * for `$this->NAME = expr`). */
 				pMeth->sFunc.iFlags |= VM_FUNC_HOOK_SET_EXPR;
+				bRefsSelf = 1;
 			}
 		}else{
 			goto HookSyntax;
@@ -9086,6 +9129,21 @@ static sxi32 GenStateCompilePropertyHooks(ph7_gen_state *pGen,ph7_class *pClass,
 		goto HookSyntax;
 	}
 	pGen->pIn++; /* Jump '}' */
+	if( !bRefsSelf ){
+		/* php 8.4 virtual-vs-backed: no hook body referenced `$this->NAME`, so
+		 * this property is VIRTUAL — php gives it no backing store and forbids
+		 * a default value (compile fatal, php's exact wording). */
+		pAttr->iFlags |= PH7_CLASS_ATTR_HOOK_VIRTUAL;
+		if( SySetUsed(&pAttr->aByteCode) > 0 ){
+			rc = PH7_GenCompileError(pGen,E_ERROR,nLine,
+				"Cannot specify default value for virtual hooked property %z::$%z",
+				&pClass->sName,&pAttr->sName);
+			if( rc == SXERR_ABORT ){
+				return SXERR_ABORT;
+			}
+			return SXERR_CORRUPT;
+		}
+	}
 	return SXRET_OK;
 HookSyntax:
 	rc = PH7_GenCompileError(pGen,E_ERROR,nLine,

--- a/src/ph7/oo.c
+++ b/src/ph7/oo.c
@@ -1451,18 +1451,19 @@ PH7_PRIVATE sxi32 PH7_ClassInstanceDump(SyBlob *pOut,ph7_class_instance *pThis,i
 			SyHashResetLoopCursor(&pThis->hAttr);
 			while((pEntry = SyHashGetNextEntry(&pThis->hAttr)) != 0){
 				VmClassAttr *pVmAttr = (VmClassAttr *)pEntry->pUserData;
-				if((pVmAttr->pAttr->iFlags & (PH7_CLASS_ATTR_CONSTANT|PH7_CLASS_ATTR_STATIC)) == 0 ){
+				if((pVmAttr->pAttr->iFlags & (PH7_CLASS_ATTR_CONSTANT|PH7_CLASS_ATTR_STATIC|PH7_CLASS_ATTR_HOOK_VIRTUAL)) == 0 ){
 					nProp++;
 				}
 			}
 		}
 		DumpClassInstanceHeader(&(*pOut),pThis->pClass,pThis->nObjId,ShowType,nProp);
 	}
-	/* Dump object attributes */
+	/* Dump object attributes (php 8.4: VIRTUAL hooked properties have no
+	 * backing store — excluded from var_dump/print_r) */
 	SyHashResetLoopCursor(&pThis->hAttr);
 	while((pEntry = SyHashGetNextEntry(&pThis->hAttr)) != 0){
 		VmClassAttr *pVmAttr = (VmClassAttr *)pEntry->pUserData;
-		if((pVmAttr->pAttr->iFlags & (PH7_CLASS_ATTR_CONSTANT|PH7_CLASS_ATTR_STATIC)) == 0 ){
+		if((pVmAttr->pAttr->iFlags & (PH7_CLASS_ATTR_CONSTANT|PH7_CLASS_ATTR_STATIC|PH7_CLASS_ATTR_HOOK_VIRTUAL)) == 0 ){
 			/* Dump non-static/constant attribute only */
 			for( i = 0 ; i < nTab ; i++ ){
 				SyBlobAppend(&(*pOut)," ",sizeof(char));
@@ -1619,6 +1620,11 @@ PH7_PRIVATE sxi32 PH7_ClassInstanceToHashmap(ph7_class_instance *pThis,ph7_hashm
 	while((pEntry = SyHashGetNextEntry(&pThis->hAttr)) != 0 ){
 		/* Point to the current attribute */
 		pAttr = (VmClassAttr *)pEntry->pUserData;
+		if( pAttr->pAttr->iFlags & PH7_CLASS_ATTR_HOOK_VIRTUAL ){
+			/* php 8.4: a VIRTUAL hooked property has no backing store — the
+			 * (array) cast excludes it (raw surface, get is NOT dispatched) */
+			continue;
+		}
 		/* Extract attribute value */
 		pValue = ExtractClassAttrValue(pThis->pVm,pAttr);
 		if( pValue ){

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -934,7 +934,15 @@ struct ph7_class_attr
                                             * __phl_hook_get_NAME (guard-bypassed inside hooks) */
 #define PH7_CLASS_ATTR_HOOK_SET     0x8000 /* property has a `set` hook (PHP 8.4): plain writes
                                             * dispatch __phl_hook_set_NAME */
-/* next free bit: 0x10000 */
+#define PH7_CLASS_ATTR_HOOK_VIRTUAL 0x10000 /* PHP 8.4 VIRTUAL hooked property: none of its own
+                                            * hook bodies references `$this->NAME`, so php gives it
+                                            * no backing store — excluded from the raw object
+                                            * surfaces (var_dump/(array)/print_r/serialize/
+                                            * get_class_vars and the get-dispatching walks when it
+                                            * has no get hook), no default allowed, reads without a
+                                            * get hook are php's "is write-only" Error. PHL still
+                                            * allocates the (null) backing slot; this flag hides it. */
+/* next free bit: 0x20000 */
 /*
  * Each class method is parsed out and stored in an instance of the following
  * structure.

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -13674,6 +13674,10 @@ case PH7_OP_FOREACH_STEP: {
 		/* Point to the next attribute */
 		while((pEntry = SyHashGetNextEntry(&pThis->hAttr)) != 0 ){
 			pVmAttr = (VmClassAttr *)pEntry->pUserData;
+			if( (pVmAttr->pAttr->iFlags & (PH7_CLASS_ATTR_HOOK_GET|PH7_CLASS_ATTR_HOOK_VIRTUAL))
+			 == PH7_CLASS_ATTR_HOOK_VIRTUAL ){
+				continue; /* virtual set-only property: iteration skips it (php) */
+			}
 			/* Check access permission */
 			if( PH7_VmClassMemberAccess(&(*pVm),pThis->pClass,&pVmAttr->pAttr->sName,
 				pVmAttr->pAttr->iProtection,FALSE) ){
@@ -13884,7 +13888,16 @@ case PH7_OP_MEMBER: {
 					 * outside the class); without __unset, an inaccessible unset is php's
 					 * catchable "Cannot access ..." Error and a missing one stays a no-op. */
 					int bUnsAccessible = pEntry ? PH7_VmClassMemberAccess(&(*pVm),pClass,&pObjAttr->pAttr->sName,pObjAttr->pAttr->iProtection,FALSE) : 0;
-					if( pEntry && bUnsAccessible ){
+					if( pEntry && (pObjAttr->pAttr->iFlags & (PH7_CLASS_ATTR_HOOK_GET|PH7_CLASS_ATTR_HOOK_SET)) != 0 ){
+						/* php 8.4: a hooked property (virtual or backed) can never be
+						 * unset — catchable Error, even from inside its own hook body
+						 * (probe-verified). */
+						SyBlob sErrMsg;
+						SyBlobInit(&sErrMsg,&pVm->sAllocator);
+						SyBlobFormat(&sErrMsg,"Cannot unset hooked property %z::$%z",
+							&pThis->pClass->sName,&pObjAttr->pAttr->sName);
+						VmBoundaryPark(&(*pVm),VmThrowBuiltinError(&(*pVm),"Error",sizeof("Error")-1,&sErrMsg));
+					}else if( pEntry && bUnsAccessible ){
 						PH7_VmReleaseInstanceAttr(&(*pVm),pObjAttr);
 						SyHashDeleteEntry2(pEntry);
 					}else{
@@ -14206,6 +14219,21 @@ case PH7_OP_MEMBER: {
 								SyBlob sErrMsg;
 								SyBlobInit(&sErrMsg,&pVm->sAllocator);
 								SyBlobFormat(&sErrMsg,"Indirect modification of %z::$%z is not allowed",
+									&pThis->pClass->sName,&pObjAttr->pAttr->sName);
+								VmBoundaryPark(&(*pVm),VmThrowBuiltinError(&(*pVm),"Error",sizeof("Error")-1,&sErrMsg));
+								PH7_ClassInstanceUnref(pThis);
+								break;
+							}
+							if( (pObjAttr->pAttr->iFlags & (PH7_CLASS_ATTR_HOOK_GET|PH7_CLASS_ATTR_HOOK_VIRTUAL))
+							 == PH7_CLASS_ATTR_HOOK_VIRTUAL ){
+								/* VIRTUAL set-only property: there is no backing store to
+								 * fall back to, so EVERY read context — plain read,
+								 * isset()/empty() (php throws there too, probe-verified),
+								 * the ??= test, an RMW read — is php's catchable
+								 * write-only Error. */
+								SyBlob sErrMsg;
+								SyBlobInit(&sErrMsg,&pVm->sAllocator);
+								SyBlobFormat(&sErrMsg,"Property %z::$%z is write-only",
 									&pThis->pClass->sName,&pObjAttr->pAttr->sName);
 								VmBoundaryPark(&(*pVm),VmThrowBuiltinError(&(*pVm),"Error",sizeof("Error")-1,&sErrMsg));
 								PH7_ClassInstanceUnref(pThis);
@@ -22344,6 +22372,10 @@ static void VmExportValue(SyBlob *pOut, ph7_value *pVal, int nIndent, int depth)
 			while( (pEntry = SyHashGetNextEntry(&pThis->hAttr)) != 0 ){
 				VmClassAttr *pVmAttr = (VmClassAttr *)pEntry->pUserData;
 				if( pVmAttr->pAttr->iFlags & (PH7_CLASS_ATTR_STATIC|PH7_CLASS_ATTR_CONSTANT) ){ continue; }
+				if( (pVmAttr->pAttr->iFlags & (PH7_CLASS_ATTR_HOOK_GET|PH7_CLASS_ATTR_HOOK_VIRTUAL))
+				 == PH7_CLASS_ATTR_HOOK_VIRTUAL ){
+					continue; /* virtual set-only property: no value to export (php) */
+				}
 				SySetPut(&sNames,(const void *)&pVmAttr->pAttr->sName);
 			}
 			aName = (SyString *)SySetBasePtr(&sNames);

--- a/src/ph7/vm_builtin_class.c
+++ b/src/ph7/vm_builtin_class.c
@@ -686,6 +686,11 @@ PH7_PRIVATE int vm_builtin_get_class_vars(ph7_context *pCtx,int nArg,ph7_value *
 	SyHashResetLoopCursor(&pClass->hAttr);
 	while((pEntry = SyHashGetNextEntry(&pClass->hAttr)) != 0 ){
 		ph7_class_attr *pAttr = (ph7_class_attr *)pEntry->pUserData;
+		if( pAttr->iFlags & PH7_CLASS_ATTR_HOOK_VIRTUAL ){
+			/* php 8.4: VIRTUAL hooked properties have no backing store —
+			 * get_class_vars() excludes them (raw surface) */
+			continue;
+		}
 		/* Check if the access is allowed */
 		if( PH7_VmClassMemberAccess(pCtx->pVm,pClass,&pAttr->sName,pAttr->iProtection,FALSE) ){
 			SyString *pAttrName = &pAttr->sName;
@@ -771,6 +776,10 @@ PH7_PRIVATE int vm_builtin_get_object_vars(ph7_context *pCtx,int nArg,ph7_value 
 			if( pVmAttr->pAttr->iFlags & (PH7_CLASS_ATTR_STATIC|PH7_CLASS_ATTR_CONSTANT) ){
 				/* Only non-static/constant attributes are extracted */
 				continue;
+			}
+			if( (pVmAttr->pAttr->iFlags & (PH7_CLASS_ATTR_HOOK_GET|PH7_CLASS_ATTR_HOOK_VIRTUAL))
+			 == PH7_CLASS_ATTR_HOOK_VIRTUAL ){
+				continue; /* virtual set-only property: no value to expose (php) */
 			}
 			SySetPut(&sNames,(const void *)&pVmAttr->pAttr->sName);
 		}

--- a/src/ph7/vm_builtin_reflection.c
+++ b/src/ph7/vm_builtin_reflection.c
@@ -409,6 +409,9 @@ static int vm_builtin_reflect_class_info(ph7_context *pCtx, int nArg, ph7_value 
 					ReflectMapAddBool(pCtx, pMeta, "readonly", (pAttr->iFlags & PH7_CLASS_ATTR_READONLY) != 0);
 					ReflectMapAddBool(pCtx, pMeta, "privset", (pAttr->iFlags & PH7_CLASS_ATTR_PRIVATE_SET) != 0);
 					ReflectMapAddBool(pCtx, pMeta, "protset", (pAttr->iFlags & PH7_CLASS_ATTR_PROTECTED_SET) != 0);
+					ReflectMapAddBool(pCtx, pMeta, "hookget", (pAttr->iFlags & PH7_CLASS_ATTR_HOOK_GET) != 0);
+					ReflectMapAddBool(pCtx, pMeta, "hookset", (pAttr->iFlags & PH7_CLASS_ATTR_HOOK_SET) != 0);
+					ReflectMapAddBool(pCtx, pMeta, "virtual", (pAttr->iFlags & PH7_CLASS_ATTR_HOOK_VIRTUAL) != 0);
 					ReflectMapAddBool(pCtx, pMeta, "hasdef", SySetUsed(&pAttr->aByteCode) > 0);
 					ReflectMapAddDyn(pCtx, pProps, &pAttr->sName, pMeta);
 				}
@@ -2464,9 +2467,13 @@ static const char zReflectLib2[] =
 "}"
 ;
 /*
- * Chunk 3: ReflectionProperty, ReflectionClassConstant.
+ * Chunk 3: PropertyHookType, ReflectionProperty, ReflectionClassConstant.
  */
 static const char zReflectLib3[] =
+"enum PropertyHookType: string {"
+" case Get = 'get';"
+" case Set = 'set';"
+"}"
 "class ReflectionProperty implements Reflector {"
 " const IS_PUBLIC = 1;"
 " const IS_PROTECTED = 2;"
@@ -2532,13 +2539,24 @@ static const char zReflectLib3[] =
 " public function isDynamic(){ $m = $this->__rpmeta(); return isset($m['dyn']); }"
 " public function isAbstract(){ return false; }"
 " public function isFinal(){ return false; }"
-" public function isVirtual(){ return false; }"
-" public function isPrivateSet(){ return false; }"
-" public function isProtectedSet(){ return false; }"
-" public function hasHooks(){ return false; }"
-" public function getHooks(){ return array(); }"
-" public function hasHook($type){ return false; }"
-" public function getHook($type){ return null; }"
+" public function isVirtual(){ $m = $this->__rpmeta(); return isset($m['virtual']) ? $m['virtual'] : false; }"
+" public function hasHooks(){ $m = $this->__rpmeta();"
+"  return (isset($m['hookget']) && $m['hookget']) || (isset($m['hookset']) && $m['hookset']); }"
+" public function getHooks(){"
+"  $m = $this->__rpmeta(); $h = array();"
+"  if(isset($m['hookget']) && $m['hookget']){ $h['get'] = new ReflectionMethod($m['decl'], '__phl_hook_get_'.$this->name); }"
+"  if(isset($m['hookset']) && $m['hookset']){ $h['set'] = new ReflectionMethod($m['decl'], '__phl_hook_set_'.$this->name); }"
+"  return $h; }"
+" public function hasHook($type){"
+"  $t = $type instanceof PropertyHookType ? $type->value : $type;"
+"  $m = $this->__rpmeta();"
+"  if($t === 'get'){ return isset($m['hookget']) && $m['hookget']; }"
+"  if($t === 'set'){ return isset($m['hookset']) && $m['hookset']; }"
+"  return false; }"
+" public function getHook($type){"
+"  $t = $type instanceof PropertyHookType ? $type->value : $type;"
+"  $h = $this->getHooks();"
+"  return isset($h[$t]) ? $h[$t] : null; }"
 " public function isLazy($object){ return false; }"
 " public function setAccessible($accessible){ }"
 " public function getValue($object = null){"

--- a/src/ph7/vm_json.c
+++ b/src/ph7/vm_json.c
@@ -282,6 +282,10 @@ static sxi32 VmJsonEncode(
 					 || pVmAttr->pAttr->iProtection != PH7_CLASS_PROT_PUBLIC ){
 						continue;
 					}
+					if( (pVmAttr->pAttr->iFlags & (PH7_CLASS_ATTR_HOOK_GET|PH7_CLASS_ATTR_HOOK_VIRTUAL))
+					 == PH7_CLASS_ATTR_HOOK_VIRTUAL ){
+						continue; /* virtual set-only property: no value to encode (php) */
+					}
 					SySetPut(&sNames,(const void *)&pVmAttr->pAttr->sName);
 				}
 				aName = (SyString *)SySetBasePtr(&sNames);

--- a/src/ph7/vm_serialize.c
+++ b/src/ph7/vm_serialize.c
@@ -153,7 +153,10 @@ static void VmSerializePropKey(SyBlob *pOut, ph7_class_attr *pAttr)
 /* True if an attribute is a serializable instance property (not static/const). */
 static int VmAttrIsProperty(VmClassAttr *pVmAttr)
 {
-	return (pVmAttr->pAttr->iFlags & (PH7_CLASS_ATTR_STATIC|PH7_CLASS_ATTR_CONSTANT)) == 0;
+	/* php 8.4: VIRTUAL hooked properties have no backing store — serialize()
+	 * excludes them (raw surface; the get hook is NOT consulted). */
+	return (pVmAttr->pAttr->iFlags
+		& (PH7_CLASS_ATTR_STATIC|PH7_CLASS_ATTR_CONSTANT|PH7_CLASS_ATTR_HOOK_VIRTUAL)) == 0;
 }
 /* __sleep() walker state: emit each named property in the array's order. */
 typedef struct sleep_ctx sleep_ctx;

--- a/tests/ph7/001-smoke/property_hooks_virtual.phpt
+++ b/tests/ph7/001-smoke/property_hooks_virtual.phpt
@@ -1,0 +1,74 @@
+--TEST--
+Property hooks (PHP 8.4) slice 3: virtual-vs-backed distinction, raw-surface exclusion, write-only/unset errors, ReflectionProperty hook API
+--FILE--
+<?php
+class HvA {
+    public int $virt { get => 42; }
+    public int $vset { set { } }
+    public int $both { get => 1; set { } }
+    public int $backed = 5 { get => $this->backed * 10; set { $this->backed = $value; } }
+}
+$hvA = new HvA();
+// raw surfaces exclude ALL virtual props (get NOT dispatched)
+echo serialize($hvA), "\n";
+echo json_encode((array)$hvA), "\n";
+// get-dispatching surfaces include virtual props WITH a get hook; set-only skipped
+foreach ($hvA as $k => $v) { echo $k, "=", $v, ";"; }
+echo "\n";
+echo json_encode(get_object_vars($hvA)), "\n";
+echo json_encode($hvA), "\n";
+var_export($hvA);
+echo "\n";
+// reads of a set-only virtual prop are php's write-only Error (isset too)
+try { echo $hvA->vset; } catch (Error $e) { echo $e->getMessage(), "\n"; }
+try { echo isset($hvA->vset) ? "T" : "F"; } catch (Error $e) { echo $e->getMessage(), "\n"; }
+try { $hvA->vset++; } catch (Error $e) { echo $e->getMessage(), "\n"; }
+try { $hvA->vset ??= 5; } catch (Error $e) { echo $e->getMessage(), "\n"; }
+// unset is forbidden on every hooked property, virtual or backed
+try { unset($hvA->virt); } catch (Error $e) { echo $e->getMessage(), "\n"; }
+try { unset($hvA->backed); } catch (Error $e) { echo $e->getMessage(), "\n"; }
+// a set-hook-only prop that references itself is BACKED: raw reads work
+class HvD { public int $w { set { $this->w = $value * 2; } } }
+$hvD = new HvD();
+$hvD->w = 4;
+echo $hvD->w, "\n";
+echo serialize($hvD), "\n";
+// get_class_vars excludes virtual
+class HvC { public int $x = 1; public int $v { get => $this->x + 1; } }
+echo json_encode(get_class_vars("HvC")), "\n";
+// ReflectionProperty hook API
+$hvRv = new ReflectionProperty("HvC", "v");
+echo $hvRv->hasHooks() ? "hooks" : "plain", "/", $hvRv->isVirtual() ? "virtual" : "backed", "/";
+echo json_encode(array_keys($hvRv->getHooks())), "\n";
+$hvRx = new ReflectionProperty("HvC", "x");
+echo $hvRx->hasHooks() ? "hooks" : "plain", "/", $hvRx->isVirtual() ? "virtual" : "backed", "/";
+echo json_encode($hvRx->getHooks()), "\n";
+$hvRb = new ReflectionProperty("HvA", "backed");
+echo $hvRb->hasHooks() ? "hooks" : "plain", "/", $hvRb->isVirtual() ? "virtual" : "backed", "/";
+echo json_encode(array_keys($hvRb->getHooks())), "\n";
+echo $hvRb->hasHook(PropertyHookType::Get) ? "hg" : "-", $hvRb->getHook(PropertyHookType::Set) !== null ? "hs" : "-", "\n";
+?>
+--EXPECT--
+O:3:"HvA":1:{s:6:"backed";i:5;}
+{"backed":5}
+virt=42;both=1;backed=50;
+{"virt":42,"both":1,"backed":50}
+{"virt":42,"both":1,"backed":50}
+\HvA::__set_state(array(
+   'virt' => 42,
+   'both' => 1,
+   'backed' => 50,
+))
+Property HvA::$vset is write-only
+Property HvA::$vset is write-only
+Property HvA::$vset is write-only
+Property HvA::$vset is write-only
+Cannot unset hooked property HvA::$virt
+Cannot unset hooked property HvA::$backed
+8
+O:3:"HvD":1:{s:1:"w";i:8;}
+{"x":1}
+hooks/virtual/["get"]
+plain/backed/[]
+hooks/backed/["get","set"]
+hghs


### PR DESCRIPTION
A hooked property is BACKED iff any of its own hook bodies references $this->NAME (the `set => expr` shorthand counts — php treats it as sugar for `$this->NAME = expr`); otherwise it is VIRTUAL, detected at compile time by scanning the hook bodies' token ranges. Defaults on virtual properties are php's compile fatal ("Cannot specify default value for virtual hooked property C::$x").

Virtual properties are excluded from the raw object surfaces — var_dump/print_r (header count included), (array) cast, serialize(), get_class_vars() — matching php's no-backing-store model, while the get-dispatching walks (foreach, get_object_vars, json_encode, var_export) keep including them through their get hook and now skip set-only virtual properties the way php silently omits them. Reads of a set-only virtual property from every context — plain read, isset()/empty() (php throws there too), the ??= test, read-modify-write — throw php's catchable "Property C::$x is write-only" Error; set-only BACKED properties keep raw-backing reads. unset() on any hooked property, virtual or backed, even inside its own hook body, throws php's catchable "Cannot unset hooked property C::$x".

ReflectionProperty gains the 8.4 hook API: hasHooks(), getHooks(), hasHook(), getHook(), isVirtual(), plus the PropertyHookType string enum; hook metadata rides new hookget/hookset/virtual keys in __reflect_class_info's property meta, and getHooks() returns ReflectionMethods of the synthesized __phl_hook_{get,set}_NAME methods (php names them "$x::get" — recorded ledger divergence). The dead duplicate stubs in the reflection chunk were removed.

Byte-verified against php 8.5.7; cross-engine test property_hooks_virtual.phpt; test-compat green under both engines; docker ASan+UBSan clean over smoke/integration/deep; MODE=tiny builds.
