### PR TITLE
Add the php.ini subsystem and INI API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ OBJECTS = \
 	$(BUILD_DIR)/src/ph7/vm$(OBJ_SUFFIX) \
 	$(BUILD_DIR)/src/ph7/vm_builtin_class$(OBJ_SUFFIX) \
 	$(BUILD_DIR)/src/ph7/vm_builtin_getopt$(OBJ_SUFFIX) \
+	$(BUILD_DIR)/src/ph7/vm_builtin_ini$(OBJ_SUFFIX) \
 	$(BUILD_DIR)/src/ph7/vm_builtin_ob$(OBJ_SUFFIX) \
 	$(BUILD_DIR)/src/ph7/vm_builtin_reflection$(OBJ_SUFFIX) \
 	$(BUILD_DIR)/src/ph7/vm_builtin_session$(OBJ_SUFFIX) \

--- a/src/ph7/constant.c
+++ b/src/ph7/constant.c
@@ -573,6 +573,30 @@ static void PH7_PHP_SESSION_ACTIVE_Const(ph7_value *pVal,void *pUserData)
 	SXUNUSED(pUserData);
 }
 /*
+ * INI_USER / INI_PERDIR / INI_SYSTEM / INI_ALL
+ *  php.ini access levels (1 / 2 / 4 / 7).
+ */
+static void PH7_INI_USER_Const(ph7_value *pVal,void *pUserData)
+{
+	ph7_value_int(pVal,1);
+	SXUNUSED(pUserData);
+}
+static void PH7_INI_PERDIR_Const(ph7_value *pVal,void *pUserData)
+{
+	ph7_value_int(pVal,2);
+	SXUNUSED(pUserData);
+}
+static void PH7_INI_SYSTEM_Const(ph7_value *pVal,void *pUserData)
+{
+	ph7_value_int(pVal,4);
+	SXUNUSED(pUserData);
+}
+static void PH7_INI_ALL_Const(ph7_value *pVal,void *pUserData)
+{
+	ph7_value_int(pVal,7);
+	SXUNUSED(pUserData);
+}
+/*
  * SPHP_ROUND_HALF_DOWN
  *  Expands 2.
  */
@@ -2066,6 +2090,10 @@ static const ph7_builtin_constant aBuiltIn[] = {
 	{"PHP_SESSION_DISABLED", PH7_PHP_SESSION_DISABLED_Const },
 	{"PHP_SESSION_NONE",     PH7_PHP_SESSION_NONE_Const },
 	{"PHP_SESSION_ACTIVE",   PH7_PHP_SESSION_ACTIVE_Const },
+	{"INI_USER",             PH7_INI_USER_Const },
+	{"INI_PERDIR",           PH7_INI_PERDIR_Const },
+	{"INI_SYSTEM",           PH7_INI_SYSTEM_Const },
+	{"INI_ALL",              PH7_INI_ALL_Const },
 	{"PASSWORD_BCRYPT",      PH7_PASSWORD_BCRYPT_Const },
 	{"PASSWORD_DEFAULT",     PH7_PASSWORD_BCRYPT_Const },
 	{"PASSWORD_BCRYPT_DEFAULT_COST", PH7_PASSWORD_COST_Const },

--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -2163,12 +2163,25 @@ static sxi32 HashmapCmpCallback1(ph7_hashmap_node *pA,ph7_hashmap_node *pB,void 
  * AS A STRING ("5" < "b", so int keys land before alphabetic ones — pre-fix
  * PHL cast "b" to 0 and sorted string keys first).
  */
+/* True lexicographic compare (memcmp on the common prefix, length breaks
+ * ties) — SyBlobCmp compares LENGTH first, which is fine for equality but
+ * wrong for ordering ("c" would sort before "a.y"). */
+static sxi32 HashmapLexCmp(const char *zA,sxu32 nA,const char *zB,sxu32 nB)
+{
+	sxu32 nMin = nA < nB ? nA : nB;
+	sxi32 rc = nMin ? SyMemcmp(zA,zB,nMin) : 0;
+	if( rc == 0 ){
+		rc = (sxi32)nA - (sxi32)nB;
+	}
+	return rc;
+}
 static sxi32 HashmapKeyNodeCmp(ph7_hashmap_node *pA,ph7_hashmap_node *pB)
 {
 	sxi32 rc;
 	if( pA->iType == HASHMAP_BLOB_NODE && pB->iType == HASHMAP_BLOB_NODE ){
 		/* Perform a string comparison */
-		rc = SyBlobCmp(&pA->xKey.sKey,&pB->xKey.sKey);
+		rc = HashmapLexCmp((const char *)SyBlobData(&pA->xKey.sKey),SyBlobLength(&pA->xKey.sKey),
+			(const char *)SyBlobData(&pB->xKey.sKey),SyBlobLength(&pB->xKey.sKey));
 	}else{
 		SyString sStr;
 		sxi64 iA = 0,iB = 0;
@@ -2211,7 +2224,7 @@ static sxi32 HashmapKeyNodeCmp(ph7_hashmap_node *pA,ph7_hashmap_node *pB)
 			}else{
 				SyStringInitFromBuf(&sB,SyBlobData(&pB->xKey.sKey),SyBlobLength(&pB->xKey.sKey));
 			}
-			rc = SyStrncmp(sA.zString,sB.zString,SXMAX(sA.nByte,sB.nByte));
+			rc = HashmapLexCmp(sA.zString,sA.nByte,sB.zString,sB.nByte);
 		}
 	}
 	return rc;

--- a/src/ph7/ph7.h
+++ b/src/ph7/ph7.h
@@ -221,6 +221,7 @@ typedef int (*ph7_clock)(void *pUserData, ph7_int64 *pSec, ph7_int64 *pUsec);
 #define PH7_VM_CONFIG_RESPONSE_STATUS  22  /* ONE ARGUMENT: int *pStatusCode */
 #define PH7_VM_CONFIG_RESPONSE_HEADERS 23  /* TWO ARGUMENTS: int (*xCallback)(const char *zName,unsigned int nName,const char *zValue,unsigned int nValue,void *pUserData), void *pUserData */
 #define PH7_VM_CONFIG_NATIVE_DEPTH    24  /* ONE ARGUMENT: int nMaxNativeDepth (native VmByteCodeExec nesting: eval/include, callbacks, coroutine resume; default 256 host / 16 embedded) */
+#define PH7_VM_CONFIG_INI_ENTRY       25  /* TWO ARGUMENTS: const char *zName,const char *zValue (a php.ini directive from -d/-c) */
 /*
  * Global Library Configuration Commands.
  *

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1209,6 +1209,15 @@ struct VmHookRmw
 	sxu32 nPc;                  /* pc of the consuming op (RMW: the modify op;
 	                             * coalesce: the OP_NULLC_STORE) */
 };
+
+/* One -d/-c php.ini directive queued for the INI chunk (name/value are
+ * allocator-owned copies; see PH7_VM_CONFIG_INI_ENTRY) */
+typedef struct VmIniEntry VmIniEntry;
+struct VmIniEntry
+{
+	SyString sName;
+	SyString sValue;
+};
 struct ph7_vm
 {
 	SyMemBackend sAllocator;	/* Memory backend */
@@ -1257,6 +1266,8 @@ struct ph7_vm
 	                             * (default "UTC"; only UTC/GMT are accepted — no tz database) */
 	sxu32 nDefTz;               /* zDefTz length in bytes */
 	SySet aShutdown;            /* Stack of shutdown user callbacks */
+	SySet aIniCli;              /* php.ini directives from the CLI (-d/-c): VmIniEntry copies,
+	                             * drained lazily by the INI chunk's __ini_cli() thunk */
 	SySet aAutoload;            /* Stack of spl_autoload callbacks */
 	SyHash hAutoloadActive;     /* Classes currently being autoloaded (reentrancy guard) */
 	SyHash hTypedSlot;          /* memobj nIdx -> VmClassAttr* for typed property enforcement */
@@ -2218,6 +2229,8 @@ PH7_PRIVATE int PH7_builtin_date_default_timezone_set(ph7_context *pCtx,int nArg
 PH7_PRIVATE sxi32 PH7_VmInstallSpl(ph7_vm *pVm);
 /* vm_builtin_session.c */
 PH7_PRIVATE sxi32 PH7_VmInstallSession(ph7_vm *pVm);
+/* vm_builtin_ini.c */
+PH7_PRIVATE sxi32 PH7_VmInstallIni(ph7_vm *pVm);
 /* vfs_zip.c function prototypes */
 PH7_PRIVATE int PH7_builtin_zip_open(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE int PH7_builtin_zip_close(ph7_context *pCtx,int nArg,ph7_value **apArg);

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -2508,6 +2508,7 @@ PH7_PRIVATE sxi32 PH7_VmInit(
 	SySetInit(&pVm->aFreeObj,&pVm->sAllocator,sizeof(VmSlot));
 	SySetInit(&pVm->aSelf,&pVm->sAllocator,sizeof(ph7_class *));
 	SySetInit(&pVm->aShutdown,&pVm->sAllocator,sizeof(VmShutdownCB));
+	SySetInit(&pVm->aIniCli,&pVm->sAllocator,sizeof(VmIniEntry));
 	SySetInit(&pVm->aAutoload,&pVm->sAllocator,sizeof(VmAutoloadCB));
 	SyHashInit(&pVm->hAutoloadActive,&pVm->sAllocator,0,0);
 	SyHashInit(&pVm->hTypedSlot,&pVm->sAllocator,0,0);
@@ -2711,6 +2712,7 @@ PH7_PRIVATE sxi32 PH7_VmInit(
 	PH7_VmInstallDateTime(&(*pVm));
 	PH7_VmInstallSpl(&(*pVm));
 	PH7_VmInstallSession(&(*pVm));
+	PH7_VmInstallIni(&(*pVm));
 	pVm->bCompilingBuiltin = 0;
 	/* Reset the code generator */
 	PH7_ResetCodeGenerator(&(*pVm),pEngine->xConf.xErr,pEngine->xConf.pErrData);
@@ -4915,6 +4917,51 @@ PH7_PRIVATE sxi32 PH7_VmConfigure(
 				SyBlobAppend(&pVm->sArgv,(const void *)" ",sizeof(char));
 			}
 			SyBlobAppend(&pVm->sArgv,(const void *)zValue,n);
+		}
+		break;
+								  }
+	case PH7_VM_CONFIG_INI_ENTRY: {
+		/* A php.ini directive from the CLI (-d name=value or a -c file line).
+		 * Copies are queued for the INI chunk's lazy seed; engine-level knobs
+		 * apply immediately so they take effect even if the script never
+		 * touches the INI API. */
+		const char *zName = va_arg(ap,const char *);
+		const char *zValue = va_arg(ap,const char *);
+		VmIniEntry sEntry;
+		char *zDupN,*zDupV;
+		sxu32 nName,nValue;
+		if( SX_EMPTY_STR(zName) ){
+			rc = SXERR_EMPTY;
+			break;
+		}
+		if( zValue == 0 ){
+			zValue = "";
+		}
+		nName = (sxu32)SyStrlen(zName);
+		nValue = (sxu32)SyStrlen(zValue);
+		zDupN = SyMemBackendStrDup(&pVm->sAllocator,zName,nName);
+		zDupV = SyMemBackendStrDup(&pVm->sAllocator,zValue,nValue);
+		if( zDupN == 0 || zDupV == 0 ){
+			rc = SXERR_MEM;
+			break;
+		}
+		SyStringInitFromBuf(&sEntry.sName,zDupN,nName);
+		SyStringInitFromBuf(&sEntry.sValue,zDupV,nValue);
+		rc = SySetPut(&pVm->aIniCli,(const void *)&sEntry);
+		if( rc == SXRET_OK ){
+			if( nName == sizeof("error_reporting")-1
+			 && SyMemcmp(zName,"error_reporting",nName) == 0 ){
+				sxi64 iLevel = 0;
+				SyStrToInt64(zValue,nValue,(void *)&iLevel,0);
+				pVm->bErrReport = iLevel != 0;
+			}else if( nName == sizeof("date.timezone")-1
+			 && SyMemcmp(zName,"date.timezone",nName) == 0
+			 && nValue == 3
+			 && (SyStrnicmp(zValue,"UTC",3) == 0 || SyStrnicmp(zValue,"GMT",3) == 0) ){
+				SyMemcpy(zValue,pVm->zDefTz,3);
+				pVm->zDefTz[3] = 0;
+				pVm->nDefTz = 3;
+			}
 		}
 		break;
 								  }

--- a/src/ph7/vm_builtin_ini.c
+++ b/src/ph7/vm_builtin_ini.c
@@ -1,0 +1,184 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include "ph7int.h"
+#ifndef PH7_DISABLE_BUILTIN_FUNC
+/*
+ * php.ini subsystem + INI API (NEWPLAN band D): a lazily seeded directive
+ * table (defaults merged with the CLI's -d/-c entries, drained from the VM's
+ * aIniCli queue by the __ini_cli() thunk) behind ini_get / ini_set /
+ * ini_restore / ini_get_all / get_cfg_var. Live-wired directives dispatch to
+ * the real knobs (error_reporting(), the session state, the default
+ * timezone) so the INI view and the engine agree.
+ */
+
+/* array __ini_cli(void) — the queued -d/-c directives, in order */
+static int vm_builtin_ini_cli(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	ph7_value *pArr,*pV;
+	VmIniEntry *aEntry;
+	sxu32 n;
+	SXUNUSED(nArg);
+	SXUNUSED(apArg);
+	pArr = ph7_context_new_array(pCtx);
+	pV = ph7_context_new_scalar(pCtx);
+	if( pArr == 0 || pV == 0 ){
+		return PH7_ContextMemoryError(pCtx);
+	}
+	aEntry = (VmIniEntry *)SySetBasePtr(&pCtx->pVm->aIniCli);
+	for( n = 0 ; n < SySetUsed(&pCtx->pVm->aIniCli) ; n++ ){
+		ph7_value_string(pV,aEntry[n].sValue.zString,(int)aEntry[n].sValue.nByte);
+		ph7_array_add_strkey_elem(pArr,aEntry[n].sName.zString,pV);
+		ph7_value_reset_string_cursor(pV);
+	}
+	ph7_result_value(pCtx,pArr);
+	return PH7_OK;
+}
+
+static const char zIniLib[] =
+"class __IniS {"
+" public static $t = null;"
+"}"
+"function __ini_seed(){"
+" if( __IniS::$t !== null ){ return; }"
+" $t = ["
+"  'allow_url_fopen' => ['1', 6],"
+"  'arg_separator.output' => ['&', 7],"
+"  'auto_detect_line_endings' => ['', 7],"
+"  'date.timezone' => ['UTC', 7],"
+"  'default_charset' => ['UTF-8', 7],"
+"  'default_mimetype' => ['text/html', 7],"
+"  'display_errors' => ['1', 7],"
+"  'error_reporting' => ['32767', 7],"
+"  'include_path' => ['.', 7],"
+"  'max_execution_time' => ['0', 7],"
+"  'memory_limit' => ['-1', 7],"
+"  'post_max_size' => ['8M', 6],"
+"  'precision' => ['14', 7],"
+"  'serialize_precision' => ['-1', 7],"
+"  'session.name' => ['PHPSESSID', 7],"
+"  'session.save_path' => ['', 7],"
+"  'short_open_tag' => ['', 6],"
+"  'upload_max_filesize' => ['2M', 6],"
+" ];"
+" foreach( __ini_cli() as $k => $v ){"
+"  if( isset($t[$k]) ){"
+"   $t[$k][0] = (string)$v;"
+"  }else{"
+"   $t[$k] = [(string)$v, 7];"
+"  }"
+" }"
+" $seeded = [];"
+" foreach( $t as $k => $pair ){"
+"  $seeded[$k] = ['g' => $pair[0], 'l' => $pair[0], 'a' => $pair[1]];"
+" }"
+" __IniS::$t = $seeded;"
+" /* boot-apply the CLI values for the live-wired knobs (the engine knobs"
+"  * error_reporting/date.timezone were already applied C-side) */"
+" if( $seeded['session.name']['g'] !== 'PHPSESSID' ){"
+"  __SessS::$name = $seeded['session.name']['g'];"
+" }"
+" if( $seeded['session.save_path']['g'] !== '' ){"
+"  __SessS::$path = rtrim($seeded['session.save_path']['g'], '/');"
+" }"
+"}"
+"function __ini_rt_get($name){"
+" /* live-wired reads: the runtime knob is the truth */"
+" if( $name === 'error_reporting' ){ return (string)error_reporting(); }"
+" if( $name === 'session.name' ){ return __SessS::$name; }"
+" if( $name === 'session.save_path' ){"
+"  return __SessS::$path === '' ? __IniS::$t[$name]['l'] : __SessS::$path;"
+" }"
+" return __IniS::$t[$name]['l'];"
+"}"
+"function __ini_rt_set($name, $value){"
+" if( $name === 'error_reporting' ){ error_reporting((int)$value); return; }"
+" if( $name === 'session.name' ){ __SessS::$name = $value; return; }"
+" if( $name === 'session.save_path' ){ __SessS::$path = rtrim($value, '/'); return; }"
+" if( $name === 'date.timezone' && preg_match('/^(UTC|GMT)$/i', $value) ){"
+"  date_default_timezone_set($value);"
+" }"
+"}"
+"function ini_get($option){"
+" __ini_seed();"
+" $option = (string)$option;"
+" if( !isset(__IniS::$t[$option]) ){ return false; }"
+" return __ini_rt_get($option);"
+"}"
+"function ini_set($option, $value){"
+" __ini_seed();"
+" $option = (string)$option;"
+" if( !isset(__IniS::$t[$option]) ){ return false; }"
+" if( (__IniS::$t[$option]['a'] & INI_USER) === 0 ){ return false; }"
+" if( strncmp($option, 'session.', 8) === 0 && headers_sent() ){"
+"  trigger_error('ini_set(): Session ini settings cannot be changed after"
+" headers have already been sent', E_USER_WARNING);"
+"  return false;"
+" }"
+" $old = __ini_rt_get($option);"
+" $value = is_bool($value) ? ($value ? '1' : '') : (string)$value;"
+" __IniS::$t[$option]['l'] = $value;"
+" __ini_rt_set($option, $value);"
+" return $old;"
+"}"
+"function ini_restore($option){"
+" __ini_seed();"
+" $option = (string)$option;"
+" if( !isset(__IniS::$t[$option]) ){ return null; }"
+" if( strncmp($option, 'session.', 8) === 0 && headers_sent() ){"
+"  trigger_error('ini_restore(): Session ini settings cannot be changed after"
+" headers have already been sent', E_USER_WARNING);"
+"  return null;"
+" }"
+" $g = __IniS::$t[$option]['g'];"
+" __IniS::$t[$option]['l'] = $g;"
+" __ini_rt_set($option, $g);"
+" return null;"
+"}"
+"function ini_get_all($extension = null, $details = true){"
+" __ini_seed();"
+" $known = ['Core' => true, 'session' => true, 'date' => true, 'standard' => true];"
+" if( $extension !== null && !isset($known[(string)$extension]) ){"
+"  trigger_error('ini_get_all(): Extension \"' . $extension . '\" cannot be"
+" found', E_USER_WARNING);"
+"  return false;"
+" }"
+" $out = [];"
+" foreach( __IniS::$t as $name => $e ){"
+"  if( $extension !== null && $extension !== 'Core' && $extension !== 'standard' ){"
+"   if( strncmp($name, $extension . '.', strlen($extension) + 1) !== 0 ){ continue; }"
+"  }elseif( $extension !== null ){"
+"   if( strpos($name, 'session.') === 0 || strpos($name, 'date.') === 0 ){ continue; }"
+"  }"
+"  $cur = __ini_rt_get($name);"
+"  if( $details ){"
+"   $out[$name] = ['global_value' => $e['g'], 'local_value' => $cur,"
+"    'access' => $e['a']];"
+"  }else{"
+"   $out[$name] = $cur;"
+"  }"
+" }"
+" ksort($out);"
+" return $out;"
+"}"
+"function get_cfg_var($option){"
+" __ini_seed();"
+" $option = (string)$option;"
+" if( !isset(__IniS::$t[$option]) ){ return false; }"
+" return __IniS::$t[$option]['g'];"
+"}"
+;
+
+PH7_PRIVATE sxi32 PH7_VmInstallIni(ph7_vm *pVm)
+{
+	ph7_create_function(&(*pVm),"__ini_cli",vm_builtin_ini_cli,0);
+	return PH7_VmEvalBuiltinChunk(&(*pVm),zIniLib,sizeof(zIniLib)-1);
+}
+
+#endif /* PH7_DISABLE_BUILTIN_FUNC */
+
+#ifdef PH7_DISABLE_BUILTIN_FUNC
+/* Tiny build: no INI API (builtin layer disabled) */
+PH7_PRIVATE sxi32 PH7_VmInstallIni(ph7_vm *pVm){ (void)pVm; return SXRET_OK; }
+#endif

--- a/src/phl/phl.c
+++ b/src/phl/phl.c
@@ -65,7 +65,7 @@ static void Fatal(const char *zMsg)
  */
 static void Help(void)
 {
-	puts("phl [-h|--help|-b|-i|-l|-v|--version|-r code|--rf name|--rc name] path/to/php_file [script args]");
+	puts("phl [-h|--help|-b|-i|-l|-v|--version|-r code|--rf name|--rc name|-d name=value|-c inifile] path/to/php_file [script args]");
 #ifdef PHL_ENABLE_SERVER
 	puts("phl -S host:port [-t docroot] [router.php]");
 #endif
@@ -228,6 +228,80 @@ static int PHL_EnvULong(const char *zName,unsigned long uFloor,unsigned long uCe
 	return 1;
 }
 /*
+ * Apply one "name=value" php.ini directive to the VM (used by -d and each
+ * -c file line). Trims surrounding whitespace and one layer of quotes off
+ * the value, php.ini style.
+ */
+static void PHL_ApplyIniPair(ph7_vm *pVm,const char *zPair)
+{
+	char zName[128];
+	char zValue[512];
+	const char *zEq = strchr(zPair,'=');
+	const char *zEnd;
+	size_t n;
+	if( zEq == 0 ){
+		/* php: a bare -d name defines the entry with value "1" */
+		zEq = zPair + strlen(zPair);
+	}
+	/* name: trim */
+	while( *zPair == ' ' || *zPair == '\t' ){ zPair++; }
+	zEnd = zEq;
+	while( zEnd > zPair && (zEnd[-1] == ' ' || zEnd[-1] == '\t') ){ zEnd--; }
+	n = (size_t)(zEnd - zPair);
+	if( n == 0 || n >= sizeof(zName) ){
+		return;
+	}
+	memcpy(zName,zPair,n);
+	zName[n] = 0;
+	/* value: trim + unquote */
+	if( *zEq == '=' ){
+		const char *zV = zEq + 1;
+		const char *zVEnd;
+		while( *zV == ' ' || *zV == '\t' ){ zV++; }
+		zVEnd = zV + strlen(zV);
+		while( zVEnd > zV && (zVEnd[-1] == ' ' || zVEnd[-1] == '\t'
+		    || zVEnd[-1] == '\r' || zVEnd[-1] == '\n') ){ zVEnd--; }
+		if( zVEnd - zV >= 2 && (zV[0] == '"' || zV[0] == '\'') && zVEnd[-1] == zV[0] ){
+			zV++;
+			zVEnd--;
+		}
+		n = (size_t)(zVEnd - zV);
+		if( n >= sizeof(zValue) ){
+			n = sizeof(zValue) - 1;
+		}
+		memcpy(zValue,zV,n);
+		zValue[n] = 0;
+	}else{
+		/* default "on" flag; avoid strcpy (MSVC C4996 under /WX) */
+		zValue[0] = '1';
+		zValue[1] = 0;
+	}
+	ph7_vm_config(pVm,PH7_VM_CONFIG_INI_ENTRY,zName,zValue);
+}
+/*
+ * Load php.ini directives from a -c file: name=value lines; [sections],
+ * empty lines and ;/# comments are ignored (enough of php's ini grammar
+ * for CLI configuration).
+ */
+static void PHL_LoadIniFile(ph7_vm *pVm,const char *zPath)
+{
+	char zLine[768];
+	FILE *pFile = fopen(zPath,"r");
+	if( pFile == 0 ){
+		fprintf(stderr,"Could not open php.ini file: %s\n",zPath);
+		return;
+	}
+	while( fgets(zLine,sizeof(zLine),pFile) ){
+		const char *z = zLine;
+		while( *z == ' ' || *z == '\t' ){ z++; }
+		if( *z == 0 || *z == ';' || *z == '#' || *z == '[' || *z == '\n' || *z == '\r' ){
+			continue;
+		}
+		PHL_ApplyIniPair(pVm,z);
+	}
+	fclose(pFile);
+}
+/*
  * Main program: Compile and execute the PHP file.
  */
 int main(int argc,char **argv)
@@ -245,6 +319,9 @@ int main(int argc,char **argv)
 #endif
 	int n;              /* Script arguments */
 	int rc;
+	const char *azIniDefine[64]; /* -d name=value directives, in order */
+	int nIniDefine = 0;
+	const char *zIniFile = 0;    /* -c php.ini path */
 	/* Process interpreter arguments first*/
 	for(n = 1 ; n < argc ; ++n ){
 		int c;
@@ -351,6 +428,24 @@ int main(int argc,char **argv)
 		}else if( c == 'v' ){
 			/* Display version */
 			Version();
+		}else if( c == 'd' ){
+			/* php CLI parity: -d name=value defines a php.ini entry
+			 * (repeatable; applied to the VM after compile, in order). */
+			if( n + 1 >= argc ){
+				FatalCode("Missing name=value argument for -d",1);
+			}
+			if( nIniDefine < (int)(sizeof(azIniDefine)/sizeof(azIniDefine[0])) ){
+				azIniDefine[nIniDefine++] = argv[++n];
+			}else{
+				FatalCode("Too many -d directives",1);
+			}
+		}else if( c == 'c' ){
+			/* php CLI parity: -c file loads php.ini directives from a file
+			 * (name=value lines; [sections] and ;/# comments ignored). */
+			if( n + 1 >= argc ){
+				FatalCode("Missing file argument for -c",1);
+			}
+			zIniFile = argv[++n];
 		}else{
 			/* Display a help message and exit */
 			Help();
@@ -572,6 +667,18 @@ int main(int argc,char **argv)
 	}
 	/* Report script run-time errors (now default behavior) */
 	ph7_vm_config(pVm,PH7_VM_CONFIG_ERR_REPORT);
+	/* Apply php.ini directives AFTER the error-report default so
+	 * `-d error_reporting=0` can lower it: the -c file first, then -d
+	 * overrides in CLI order (php's precedence). */
+	if( zIniFile ){
+		PHL_LoadIniFile(pVm,zIniFile);
+	}
+	{
+		int i;
+		for( i = 0 ; i < nIniDefine ; i++ ){
+			PHL_ApplyIniPair(pVm,azIniDefine[i]);
+		}
+	}
 	if( dump_vm ){
 		/* Dump PH7 byte-code instructions */
 		ph7_vm_dump_v2(pVm,

--- a/tests/ph7/002-integration/cli/dash-d-ini.phpt
+++ b/tests/ph7/002-integration/cli/dash-d-ini.phpt
@@ -1,0 +1,47 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+phl interpreter -d/-c php.ini directives
+--SKIPIF--
+<?php
+// Only run under PHL; the flags are tested through the phl binary itself.
+if (!defined('PH7_VERSION')) {
+    echo "skip";
+}
+// The harness spawns the interpreter with single-quoted `-r '...'` arguments —
+// POSIX shell quoting that cmd.exe does not honour (php fails this on Windows too).
+if (DIRECTORY_SEPARATOR === '\\') { echo 'skip POSIX shell quoting in the subprocess harness'; }
+?>
+--FILE--
+<?php
+$phl = getenv('PHPT_TARGET_EXECUTABLE');
+function dashd_run($cmd) {
+    $fp = popen($cmd, 'r');
+    $out = '';
+    while (!feof($fp)) { $out .= fgets($fp); }
+    pclose($fp);
+    return trim($out);
+}
+// -d name=value reaches both the INI view and the live knob
+echo dashd_run("\"$phl\" -d session.name=CLISESS -r 'echo ini_get(\"session.name\"), \"|\", session_name(), \"|\", get_cfg_var(\"session.name\");'"), "\n";
+// -d bare name defaults to "1"
+echo dashd_run("\"$phl\" -d display_errors -r 'echo ini_get(\"display_errors\");'"), "\n";
+// -c file, then -d overrides it
+$ini = tempnam(sys_get_temp_dir(), 'phlini');
+file_put_contents($ini, "[PHP]\n; comment\nsession.name = \"FILESESS\"\nmemory_limit = 128M\n");
+echo dashd_run("\"$phl\" -c \"$ini\" -r 'echo ini_get(\"session.name\"), \"|\", ini_get(\"memory_limit\");'"), "\n";
+echo dashd_run("\"$phl\" -c \"$ini\" -d session.name=DOVERRIDE -r 'echo ini_get(\"session.name\");'"), "\n";
+// engine knob: -d error_reporting=0 silences the report flag
+echo dashd_run("\"$phl\" -d error_reporting=0 -r 'echo error_reporting();'"), "\n";
+@unlink($ini);
+?>
+--EXPECT--
+CLISESS|CLISESS|CLISESS
+1
+FILESESS|128M
+DOVERRIDE
+0
+--CLEAN--
+<?php
+unset($phl, $ini);

--- a/tests/ph7/002-integration/cli/help.phpt
+++ b/tests/ph7/002-integration/cli/help.phpt
@@ -17,7 +17,7 @@ fclose($fp);
 echo $out;
 ?>
 --EXPECT--
-phl [-h|--help|-b|-i|-l|-v|--version|-r code|--rf name|--rc name] path/to/php_file [script args]
+phl [-h|--help|-b|-i|-l|-v|--version|-r code|--rf name|--rc name|-d name=value|-c inifile] path/to/php_file [script args]
 phl -S host:port [-t docroot] [router.php]
 	-b: Dump PH7 byte-code instructions
 	-i: Display interpreter information and exit

--- a/tests/ph7/002-integration/function/ini/ini_api.phpt
+++ b/tests/ph7/002-integration/function/ini/ini_api.phpt
@@ -1,0 +1,56 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: INI API — ini_get/ini_set/ini_restore/ini_get_all/get_cfg_var
+--FILE--
+<?php
+$log = [];
+// session ini mutations must precede any output (php headers rule)
+$log[] = var_export(ini_get('session.name'), true);
+$log[] = var_export(ini_set('session.name', 'X2'), true);
+$log[] = var_export(ini_get('session.name'), true);
+$log[] = var_export(session_name(), true);
+$log[] = var_export(ini_restore('session.name'), true);
+$log[] = var_export(ini_get('session.name'), true);
+$log[] = var_export(ini_set('session.name', 'Y3'), true);
+$log[] = var_export(get_cfg_var('session.name'), true);
+$all = ini_get_all('session');
+$log[] = var_export($all['session.name'], true);
+// unknown keys
+$log[] = var_export(ini_get('nonexistent.key'), true);
+$log[] = var_export(ini_set('nonexistent.key', 'v'), true);
+$log[] = var_export(get_cfg_var('nonexistent.key'), true);
+// constants
+$log[] = INI_USER . INI_PERDIR . INI_SYSTEM . INI_ALL;
+// non-session round-trip that avoids install-dependent defaults
+ini_set('memory_limit', '96M');
+$log[] = var_export(ini_set('memory_limit', '64M'), true);
+$log[] = var_export(ini_get('memory_limit'), true);
+$log[] = var_export(ini_get('date.timezone'), true);
+echo implode("\n", $log), "\n";
+?>
+--EXPECT--
+'PHPSESSID'
+'PHPSESSID'
+'X2'
+'X2'
+NULL
+'PHPSESSID'
+'PHPSESSID'
+'PHPSESSID'
+array (
+  'global_value' => 'PHPSESSID',
+  'local_value' => 'Y3',
+  'access' => 7,
+)
+false
+false
+false
+1247
+'96M'
+'64M'
+'UTC'
+--CLEAN--
+<?php
+unset($log, $all);


### PR DESCRIPTION
Implement ini_get, ini_set, ini_restore, ini_get_all, and get_cfg_var over a lazily seeded directive table with php's return-value and warning contract, live-wired to error_reporting, the session state, and the default timezone. The new -d name=value and -c file CLI flags feed a per-VM directive queue through PH7_VM_CONFIG_INI_ENTRY; engine knobs apply immediately in C, ordered after the error-report default so -d error_reporting=0 can lower it. Register the INI_* and access-level constants in constant.c.

Fix ksort/krsort ordering string keys length-first: SyBlobCmp compares lengths before bytes, so "c" sorted before "a.y". The shared key comparator now uses a bounded memcmp-then-length compare, which also replaces the mixed-key path's NUL-dependent SyStrncmp.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
