### PR TITLE
Add runner skip reasons and a gap report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,9 +165,41 @@ $(BUILD_DIR)-test-stress: $(PHL_BIN)
 
 $(BUILD_DIR)-test-integration-compat: $(PHL_BIN)
 	"$(PHP_BIN)" --version
-	$(TEST_INTEGRATION_PHP_CMD) 
+	$(TEST_INTEGRATION_PHP_CMD)
 	"$(PHL_BIN)" --version
-	$(TEST_INTEGRATION_CMD) 
+	$(TEST_INTEGRATION_CMD)
+
+# Oracle-coverage gap report (POSIX shell): lists every test that SKIPS under
+# exactly one engine — the §6 oracle-blind debt as a tracked, only-goes-down
+# number. Runs smoke + integration in TAP mode under both engines and compares
+# the skip sets; the skip REASONS printed by the runner say why each side skips.
+test-oracle-gap: .ALWAYS $(PHL_BIN)
+	@mkdir -p "$(BUILD_DIR)/oracle-gap"
+	@echo "# collecting smoke skips (phl in-process / php oracle)..."
+	@"$(PHL_BIN)" tests/phpt.php --target-dir tests/ph7/001-smoke \
+		| grep '^ok .* # skip' | awk '{print $$4}' | sort > "$(BUILD_DIR)/oracle-gap/smoke-phl.txt" || true
+	@"$(PHP_BIN)" tests/phpt.php --target-dir tests/ph7/001-smoke \
+		| grep '^ok .* # skip' | awk '{print $$4}' | sort > "$(BUILD_DIR)/oracle-gap/smoke-php.txt" || true
+	@echo "# collecting integration skips (phl target / php target)..."
+	@"$(PHL_BIN)" tests/phpt.php --target-executable "$(PHL_BIN)" --target-dir tests/ph7/002-integration \
+		| grep '^ok .* # skip' | awk '{print $$4}' | sort > "$(BUILD_DIR)/oracle-gap/integ-phl.txt" || true
+	@"$(PHL_BIN)" tests/phpt.php --target-executable "$(PHP_BIN)" --target-dir tests/ph7/002-integration \
+		| grep '^ok .* # skip' | awk '{print $$4}' | sort > "$(BUILD_DIR)/oracle-gap/integ-php.txt" || true
+	@echo ""
+	@echo "# ============ ORACLE GAP REPORT ============"
+	@echo "# smoke: skip under php only (oracle-blind):"
+	@comm -13 "$(BUILD_DIR)/oracle-gap/smoke-phl.txt" "$(BUILD_DIR)/oracle-gap/smoke-php.txt" | sed 's/^/#   /'
+	@echo "# smoke: skip under phl only:"
+	@comm -23 "$(BUILD_DIR)/oracle-gap/smoke-phl.txt" "$(BUILD_DIR)/oracle-gap/smoke-php.txt" | sed 's/^/#   /'
+	@echo "# integration: skip under php target only (oracle-blind):"
+	@comm -13 "$(BUILD_DIR)/oracle-gap/integ-phl.txt" "$(BUILD_DIR)/oracle-gap/integ-php.txt" | sed 's/^/#   /'
+	@echo "# integration: skip under phl target only:"
+	@comm -23 "$(BUILD_DIR)/oracle-gap/integ-phl.txt" "$(BUILD_DIR)/oracle-gap/integ-php.txt" | sed 's/^/#   /'
+	@echo "# ------------------------------------------"
+	@printf '# oracle-blind totals: smoke %s + integration %s = ' \
+		"$$(comm -13 '$(BUILD_DIR)/oracle-gap/smoke-phl.txt' '$(BUILD_DIR)/oracle-gap/smoke-php.txt' | wc -l | tr -d ' ')" \
+		"$$(comm -13 '$(BUILD_DIR)/oracle-gap/integ-phl.txt' '$(BUILD_DIR)/oracle-gap/integ-php.txt' | wc -l | tr -d ' ')"
+	@echo "$$(( $$(comm -13 '$(BUILD_DIR)/oracle-gap/smoke-phl.txt' '$(BUILD_DIR)/oracle-gap/smoke-php.txt' | wc -l) + $$(comm -13 '$(BUILD_DIR)/oracle-gap/integ-phl.txt' '$(BUILD_DIR)/oracle-gap/integ-php.txt' | wc -l) )) tests never run under the php oracle"
 
 $(BUILD_DIR)/coverage/markdown:
 	@"$(PHL_BIN)" \

--- a/tests/phpt.php
+++ b/tests/phpt.php
@@ -421,6 +421,7 @@ $phpt_skipped = 0;
 $phpt_nimp = 0;
 $phpt_count = 1;
 $phpt_failures = array();
+$phpt_skip_reasons = array();
 
 foreach ($phpt_files as $phpt_file) {
     $phpt_sections = parse_phpt_sections($phpt_file, $phpt_valid_sections);
@@ -454,10 +455,12 @@ foreach ($phpt_files as $phpt_file) {
 
     // SKIPIF check
     $phpt_skip = false;
+    $phpt_skip_reason = '';
     if ($phpt_env_unsupported) {
         // --ENV-- is only honored for a fresh child process (see the parse note);
         // skip rather than run in-process with the env silently dropped.
         $phpt_skip = true;
+        $phpt_skip_reason = '--ENV-- requires --target-executable';
     } elseif (isset($phpt_sections['skipif'])) {
         $phpt_skipif_path = $phpt_file . '.skipif';
         if (!empty($phpt_target_executable)) {
@@ -477,15 +480,30 @@ foreach ($phpt_files as $phpt_file) {
         $phpt_skip_output = trim($phpt_skip_output);
         if (!empty($phpt_skip_output)) {
             $phpt_skip = true;
+            // Normalize the SKIPIF's message into a one-line TAP reason: drop
+            // the conventional leading "skip" word (the directive adds its
+            // own) and collapse newlines.
+            $phpt_skip_reason = str_replace(array("\r", "\n"), ' ', $phpt_skip_output);
+            if (strncasecmp($phpt_skip_reason, 'skip', 4) === 0) {
+                $phpt_skip_reason = ltrim(substr($phpt_skip_reason, 4), " \t-:");
+            }
+            $phpt_skip_reason = trim($phpt_skip_reason);
         }
     }
 
     if ($phpt_skip) {
+        if ($phpt_skip_reason === '') {
+            $phpt_skip_reason = '(no reason given)';
+        }
         if ($phpt_output_format == "tap") {
-            echo "ok $phpt_count - $phpt_test_name # skip\n";
+            echo "ok $phpt_count - $phpt_test_name # skip $phpt_skip_reason\n";
         } else {
             echo "S";
         }
+        if (!isset($phpt_skip_reasons[$phpt_skip_reason])) {
+            $phpt_skip_reasons[$phpt_skip_reason] = 0;
+        }
+        $phpt_skip_reasons[$phpt_skip_reason]++;
         $phpt_skipped++;
     } else {
         // Check for unimplemented sections
@@ -612,6 +630,15 @@ if ($phpt_output_format == "tap") {
     echo "# ----------------\n";
     echo "#  Total: " . ($phpt_skipped + $phpt_nimp) . " incomplete\n";
     echo "\n";
+    if (!empty($phpt_skip_reasons)) {
+        echo "# Skips by reason\n";
+        echo "# ----------------\n";
+        arsort($phpt_skip_reasons);
+        foreach ($phpt_skip_reasons as $phpt_reason => $phpt_reason_count) {
+            echo "# " . $phpt_reason_count . "\t" . $phpt_reason . "\n";
+        }
+        echo "\n";
+    }
     echo "# Test Summary\n";
     echo "# ----------------\n";
     echo "#     ok: " . ($phpt_passed + $phpt_skipped) . "\n";


### PR DESCRIPTION
The TAP skip directive now carries the SKIPIF's message (normalized to one line, the conventional leading "skip" word stripped, "(no reason given)" for bare-skip SKIPIFs), and TAP summaries print a skips-per-reason table so the oracle-blind debt is triageable by reason. Runs identically under both engines (plain string ops only).

The new `make test-oracle-gap` target runs smoke (in-process, both runners) and integration (child-process, both targets) in TAP mode and reports the tests that skip under exactly one engine plus the oracle-blind total. First measured baseline: 497 tests never run under the php oracle (smoke 319 + integration 178 of 3239, ~15%), replacing the hand-counted ~523 estimate; the 7 phl-only skips are the expected *_zend twins and reasoned engine guards. The reason table surfaced the next corpus-hygiene target: 262 smoke SKIPIFs print bare "skip" with no reason.

test-compat green under both engines with the new runner; docker ASan+UBSan clean over smoke/integration/deep; MODE=tiny builds.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
