### PR TITLE
Add ArrayIterator, ArrayObject and natsort

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ OBJECTS = \
 	$(BUILD_DIR)/src/ph7/vm_builtin_getopt$(OBJ_SUFFIX) \
 	$(BUILD_DIR)/src/ph7/vm_builtin_ob$(OBJ_SUFFIX) \
 	$(BUILD_DIR)/src/ph7/vm_builtin_reflection$(OBJ_SUFFIX) \
+	$(BUILD_DIR)/src/ph7/vm_builtin_spl$(OBJ_SUFFIX) \
 	$(BUILD_DIR)/src/ph7/vm_http$(OBJ_SUFFIX) \
 	$(BUILD_DIR)/src/ph7/vm_http_response$(OBJ_SUFFIX) \
 	$(BUILD_DIR)/src/ph7/vm_json$(OBJ_SUFFIX) \

--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -2036,6 +2036,90 @@ static int PH7_builtin_strcmp(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	return PH7_OK;
 }
 /*
+ * Natural-order comparison core (Martin Pool's natcompare as adapted by php's
+ * ext/standard/strnatcmp.c): digit runs compare numerically — the longer run
+ * wins, a leading zero flips to fractional first-difference-wins semantics —
+ * everything else compares bytewise with whitespace skipped.
+ */
+static int StrNatCompareRight(const char **pa,const char *aEnd,const char **pb,const char *bEnd)
+{
+	int bias = 0;
+	for(;;){
+		int da = (*pa < aEnd) && SyisDigit(**pa);
+		int db = (*pb < bEnd) && SyisDigit(**pb);
+		if( !da && !db ){ return bias; }
+		if( !da ){ return -1; }
+		if( !db ){ return 1; }
+		if( **pa < **pb ){ if( !bias ){ bias = -1; } }
+		else if( **pa > **pb ){ if( !bias ){ bias = 1; } }
+		(*pa)++;
+		(*pb)++;
+	}
+}
+static int StrNatCompareLeft(const char **pa,const char *aEnd,const char **pb,const char *bEnd)
+{
+	for(;;){
+		int da = (*pa < aEnd) && SyisDigit(**pa);
+		int db = (*pb < bEnd) && SyisDigit(**pb);
+		if( !da && !db ){ return 0; }
+		if( !da ){ return -1; }
+		if( !db ){ return 1; }
+		if( **pa < **pb ){ return -1; }
+		if( **pa > **pb ){ return 1; }
+		(*pa)++;
+		(*pb)++;
+	}
+}
+static int StrNatCmpCore(const char *zA,int nA,const char *zB,int nB,int bFold)
+{
+	const char *a = zA,*aEnd = &zA[nA];
+	const char *b = zB,*bEnd = &zB[nB];
+	for(;;){
+		int ca,cb;
+		while( a < aEnd && SyisSpace(a[0]) ){ a++; }
+		while( b < bEnd && SyisSpace(b[0]) ){ b++; }
+		ca = (a < aEnd) ? (unsigned char)a[0] : 0;
+		cb = (b < bEnd) ? (unsigned char)b[0] : 0;
+		if( SyisDigit(ca) && SyisDigit(cb) ){
+			int r = (ca == '0' || cb == '0')
+				? StrNatCompareLeft(&a,aEnd,&b,bEnd)
+				: StrNatCompareRight(&a,aEnd,&b,bEnd);
+			if( r ){ return r; }
+			continue;
+		}
+		if( ca == 0 && cb == 0 ){ return 0; }
+		if( bFold ){
+			ca = SyToLower(ca);
+			cb = SyToLower(cb);
+		}
+		if( ca < cb ){ return -1; }
+		if( ca > cb ){ return 1; }
+		a++;
+		b++;
+	}
+}
+/*
+ * int strnatcmp(string $string1, string $string2)
+ * int strnatcasecmp(string $string1, string $string2)
+ *  Natural-order string comparison ("img2" < "img10"), case folded for the
+ *  latter. php 8.2+ normalizes the result to -1/0/1.
+ */
+static int PH7_builtin_strnatcmp(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	const char *z1,*z2,*zFunc;
+	int n1,n2,bFold;
+	if( nArg < 2 ){
+		ph7_result_int(pCtx,0);
+		return PH7_OK;
+	}
+	zFunc = ph7_function_name(pCtx);
+	bFold = zFunc[sizeof("strnat")-1] == 'c'; /* strnatCasecmp */
+	z1 = ph7_value_to_string(apArg[0],&n1);
+	z2 = ph7_value_to_string(apArg[1],&n2);
+	ph7_result_int(pCtx,StrNatCmpCore(z1,n1,z2,n2,bFold));
+	return PH7_OK;
+}
+/*
  * int strncmp(string $str1,string $str2,int n)
  *  Perform a binary safe string comparison of the first n characters.
  * Parameter
@@ -9344,6 +9428,8 @@ static const ph7_builtin_func aBuiltInFunc[] = {
 	{ "strlen"     , PH7_builtin_strlen     },
 	{ "strcmp"     , PH7_builtin_strcmp     },
 	{ "strcoll"    , PH7_builtin_strcmp     },
+	{ "strnatcmp"  , PH7_builtin_strnatcmp  },
+	{ "strnatcasecmp", PH7_builtin_strnatcmp },
 	{ "strncmp"    , PH7_builtin_strncmp    },
 	{ "strcasecmp" , PH7_builtin_strcasecmp },
 	{ "strncasecmp", PH7_builtin_strncasecmp},

--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -2157,25 +2157,26 @@ static sxi32 HashmapCmpCallback1(ph7_hashmap_node *pA,ph7_hashmap_node *pB,void 
 	return rc;
 }
 /*
- * Node comparison callback: Compare nodes by keys only.
- * used-by: [ksort()]
+ * Shared key comparison for ksort()/krsort(): php 8 semantics. Two string
+ * keys compare bytewise. Mixed int/string keys: a NUMERIC string compares
+ * numerically with the int key; a non-numeric one makes the int key compare
+ * AS A STRING ("5" < "b", so int keys land before alphabetic ones — pre-fix
+ * PHL cast "b" to 0 and sorted string keys first).
  */
-static sxi32 HashmapCmpCallback2(ph7_hashmap_node *pA,ph7_hashmap_node *pB,void *pCmpData)
+static sxi32 HashmapKeyNodeCmp(ph7_hashmap_node *pA,ph7_hashmap_node *pB)
 {
 	sxi32 rc;
-	SXUNUSED(pCmpData); /* cc warning */
 	if( pA->iType == HASHMAP_BLOB_NODE && pB->iType == HASHMAP_BLOB_NODE ){
 		/* Perform a string comparison */
 		rc = SyBlobCmp(&pA->xKey.sKey,&pB->xKey.sKey);
 	}else{
 		SyString sStr;
-		sxi64 iA,iB;
-		/* Perform a numeric comparison */
+		sxi64 iA = 0,iB = 0;
+		int bNum = 1;
 		if( pA->iType == HASHMAP_BLOB_NODE ){
-			/* Cast to 64-bit integer */
 			SyStringInitFromBuf(&sStr,SyBlobData(&pA->xKey.sKey),SyBlobLength(&pA->xKey.sKey));
-			if( sStr.nByte < 1 ){
-				iA = 0;
+			if( sStr.nByte < 1 || SyStrIsNumeric(sStr.zString,sStr.nByte,0,0) != SXRET_OK ){
+				bNum = 0;
 			}else{
 				SyStrToInt64(sStr.zString,sStr.nByte,(void *)&iA,0);
 			}
@@ -2183,20 +2184,46 @@ static sxi32 HashmapCmpCallback2(ph7_hashmap_node *pA,ph7_hashmap_node *pB,void 
 			iA = pA->xKey.iKey;
 		}
 		if( pB->iType == HASHMAP_BLOB_NODE ){
-			/* Cast to 64-bit integer */
 			SyStringInitFromBuf(&sStr,SyBlobData(&pB->xKey.sKey),SyBlobLength(&pB->xKey.sKey));
-			if( sStr.nByte < 1 ){
-				iB = 0;
+			if( sStr.nByte < 1 || SyStrIsNumeric(sStr.zString,sStr.nByte,0,0) != SXRET_OK ){
+				bNum = 0;
 			}else{
 				SyStrToInt64(sStr.zString,sStr.nByte,(void *)&iB,0);
 			}
 		}else{
 			iB = pB->xKey.iKey;
 		}
-		rc = (sxi32)(iA-iB);
+		if( bNum ){
+			rc = iA < iB ? -1 : (iA > iB ? 1 : 0);
+		}else{
+			/* Render the int key and compare bytewise like php */
+			char zNumA[24],zNumB[24];
+			SyString sA,sB;
+			if( pA->iType != HASHMAP_BLOB_NODE ){
+				sxu32 n = SyBufferFormat(zNumA,sizeof(zNumA),"%qd",pA->xKey.iKey);
+				SyStringInitFromBuf(&sA,zNumA,n);
+			}else{
+				SyStringInitFromBuf(&sA,SyBlobData(&pA->xKey.sKey),SyBlobLength(&pA->xKey.sKey));
+			}
+			if( pB->iType != HASHMAP_BLOB_NODE ){
+				sxu32 n = SyBufferFormat(zNumB,sizeof(zNumB),"%qd",pB->xKey.iKey);
+				SyStringInitFromBuf(&sB,zNumB,n);
+			}else{
+				SyStringInitFromBuf(&sB,SyBlobData(&pB->xKey.sKey),SyBlobLength(&pB->xKey.sKey));
+			}
+			rc = SyStrncmp(sA.zString,sB.zString,SXMAX(sA.nByte,sB.nByte));
+		}
 	}
-	/* Comparison result */
 	return rc;
+}
+/*
+ * Node comparison callback: Compare nodes by keys only.
+ * used-by: [ksort()]
+ */
+static sxi32 HashmapCmpCallback2(ph7_hashmap_node *pA,ph7_hashmap_node *pB,void *pCmpData)
+{
+	SXUNUSED(pCmpData); /* cc warning */
+	return HashmapKeyNodeCmp(pA,pB);
 }
 /*
  * Node comparison callback.
@@ -2301,40 +2328,8 @@ static sxi32 HashmapCmpCallback4(ph7_hashmap_node *pA,ph7_hashmap_node *pB,void 
  */
 static sxi32 HashmapCmpCallback5(ph7_hashmap_node *pA,ph7_hashmap_node *pB,void *pCmpData)
 {
-	sxi32 rc;
 	SXUNUSED(pCmpData); /* cc warning */
-	if( pA->iType == HASHMAP_BLOB_NODE && pB->iType == HASHMAP_BLOB_NODE ){
-		/* Perform a string comparison */
-		rc = SyBlobCmp(&pA->xKey.sKey,&pB->xKey.sKey);
-	}else{
-		SyString sStr;
-		sxi64 iA,iB;
-		/* Perform a numeric comparison */
-		if( pA->iType == HASHMAP_BLOB_NODE ){
-			/* Cast to 64-bit integer */
-			SyStringInitFromBuf(&sStr,SyBlobData(&pA->xKey.sKey),SyBlobLength(&pA->xKey.sKey));
-			if( sStr.nByte < 1 ){
-				iA = 0;
-			}else{
-				SyStrToInt64(sStr.zString,sStr.nByte,(void *)&iA,0);
-			}
-		}else{
-			iA = pA->xKey.iKey;
-		}
-		if( pB->iType == HASHMAP_BLOB_NODE ){
-			/* Cast to 64-bit integer */
-			SyStringInitFromBuf(&sStr,SyBlobData(&pB->xKey.sKey),SyBlobLength(&pB->xKey.sKey));
-			if( sStr.nByte < 1 ){
-				iB = 0;
-			}else{
-				SyStrToInt64(sStr.zString,sStr.nByte,(void *)&iB,0);
-			}
-		}else{
-			iB = pB->xKey.iKey;
-		}
-		rc = (sxi32)(iA-iB);
-	}
-	return -rc; /* Reverse result */
+	return -HashmapKeyNodeCmp(pA,pB); /* Reverse result */
 }
 /*
  * Node comparison callback: Invoke an user-defined callback for the purpose of node comparison.

--- a/src/ph7/oo.c
+++ b/src/ph7/oo.c
@@ -542,8 +542,16 @@ PH7_PRIVATE sxi32 PH7_ClassInherit(ph7_gen_state *pGen,ph7_class *pSub,ph7_class
 			}
 			continue;
 		}
-		/* Install the method */
-		if( pMeth->iProtection != PH7_CLASS_PROT_PRIVATE ){
+		/* Install the method. php: a base class's private INSTANCE method is
+		 * dispatchable on child instances too — an inherited public method
+		 * calling $this->priv() must find it (the call-site visibility check
+		 * binds by DECLARING class, sFunc.pUserData, so child code and
+		 * outsiders still can't call it; a private ctor copied down also
+		 * blocks `new Child` from outside like php). Private STATICS stay
+		 * uncopied — base methods reach those through self:: against the
+		 * declaring class directly. */
+		if( pMeth->iProtection != PH7_CLASS_PROT_PRIVATE
+		 || (pMeth->iFlags & PH7_CLASS_ATTR_STATIC) == 0 ){
 			rc = SyHashInsert(&pSub->hMethod,(const void *)pName->zString,pName->nByte,pMeth);
 			if( rc != SXRET_OK ){
 				return rc;

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -2214,6 +2214,8 @@ PH7_PRIVATE int PH7_builtin_idate(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE int PH7_builtin_mktime(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE int PH7_builtin_date_default_timezone_get(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE int PH7_builtin_date_default_timezone_set(ph7_context *pCtx,int nArg,ph7_value **apArg);
+/* vm_builtin_spl.c */
+PH7_PRIVATE sxi32 PH7_VmInstallSpl(ph7_vm *pVm);
 /* vfs_zip.c function prototypes */
 PH7_PRIVATE int PH7_builtin_zip_open(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE int PH7_builtin_zip_close(ph7_context *pCtx,int nArg,ph7_value **apArg);
@@ -2506,9 +2508,8 @@ PH7_PRIVATE sxi32 SyMemcmp(const void *pB1,const void *pB2,sxu32 nSize);
 PH7_PRIVATE void SyZero(void *pSrc,sxu32 nSize);
 PH7_PRIVATE sxi32 SyStrnicmp(const char *zLeft,const char *zRight,sxu32 SLen);
 PH7_PRIVATE sxi32 SyStrnmicmp(const void *pLeft, const void *pRight,sxu32 SLen);
-#ifndef PH7_DISABLE_BUILTIN_FUNC
+/* used by hashmap.c's key sorting — must stay visible in the tiny build */
 PH7_PRIVATE sxi32 SyStrncmp(const char *zLeft,const char *zRight,sxu32 nLen);
-#endif
 PH7_PRIVATE sxi32 SyByteListFind(const char *zSrc,sxu32 nLen,const char *zList,sxu32 *pFirstPos);
 #ifndef PH7_DISABLE_BUILTIN_FUNC
 PH7_PRIVATE sxi32 SyByteFind2(const char *zStr,sxu32 nLen,sxi32 c,sxu32 *pPos);

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -428,6 +428,8 @@ static const struct VmBuiltinArity {
 	{ "strcasecmp",                2, 0 },
 	{ "strchr",                    2, 1 },
 	{ "strcmp",                    2, 0 },
+	{ "strnatcasecmp",             2, 0 },
+	{ "strnatcmp",                 2, 0 },
 	{ "strcoll",                   2, 0 },
 	{ "strip_tags",                1, 1 },
 	{ "stripslashes",              1, 0 },
@@ -2707,6 +2709,7 @@ PH7_PRIVATE sxi32 PH7_VmInit(
 	 * internal; the Traversable pointer above must already be cached. */
 	PH7_VmInstallReflection(&(*pVm));
 	PH7_VmInstallDateTime(&(*pVm));
+	PH7_VmInstallSpl(&(*pVm));
 	pVm->bCompilingBuiltin = 0;
 	/* Reset the code generator */
 	PH7_ResetCodeGenerator(&(*pVm),pEngine->xConf.xErr,pEngine->xConf.pErrData);
@@ -3458,6 +3461,8 @@ static const struct VmBuiltinSig {
 	{ "strcasecmp", "string $string1, string $string2", "int" },
 	{ "strchr", "string $haystack, string $needle, bool $before_needle = false", "string|false" },
 	{ "strcmp", "string $string1, string $string2", "int" },
+	{ "strnatcasecmp", "string $string1, string $string2", "int" },
+	{ "strnatcmp", "string $string1, string $string2", "int" },
 	{ "strcoll", "string $string1, string $string2", "int" },
 	{ "strcspn", "string $string, string $characters, int $offset = 0, ?int $length = NULL", "int" },
 	{ "strftime", "string $format, ?int $timestamp = NULL", "string|false" },
@@ -13870,11 +13875,34 @@ case PH7_OP_MEMBER: {
 				}else{
 					ph7_class_method *pDeniedCall = 0;
 					if( pMeth->iProtection != PH7_CLASS_PROT_PUBLIC
-					 && !PH7_VmClassMemberAccess(&(*pVm),pClass,&sName,pMeth->iProtection,FALSE) ){
-						/* Inaccessible from this scope: php routes through __call when
-						 * declared (band A #3b); without it OP_CALL raises its
-						 * "Call to private/protected method" Error as before. */
-						pDeniedCall = PH7_ClassExtractMethod(pClass,"__call",sizeof("__call")-1);
+					 && !PH7_VmClassMemberAccess(&(*pVm),
+						pMeth->sFunc.pUserData ? (ph7_class *)pMeth->sFunc.pUserData : pClass,
+						&sName,pMeth->iProtection,FALSE) ){
+						int bRebound = 0;
+						if( pMeth->iProtection == PH7_CLASS_PROT_PRIVATE ){
+							/* php: when the instance's class SHADOWS the caller's
+							 * private method (child redeclares private m), code in
+							 * the caller's class dispatches its OWN private m, not
+							 * the shadow. Rebind to the calling scope's method when
+							 * that scope declares a private one of this name. */
+							VmFrame *pFrameLocal = VmSkipExceptionFrames(pVm->pFrame);
+							ph7_vm_func *pCallerFunc = (ph7_vm_func *)pFrameLocal->pUserData;
+							if( pCallerFunc && (pCallerFunc->iFlags & VM_FUNC_CLASS_METHOD) && pCallerFunc->pUserData ){
+								ph7_class *pScope = (ph7_class *)pCallerFunc->pUserData;
+								ph7_class_method *pOwn = PH7_ClassExtractMethod(pScope,sName.zString,sName.nByte);
+								if( pOwn && pOwn->iProtection == PH7_CLASS_PROT_PRIVATE
+								 && (ph7_class *)pOwn->sFunc.pUserData == pScope ){
+									pMeth = pOwn;
+									bRebound = 1;
+								}
+							}
+						}
+						if( !bRebound ){
+							/* Inaccessible from this scope: php routes through __call when
+							 * declared (band A #3b); without it OP_CALL raises its
+							 * "Call to private/protected method" Error as before. */
+							pDeniedCall = PH7_ClassExtractMethod(pClass,"__call",sizeof("__call")-1);
+						}
 					}
 					if( pDeniedCall ){
 						SyBlobReset(&pVm->sMagicCallName);
@@ -15891,15 +15919,25 @@ case PH7_OP_CALL: {
 					pVm->bReflectBypass = 0;
 				}else
 				if( pSelf ){ /* Paranoid edition */
-					/* Check if the call is allowed */
-					pMeth = PH7_ClassExtractMethod(pSelf,pVmFunc->sName.zString,pVmFunc->sName.nByte);
+					/* Check if the call is allowed. php binds non-public method
+					 * access by the DECLARING class (pVmFunc->pUserData — the class
+					 * the callee was compiled in), NOT the instance's class: an
+					 * inherited base method calling $this->priv() on a child
+					 * instance passes, a child's private SHADOW doesn't hijack the
+					 * check for a parent callee, and the denial message names the
+					 * declaring class like php. */
+					ph7_class *pDeclClass = pVmFunc->pUserData ? (ph7_class *)pVmFunc->pUserData : pSelf;
+					pMeth = PH7_ClassExtractMethod(pDeclClass,pVmFunc->sName.zString,pVmFunc->sName.nByte);
+					if( pMeth == 0 && pDeclClass != pSelf ){
+						pMeth = PH7_ClassExtractMethod(pSelf,pVmFunc->sName.zString,pVmFunc->sName.nByte);
+					}
 					if( pMeth && pMeth->iProtection != PH7_CLASS_PROT_PUBLIC ){
-						if( !PH7_VmClassMemberAccess(&(*pVm),pSelf,&pVmFunc->sName,pMeth->iProtection,FALSE) ){
+						if( !PH7_VmClassMemberAccess(&(*pVm),pDeclClass,&pVmFunc->sName,pMeth->iProtection,FALSE) ){
 							/* Throw Error exception (PHP-compatible) */
 							char zMsg[256];
 							const char *zVis = pMeth->iProtection == PH7_CLASS_PROT_PRIVATE ? "private" : "protected";
 							SyBufferFormat(zMsg,sizeof(zMsg),"Call to %s method %.*s::%.*s() from global scope",
-								zVis,(int)pSelf->sName.nByte,pSelf->sName.zString,
+								zVis,(int)pDeclClass->sName.nByte,pDeclClass->sName.zString,
 								(int)pVmFunc->sName.nByte,pVmFunc->sName.zString);
 							/* Consume this call's captured spread runs — this visibility
 							 * error exits before the pVmFunc build below. */

--- a/src/ph7/vm_builtin_spl.c
+++ b/src/ph7/vm_builtin_spl.c
@@ -1,0 +1,154 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include "ph7int.h"
+#ifndef PH7_DISABLE_BUILTIN_FUNC
+/*
+ * SPL iterators, slice 1 (NEWPLAN band D): SeekableIterator, ArrayIterator,
+ * ArrayObject, plus the natsort()/natcasesort() array functions they need.
+ * Embedded-PHP chunk following the Reflection architecture — installed
+ * inside the bCompilingBuiltin window, backed by the engine's native array
+ * internal-pointer builtins (reset/next/key/current keep their position on a
+ * property, so ArrayIterator's cursor IS the backing array's pointer).
+ */
+
+/* void __spl_deprecated(string $msg) — E_DEPRECATED with php's exact text
+ * (no auto-prepended function name, unlike ph7_context_throw_error) */
+static int vm_builtin_spl_deprecated(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	const char *zMsg;
+	int nMsg;
+	if( nArg < 1 ){
+		return PH7_OK;
+	}
+	zMsg = ph7_value_to_string(apArg[0],&nMsg);
+	PH7_VmThrowDeprecatedFmt(pCtx->pVm,"%.*s",nMsg,zMsg);
+	return PH7_OK;
+}
+
+static const char zSplLib[] =
+"interface SeekableIterator extends Iterator {"
+" public function seek($offset);"
+"}"
+"trait __SplStoreT {"
+" private $__d = [];"
+" private $__f = 0;"
+" private function __splInitStore($array, $flags, $ctor){"
+"  if( is_array($array) ){"
+"   $this->__d = $array;"
+"  }elseif( is_object($array) ){"
+"   __spl_deprecated(get_class($this) . '::' . $ctor . '(): Using an object as a"
+" backing array for ' . get_class($this) . ' is deprecated, as it allows violating"
+" class constraints and invariants');"
+"  $this->__d = get_object_vars($array);"
+"  }else{"
+"   throw new TypeError(get_class($this) . '::' . $ctor . '(): Argument #1 ($array)"
+" must be of type array, ' . get_debug_type($array) . ' given');"
+"  }"
+"  $this->__f = (int)$flags;"
+" }"
+" public function offsetExists($key){ return array_key_exists($key, $this->__d); }"
+" public function offsetGet($key){ return $this->__d[$key]; }"
+" public function offsetSet($key, $value){"
+"  if( $key === null ){ $this->__d[] = $value; }"
+"  else { $this->__d[$key] = $value; }"
+" }"
+" public function offsetUnset($key){ unset($this->__d[$key]); }"
+" public function append($value){ $this->__d[] = $value; }"
+" public function getArrayCopy(){ return $this->__d; }"
+" public function count(){ return count($this->__d); }"
+" public function getFlags(){ return $this->__f; }"
+" public function setFlags($flags){ $this->__f = (int)$flags; }"
+" public function asort($flags = 0){ asort($this->__d); return true; }"
+" public function ksort($flags = 0){ ksort($this->__d); return true; }"
+" public function uasort($callback){ uasort($this->__d, $callback); return true; }"
+" public function uksort($callback){ uksort($this->__d, $callback); return true; }"
+" public function natsort(){ uasort($this->__d, 'strnatcmp'); return true; }"
+" public function natcasesort(){ uasort($this->__d, 'strnatcasecmp'); return true; }"
+"}"
+"class ArrayIterator implements SeekableIterator, ArrayAccess, Countable {"
+" use __SplStoreT;"
+" const STD_PROP_LIST = 1;"
+" const ARRAY_AS_PROPS = 2;"
+" public function __construct($array = [], $flags = 0){"
+"  $this->__splInitStore($array, $flags, '__construct');"
+"  reset($this->__d);"
+" }"
+" public function current(){"
+"  if( key($this->__d) === null ){ return null; }"
+"  return current($this->__d);"
+" }"
+" public function key(){ return key($this->__d); }"
+" public function next(){ next($this->__d); }"
+" public function rewind(){ reset($this->__d); }"
+" public function valid(){ return key($this->__d) !== null; }"
+" public function seek($offset){"
+"  $offset = (int)$offset;"
+"  if( $offset < 0 || $offset >= count($this->__d) ){"
+"   throw new OutOfBoundsException('Seek position ' . $offset . ' is out of range');"
+"  }"
+"  reset($this->__d);"
+"  for( $i = 0; $i < $offset; $i++ ){ next($this->__d); }"
+" }"
+"}"
+"class ArrayObject implements IteratorAggregate, ArrayAccess, Countable {"
+" use __SplStoreT;"
+" const STD_PROP_LIST = 1;"
+" const ARRAY_AS_PROPS = 2;"
+" private $__it = 'ArrayIterator';"
+" public function __construct($array = [], $flags = 0, $iteratorClass = 'ArrayIterator'){"
+"  $this->__splInitStore($array, $flags, '__construct');"
+"  if( $iteratorClass !== 'ArrayIterator' ){ $this->setIteratorClass($iteratorClass); }"
+" }"
+" public function getIterator(){"
+"  $c = $this->__it;"
+"  return new $c($this->__d);"
+" }"
+" public function exchangeArray($array){"
+"  $old = $this->__d;"
+"  $this->__splInitStore($array, $this->__f, 'exchangeArray');"
+"  return $old;"
+" }"
+" public function setIteratorClass($iteratorClass){"
+"  $c = (string)$iteratorClass;"
+"  if( $c !== 'ArrayIterator'"
+"   && (!class_exists($c) || !is_subclass_of($c, 'ArrayIterator')) ){"
+"   throw new TypeError('ArrayObject::setIteratorClass(): Argument #1"
+" ($iteratorClass) must be a class name derived from ArrayIterator, ' . $c . ' given');"
+"  }"
+"  $this->__it = $c;"
+" }"
+" public function getIteratorClass(){ return $this->__it; }"
+" public function __get($name){"
+"  if( $this->__f & 2 ){ return $this->__d[$name]; }"
+"  return null;"
+" }"
+" public function __set($name, $value){"
+"  if( $this->__f & 2 ){ $this->__d[$name] = $value; return; }"
+"  $this->{$name} = $value;"
+" }"
+" public function __isset($name){"
+"  if( $this->__f & 2 ){ return isset($this->__d[$name]); }"
+"  return false;"
+" }"
+" public function __unset($name){"
+"  if( $this->__f & 2 ){ unset($this->__d[$name]); }"
+" }"
+"}"
+"function natsort(&$array){ return uasort($array, 'strnatcmp'); }"
+"function natcasesort(&$array){ return uasort($array, 'strnatcasecmp'); }"
+;
+
+PH7_PRIVATE sxi32 PH7_VmInstallSpl(ph7_vm *pVm)
+{
+	ph7_create_function(&(*pVm),"__spl_deprecated",vm_builtin_spl_deprecated,0);
+	return PH7_VmEvalBuiltinChunk(&(*pVm),zSplLib,sizeof(zSplLib)-1);
+}
+
+#endif /* PH7_DISABLE_BUILTIN_FUNC */
+
+#ifdef PH7_DISABLE_BUILTIN_FUNC
+/* Tiny build: no SPL (builtin layer disabled) */
+PH7_PRIVATE sxi32 PH7_VmInstallSpl(ph7_vm *pVm){ (void)pVm; return SXRET_OK; }
+#endif

--- a/src/sx/sxstr.c
+++ b/src/sx/sxstr.c
@@ -68,7 +68,7 @@ PH7_PRIVATE sxi32 SyByteListFind(const char *zSrc,sxu32 nLen,const char *zList,s
 	}
 	return SXERR_NOTFOUND;
 }
-#ifndef PH7_DISABLE_BUILTIN_FUNC
+/* used by hashmap.c's key sorting — must stay in the tiny build */
 PH7_PRIVATE sxi32 SyStrncmp(const char *zLeft,const char *zRight,sxu32 nLen)
 {
 	const unsigned char *zP = (const unsigned char *)zLeft;
@@ -88,7 +88,6 @@ PH7_PRIVATE sxi32 SyStrncmp(const char *zLeft,const char *zRight,sxu32 nLen)
 	}
 	return (sxi32)(zP[0] - zQ[0]);
 }
-#endif
 PH7_PRIVATE sxi32 SyStrnicmp(const char *zLeft, const char *zRight,sxu32 SLen)
 {
   	register unsigned char *p = (unsigned char *)zLeft;

--- a/tests/ph7/001-smoke/function/spl/array_iterator.phpt
+++ b/tests/ph7/001-smoke/function/spl/array_iterator.phpt
@@ -1,0 +1,130 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: ArrayIterator (band D SPL slice 1)
+--FILE--
+<?php
+$it = new ArrayIterator(['a' => 1, 'b' => 2, 5 => 'x']);
+foreach ($it as $k => $v) { echo "$k=$v;"; }
+echo "\n";
+echo count($it), $it->count(), "\n";
+echo $it['a'], $it->offsetExists('a') ? 'y' : 'n', $it->offsetExists('zz') ? 'y' : 'n', "\n";
+// offsetExists is array_key_exists-like: a null value still exists
+$nul = new ArrayIterator(['n' => null]);
+echo $nul->offsetExists('n') ? 'y' : 'n', "\n";
+$it['c'] = 9;
+$it[] = 'app';
+unset($it['a']);
+print_r($it->getArrayCopy());
+$it->seek(1);
+echo $it->key(), '=', $it->current(), "\n";
+try {
+    $it->seek(99);
+} catch (OutOfBoundsException $e) {
+    echo $e->getMessage(), "\n";
+}
+try {
+    $it->seek(-1);
+} catch (OutOfBoundsException $e) {
+    echo $e->getMessage(), "\n";
+}
+$it->rewind();
+echo $it->key(), "\n";
+echo $it->asort() ? 'T' : 'F', "\n";
+print_r($it->getArrayCopy());
+$it->ksort();
+print_r($it->getArrayCopy());
+echo $it->getFlags(), "\n";
+try {
+    new ArrayIterator('nope');
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+$e2 = new ArrayIterator([]);
+echo $e2->valid() ? 'T' : 'F', var_export($e2->key(), true), var_export($e2->current(), true), "\n";
+// natural sort: methods and the global natsort()/natcasesort()
+$nv = new ArrayIterator(['a' => 'img12', 'b' => 'img2']);
+$nv->natsort();
+print_r($nv->getArrayCopy());
+$arr = ['img12', 'img10', 'img2'];
+natsort($arr);
+print_r($arr);
+$arr2 = ['IMG12', 'img10'];
+natcasesort($arr2);
+print_r($arr2);
+echo strnatcmp('img12', 'img10'), strnatcmp('img2', 'img10'), strnatcasecmp('IMG2', 'img10'), strnatcmp('a', 'a'), "\n";
+echo strnatcmp('x01', 'x1'), strnatcmp('x 1', 'x1'), "\n";
+// interface wiring + independent re-iteration
+echo (new ArrayIterator([]) instanceof SeekableIterator) ? 'T' : 'F';
+echo (new ArrayIterator([]) instanceof Iterator) ? 'T' : 'F';
+echo (new ArrayIterator([]) instanceof Traversable) ? 'T' : 'F', "\n";
+$it2 = new ArrayIterator([1, 2]);
+foreach ($it2 as $x) { echo $x; }
+foreach ($it2 as $x) { echo $x; }
+echo "\n";
+// mixed int/string ksort follows php 8 comparison rules
+$mk = ['b' => 2, 5 => 1, 'c' => 4, 6 => 3, '10' => 9];
+ksort($mk);
+echo implode(',', array_keys($mk)), '|';
+krsort($mk);
+echo implode(',', array_keys($mk)), "\n";
+?>
+--EXPECT--
+a=1;b=2;5=x;
+33
+1yn
+y
+Array
+(
+    [b] => 2
+    [5] => x
+    [c] => 9
+    [6] => app
+)
+5=x
+Seek position 99 is out of range
+Seek position -1 is out of range
+b
+T
+Array
+(
+    [b] => 2
+    [c] => 9
+    [6] => app
+    [5] => x
+)
+Array
+(
+    [5] => x
+    [6] => app
+    [b] => 2
+    [c] => 9
+)
+0
+ArrayIterator::__construct(): Argument #1 ($array) must be of type array, string given
+FNULLNULL
+Array
+(
+    [b] => img2
+    [a] => img12
+)
+Array
+(
+    [2] => img2
+    [1] => img10
+    [0] => img12
+)
+Array
+(
+    [1] => img10
+    [0] => IMG12
+)
+1-1-10
+-10
+TTT
+1212
+5,6,10,b,c|c,b,10,6,5
+--CLEAN--
+<?php
+unset($it, $nul, $e2, $nv, $arr, $arr2, $it2, $mk, $k, $v, $x);

--- a/tests/ph7/001-smoke/function/spl/array_object.phpt
+++ b/tests/ph7/001-smoke/function/spl/array_object.phpt
@@ -1,0 +1,100 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: ArrayObject (band D SPL slice 1)
+--FILE--
+<?php
+$ao = new ArrayObject(['a' => 1, 'b' => 2]);
+foreach ($ao as $k => $v) { echo "$k=$v;"; }
+echo "\n";
+echo get_class($ao->getIterator()), count($ao), "\n";
+$ao['c'] = 3;
+$ao->append(9);
+unset($ao['a']);
+print_r($ao->getArrayCopy());
+$old = $ao->exchangeArray(['z' => 26]);
+print_r($old);
+print_r($ao->getArrayCopy());
+echo $ao->getIteratorClass(), "\n";
+// ARRAY_AS_PROPS maps property access onto the array
+$q = new ArrayObject(['k' => 1], ArrayObject::ARRAY_AS_PROPS);
+$q->k2 = 5;
+echo $q['k2'], $q->k, "\n";
+echo isset($q->k) ? 'T' : 'F', isset($q->nope) ? 'T' : 'F', "\n";
+unset($q->k);
+echo isset($q['k']) ? 'T' : 'F', "\n";
+echo $q->missing ?? 'NC', "\n";
+echo ArrayObject::STD_PROP_LIST, ArrayObject::ARRAY_AS_PROPS,
+     ArrayIterator::STD_PROP_LIST, ArrayIterator::ARRAY_AS_PROPS, "\n";
+try {
+    new ArrayObject(3);
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+try {
+    $ao->setIteratorClass('stdClass');
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+try {
+    $ao->setIteratorClass('OaoNopeClass');
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+class OaoMyIt extends ArrayIterator {}
+$ao->setIteratorClass('OaoMyIt');
+echo get_class($ao->getIterator()), "\n";
+// sorting through the object
+$s = new ArrayObject(['b' => 2, 'a' => 1]);
+$s->ksort();
+print_r($s->getArrayCopy());
+$s->uasort(fn ($x, $y) => $y <=> $x);
+print_r($s->getArrayCopy());
+echo (new ArrayObject([]) instanceof IteratorAggregate) ? 'T' : 'F';
+echo (new ArrayObject([]) instanceof ArrayAccess) ? 'T' : 'F';
+echo (new ArrayObject([]) instanceof Countable) ? 'T' : 'F', "\n";
+?>
+--EXPECT--
+a=1;b=2;
+ArrayIterator2
+Array
+(
+    [b] => 2
+    [c] => 3
+    [0] => 9
+)
+Array
+(
+    [b] => 2
+    [c] => 3
+    [0] => 9
+)
+Array
+(
+    [z] => 26
+)
+ArrayIterator
+51
+TF
+F
+NC
+1212
+ArrayObject::__construct(): Argument #1 ($array) must be of type array, int given
+ArrayObject::setIteratorClass(): Argument #1 ($iteratorClass) must be a class name derived from ArrayIterator, stdClass given
+ArrayObject::setIteratorClass(): Argument #1 ($iteratorClass) must be a class name derived from ArrayIterator, OaoNopeClass given
+OaoMyIt
+Array
+(
+    [a] => 1
+    [b] => 2
+)
+Array
+(
+    [b] => 2
+    [a] => 1
+)
+TTT
+--CLEAN--
+<?php
+unset($ao, $old, $q, $s, $k, $v);

--- a/tests/ph7/001-smoke/oo/inherited_private_method.phpt
+++ b/tests/ph7/001-smoke/oo/inherited_private_method.phpt
@@ -1,0 +1,50 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: inherited methods reach the base class's private methods on child instances
+--FILE--
+<?php
+class IpmA {
+    private function m() { return 'p'; }
+    public function c() { return $this->m(); }
+}
+class IpmB extends IpmA {}
+echo (new IpmB)->c(), "\n";
+
+trait IpmT {
+    private function tm() { return 't'; }
+}
+class IpmC {
+    use IpmT;
+    public function c() { return $this->tm(); }
+}
+class IpmD extends IpmC {}
+echo (new IpmD)->c(), "\n";
+
+class IpmE {
+    protected function p() { return 'pr'; }
+    public function c() { return $this->p(); }
+}
+class IpmF extends IpmE {}
+echo (new IpmF)->c(), "\n";
+
+// php binds private calls by declaring class: the child's private shadow
+// does not hijack the parent's own call site, and vice versa
+class IpmG {
+    private function s() { return 'base'; }
+    public function c() { return $this->s(); }
+}
+class IpmH extends IpmG {
+    private function s() { return 'child'; }
+    public function d() { return $this->s(); }
+}
+echo (new IpmH)->c(), ' ', (new IpmH)->d(), "\n";
+?>
+--EXPECT--
+p
+t
+pr
+base child
+--CLEAN--
+<?php


### PR DESCRIPTION
Implement SeekableIterator, ArrayIterator, and ArrayObject as an embedded chunk backed by the engine's native array internal pointer, with php's exact seek/constructor/setIteratorClass error messages, ARRAY_AS_PROPS magic mapping, exchangeArray, and the sort methods. Add strnatcmp and strnatcasecmp as C builtins (php's strnatcmp_ex algorithm) plus the natsort/natcasesort array functions built on them.

Fix three engine bugs surfaced by the work: ksort/krsort ordered string keys before int keys because non-numeric keys were cast to int zero (the shared comparator now follows php 8's mixed-key rules); private instance methods were not inherited at all, so an inherited public method calling a base private method died with "Undefined class method" — they now copy to children with visibility bound by the declaring class, including php's private-shadow dispatch rule; and SyStrncmp lived inside builtin-func guards, breaking the tiny build once hashmap.c needed it.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
