### PR TITLE
Serve requests with PHP_CLI_SERVER_WORKERS

### DIFF
--- a/src/phl/server.c
+++ b/src/phl/server.c
@@ -44,6 +44,12 @@
 
 /* Shutdown flag set by signal handler */
 static volatile int g_shutdown = 0;
+#ifndef __WINNT__
+/* Pre-forked worker pids (parent only) — signalled on shutdown so killing
+ * the parent doesn't orphan workers holding the port */
+static pid_t g_aWorkerPid[64];
+static int g_nWorkerPid = 0;
+#endif
 
 /* Resolved interpreter path, exposed to scripts as the PHP_BINARY constant.
  * Set once in phl_serve(); the matching expand callback mirrors the CLI's
@@ -804,6 +810,44 @@ int phl_serve(const char *zHost, int iPort, const char *zDocRoot, const char *zR
 		fprintf(stderr, "Router script: %s\n", zRouter);
 	}
 	fprintf(stderr, "Press Ctrl+C to stop.\n");
+#ifndef __WINNT__
+	/* php CLI-server parity: PHP_CLI_SERVER_WORKERS=N pre-forks N workers
+	 * that all accept() on the shared listen socket (the kernel load-balances
+	 * connections). Each worker keeps its own warm VM cache and runs the
+	 * unchanged sequential loop, so no locking is needed anywhere. Like php,
+	 * the default (unset/1) stays single-process; Windows keeps the
+	 * single-process model (no fork — recorded). */
+	{
+		const char *zWorkers = getenv("PHP_CLI_SERVER_WORKERS");
+		int nWorkers = zWorkers ? atoi(zWorkers) : 0;
+		if( nWorkers > 1 ){
+			int iWorker;
+			int bChild = 0;
+			if( nWorkers > 64 ){
+				nWorkers = 64;
+			}
+			/* No zombies if a worker crashes mid-run */
+			signal(SIGCHLD, SIG_IGN);
+			for( iWorker = 1 ; iWorker < nWorkers ; iWorker++ ){
+				pid_t pid = fork();
+				if( pid == 0 ){
+					/* worker child: fall through to the accept loop */
+					bChild = 1;
+					g_nWorkerPid = 0; /* children propagate nothing */
+					break;
+				}
+				if( pid < 0 ){
+					fprintf(stderr, "Warning: fork failed; continuing with %d worker(s)\n", iWorker);
+					break;
+				}
+				g_aWorkerPid[g_nWorkerPid++] = pid;
+			}
+			if( !bChild ){
+				fprintf(stderr, "Using %d worker processes\n", nWorkers);
+			}
+		}
+	}
+#endif
 	/* Allocate request buffer */
 	zRequestBuf = (char *)malloc(PHL_MAX_REQUEST);
 	if( zRequestBuf == 0 ){
@@ -845,6 +889,15 @@ int phl_serve(const char *zHost, int iPort, const char *zDocRoot, const char *zR
 		PH7_NetClose(clientSock);
 	}
 	/* Cleanup */
+#ifndef __WINNT__
+	/* Parent: take the workers down with us */
+	{
+		int k;
+		for( k = 0 ; k < g_nWorkerPid ; k++ ){
+			kill(g_aWorkerPid[k], SIGTERM);
+		}
+	}
+#endif
 	fprintf(stderr, "\nShutting down...\n");
 	ReleaseVmCache();
 	free(zRequestBuf);

--- a/tests/ph7/002-integration/server/concurrent_workers.phpt
+++ b/tests/ph7/002-integration/server/concurrent_workers.phpt
@@ -1,0 +1,53 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Built-in server: PHP_CLI_SERVER_WORKERS handles requests concurrently
+--SKIPIF--
+<?php
+$fp = popen("curl --version 2>/dev/null", "r");
+$out = fgets($fp);
+fclose($fp);
+if (strlen($out) == 0) { echo "skip curl not available"; }
+if (!defined('PH7_VERSION')) { echo "skip PHL-only server flag"; }
+if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') { echo "skip fork workers are POSIX-only"; }
+?>
+--FILE--
+<?php
+$phl = getenv('PHPT_TARGET_EXECUTABLE');
+$tmpdir = sys_get_temp_dir() . '/phl_cwtest_' . getmypid();
+$port = 19400 + (getmypid() % 100);
+mkdir($tmpdir);
+// each request sleeps a second, so two sequential ones would take >= 2s
+file_put_contents($tmpdir . '/slow.php', '<?php sleep(1); echo "done";');
+
+$fp = popen('PHP_CLI_SERVER_WORKERS=4 "' . $phl . '" -S localhost:' . $port
+    . ' -t "' . $tmpdir . '" >/dev/null 2>&1 & echo $!', 'r');
+$pid = trim(fgets($fp));
+fclose($fp);
+usleep(700000);
+
+// fire two overlapping requests and time the pair
+$start = microtime(true);
+$cmd = 'curl -s http://localhost:' . $port . '/slow.php > /dev/null 2>&1 & '
+     . 'curl -s http://localhost:' . $port . '/slow.php 2>/dev/null; wait';
+$fp2 = popen($cmd, 'r');
+$out = '';
+while (!feof($fp2)) { $out .= fgets($fp2); }
+fclose($fp2);
+$elapsed = microtime(true) - $start;
+
+echo trim($out), "\n";
+echo $elapsed < 1.8 ? "concurrent" : "serialized ($elapsed)", "\n";
+
+popen('kill ' . $pid . ' 2>/dev/null', 'r');
+usleep(300000);
+@unlink($tmpdir . '/slow.php');
+@rmdir($tmpdir);
+?>
+--EXPECT--
+done
+concurrent
+--CLEAN--
+<?php
+unset($phl, $tmpdir, $port, $fp, $pid, $fp2, $out, $start, $elapsed, $cmd);


### PR DESCRIPTION
Pre-fork N-1 workers after the listen socket exists so every worker accepts on the same socket and the kernel load-balances connections. Each worker keeps its own warm VM cache and runs the unchanged sequential loop, so no locking is needed anywhere. The parent SIGTERMs its workers on shutdown, SIGCHLD is ignored so a crashed worker cannot zombie, and the default stays single-process like php. Fork workers are POSIX-only; Windows keeps the single-process model.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
