### PR TITLE
Implement WeakReference and WeakMap

### DIFF
--- a/src/ph7/oo.c
+++ b/src/ph7/oo.c
@@ -1161,6 +1161,17 @@ static void PH7_ClassInstanceRelease(ph7_class_instance *pThis)
 		pThis->iRef = 2; /* Prevent garbage collection */
 		PH7_VmCallClassMethod(pVm,pThis,pDestr,0,0,0);
 	}
+	/* Weak-reference registry: kill the cell for this instance so every
+	 * WeakReference/WeakMap handle observes the death (the cell outlives the
+	 * instance until its own handles drop; removing the hash entry here keeps
+	 * a pool-reused address from resurrecting a dead cell). */
+	if( SyHashTotalEntry(&pVm->hWeakCell) > 0 ){
+		void *pCellData = 0;
+		if( SyHashDeleteEntry(&pVm->hWeakCell,(const void *)&pThis,sizeof(void *),&pCellData) == SXRET_OK
+		 && pCellData ){
+			((VmWeakCell *)pCellData)->pObj = 0;
+		}
+	}
 	/* Release non-static attributes (the wholesale SyHashRelease below frees the entry nodes,
 	 * so the helper must not delete them mid-walk). */
 	SyHashResetLoopCursor(&pThis->hAttr);

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1210,6 +1210,15 @@ struct VmHookRmw
 	                             * coalesce: the OP_NULLC_STORE) */
 };
 
+/* A shared weak cell: one per weakly-referenced target instance. pObj nulls
+ * when the target is released (the PH7_ClassInstanceRelease hook); nRef
+ * counts the PHP-side handles (WeakReference objects, WeakMap entries). */
+typedef struct VmWeakCell VmWeakCell;
+struct VmWeakCell
+{
+	ph7_class_instance *pObj; /* target instance; 0 once dead */
+	sxu32 nRef;               /* PHP-side handle count */
+};
 /* One -d/-c php.ini directive queued for the INI chunk (name/value are
  * allocator-owned copies; see PH7_VM_CONFIG_INI_ENTRY) */
 typedef struct VmIniEntry VmIniEntry;
@@ -1268,6 +1277,8 @@ struct ph7_vm
 	SySet aShutdown;            /* Stack of shutdown user callbacks */
 	SySet aIniCli;              /* php.ini directives from the CLI (-d/-c): VmIniEntry copies,
 	                             * drained lazily by the INI chunk's __ini_cli() thunk */
+	SyHash hWeakCell;           /* instance pointer bytes -> VmWeakCell* (weak-reference registry;
+	                             * PH7_ClassInstanceRelease kills matching cells on free) */
 	SySet aAutoload;            /* Stack of spl_autoload callbacks */
 	SyHash hAutoloadActive;     /* Classes currently being autoloaded (reentrancy guard) */
 	SyHash hTypedSlot;          /* memobj nIdx -> VmClassAttr* for typed property enforcement */

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -2511,6 +2511,7 @@ PH7_PRIVATE sxi32 PH7_VmInit(
 	SySetInit(&pVm->aIniCli,&pVm->sAllocator,sizeof(VmIniEntry));
 	SySetInit(&pVm->aAutoload,&pVm->sAllocator,sizeof(VmAutoloadCB));
 	SyHashInit(&pVm->hAutoloadActive,&pVm->sAllocator,0,0);
+	SyHashInit(&pVm->hWeakCell,&pVm->sAllocator,0,0);
 	SyHashInit(&pVm->hTypedSlot,&pVm->sAllocator,0,0);
 	SySetInit(&pVm->aException,&pVm->sAllocator,sizeof(ph7_exception *));
 	SySetInit(&pVm->aMagicGuard,&pVm->sAllocator,sizeof(VmMagicGuard));
@@ -4159,6 +4160,7 @@ PH7_PRIVATE sxi32 PH7_VmReset(ph7_vm *pVm)
 	if( SyHashTotalEntry(&pVm->hAutoloadActive) ){
 		SyHashRelease(&pVm->hAutoloadActive);
 		SyHashInit(&pVm->hAutoloadActive,&pVm->sAllocator,0,0);
+	SyHashInit(&pVm->hWeakCell,&pVm->sAllocator,0,0);
 	}
 	/* Output buffers */
 	for( n = 0 ; n < SySetUsed(&pVm->aOB) ; ++n ){

--- a/src/ph7/vm_builtin_spl.c
+++ b/src/ph7/vm_builtin_spl.c
@@ -27,6 +27,90 @@ static int vm_builtin_spl_deprecated(ph7_context *pCtx,int nArg,ph7_value **apAr
 	return PH7_OK;
 }
 
+/* int __weak_create(object $obj) — register/share the weak cell for $obj,
+ * returning the cell pointer as an opaque int handle */
+static int vm_builtin_weak_create(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	ph7_vm *pVm = pCtx->pVm;
+	ph7_class_instance *pObj;
+	VmWeakCell *pCell = 0;
+	SyHashEntry *pEntry;
+	if( nArg < 1 || (apArg[0]->iFlags & MEMOBJ_OBJ) == 0 ){
+		ph7_result_int(pCtx,0);
+		return PH7_OK;
+	}
+	pObj = (ph7_class_instance *)apArg[0]->x.pOther;
+	pEntry = SyHashGet(&pVm->hWeakCell,(const void *)&pObj,sizeof(void *));
+	if( pEntry ){
+		pCell = (VmWeakCell *)pEntry->pUserData;
+		pCell->nRef++;
+	}else{
+		pCell = (VmWeakCell *)SyMemBackendAlloc(&pVm->sAllocator,sizeof(VmWeakCell));
+		if( pCell == 0 ){
+			return PH7_ContextMemoryError(pCtx);
+		}
+		pCell->pObj = pObj;
+		pCell->nRef = 1;
+		/* SyHash stores the key POINTER (no copy): key off the cell's own
+		 * pObj field — heap-stable for the entry's whole lifetime, and it
+		 * holds the live pointer bytes until the release hook nulls it
+		 * (which happens only after the entry is deleted). */
+		if( SyHashInsert(&pVm->hWeakCell,(const void *)&pCell->pObj,sizeof(void *),pCell) != SXRET_OK ){
+			SyMemBackendFree(&pVm->sAllocator,pCell);
+			return PH7_ContextMemoryError(pCtx);
+		}
+	}
+	ph7_result_int64(pCtx,(ph7_int64)(sxu64)(sxuptr)pCell);
+	return PH7_OK;
+}
+/* ?object __weak_get(int $handle) — the target instance, or null once dead */
+static int vm_builtin_weak_get(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	VmWeakCell *pCell;
+	if( nArg < 1 ){
+		ph7_result_null(pCtx);
+		return PH7_OK;
+	}
+	pCell = (VmWeakCell *)(sxuptr)(sxu64)ph7_value_to_int64(apArg[0]);
+	if( pCell == 0 || pCell->pObj == 0 ){
+		ph7_result_null(pCtx);
+		return PH7_OK;
+	}
+	{
+		/* Hand the instance back: ph7_result_value's MemObjStore takes the
+		 * reference, so the temp holds none of its own. */
+		ph7_value sObj;
+		PH7_MemObjInit(pCtx->pVm,&sObj);
+		sObj.x.pOther = pCell->pObj;
+		MemObjSetType(&sObj,MEMOBJ_OBJ);
+		ph7_result_value(pCtx,&sObj);
+	}
+	return PH7_OK;
+}
+/* void __weak_drop(int $handle) — release one PHP-side handle */
+static int vm_builtin_weak_drop(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	ph7_vm *pVm = pCtx->pVm;
+	VmWeakCell *pCell;
+	if( nArg < 1 ){
+		return PH7_OK;
+	}
+	pCell = (VmWeakCell *)(sxuptr)(sxu64)ph7_value_to_int64(apArg[0]);
+	if( pCell == 0 || pCell->nRef == 0 ){
+		return PH7_OK;
+	}
+	pCell->nRef--;
+	if( pCell->nRef == 0 ){
+		if( pCell->pObj ){
+			/* Still alive: unhook the registry entry before freeing */
+			void *pDummy = 0;
+			SyHashDeleteEntry(&pVm->hWeakCell,(const void *)&pCell->pObj,sizeof(void *),&pDummy);
+		}
+		SyMemBackendFree(&pVm->sAllocator,pCell);
+	}
+	return PH7_OK;
+}
+
 static const char zSplLib[] =
 "interface SeekableIterator extends Iterator {"
 " public function seek($offset);"
@@ -333,6 +417,89 @@ static const char zSplLib[] =
 "}"
 "class NoRewindIterator extends IteratorIterator {"
 " public function rewind(){}"
+"}"
+"class WeakReference {"
+" private $__h = 0;"
+" private function __construct(){}"
+" public static function create($object){"
+"  if( !is_object($object) ){"
+"   throw new TypeError('WeakReference::create(): Argument #1 ($object) must be"
+" of type object, ' . get_debug_type($object) . ' given');"
+"  }"
+"  $w = new WeakReference();"
+"  $w->__h = __weak_create($object);"
+"  return $w;"
+" }"
+" public function get(){ return $this->__h ? __weak_get($this->__h) : null; }"
+" public function __destruct(){"
+"  if( $this->__h ){ __weak_drop($this->__h); $this->__h = 0; }"
+" }"
+"}"
+"class WeakMap implements ArrayAccess, Countable, IteratorAggregate {"
+" private $__e = [];"
+" private function __wmPrune(){"
+"  foreach( $this->__e as $id => $p ){"
+"   if( __weak_get($p[0]) === null ){"
+"    __weak_drop($p[0]);"
+"    unset($this->__e[$id]);"
+"   }"
+"  }"
+" }"
+" public function offsetSet($object, $value){"
+"  if( !is_object($object) ){"
+"   throw new TypeError('WeakMap key must be an object');"
+"  }"
+"  $id = spl_object_id($object);"
+"  if( isset($this->__e[$id]) && __weak_get($this->__e[$id][0]) !== null ){"
+"   $this->__e[$id][1] = $value;"
+"   return;"
+"  }"
+"  if( isset($this->__e[$id]) ){ __weak_drop($this->__e[$id][0]); }"
+"  $this->__e[$id] = [__weak_create($object), $value];"
+" }"
+" public function offsetGet($object){"
+"  if( !is_object($object) ){"
+"   throw new TypeError('WeakMap key must be an object');"
+"  }"
+"  $id = spl_object_id($object);"
+"  if( isset($this->__e[$id]) && __weak_get($this->__e[$id][0]) === $object ){"
+"   return $this->__e[$id][1];"
+"  }"
+"  throw new Error('Object ' . get_class($object) . '#' . $id . ' not contained"
+" in WeakMap');"
+" }"
+" public function offsetExists($object){"
+"  if( !is_object($object) ){"
+"   throw new TypeError('WeakMap key must be an object');"
+"  }"
+"  $id = spl_object_id($object);"
+"  return isset($this->__e[$id]) && __weak_get($this->__e[$id][0]) === $object;"
+" }"
+" public function offsetUnset($object){"
+"  if( !is_object($object) ){"
+"   throw new TypeError('WeakMap key must be an object');"
+"  }"
+"  $id = spl_object_id($object);"
+"  if( isset($this->__e[$id]) ){"
+"   __weak_drop($this->__e[$id][0]);"
+"   unset($this->__e[$id]);"
+"  }"
+" }"
+" public function count(){"
+"  $this->__wmPrune();"
+"  return count($this->__e);"
+" }"
+" public function getIterator(): Generator {"
+"  $this->__wmPrune();"
+"  foreach( $this->__e as $p ){"
+"   $o = __weak_get($p[0]);"
+"   if( $o !== null ){ yield $o => $p[1]; }"
+"  }"
+" }"
+" public function __destruct(){"
+"  foreach( $this->__e as $p ){ __weak_drop($p[0]); }"
+"  $this->__e = [];"
+" }"
 "}"
 "class EmptyIterator implements Iterator {"
 " public function current(){"
@@ -745,6 +912,9 @@ static const char zSplLib[] =
 PH7_PRIVATE sxi32 PH7_VmInstallSpl(ph7_vm *pVm)
 {
 	ph7_create_function(&(*pVm),"__spl_deprecated",vm_builtin_spl_deprecated,0);
+	ph7_create_function(&(*pVm),"__weak_create",vm_builtin_weak_create,0);
+	ph7_create_function(&(*pVm),"__weak_get",vm_builtin_weak_get,0);
+	ph7_create_function(&(*pVm),"__weak_drop",vm_builtin_weak_drop,0);
 	return PH7_VmEvalBuiltinChunk(&(*pVm),zSplLib,sizeof(zSplLib)-1);
 }
 

--- a/src/sx/sxtypes.h
+++ b/src/sx/sxtypes.h
@@ -19,7 +19,9 @@ typedef unsigned short int sxu16; /* 16 bits(2 bytes) unsigned integer */
 typedef int                sxi32; /* 32 bits(4 bytes) integer */
 typedef unsigned int       sxu32; /* 32 bits(4 bytes) unsigned integer */
 typedef long               sxptr;
-typedef unsigned long      sxuptr;
+/* Pointer-sized: MUST hold a round-tripped pointer. `unsigned long` is 32-bit on
+ * LLP64 (64-bit Windows) and silently truncates a pointer's high half. */
+typedef sxu64              sxuptr;
 typedef long               sxlong;
 typedef unsigned long      sxulong;
 typedef sxi32              sxofft;

--- a/tests/ph7/001-smoke/oo/weakref_weakmap.phpt
+++ b/tests/ph7/001-smoke/oo/weakref_weakmap.phpt
@@ -1,0 +1,54 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: WeakReference and WeakMap (band D)
+--FILE--
+<?php
+$o = new stdClass; $o->x = 1;
+$w = WeakReference::create($o);
+var_export($w->get() === $o); echo "\n";
+unset($o);
+var_export($w->get()); echo "\n";
+try { WeakReference::create(5); } catch (TypeError $e) { echo $e->getMessage(), "\n"; }
+$m = new WeakMap();
+$k = new stdClass;
+$m[$k] = "val";
+var_export(count($m)); echo "|", $m[$k], "|", isset($m[$k]) ? "y" : "n", "\n";
+foreach ($m as $obj => $v) { var_export($obj === $k); echo "|$v\n"; }
+unset($obj);
+unset($k);
+var_export(count($m)); echo "\n";
+$k2 = new stdClass;
+try { $m[$k2]; } catch (Error $e) { echo $e->getMessage(), "\n"; }
+try { $m["str"] = 1; } catch (TypeError $e) { echo $e->getMessage(), "\n"; }
+var_export($m instanceof ArrayAccess && $m instanceof Countable && $m instanceof IteratorAggregate); echo "\n";
+$m2 = new WeakMap(); $tmp = new stdClass; $m2[$tmp] = 9; unset($m2[$tmp]); var_export(count($m2)); echo "\n";
+// value replacement + many refs
+$a = new stdClass; $wA = WeakReference::create($a); $wB = WeakReference::create($a);
+unset($a);
+var_export($wA->get()); var_export($wB->get()); echo "\n";
+// map key death releases only that entry
+$p = new stdClass; $q = new stdClass;
+$m3 = new WeakMap(); $m3[$p] = 1; $m3[$q] = 2;
+unset($p);
+var_export(count($m3)); echo "\n";
+foreach ($m3 as $ko => $vo) { echo get_class($ko), "=", $vo, "\n"; }
+?>
+--EXPECTF--
+true
+NULL
+WeakReference::create(): Argument #1 ($object) must be of type object, int given
+1|val|y
+true|val
+0
+Object stdClass#%d not contained in WeakMap
+WeakMap key must be an object
+true
+0
+NULLNULL
+1
+stdClass=2
+--CLEAN--
+<?php
+unset($w, $m, $k2, $m2, $tmp, $wA, $wB, $m3, $q, $ko, $vo, $v);


### PR DESCRIPTION
Add a per-target shared weak-cell registry keyed by instance pointer and killed from the instance release path, so weak handles observe object death without holding references. The hash keys off the cell's own target field since SyHash stores key pointers rather than copies, and the release hook deletes the entry before nulling the target so a pool-reused address cannot resurrect a dead cell.

WeakReference (create/get, private constructor) and WeakMap (ArrayAccess, Countable, IteratorAggregate with php's TypeError and not-contained Error shapes, lazy pruning, key-object iteration) ride three small thunks over the registry.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
