### PR TITLE
Add the DateTime family with a UTC default

### DIFF
--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -9455,6 +9455,8 @@ static const ph7_builtin_func aBuiltInFunc[] = {
 	{ "localtime",   PH7_builtin_localtime    },
 	{ "mktime",      PH7_builtin_mktime       },
 	{ "gmmktime",    PH7_builtin_mktime       },
+	{ "date_default_timezone_get", PH7_builtin_date_default_timezone_get },
+	{ "date_default_timezone_set", PH7_builtin_date_default_timezone_set },
 	        /* URL functions */
 	{ "base64_encode",PH7_builtin_base64_encode },
 	{ "base64_decode",PH7_builtin_base64_decode },

--- a/src/ph7/builtin_date.c
+++ b/src/ph7/builtin_date.c
@@ -11,6 +11,22 @@
  *    Devel.
  */
 #include <time.h>
+/* Civil-date helpers (defined with the DateTime layer below) */
+static sxi64 DtDaysFromCivil(sxi64 y,int m,int d);
+static void DtCivilFromDays(sxi64 z,sxi64 *py,int *pm,int *pd);
+static sxi64 DtFloorDiv(sxi64 a,sxi64 b);
+/*
+ * STRUCT_TM_TO_SYTM zeroes tm_gmtoff (struct tm carries it only as a BSD/glibc
+ * extension, absent on newlib/ESP32). Derive the zone offset portably from the
+ * broken-down civil fields and the timestamp they came from: for localtime()
+ * fills this yields the local UTC offset, for gmtime() fills it yields 0.
+ */
+static void DtSytmFillOffset(Sytm *pSTm,time_t t)
+{
+	sxi64 iCivil = DtDaysFromCivil((sxi64)pSTm->tm_year,pSTm->tm_mon+1,pSTm->tm_mday) * 86400
+		+ (sxi64)pSTm->tm_hour*3600 + (sxi64)pSTm->tm_min*60 + (sxi64)pSTm->tm_sec;
+	pSTm->tm_gmtoff = (long)(iCivil - (sxi64)t);
+}
 #ifdef __WINNT__
 #ifdef _MSC_VER
 #if _MSC_VER >= 1400 /* Visual Studio 2005 and up */
@@ -185,8 +201,9 @@ PH7_PRIVATE int PH7_builtin_getdate(ph7_context *pCtx,int nArg,ph7_value **apArg
 		struct tm *pTm;
 		time_t t;
 		time(&t);
-		pTm = localtime(&t);
+		pTm = gmtime(&t);
 		STRUCT_TM_TO_SYTM(pTm,&sTm);
+		DtSytmFillOffset(&sTm,t);
 #endif
 	}else{
 		/* Use the given timestamp */
@@ -194,15 +211,16 @@ PH7_PRIVATE int PH7_builtin_getdate(ph7_context *pCtx,int nArg,ph7_value **apArg
 		struct tm *pTm;
 		if( ph7_value_is_int(apArg[0]) ){
 			t = (time_t)ph7_value_to_int64(apArg[0]);
-			pTm = localtime(&t);
+			pTm = gmtime(&t);
 			if( pTm == 0 ){
 				time(&t);
 			}
 		}else{
 			time(&t);
 		}
-		pTm = localtime(&t);
+		pTm = gmtime(&t);
 		STRUCT_TM_TO_SYTM(pTm,&sTm);
+		DtSytmFillOffset(&sTm,t);
 	}
 	/* Element value */
 	pValue = ph7_context_new_scalar(pCtx);
@@ -419,13 +437,41 @@ static sxi32 DateFormat(ph7_context *pCtx,const char *zIn,int nLen,Sytm *pTm)
 			ph7_result_string_format(pCtx,"%d",isLeap);
 			break;
 				 }
-		case 'o':
-			/* ISO-8601 year number.*/
-			ph7_result_string_format(pCtx,"%4d",pTm->tm_year);
+		case 'o': case 'W': {
+			/* ISO-8601 week-numbering year / week number: both belong to the
+			 * year owning the Thursday of the civil week (php: 2024-12-31 is
+			 * 2025-W01, 2027-01-01 is 2026-W53). php pads W but not o. */
+			sxi64 days = DtDaysFromCivil((sxi64)pTm->tm_year,pTm->tm_mon+1,pTm->tm_mday);
+			int isoDow = (int)(((days + 3) % 7 + 7) % 7) + 1; /* Mon=1..Sun=7 */
+			sxi64 thu = days + (4 - isoDow);
+			sxi64 wy;
+			int wm,wd;
+			DtCivilFromDays(thu,&wy,&wm,&wd);
+			if( zIn[0] == 'o' ){
+				ph7_result_string_format(pCtx,"%d",(int)wy);
+			}else{
+				ph7_result_string_format(pCtx,"%02d",
+					(int)((thu - DtDaysFromCivil(wy,1,1)) / 7) + 1);
+			}
 			break;
+				 }
 		case 'Y':
 			/*	A full numeric representation of a year, 4 digits */
-			ph7_result_string_format(pCtx,"%4d",pTm->tm_year);
+			ph7_result_string_format(pCtx,"%04d",pTm->tm_year);
+			break;
+		case 'X':
+			/* Expanded full year, always signed (php 8.2+): +2024 */
+			ph7_result_string_format(pCtx,"%c%04d",
+				pTm->tm_year < 0 ? '-' : '+',
+				pTm->tm_year < 0 ? -pTm->tm_year : pTm->tm_year);
+			break;
+		case 'x':
+			/* Expanded year, signed only past 4 digits (php 8.2+) */
+			if( pTm->tm_year > 9999 ){
+				ph7_result_string_format(pCtx,"+%d",pTm->tm_year);
+			}else{
+				ph7_result_string_format(pCtx,"%04d",pTm->tm_year);
+			}
 			break;
 		case 'y':
 			/*A two digit representation of a year*/
@@ -433,15 +479,28 @@ static sxi32 DateFormat(ph7_context *pCtx,const char *zIn,int nLen,Sytm *pTm)
 			break;
 		case 'a':
 			/*	Lowercase Ante meridiem and Post meridiem */
-			ph7_result_string(pCtx,pTm->tm_hour > 12 ? "pm" : "am",2);
+			ph7_result_string(pCtx,pTm->tm_hour >= 12 ? "pm" : "am",2);
 			break;
 		case 'A':
 			/*	Uppercase Ante meridiem and Post meridiem */
-			ph7_result_string(pCtx,pTm->tm_hour > 12 ? "PM" : "AM",2);
+			ph7_result_string(pCtx,pTm->tm_hour >= 12 ? "PM" : "AM",2);
 			break;
+		case 'B':{
+			/* Swatch Internet time: thousandths of the UTC+1 day */
+			sxi64 iUtc = DtDaysFromCivil((sxi64)pTm->tm_year,pTm->tm_mon+1,pTm->tm_mday) * 86400
+				+ (sxi64)pTm->tm_hour*3600 + (sxi64)pTm->tm_min*60 + (sxi64)pTm->tm_sec
+				- (sxi64)pTm->tm_gmtoff;
+			sxi64 iBie = (iUtc + 3600) % 86400;
+			if( iBie < 0 ){
+				iBie += 86400;
+			}
+			ph7_result_string_format(pCtx,"%03d",(int)(iBie * 1000 / 86400));
+			break;
+				 }
 		case 'g':
 			/*	12-hour format of an hour without leading zeros*/
-			ph7_result_string_format(pCtx,"%d",1+(pTm->tm_hour%12));
+			ph7_result_string_format(pCtx,"%d",
+				(pTm->tm_hour % 12) == 0 ? 12 : pTm->tm_hour % 12);
 			break;
 		case 'G':
 			/* 24-hour format of an hour without leading zeros */
@@ -449,7 +508,8 @@ static sxi32 DateFormat(ph7_context *pCtx,const char *zIn,int nLen,Sytm *pTm)
 			break;
 		case 'h':
 			/* 12-hour format of an hour with leading zeros */
-			ph7_result_string_format(pCtx,"%02d",1+(pTm->tm_hour%12));
+			ph7_result_string_format(pCtx,"%02d",
+				(pTm->tm_hour % 12) == 0 ? 12 : pTm->tm_hour % 12);
 			break;
 		case 'H':
 			/*	24-hour format of an hour with leading zeros */
@@ -464,8 +524,12 @@ static sxi32 DateFormat(ph7_context *pCtx,const char *zIn,int nLen,Sytm *pTm)
 			ph7_result_string_format(pCtx,"%02d",pTm->tm_sec);
 			break;
 		case 'u':
-			/* 	Microseconds */
-			ph7_result_string_format(pCtx,"%u",pTm->tm_sec * SX_USEC_PER_SEC);
+			/* 	Microseconds (whole-second timestamps only: php pads zeros) */
+			ph7_result_string(pCtx,"000000",6);
+			break;
+		case 'v':
+			/* 	Milliseconds (same) */
+			ph7_result_string(pCtx,"000",3);
 			break;
 		case 'S':{
 			/* English ordinal suffix for the day of the month, 2 characters */
@@ -478,11 +542,33 @@ static sxi32 DateFormat(ph7_context *pCtx,const char *zIn,int nLen,Sytm *pTm)
 			/* 	Timezone identifier */
 			zCur = pTm->tm_zone;
 			if( zCur == 0 ){
-				/* Assume GMT */
-				zCur = "GMT";
+				/* date()-family fills: the script default timezone */
+				zCur = pCtx->pVm->zDefTz;
 			}
 			ph7_result_string(pCtx,zCur,-1);
 			break;
+		case 'T':{
+			/* Timezone abbreviation: "UTC" for offset 0, "GMT+0530" for a
+			 * fixed offset (php's shape). PHL has no tz database, so the
+			 * zone-name path only ever sees UTC/GMT, uppercased. */
+			const char *z;
+			if( pTm->tm_gmtoff != 0 ){
+				long a = pTm->tm_gmtoff < 0 ? -pTm->tm_gmtoff : pTm->tm_gmtoff;
+				ph7_result_string_format(pCtx,"GMT%c%02d%02d",
+					pTm->tm_gmtoff < 0 ? '-' : '+',(int)(a / 3600),(int)((a % 3600) / 60));
+				break;
+			}
+			z = pTm->tm_zone ? pTm->tm_zone : pCtx->pVm->zDefTz;
+			while( *z ){
+				int c = (unsigned char)*z;
+				if( c >= 'a' && c <= 'z' ){
+					c -= 'a' - 'A';
+				}
+				ph7_result_string_format(pCtx,"%c",c);
+				z++;
+			}
+			break;
+				 }
 		case 'I':
 			/* Whether or not the date is in daylight saving time */
 #ifdef __WINNT__
@@ -494,48 +580,75 @@ static sxi32 DateFormat(ph7_context *pCtx,const char *zIn,int nLen,Sytm *pTm)
 #endif
 			ph7_result_string_format(pCtx,"%d",pTm->tm_isdst == 1);
 			break;
-		case 'r':
-			/* RFC 2822 formatted date 	Example: Thu, 21 Dec 2000 16:01:07 */
-			ph7_result_string_format(pCtx,"%.3s, %02d %.3s %4d %02d:%02d:%02d",
+		case 'r':{
+			/* RFC 2822 formatted date 	Example: Thu, 21 Dec 2000 16:01:07 +0200 */
+			long a = pTm->tm_gmtoff < 0 ? -pTm->tm_gmtoff : pTm->tm_gmtoff;
+			ph7_result_string_format(pCtx,"%.3s, %02d %.3s %4d %02d:%02d:%02d %c%02d%02d",
 				SyTimeGetDay(pTm->tm_wday),
 				pTm->tm_mday,
 				SyTimeGetMonth(pTm->tm_mon),
 				pTm->tm_year,
 				pTm->tm_hour,
 				pTm->tm_min,
-				pTm->tm_sec
+				pTm->tm_sec,
+				pTm->tm_gmtoff < 0 ? '-' : '+',
+				(int)(a / 3600),(int)((a % 3600) / 60)
 				);
 			break;
-		case 'U':{
-			time_t tt;
-			/* Seconds since the Unix Epoch */
-			time(&tt);
-			ph7_result_string_format(pCtx,"%u",(unsigned int)tt);
+				 }
+		case 'U':
+			/* Seconds since the Unix Epoch FOR THIS Sytm (php: the timestamp
+			 * being formatted — pre-fix this printed time(0) regardless of the
+			 * date under format). */
+			ph7_result_string_format(pCtx,"%qd",
+				DtDaysFromCivil((sxi64)pTm->tm_year,pTm->tm_mon+1,pTm->tm_mday) * 86400
+				+ (sxi64)pTm->tm_hour*3600 + (sxi64)pTm->tm_min*60 + (sxi64)pTm->tm_sec
+				- (sxi64)pTm->tm_gmtoff);
+			break;
+		case 'O':{
+			/* Difference to GMT without colon: +0530 (php) */
+			long a = pTm->tm_gmtoff < 0 ? -pTm->tm_gmtoff : pTm->tm_gmtoff;
+			ph7_result_string_format(pCtx,"%c%02d%02d",
+				pTm->tm_gmtoff < 0 ? '-' : '+',(int)(a / 3600),(int)((a % 3600) / 60));
 			break;
 				 }
-		case 'O':
-		case 'P':
-			/* Difference to Greenwich time (GMT) in hours */
-			ph7_result_string_format(pCtx,"%+05d",pTm->tm_gmtoff);
+		case 'P':{
+			/* Difference to GMT with colon: +05:30 (php) */
+			long a = pTm->tm_gmtoff < 0 ? -pTm->tm_gmtoff : pTm->tm_gmtoff;
+			ph7_result_string_format(pCtx,"%c%02d:%02d",
+				pTm->tm_gmtoff < 0 ? '-' : '+',(int)(a / 3600),(int)((a % 3600) / 60));
 			break;
+				 }
+		case 'p':{
+			/* Like P, but "Z" for UTC (php 8.0+) */
+			long a;
+			if( pTm->tm_gmtoff == 0 ){
+				ph7_result_string(pCtx,"Z",1);
+				break;
+			}
+			a = pTm->tm_gmtoff < 0 ? -pTm->tm_gmtoff : pTm->tm_gmtoff;
+			ph7_result_string_format(pCtx,"%c%02d:%02d",
+				pTm->tm_gmtoff < 0 ? '-' : '+',(int)(a / 3600),(int)((a % 3600) / 60));
+			break;
+				 }
 		case 'Z':
-			/* Timezone offset in seconds. The offset for timezones west of UTC
-			 * is always negative, and for those east of UTC is always positive.
-			 */
-			ph7_result_string_format(pCtx,"%+05d",pTm->tm_gmtoff);
+			/* Timezone offset in seconds, plain integer (php) */
+			ph7_result_string_format(pCtx,"%d",(int)pTm->tm_gmtoff);
 			break;
-		case 'c':
-			/* 	ISO 8601 date */
-			ph7_result_string_format(pCtx,"%4d-%02d-%02dT%02d:%02d:%02d%+05d",
+		case 'c':{
+			/* 	ISO 8601 date: 2004-02-12T15:19:21+00:00 (php) */
+			long a = pTm->tm_gmtoff < 0 ? -pTm->tm_gmtoff : pTm->tm_gmtoff;
+			ph7_result_string_format(pCtx,"%4d-%02d-%02dT%02d:%02d:%02d%c%02d:%02d",
 				pTm->tm_year,
 				pTm->tm_mon+1,
 				pTm->tm_mday,
 				pTm->tm_hour,
 				pTm->tm_min,
 				pTm->tm_sec,
-				pTm->tm_gmtoff
+				pTm->tm_gmtoff < 0 ? '-' : '+',(int)(a / 3600),(int)((a % 3600) / 60)
 				);
 			break;
+				 }
 		case '\\':
 			zIn++;
 			/* Expand verbatim */
@@ -717,8 +830,8 @@ static int PH7_Strftime(
 			/* 	Timezone identifier */
 			zCur = pTm->tm_zone;
 			if( zCur == 0 ){
-				/* Assume GMT */
-				zCur = "GMT";
+				/* date()-family fills: the script default timezone */
+				zCur = pCtx->pVm->zDefTz;
 			}
 			ph7_result_string(pCtx,zCur,-1);
 			break;
@@ -872,8 +985,9 @@ PH7_PRIVATE int PH7_builtin_date(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		struct tm *pTm;
 		time_t t;
 		time(&t);
-		pTm = localtime(&t);
+		pTm = gmtime(&t);
 		STRUCT_TM_TO_SYTM(pTm,&sTm);
+		DtSytmFillOffset(&sTm,t);
 #endif
 	}else{
 		/* Use the given timestamp (php 8 ?int weak ZPP; TypeError otherwise) */
@@ -887,12 +1001,13 @@ PH7_PRIVATE int PH7_builtin_date(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		if( bUseNow ){
 			time(&t);
 		}
-		pTm = localtime(&t);
+		pTm = gmtime(&t);
 		if( pTm == 0 ){
 			time(&t);
-			pTm = localtime(&t);
+			pTm = gmtime(&t);
 		}
 		STRUCT_TM_TO_SYTM(pTm,&sTm);
+		DtSytmFillOffset(&sTm,t);
 	}
 	/* Format the given string */
 	DateFormat(pCtx,zFormat,nLen,&sTm);
@@ -940,8 +1055,9 @@ PH7_PRIVATE int PH7_builtin_strftime(ph7_context *pCtx,int nArg,ph7_value **apAr
 		struct tm *pTm;
 		time_t t;
 		time(&t);
-		pTm = localtime(&t);
+		pTm = gmtime(&t);
 		STRUCT_TM_TO_SYTM(pTm,&sTm);
+		DtSytmFillOffset(&sTm,t);
 #endif
 	}else{
 		/* Use the given timestamp */
@@ -949,15 +1065,16 @@ PH7_PRIVATE int PH7_builtin_strftime(ph7_context *pCtx,int nArg,ph7_value **apAr
 		struct tm *pTm;
 		if( ph7_value_is_int(apArg[1]) ){
 			t = (time_t)ph7_value_to_int64(apArg[1]);
-			pTm = localtime(&t);
+			pTm = gmtime(&t);
 			if( pTm == 0 ){
 				time(&t);
 			}
 		}else{
 			time(&t);
 		}
-		pTm = localtime(&t);
+		pTm = gmtime(&t);
 		STRUCT_TM_TO_SYTM(pTm,&sTm);
+		DtSytmFillOffset(&sTm,t);
 	}
 	/* Format the given string */
 	PH7_Strftime(pCtx,zFormat,nLen,&sTm);
@@ -1007,6 +1124,7 @@ PH7_PRIVATE int PH7_builtin_gmdate(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		time(&t);
 		pTm = gmtime(&t);
 		STRUCT_TM_TO_SYTM(pTm,&sTm);
+		DtSytmFillOffset(&sTm,t);
 #endif
 	}else{
 		/* Use the given timestamp (php 8 ?int weak ZPP; TypeError otherwise) */
@@ -1026,6 +1144,7 @@ PH7_PRIVATE int PH7_builtin_gmdate(ph7_context *pCtx,int nArg,ph7_value **apArg)
 			pTm = gmtime(&t);
 		}
 		STRUCT_TM_TO_SYTM(pTm,&sTm);
+		DtSytmFillOffset(&sTm,t);
 	}
 	/* Format the given string */
 	DateFormat(pCtx,zFormat,nLen,&sTm);
@@ -1069,8 +1188,9 @@ PH7_PRIVATE int PH7_builtin_localtime(ph7_context *pCtx,int nArg,ph7_value **apA
 		struct tm *pTm;
 		time_t t;
 		time(&t);
-		pTm = localtime(&t);
+		pTm = gmtime(&t);
 		STRUCT_TM_TO_SYTM(pTm,&sTm);
+		DtSytmFillOffset(&sTm,t);
 #endif
 	}else{
 		/* Use the given timestamp */
@@ -1078,15 +1198,16 @@ PH7_PRIVATE int PH7_builtin_localtime(ph7_context *pCtx,int nArg,ph7_value **apA
 		struct tm *pTm;
 		if( ph7_value_is_int(apArg[0]) ){
 			t = (time_t)ph7_value_to_int64(apArg[0]);
-			pTm = localtime(&t);
+			pTm = gmtime(&t);
 			if( pTm == 0 ){
 				time(&t);
 			}
 		}else{
 			time(&t);
 		}
-		pTm = localtime(&t);
+		pTm = gmtime(&t);
 		STRUCT_TM_TO_SYTM(pTm,&sTm);
+		DtSytmFillOffset(&sTm,t);
 	}
 	/* Element value */
 	pValue = ph7_context_new_scalar(pCtx);
@@ -1238,8 +1359,9 @@ PH7_PRIVATE int PH7_builtin_idate(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		struct tm *pTm;
 		time_t t;
 		time(&t);
-		pTm = localtime(&t);
+		pTm = gmtime(&t);
 		STRUCT_TM_TO_SYTM(pTm,&sTm);
+		DtSytmFillOffset(&sTm,t);
 #endif
 	}else{
 		/* Use the given timestamp */
@@ -1247,15 +1369,16 @@ PH7_PRIVATE int PH7_builtin_idate(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		struct tm *pTm;
 		if( ph7_value_is_int(apArg[1]) ){
 			t = (time_t)ph7_value_to_int64(apArg[1]);
-			pTm = localtime(&t);
+			pTm = gmtime(&t);
 			if( pTm == 0 ){
 				time(&t);
 			}
 		}else{
 			time(&t);
 		}
-		pTm = localtime(&t);
+		pTm = gmtime(&t);
 		STRUCT_TM_TO_SYTM(pTm,&sTm);
+		DtSytmFillOffset(&sTm,t);
 	}
 	/* Perform the requested operation */
 	switch(zFormat[0]){
@@ -1392,7 +1515,9 @@ PH7_PRIVATE int PH7_builtin_idate(ph7_context *pCtx,int nArg,ph7_value **apArg)
 PH7_PRIVATE int PH7_builtin_mktime(ph7_context *pCtx,int nArg,ph7_value **apArg)
 {
 	const char *zFunction;
-	ph7_int64 iVal = 0;
+	ph7_int64 iVal;
+	sxi64 h,mi,s,mo,d,y,yAdj;
+	int moN;
 	struct tm *pTm;
 	time_t t;
 	/* Extract function name */
@@ -1405,52 +1530,694 @@ PH7_PRIVATE int PH7_builtin_mktime(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		return PH7_VmThrowException(pCtx,"ArgumentCountError",
 			"%s() expects at most 6 arguments, %d given",zFunction,nArg);
 	}
-	/* Get the current time */
-	time(&t);
-	if( zFunction[0] == 'g' /* gmmktime */ ){
-		pTm = gmtime(&t);
-	}else{
-		/* localtime */
-		pTm = localtime(&t);
+	if( nArg < 1 ){
+		return PH7_VmThrowException(pCtx,"ArgumentCountError",
+			"%s() expects at least 1 argument, 0 given",zFunction);
 	}
-	if( nArg > 0 ){
-		int iTmp;
-		/* Hour */
-		iTmp = ph7_value_to_int(apArg[0]);
-		pTm->tm_hour = iTmp;
-		if( nArg > 1 ){
-			/* Minutes */
-			iTmp = ph7_value_to_int(apArg[1]);
-			pTm->tm_min = iTmp;
-			if( nArg > 2 ){
-				/* Seconds */
-				iTmp = ph7_value_to_int(apArg[2]);
-				pTm->tm_sec = iTmp;
-				if( nArg > 3 ){
-					/* Month */
-					iTmp = ph7_value_to_int(apArg[3]);
-					pTm->tm_mon = iTmp - 1;
-					if( nArg > 4 ){
-						/* mday */
-						iTmp = ph7_value_to_int(apArg[4]);
-						pTm->tm_mday = iTmp;
-						if( nArg > 5 ){
-							/* Year */
-							iTmp = ph7_value_to_int(apArg[5]);
-							if( iTmp > 1900 ){
-								iTmp -= 1900;
-							}
-							pTm->tm_year = iTmp;
+	/* Missing components default from the current time in php's default
+	 * timezone. PHL's date_default_timezone_set() only accepts UTC/GMT (no tz
+	 * database), so mktime() and gmmktime() agree and both read gmtime(). */
+	time(&t);
+	pTm = gmtime(&t);
+	SXUNUSED(zFunction);
+	h  = pTm->tm_hour;
+	mi = pTm->tm_min;
+	s  = pTm->tm_sec;
+	mo = pTm->tm_mon + 1;
+	d  = pTm->tm_mday;
+	y  = pTm->tm_year + 1900;
+	h = ph7_value_to_int64(apArg[0]);
+	if( nArg > 1 ){
+		mi = ph7_value_to_int64(apArg[1]);
+		if( nArg > 2 ){
+			s = ph7_value_to_int64(apArg[2]);
+			if( nArg > 3 ){
+				mo = ph7_value_to_int64(apArg[3]);
+				if( nArg > 4 ){
+					d = ph7_value_to_int64(apArg[4]);
+					if( nArg > 5 ){
+						/* php's legacy two-digit mapping: 0-69 -> 2000-2069,
+						 * 70-100 -> 1970-2000; anything else is verbatim */
+						y = ph7_value_to_int64(apArg[5]);
+						if( y >= 0 && y <= 69 ){
+							y += 2000;
+						}else if( y >= 70 && y <= 100 ){
+							y += 1900;
 						}
 					}
 				}
 			}
 		}
 	}
-	/* Make the time */
-	iVal = (ph7_int64)mktime(pTm);
-	/* Return the timesatmp as a 64bit integer */
+	/* Normalize the month with floor semantics, then let day/time components
+	 * overflow linearly (php: mktime(25,-30,0,1,1,2024) == Jan 2 00:30). */
+	yAdj = y + DtFloorDiv(mo - 1,12);
+	moN  = (int)(mo - 1 - DtFloorDiv(mo - 1,12) * 12) + 1;
+	iVal = (DtDaysFromCivil(yAdj,moN,1) + (d - 1)) * 86400 + h*3600 + mi*60 + s;
+	/* Return the timestamp as a 64bit integer */
 	ph7_result_int64(pCtx,iVal);
 	return PH7_OK;
 }
+/*
+ * string date_default_timezone_get(void)
+ *  Gets the default timezone used by all date/time functions in a script.
+ */
+PH7_PRIVATE int PH7_builtin_date_default_timezone_get(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	ph7_vm *pVm = pCtx->pVm;
+	SXUNUSED(nArg);
+	SXUNUSED(apArg);
+	ph7_result_string(pCtx,pVm->zDefTz,(int)pVm->nDefTz);
+	return PH7_OK;
+}
+/*
+ * bool date_default_timezone_set(string $timezoneId)
+ *  Sets the default timezone used by all date/time functions in a script.
+ *  php validates against the tz database and stores the id verbatim (get()
+ *  echoes back "utc" if that's what was set). PHL ships no tz database, so
+ *  only UTC and GMT are accepted; every other id — including region names php
+ *  would accept — is rejected with php's invalid-id notice (recorded scope cut).
+ */
+PH7_PRIVATE int PH7_builtin_date_default_timezone_set(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	ph7_vm *pVm = pCtx->pVm;
+	const char *zId;
+	int nId;
+	if( nArg < 1 ){
+		ph7_result_bool(pCtx,0);
+		return PH7_OK;
+	}
+	zId = ph7_value_to_string(apArg[0],&nId);
+	if( nId == 3 && (SyStrnicmp(zId,"UTC",3) == 0 || SyStrnicmp(zId,"GMT",3) == 0) ){
+		SyMemcpy(zId,pVm->zDefTz,3);
+		pVm->zDefTz[3] = 0;
+		pVm->nDefTz = 3;
+		ph7_result_bool(pCtx,1);
+		return PH7_OK;
+	}
+	/* ph7_context_throw_error_format prepends "date_default_timezone_set(): "
+	 * — exactly php's notice shape here */
+	ph7_context_throw_error_format(pCtx,PH7_CTX_NOTICE,"Timezone ID '%.*s' is invalid",nId,zId);
+	ph7_result_bool(pCtx,0);
+	return PH7_OK;
+}
+
+/* ===========================================================================
+ * DateTime family (NEWPLAN band D slice 1): DateTimeInterface, DateTime,
+ * DateTimeImmutable, DateTimeZone (UTC + fixed offsets), date_create(),
+ * date_create_immutable(). Embedded-PHP chunk + C thunks, following the
+ * Reflection architecture (installed inside the bCompilingBuiltin window).
+ * Timezone SCOPE: UTC and fixed "+HH:MM" offsets only — no tz database
+ * (recorded §10 scope cut; named region zones throw like unknown zones).
+ * ======================================================================== */
+
+/*
+ * Proleptic-Gregorian civil <-> day-count conversions (Howard Hinnant's
+ * algorithms): no time_t / libc dependence, correct far past 2038 and
+ * before 1970 on every platform. Day 0 == 1970-01-01.
+ */
+static sxi64 DtDaysFromCivil(sxi64 y,int m,int d)
+{
+	sxi64 era;
+	unsigned yoe,doy,doe;
+	y -= (m <= 2);
+	era = (y >= 0 ? y : y - 399) / 400;
+	yoe = (unsigned)(y - era * 400);
+	doy = (unsigned)((153 * (m + (m > 2 ? -3 : 9)) + 2) / 5 + d - 1);
+	doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+	return era * 146097 + (sxi64)doe - 719468;
+}
+static void DtCivilFromDays(sxi64 z,sxi64 *py,int *pm,int *pd)
+{
+	sxi64 era;
+	unsigned doe,yoe,doy,mp;
+	z += 719468;
+	era = (z >= 0 ? z : z - 146096) / 146097;
+	doe = (unsigned)(z - era * 146097);
+	yoe = (doe - doe/1460 + doe/36524 - doe/146096) / 365;
+	*py = (sxi64)yoe + era * 400;
+	doy = doe - (365 * yoe + yoe/4 - yoe/100);
+	mp = (5 * doy + 2) / 153;
+	*pd = (int)(doy - (153 * mp + 2) / 5 + 1);
+	*pm = (int)(mp < 10 ? mp + 3 : mp - 9);
+	if( *pm <= 2 ){
+		*py += 1;
+	}
+}
+static sxi64 DtFloorDiv(sxi64 a,sxi64 b)
+{
+	sxi64 q = a / b;
+	if( (a % b) != 0 && ((a < 0) != (b < 0)) ){
+		q--;
+	}
+	return q;
+}
+/* Timestamp + offset -> Sytm (with zone metadata for DateFormat's T/e/O/P/Z) */
+static void DtFillSytm(sxi64 iTs,sxi32 iOff,char *zZone,Sytm *pTm)
+{
+	sxi64 t = iTs + iOff;
+	sxi64 days = DtFloorDiv(t,86400);
+	sxi64 secs = t - days * 86400;
+	sxi64 y;
+	int mo,d;
+	DtCivilFromDays(days,&y,&mo,&d);
+	pTm->tm_sec  = (int)(secs % 60);
+	pTm->tm_min  = (int)((secs / 60) % 60);
+	pTm->tm_hour = (int)(secs / 3600);
+	pTm->tm_mday = d;
+	pTm->tm_mon  = mo - 1;
+	pTm->tm_year = (int)y;
+	pTm->tm_wday = (int)(((days % 7) + 11) % 7); /* day 0 = Thursday(4) */
+	pTm->tm_yday = (int)(days - DtDaysFromCivil(y,1,1));
+	pTm->tm_isdst = 0;
+	pTm->tm_zone = zZone;
+	pTm->tm_gmtoff = (long)iOff;
+}
+static sxi64 DtMakeTs(sxi64 y,int mo,int d,int h,int mi,int s,sxi32 iOff)
+{
+	return DtDaysFromCivil(y,mo,d) * 86400 + (sxi64)h*3600 + (sxi64)mi*60 + s - iOff;
+}
+/* Month-arithmetic with php's overflow semantics (Jan 31 +1 month -> Mar 2/3):
+ * normalize the month, keep the day — the civil day-count formula is linear in
+ * d, so an out-of-range day simply lands in the following month. */
+static sxi64 DtAddMonths(sxi64 iTs,sxi32 iOff,sxi64 nMonths)
+{
+	sxi64 t = iTs + iOff;
+	sxi64 days = DtFloorDiv(t,86400);
+	sxi64 secs = t - days * 86400;
+	sxi64 y;
+	int mo,d;
+	sxi64 m0;
+	DtCivilFromDays(days,&y,&mo,&d);
+	m0 = (y * 12 + (mo - 1)) + nMonths;
+	y  = DtFloorDiv(m0,12);
+	mo = (int)(m0 - y * 12) + 1;
+	return DtDaysFromCivil(y,mo,d) * 86400 + secs - iOff;
+}
+/*
+ * Minimal php-datetime-string parser (slice 1): absolute forms
+ * "now" | "@<ts>" | "YYYY-MM-DD[( |T)HH:MM[:SS]][Z|±HH[:MM]]" | "HH:MM[:SS]",
+ * keywords today/midnight/noon/tomorrow/yesterday, and relative sequences
+ * "[+|-]N (sec|min|hour|day|week|fortnight|month|year)[s]". Returns 0 on
+ * success (ts/off/bOffSet out), or the byte position of the first
+ * unparseable character +1 (for php's "at position N" message).
+ */
+static int DtParse(const char *zIn,int nLen,sxi64 iBaseTs,sxi32 iBaseOff,
+	sxi64 *pTs,sxi32 *pOff,int *pbOffSet)
+{
+	const char *z = zIn, *zEnd = &zIn[nLen];
+	sxi64 iTs = iBaseTs;
+	sxi32 iOff = iBaseOff;
+	int bOffSet = 0;
+	int bAny = 0;
+#define DT_SKIP_WS() while( z < zEnd && (z[0]==' '||z[0]=='\t'||z[0]==',') ){ z++; }
+#define DT_LOWEQ(zKw,nKw) (zEnd-z >= (nKw) && SyStrnicmp(z,zKw,nKw) == 0 \
+	&& (zEnd-z == (nKw) || !SyisAlpha(z[(nKw)])))
+	DT_SKIP_WS();
+	if( z >= zEnd ){
+		/* php: the empty string is "now" */
+		*pTs = iTs;
+		*pOff = iOff;
+		*pbOffSet = bOffSet;
+		return 0;
+	}
+	/* "@<seconds>" absolute epoch */
+	if( z[0] == '@' ){
+		int neg = 0;
+		sxi64 v = 0;
+		const char *zAt = z;
+		z++;
+		if( z < zEnd && (z[0]=='-'||z[0]=='+') ){ neg = (z[0]=='-'); z++; }
+		/* php's lexer rejects the whole token: the error points at the '@' */
+		if( z >= zEnd || !SyisDigit(z[0]) ){ return (int)(zAt - zIn) + 1; }
+		while( z < zEnd && SyisDigit(z[0]) ){ v = v*10 + (z[0]-'0'); z++; }
+		*pTs = neg ? -v : v;
+		*pOff = 0;
+		*pbOffSet = 1;
+		DT_SKIP_WS();
+		return (z < zEnd) ? (int)(z - zIn) + 1 : 0;
+	}
+	/* Absolute date: YYYY-MM-DD[...] */
+	if( zEnd-z >= 10 && SyisDigit(z[0]) && SyisDigit(z[1]) && SyisDigit(z[2])
+	 && SyisDigit(z[3]) && z[4]=='-' ){
+		sxi64 y = (z[0]-'0')*1000 + (z[1]-'0')*100 + (z[2]-'0')*10 + (z[3]-'0');
+		int mo,d,h=0,mi=0,s=0;
+		if( !SyisDigit(z[5])||!SyisDigit(z[6])||z[7] != '-'||!SyisDigit(z[8])||!SyisDigit(z[9]) ){
+			return (int)(z - zIn) + 1;
+		}
+		mo = (z[5]-'0')*10 + (z[6]-'0');
+		d  = (z[8]-'0')*10 + (z[9]-'0');
+		/* php's lexer dies on the SECOND digit of an out-of-range month/day
+		 * (either the two-digit pattern fails there, or a one-digit component
+		 * matched and the separator check fails there); "00" lexes fine and
+		 * normalizes (month 0 == December of the previous year). */
+		if( mo > 12 ){ return (int)(&z[6] - zIn) + 1; }
+		if( d > 31 ){ return (int)(&z[9] - zIn) + 1; }
+		if( mo == 0 ){ mo = 12; y--; }
+		z += 10;
+		if( z < zEnd && (z[0]=='T' || z[0]==' ') && zEnd-z >= 6
+		 && SyisDigit(z[1]) && SyisDigit(z[2]) && z[3]==':' ){
+			z++;
+			h  = (z[0]-'0')*10 + (z[1]-'0');
+			mi = (z[3]-'0')*10 + (z[4]-'0');
+			/* a 25+ hour kills php's whole time token: error at its start */
+			if( h > 24 ){ return (int)(z - zIn) + 1; }
+			/* php lexes HH:M, then the minute's second digit starts a SECOND
+			 * time token: "Double time specification" (negative encoding) */
+			if( mi > 59 ){ return -((int)(&z[4] - zIn) + 1); }
+			z += 5;
+			if( z+2 < zEnd+1 && z < zEnd && z[0]==':' && zEnd-z >= 3
+			 && SyisDigit(z[1]) && SyisDigit(z[2]) ){
+				s = (z[1]-'0')*10 + (z[2]-'0');
+				if( s > 59 ){ return (int)(&z[2] - zIn) + 1; }
+				z += 3;
+			}
+			if( z < zEnd && z[0]=='.' ){ /* fractional seconds: consume */
+				z++;
+				while( z < zEnd && SyisDigit(z[0]) ){ z++; }
+			}
+			if( z < zEnd && (z[0]=='Z' || z[0]=='z') ){
+				/* 2 = explicit "Z" zone: php names it "Z", not "+00:00" */
+				iOff = 0; bOffSet = 2; z++;
+			}else if( z < zEnd && (z[0]=='+' || z[0]=='-') ){
+				int sign = (z[0]=='-') ? -1 : 1;
+				int oh,om = 0;
+				z++;
+				if( zEnd-z < 2 || !SyisDigit(z[0]) || !SyisDigit(z[1]) ){ return (int)(z - zIn) + 1; }
+				oh = (z[0]-'0')*10 + (z[1]-'0');
+				z += 2;
+				if( z < zEnd && z[0]==':' ){ z++; }
+				if( zEnd-z >= 2 && SyisDigit(z[0]) && SyisDigit(z[1]) ){
+					om = (z[0]-'0')*10 + (z[1]-'0');
+					z += 2;
+				}
+				iOff = sign * (oh*3600 + om*60);
+				bOffSet = 1;
+			}
+		}
+		iTs = DtMakeTs(y,mo,d,h,mi,s,iOff);
+		bAny = 1;
+	}else if( zEnd-z >= 5 && SyisDigit(z[0]) && SyisDigit(z[1]) && z[2]==':'
+	 && SyisDigit(z[3]) && SyisDigit(z[4]) ){
+		/* Time-only: HH:MM[:SS] on the base date */
+		sxi64 t = iTs + iOff;
+		sxi64 days = DtFloorDiv(t,86400);
+		int h  = (z[0]-'0')*10 + (z[1]-'0');
+		int mi = (z[3]-'0')*10 + (z[4]-'0');
+		int s = 0;
+		/* php: bad hour kills the token (error at its start); bad minute /
+		 * second dies on the component's second digit */
+		if( h > 24 ){ return (int)(z - zIn) + 1; }
+		if( mi > 59 ){ return (int)(&z[4] - zIn) + 1; }
+		z += 5;
+		if( z < zEnd && z[0]==':' && zEnd-z >= 3 && SyisDigit(z[1]) && SyisDigit(z[2]) ){
+			s = (z[1]-'0')*10 + (z[2]-'0');
+			if( s > 59 ){ return (int)(&z[2] - zIn) + 1; }
+			z += 3;
+		}
+		iTs = days*86400 + (sxi64)h*3600 + (sxi64)mi*60 + s - iOff;
+		bAny = 1;
+	}else if( DT_LOWEQ("now",3) ){
+		z += 3;
+		bAny = 1;
+	}
+	/* Relative / keyword sequence */
+	for(;;){
+		DT_SKIP_WS();
+		if( z >= zEnd ){
+			break;
+		}
+		if( DT_LOWEQ("today",5) || DT_LOWEQ("midnight",8) ){
+			sxi64 days = DtFloorDiv(iTs + iOff,86400);
+			iTs = days*86400 - iOff;
+			z += (SyToLower(z[0])=='t') ? 5 : 8;
+			bAny = 1;
+			continue;
+		}
+		if( DT_LOWEQ("noon",4) ){
+			sxi64 days = DtFloorDiv(iTs + iOff,86400);
+			iTs = days*86400 + 12*3600 - iOff;
+			z += 4;
+			bAny = 1;
+			continue;
+		}
+		if( DT_LOWEQ("tomorrow",8) ){
+			sxi64 days = DtFloorDiv(iTs + iOff,86400) + 1;
+			iTs = days*86400 - iOff;
+			z += 8;
+			bAny = 1;
+			continue;
+		}
+		if( DT_LOWEQ("yesterday",9) ){
+			sxi64 days = DtFloorDiv(iTs + iOff,86400) - 1;
+			iTs = days*86400 - iOff;
+			z += 9;
+			bAny = 1;
+			continue;
+		}
+		if( SyisDigit(z[0]) || z[0]=='+' || z[0]=='-' ){
+			int neg = 0;
+			sxi64 v = 0;
+			const char *zNumStart = z;
+			if( z[0]=='+' || z[0]=='-' ){ neg = (z[0]=='-'); z++; }
+			if( z >= zEnd || !SyisDigit(z[0]) ){ return (int)(zNumStart - zIn) + 1; }
+			while( z < zEnd && SyisDigit(z[0]) ){ v = v*10 + (z[0]-'0'); z++; }
+			if( neg ){ v = -v; }
+			DT_SKIP_WS();
+			if( DT_LOWEQ("seconds",7) )     { iTs += v;            z += 7; }
+			else if( DT_LOWEQ("second",6) ) { iTs += v;            z += 6; }
+			else if( DT_LOWEQ("secs",4) )   { iTs += v;            z += 4; }
+			else if( DT_LOWEQ("sec",3) )    { iTs += v;            z += 3; }
+			else if( DT_LOWEQ("minutes",7) ){ iTs += v*60;         z += 7; }
+			else if( DT_LOWEQ("minute",6) ) { iTs += v*60;         z += 6; }
+			else if( DT_LOWEQ("mins",4) )   { iTs += v*60;         z += 4; }
+			else if( DT_LOWEQ("min",3) )    { iTs += v*60;         z += 3; }
+			else if( DT_LOWEQ("hours",5) )  { iTs += v*3600;       z += 5; }
+			else if( DT_LOWEQ("hour",4) )   { iTs += v*3600;       z += 4; }
+			else if( DT_LOWEQ("days",4) )   { iTs += v*86400;      z += 4; }
+			else if( DT_LOWEQ("day",3) )    { iTs += v*86400;      z += 3; }
+			else if( DT_LOWEQ("weeks",5) )  { iTs += v*7*86400;    z += 5; }
+			else if( DT_LOWEQ("week",4) )   { iTs += v*7*86400;    z += 4; }
+			else if( DT_LOWEQ("fortnights",10) ){ iTs += v*14*86400; z += 10; }
+			else if( DT_LOWEQ("fortnight",9) )  { iTs += v*14*86400; z += 9; }
+			else if( DT_LOWEQ("months",6) ) { iTs = DtAddMonths(iTs,iOff,v); z += 6; }
+			else if( DT_LOWEQ("month",5) )  { iTs = DtAddMonths(iTs,iOff,v); z += 5; }
+			else if( DT_LOWEQ("years",5) )  { iTs = DtAddMonths(iTs,iOff,v*12); z += 5; }
+			else if( DT_LOWEQ("year",4) )   { iTs = DtAddMonths(iTs,iOff,v*12); z += 4; }
+			else{
+				return (int)(z - zIn) + 1;
+			}
+			bAny = 1;
+			continue;
+		}
+		return (int)(z - zIn) + 1;
+	}
+	if( !bAny ){
+		return 1;
+	}
+	*pTs = iTs;
+	*pOff = iOff;
+	*pbOffSet = bOffSet;
+	return 0;
+#undef DT_SKIP_WS
+#undef DT_LOWEQ
+}
+/* int __dt_now() */
+static int vm_builtin_dt_now(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	SXUNUSED(nArg);
+	SXUNUSED(apArg);
+	ph7_result_int64(pCtx,(ph7_int64)time(0));
+	return PH7_OK;
+}
+/* mixed __dt_parse(string $s, int $baseTs, int $baseOff)
+ *   -> [ts, off, offWasExplicit] on success; php's error MESSAGE string on
+ *      failure (the chunk wraps it in DateMalformedStringException). */
+static int vm_builtin_dt_parse(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	const char *zIn;
+	int nLen;
+	sxi64 iBaseTs;
+	sxi32 iBaseOff;
+	sxi64 iTs = 0;
+	sxi32 iOff = 0;
+	int bOffSet = 0;
+	int iErrPos;
+	if( nArg < 3 ){
+		ph7_result_bool(pCtx,0);
+		return PH7_OK;
+	}
+	zIn = ph7_value_to_string(apArg[0],&nLen);
+	iBaseTs  = ph7_value_to_int64(apArg[1]);
+	iBaseOff = (sxi32)ph7_value_to_int64(apArg[2]);
+	iErrPos = DtParse(zIn,nLen,iBaseTs,iBaseOff,&iTs,&iOff,&bOffSet);
+	if( iErrPos != 0 ){
+		/* Negative encoding: php's "Double time specification" reason */
+		int bDouble = iErrPos < 0;
+		int iPos = (bDouble ? -iErrPos : iErrPos) - 1;
+		char cAt = (iPos < nLen) ? zIn[iPos] : ' ';
+		/* php appends a reason: an alphabetic token is assumed to be a timezone
+		 * lookup miss, anything else an unexpected character. */
+		ph7_result_string_format(pCtx,
+			"Failed to parse time string (%.*s) at position %d (%c): %s",
+			nLen,zIn,iPos,cAt,
+			bDouble ? "Double time specification"
+			: ((cAt >= 'a' && cAt <= 'z') || (cAt >= 'A' && cAt <= 'Z'))
+				? "The timezone could not be found in the database"
+				: "Unexpected character");
+		return PH7_OK;
+	}
+	{
+		ph7_value *pArr = ph7_context_new_array(pCtx);
+		ph7_value *pV = ph7_context_new_scalar(pCtx);
+		if( pArr == 0 || pV == 0 ){
+			return PH7_ContextMemoryError(pCtx);
+		}
+		ph7_value_int64(pV,iTs);
+		ph7_array_add_elem(pArr,0,pV);
+		ph7_value_int64(pV,iOff);
+		ph7_array_add_elem(pArr,0,pV);
+		/* int, not bool: 0 = no explicit offset, 1 = numeric offset/@epoch,
+		 * 2 = literal "Z" (php keeps the distinction in the zone name) */
+		ph7_value_int64(pV,bOffSet);
+		ph7_array_add_elem(pArr,0,pV);
+		ph7_result_value(pCtx,pArr);
+	}
+	return PH7_OK;
+}
+/* string __dt_default_tz(void) — the date_default_timezone_set() identifier */
+static int vm_builtin_dt_default_tz(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	SXUNUSED(nArg);
+	SXUNUSED(apArg);
+	ph7_result_string(pCtx,pCtx->pVm->zDefTz,(int)pCtx->pVm->nDefTz);
+	return PH7_OK;
+}
+/* string __dt_format(int $ts, int $off, string $tzname, string $format) */
+static int vm_builtin_dt_format(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	Sytm sTm;
+	sxi64 iTs;
+	sxi32 iOff;
+	const char *zName,*zFmt;
+	int nName,nFmt;
+	char zZone[64];
+	if( nArg < 4 ){
+		ph7_result_bool(pCtx,0);
+		return PH7_OK;
+	}
+	iTs  = ph7_value_to_int64(apArg[0]);
+	iOff = (sxi32)ph7_value_to_int64(apArg[1]);
+	zName = ph7_value_to_string(apArg[2],&nName);
+	zFmt  = ph7_value_to_string(apArg[3],&nFmt);
+	if( nName >= (int)sizeof(zZone) ){ nName = (int)sizeof(zZone) - 1; }
+	SyMemcpy(zName,zZone,(sxu32)nName);
+	zZone[nName] = 0;
+	DtFillSytm(iTs,iOff,zZone,&sTm);
+	DateFormat(pCtx,zFmt,nFmt,&sTm);
+	return PH7_OK;
+}
+/* int __dt_make(int y, int mo, int d, int h, int i, int s, int off) */
+static int vm_builtin_dt_make(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	sxi64 y;
+	int mo,d,h,mi,s;
+	sxi32 iOff;
+	if( nArg < 7 ){
+		ph7_result_bool(pCtx,0);
+		return PH7_OK;
+	}
+	y   = ph7_value_to_int64(apArg[0]);
+	mo  = ph7_value_to_int(apArg[1]);
+	d   = ph7_value_to_int(apArg[2]);
+	h   = ph7_value_to_int(apArg[3]);
+	mi  = ph7_value_to_int(apArg[4]);
+	s   = ph7_value_to_int(apArg[5]);
+	iOff = (sxi32)ph7_value_to_int64(apArg[6]);
+	ph7_result_int64(pCtx,DtMakeTs(y,mo,d,h,mi,s,iOff));
+	return PH7_OK;
+}
+/*
+ * The embedded DateTime library. Timezone scope: UTC + fixed offsets.
+ */
+static const char zDateTimeLib[] =
+"class DateMalformedStringException extends Exception {}"
+"class DateInvalidTimeZoneException extends Exception {}"
+"interface DateTimeInterface {"
+" const ATOM = 'Y-m-d\\TH:i:sP';"
+" const COOKIE = 'l, d-M-Y H:i:s T';"
+" const ISO8601 = 'Y-m-d\\TH:i:sO';"
+" const ISO8601_EXPANDED = 'X-m-d\\TH:i:sP';"
+" const RFC822 = 'D, d M y H:i:s O';"
+" const RFC850 = 'l, d-M-y H:i:s T';"
+" const RFC1036 = 'D, d M y H:i:s O';"
+" const RFC1123 = 'D, d M Y H:i:s O';"
+" const RFC7231 = 'D, d M Y H:i:s \\G\\M\\T';"
+" const RFC2822 = 'D, d M Y H:i:s O';"
+" const RFC3339 = 'Y-m-d\\TH:i:sP';"
+" const RFC3339_EXTENDED = 'Y-m-d\\TH:i:s.vP';"
+" const RSS = 'D, d M Y H:i:s O';"
+" const W3C = 'Y-m-d\\TH:i:sP';"
+"}"
+"class DateTimeZone {"
+" private $__dtzOff = 0;"
+" private $__dtzName = 'UTC';"
+" public function __construct($timezone = 'UTC'){"
+"  $tz = (string)$timezone;"
+"  if( strcasecmp($tz, 'UTC') === 0 ){"
+"   $this->__dtzOff = 0; $this->__dtzName = 'UTC';"
+"   return;"
+"  }"
+"  if( $tz === 'Z' ){"
+"   $this->__dtzOff = 0; $this->__dtzName = 'Z';"
+"   return;"
+"  }"
+"  if( strcasecmp($tz, 'GMT') === 0 ){"
+"   $this->__dtzOff = 0; $this->__dtzName = 'GMT';"
+"   return;"
+"  }"
+"  $m = null;"
+"  if( preg_match('/^([+-])(\\d{2}):?(\\d{2})$/', $tz, $m) ){"
+"   $off = ((int)$m[2]) * 3600 + ((int)$m[3]) * 60;"
+"   if( $m[1] === '-' ){ $off = -$off; }"
+"   $this->__dtzOff = $off;"
+"   $this->__dtzName = $m[1] . $m[2] . ':' . $m[3];"
+"   return;"
+"  }"
+"  throw new DateInvalidTimeZoneException("
+"   'DateTimeZone::__construct(): Unknown or bad timezone (' . $tz . ')');"
+" }"
+" public function getName(){ return $this->__dtzName; }"
+" public function getOffset($datetime = null){ return $this->__dtzOff; }"
+"}"
+"trait __DtCoreT {"
+" private $__dtTs = 0;"
+" private $__dtOff = 0;"
+" private $__dtName = 'UTC';"
+" private function __dtInit($datetime, $timezone){"
+"  $off = 0; $name = __dt_default_tz();"
+"  if( $timezone !== null ){"
+"   $off = $timezone->getOffset($this);"
+"   $name = $timezone->getName();"
+"  }"
+"  $r = __dt_parse((string)$datetime, __dt_now(), $off);"
+"  if( is_string($r) ){ throw new DateMalformedStringException($r); }"
+"  $this->__dtTs = $r[0];"
+"  if( $r[2] ){"
+"   $this->__dtOff = $r[1];"
+"   $this->__dtName = $r[2] === 2 ? 'Z' : $this->__dtOffName($r[1]);"
+"  }else{"
+"   $this->__dtOff = $off;"
+"   $this->__dtName = $name;"
+"  }"
+" }"
+" private function __dtOffName($off){"
+"  $s = $off < 0 ? '-' : '+';"
+"  $a = $off < 0 ? -$off : $off;"
+"  return $s . sprintf('%02d:%02d', intdiv($a, 3600), intdiv($a % 3600, 60));"
+" }"
+" public function format($format){ return __dt_format($this->__dtTs, $this->__dtOff, $this->__dtName, (string)$format); }"
+" public function getTimestamp(){ return $this->__dtTs; }"
+" public function getOffset(){ return $this->__dtOff; }"
+" public function getTimezone(){ return new DateTimeZone($this->__dtName); }"
+"}"
+"class DateTime implements DateTimeInterface {"
+" use __DtCoreT;"
+" public function __construct($datetime = 'now', $timezone = null){"
+"  $this->__dtInit($datetime, $timezone);"
+" }"
+" public function modify($modifier){"
+"  $r = __dt_parse((string)$modifier, $this->__dtTs, $this->__dtOff);"
+"  if( is_string($r) ){ throw new DateMalformedStringException('DateTime::modify(): ' . $r); }"
+"  $this->__dtTs = $r[0];"
+"  return $this;"
+" }"
+" public function setTimestamp($timestamp){ $this->__dtTs = (int)$timestamp; return $this; }"
+" public function setTimezone($timezone){"
+"  $this->__dtOff = $timezone->getOffset($this);"
+"  $this->__dtName = $timezone->getName();"
+"  return $this;"
+" }"
+" public function setDate($year, $month, $day){"
+"  $this->__dtTs = __dt_make($year, $month, $day, (int)$this->format('G'), (int)$this->format('i'), (int)$this->format('s'), $this->__dtOff);"
+"  return $this;"
+" }"
+" public function setTime($hour, $minute, $second = 0, $microsecond = 0){"
+"  $this->__dtTs = __dt_make((int)$this->format('Y'), (int)$this->format('n'), (int)$this->format('j'), $hour, $minute, $second, $this->__dtOff);"
+"  return $this;"
+" }"
+"}"
+"class DateTimeImmutable implements DateTimeInterface {"
+" use __DtCoreT;"
+" public function __construct($datetime = 'now', $timezone = null){"
+"  $this->__dtInit($datetime, $timezone);"
+" }"
+" public function modify($modifier){"
+"  $r = __dt_parse((string)$modifier, $this->__dtTs, $this->__dtOff);"
+"  if( is_string($r) ){ throw new DateMalformedStringException('DateTimeImmutable::modify(): ' . $r); }"
+"  $c = clone $this;"
+"  $c->__dtTs = $r[0];"
+"  return $c;"
+" }"
+" public function setTimestamp($timestamp){ $c = clone $this; $c->__dtTs = (int)$timestamp; return $c; }"
+" public function setTimezone($timezone){"
+"  $c = clone $this;"
+"  $c->__dtOff = $timezone->getOffset($this);"
+"  $c->__dtName = $timezone->getName();"
+"  return $c;"
+" }"
+" public function setDate($year, $month, $day){"
+"  $c = clone $this;"
+"  $c->__dtTs = __dt_make($year, $month, $day, (int)$this->format('G'), (int)$this->format('i'), (int)$this->format('s'), $this->__dtOff);"
+"  return $c;"
+" }"
+" public function setTime($hour, $minute, $second = 0, $microsecond = 0){"
+"  $c = clone $this;"
+"  $c->__dtTs = __dt_make((int)$this->format('Y'), (int)$this->format('n'), (int)$this->format('j'), $hour, $minute, $second, $this->__dtOff);"
+"  return $c;"
+" }"
+"}"
+"function date_create($datetime = 'now', $timezone = null){"
+" try { return new DateTime($datetime, $timezone); } catch (Exception $e) { return false; }"
+"}"
+"function date_create_immutable($datetime = 'now', $timezone = null){"
+" try { return new DateTimeImmutable($datetime, $timezone); } catch (Exception $e) { return false; }"
+"}"
+;
+/*
+ * Install the DateTime family: thunks first, then the chunk. Called from
+ * PH7_VmInit inside the bCompilingBuiltin window, after the Reflection
+ * install (Exception must exist).
+ */
+PH7_PRIVATE sxi32 PH7_VmInstallDateTime(ph7_vm *pVm)
+{
+	static const struct {
+		const char *zName;
+		ProchHostFunction xFunc;
+	} aFunc[] = {
+		{ "__dt_now",    vm_builtin_dt_now },
+		{ "__dt_default_tz", vm_builtin_dt_default_tz },
+		{ "__dt_parse",  vm_builtin_dt_parse },
+		{ "__dt_format", vm_builtin_dt_format },
+		{ "__dt_make",   vm_builtin_dt_make },
+	};
+	sxu32 n;
+	/* php's date.timezone default */
+	SyMemcpy("UTC",pVm->zDefTz,sizeof("UTC"));
+	pVm->nDefTz = sizeof("UTC") - 1;
+	for( n = 0 ; n < sizeof(aFunc)/sizeof(aFunc[0]) ; n++ ){
+		ph7_create_function(&(*pVm),aFunc[n].zName,aFunc[n].xFunc,0);
+	}
+	return PH7_VmEvalBuiltinChunk(&(*pVm),zDateTimeLib,sizeof(zDateTimeLib)-1);
+}
+
 #endif /* PH7_DISABLE_BUILTIN_FUNC */
+
+#ifdef PH7_DISABLE_BUILTIN_FUNC
+/* Tiny build: no DateTime family (builtin layer disabled) */
+PH7_PRIVATE sxi32 PH7_VmInstallDateTime(ph7_vm *pVm){
+	SyMemcpy("UTC",pVm->zDefTz,sizeof("UTC"));
+	pVm->nDefTz = sizeof("UTC") - 1;
+	return SXRET_OK;
+}
+#endif

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1253,6 +1253,9 @@ struct ph7_vm
 	int bReflectBypass;         /* Consume-once: the next method OP_CALL skips the visibility
 	                             * check (ReflectionMethod::invoke bypasses protection like PHP
 	                             * 8.1+). Cleared by the check site; never survives past one call. */
+	char zDefTz[68];            /* date_default_timezone_set() identifier, stored verbatim like php
+	                             * (default "UTC"; only UTC/GMT are accepted — no tz database) */
+	sxu32 nDefTz;               /* zDefTz length in bytes */
 	SySet aShutdown;            /* Stack of shutdown user callbacks */
 	SySet aAutoload;            /* Stack of spl_autoload callbacks */
 	SyHash hAutoloadActive;     /* Classes currently being autoloaded (reentrancy guard) */
@@ -1992,6 +1995,7 @@ PH7_PRIVATE sxi32 PH7_VmThrowExceptionTrace(ph7_context *pCtx,const char *zClass
 PH7_PRIVATE void  PH7_VmExpandConstantValue(ph7_value *pVal,void *pUserData);
 PH7_PRIVATE sxi32 PH7_VmDump(ph7_vm *pVm,ProcConsumer xConsumer,void *pUserData);
 PH7_PRIVATE sxi32 PH7_VmEvalBuiltinChunk(ph7_vm *pVm,const char *zSrc,sxu32 nLen);
+PH7_PRIVATE sxi32 PH7_VmInstallDateTime(ph7_vm *pVm);
 PH7_PRIVATE const char * PH7_VmBuiltinSigLookup(const char *zName,sxu32 nLen,const char **pzRet);
 PH7_PRIVATE void PH7_VmStoreArgByRef(ph7_vm *pVm,ph7_value *pArg,ph7_value *pNewVal);
 PH7_PRIVATE void PH7_VmThrowDeprecatedFmt(ph7_vm *pVm,const char *zFmt,...);
@@ -2208,6 +2212,8 @@ PH7_PRIVATE int PH7_builtin_gmdate(ph7_context *pCtx,int nArg,ph7_value **apArg)
 PH7_PRIVATE int PH7_builtin_localtime(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE int PH7_builtin_idate(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE int PH7_builtin_mktime(ph7_context *pCtx,int nArg,ph7_value **apArg);
+PH7_PRIVATE int PH7_builtin_date_default_timezone_get(ph7_context *pCtx,int nArg,ph7_value **apArg);
+PH7_PRIVATE int PH7_builtin_date_default_timezone_set(ph7_context *pCtx,int nArg,ph7_value **apArg);
 /* vfs_zip.c function prototypes */
 PH7_PRIVATE int PH7_builtin_zip_open(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE int PH7_builtin_zip_close(ph7_context *pCtx,int nArg,ph7_value **apArg);

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -583,6 +583,7 @@ static const struct VmBuiltinArity {
 	{ "stat",                      1, 0 },
 	/* Date family */
 	{ "date",                      1, 1 },
+	{ "date_default_timezone_set", 1, 1 },
 	{ "gmdate",                    1, 1 },
 	{ "gmmktime",                  1, 1 },
 	{ "idate",                     1, 1 },
@@ -2705,6 +2706,7 @@ PH7_PRIVATE sxi32 PH7_VmInit(
 	 * Still inside the bCompilingBuiltin window so its classes are flagged
 	 * internal; the Traversable pointer above must already be cached. */
 	PH7_VmInstallReflection(&(*pVm));
+	PH7_VmInstallDateTime(&(*pVm));
 	pVm->bCompilingBuiltin = 0;
 	/* Reset the code generator */
 	PH7_ResetCodeGenerator(&(*pVm),pEngine->xConf.xErr,pEngine->xConf.pErrData);
@@ -3183,6 +3185,8 @@ static const struct VmBuiltinSig {
 	{ "ctype_xdigit", "mixed $text", "bool" },
 	{ "current", "object|array $array", "mixed" },
 	{ "date", "string $format, ?int $timestamp = NULL", "string" },
+	{ "date_default_timezone_get", "", "string" },
+	{ "date_default_timezone_set", "string $timezoneId", "bool" },
 	{ "debug_backtrace", "int $options = 1, int $limit = 0", "array" },
 	{ "debug_print_backtrace", "int $options = 0, int $limit = 0", "void" },
 	{ "decbin", "int $num", "string" },

--- a/tests/ph7/001-smoke/function/date/date_default_timezone.phpt
+++ b/tests/ph7/001-smoke/function/date/date_default_timezone.phpt
@@ -1,0 +1,54 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: date_default_timezone_get/set, UTC date() default, mktime family
+--FILE--
+<?php
+// php's date.timezone default is UTC — date() must not read the system zone
+echo date_default_timezone_get(), "\n";
+echo date('Y-m-d H:i:s T e O', 1700000000), "\n";
+echo gmdate('Y-m-d H:i:s', 1700000000), "\n";
+
+// set() stores the id verbatim like php; GMT flips the zone label
+echo date_default_timezone_set('GMT') ? 'true' : 'false', "\n";
+echo date('T e', 0), "\n";
+echo date_default_timezone_set('utc') ? 'true' : 'false', "\n";
+echo date_default_timezone_get(), "\n";
+
+// mktime: verbatim years except php's legacy two-digit mapping,
+// month/day/time overflow normalizes, gmmktime agrees under UTC
+echo mktime(1, 2, 3, 4, 5, 2024), ' ', gmmktime(1, 2, 3, 4, 5, 2024), "\n";
+echo mktime(0, 0, 0, 14, 1, 2024), "\n";
+echo mktime(0, 0, 0, 1, 1, 70), ' ', mktime(0, 0, 0, 1, 1, 0), ' ', mktime(0, 0, 0, 1, 1, 100), "\n";
+echo mktime(0, 0, 0, 1, 1, 101), "\n";
+echo mktime(25, -30, 0, 1, 1, 2024), "\n";
+echo mktime(0, 0, 0, 1, 0, 2024), "\n";
+try {
+    mktime();
+} catch (ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+// date('U') must format the passed timestamp, not the current clock
+echo date('U', 1700000000), "\n";
+?>
+--EXPECT--
+UTC
+2023-11-14 22:13:20 UTC UTC +0000
+2023-11-14 22:13:20
+true
+GMT GMT
+true
+utc
+1712278923 1712278923
+1738368000
+0 946684800 946684800
+-58979923200
+1704155400
+1703980800
+mktime() expects at least 1 argument, 0 given
+1700000000
+--CLEAN--
+<?php
+date_default_timezone_set('UTC');

--- a/tests/ph7/001-smoke/function/date/date_iso8601.phpt
+++ b/tests/ph7/001-smoke/function/date/date_iso8601.phpt
@@ -2,14 +2,12 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: date ISO 8601 format
---SKIPIF--
-<?php if(function_exists('zend_version')) { echo 'skip'; } ?>
+PH7 / PHP: date ISO 8601 format
 --FILE--
 <?php
-// Test ISO 8601 format
+// Test ISO 8601 format (php shape: 2024-01-15T10:30:45+00:00 = 25 chars)
 $result = date("c");
-echo strlen($result) === 24 ? "ISO8601_OK\n" : "ISO8601_FAIL: '$result'\n";
+echo strlen($result) === 25 ? "ISO8601_OK\n" : "ISO8601_FAIL: '$result'\n";
 ?>
 --EXPECT--
 ISO8601_OK

--- a/tests/ph7/001-smoke/function/date/datetime_core.phpt
+++ b/tests/ph7/001-smoke/function/date/datetime_core.phpt
@@ -1,0 +1,69 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: DateTime / DateTimeImmutable / DateTimeZone core (band D slice 1)
+--FILE--
+<?php
+$d = new DateTime('2024-01-15 10:30:00', new DateTimeZone('UTC'));
+echo $d->getTimestamp(), "\n";
+echo $d->format('Y-m-d H:i:s'), "\n";
+$d->modify('+1 day');
+echo $d->format('Y-m-d'), "\n";
+$d->modify('+2 months');
+echo $d->format('Y-m-d'), "\n";
+
+// Immutable: modify returns a new object, base unchanged; Jan 31 overflow
+$i = new DateTimeImmutable('2024-01-31', new DateTimeZone('UTC'));
+$j = $i->modify('+1 month');
+echo $i->format('Y-m-d'), ' ', $j->format('Y-m-d'), "\n";
+
+// @timestamp and fixed-offset zones
+$e = new DateTime('@1700000000');
+echo $e->getTimestamp(), ' ', $e->getTimezone()->getName(), "\n";
+$f = new DateTime('2024-06-01 08:30:00', new DateTimeZone('+05:30'));
+echo $f->getTimestamp(), ' ', $f->getOffset(), ' ', $f->format('P'), "\n";
+
+// Offset parsed from the string wins over the zone argument
+$g = new DateTime('2024-06-01T08:30:00+02:00', new DateTimeZone('UTC'));
+echo $g->getTimestamp(), ' ', $g->getOffset(), "\n";
+
+// Setters
+$s = new DateTime('2024-01-15 10:30:00', new DateTimeZone('UTC'));
+$s->setDate(2025, 3, 9);
+$s->setTime(4, 5, 6);
+echo $s->format('Y-m-d H:i:s'), "\n";
+$s->setTimestamp(1600000000);
+echo $s->format('Y-m-d H:i:s'), "\n";
+
+// date_create returns false on garbage, object on success
+$ok = date_create('2024-02-29 12:00:00', new DateTimeZone('UTC'));
+echo $ok === false ? 'false' : $ok->format('Y-m-d H:i:s'), "\n";
+echo date_create('total nonsense') === false ? 'false' : 'object', "\n";
+$im = date_create_immutable('@123456');
+echo $im instanceof DateTimeImmutable ? 'immutable' : 'plain', "\n";
+
+// GMT zone identity
+$z = new DateTimeZone('GMT');
+echo $z->getName(), ' ', $z->getOffset(new DateTime('@0')), "\n";
+echo (new DateTimeZone('utc'))->getName(), "\n";
+?>
+--EXPECT--
+1705314600
+2024-01-15 10:30:00
+2024-01-16
+2024-03-16
+2024-01-31 2024-03-02
+1700000000 +00:00
+1717210800 19800 +05:30
+1717223400 7200
+2025-03-09 04:05:06
+2020-09-13 12:26:40
+2024-02-29 12:00:00
+false
+immutable
+GMT 0
+UTC
+--CLEAN--
+<?php
+unset($d, $i, $j, $e, $f, $g, $s, $ok, $im, $z);

--- a/tests/ph7/001-smoke/function/date/datetime_parse_errors.phpt
+++ b/tests/ph7/001-smoke/function/date/datetime_parse_errors.phpt
@@ -1,0 +1,68 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: DateTime parse failures throw php's exact DateMalformedStringException messages
+--FILE--
+<?php
+$inputs = [
+    'total nonsense',
+    'next xyz',
+    '@abc',
+    '2024-13-45 99:99:99',
+    '2024-91-05',
+    '2024-01-45',
+    '2024-01-15 25:00:00',
+    '2024-01-15 19:99:00',
+    '2024-01-15 19:00:99',
+    '25:30',
+    '10:99',
+    '10:30:99',
+];
+foreach ($inputs as $s) {
+    try {
+        new DateTime($s, new DateTimeZone('UTC'));
+        echo "OK($s)\n";
+    } catch (DateMalformedStringException $e) {
+        echo $e->getMessage(), "\n";
+    }
+}
+
+// modify() keeps its method prefix; the constructor does not
+try {
+    (new DateTime('@0'))->modify('bogus!');
+} catch (DateMalformedStringException $e) {
+    echo $e->getMessage(), "\n";
+}
+
+// month/day zero normalize instead of failing
+echo (new DateTime('2024-00-15', new DateTimeZone('UTC')))->format('Y-m-d'), "\n";
+echo (new DateTime('2024-01-00', new DateTimeZone('UTC')))->format('Y-m-d'), "\n";
+
+// unknown zone name (PHL has no tz database; php agrees on truly-bad ids)
+try {
+    new DateTimeZone('Xyz/Abc');
+} catch (DateInvalidTimeZoneException $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+Failed to parse time string (total nonsense) at position 0 (t): The timezone could not be found in the database
+Failed to parse time string (next xyz) at position 0 (n): The timezone could not be found in the database
+Failed to parse time string (@abc) at position 0 (@): Unexpected character
+Failed to parse time string (2024-13-45 99:99:99) at position 6 (3): Unexpected character
+Failed to parse time string (2024-91-05) at position 6 (1): Unexpected character
+Failed to parse time string (2024-01-45) at position 9 (5): Unexpected character
+Failed to parse time string (2024-01-15 25:00:00) at position 11 (2): Unexpected character
+Failed to parse time string (2024-01-15 19:99:00) at position 15 (9): Double time specification
+Failed to parse time string (2024-01-15 19:00:99) at position 18 (9): Unexpected character
+Failed to parse time string (25:30) at position 0 (2): Unexpected character
+Failed to parse time string (10:99) at position 4 (9): Unexpected character
+Failed to parse time string (10:30:99) at position 7 (9): Unexpected character
+DateTime::modify(): Failed to parse time string (bogus!) at position 0 (b): The timezone could not be found in the database
+2023-12-15
+2023-12-31
+DateTimeZone::__construct(): Unknown or bad timezone (Xyz/Abc)
+--CLEAN--
+<?php
+unset($inputs, $s);


### PR DESCRIPTION
Add DateTimeInterface, DateTime, DateTimeImmutable, DateTimeZone (UTC/GMT/Z/fixed offsets — no tz database), the Date* exception classes, date_create/date_create_immutable and date_default_timezone_get/set as an embedded-PHP chunk plus __dt_* C thunks, with libc-free civil-date arithmetic. Parse failures throw php's exact DateMalformedStringException messages including reason suffixes and lexer positions.

Switch the pre-existing date() family from system localtime to php's UTC default, rewrite mktime/gmmktime on civil arithmetic (verbatim years with the legacy two-digit mapping, month/day/time normalization, ArgumentCountError), and fix the DateFormat tokens: U formatted the current wallclock, O/P/Z/c printed raw offset seconds, r lacked its RFC2822 offset, a/A flipped at 13:00 instead of noon, g/h were off by one, u printed seconds scaled. Add W/o ISO week handling, X/x expanded years, B, v, p, and the GMT±HHMM form of T.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
