### PR TITLE
Resolve int parameters through the ZPP helper

### DIFF
--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -12,6 +12,108 @@
 #include <errno.h>   /* ERANGE (strtod range-error signal) */
 #include <stdio.h>   /* snprintf (printf-family float conversions — correctly
                       * rounded digits like php's zend_dtoa; see PH7_InputFormat) */
+/* Shared ZPP helper for `int` parameters — defined OUTSIDE the
+ * PH7_DISABLE_BUILTIN_FUNC guard because hashmap.c (array_slice) and
+ * builtin_math.c (intdiv) call it and both compile in the tiny build. */
+PH7_PRIVATE sxi32 PH7_IntArgResolve(
+	ph7_context *pCtx,
+	ph7_value *pArg,
+	const char *zFunc,
+	int iArgNum,
+	const char *zParamName,
+	const char *zTypeStr,
+	sxi64 *pOut
+){
+	if( ph7_value_is_null(pArg) ){
+		PH7_VmThrowDeprecatedFmt(pCtx->pVm,
+			"%s(): Passing null to parameter #%d (%s) of type %s is deprecated",
+			zFunc,iArgNum,zParamName,zTypeStr
+			);
+		*pOut = 0;
+		return PH7_OK;
+	}
+	if( ph7_value_is_float(pArg) ){
+		double dVal = ph7_value_to_double(pArg);
+		sxi64 iVal;
+		/* php: NAN/INF/out-of-int64-range floats fail ZPP outright */
+		if( dVal != dVal || dVal >= 9223372036854775808.0 || dVal < -9223372036854775808.0 ){
+			return PH7_VmThrowException(pCtx,
+				"TypeError",
+				"%s(): Argument #%d (%s) must be of type %s, float given",
+				zFunc,iArgNum,zParamName,zTypeStr
+				);
+		}
+		iVal = (sxi64)dVal;
+		if( (double)iVal != dVal ){
+			PH7_VmThrowDeprecatedFmt(pCtx->pVm,
+				"Implicit conversion from float %s to int loses precision",
+				ph7_value_to_string(pArg,0)
+				);
+		}
+		*pOut = iVal;
+		return PH7_OK;
+	}
+	if( ph7_value_is_string(pArg) ){
+		const char *zNum;
+		int nSlen;
+		int i,bFloat = 0;
+		if( !PH7_MemObjStringIsNumeric(pArg) ){
+			return PH7_VmThrowException(pCtx,
+				"TypeError",
+				"%s(): Argument #%d (%s) must be of type %s, string given",
+				zFunc,iArgNum,zParamName,zTypeStr
+				);
+		}
+		zNum = ph7_value_to_string(pArg,&nSlen);
+		for( i = 0 ; i < nSlen ; i++ ){
+			if( zNum[i] == '.' || zNum[i] == 'e' || zNum[i] == 'E' ){
+				bFloat = 1;
+				break;
+			}
+		}
+		if( bFloat ){
+			double dVal = 0;
+			sxi64 iVal;
+			SyStrToReal(zNum,(sxu32)nSlen,(void *)&dVal,0);
+			if( dVal != dVal || dVal >= 9223372036854775808.0 || dVal < -9223372036854775808.0 ){
+				return PH7_VmThrowException(pCtx,
+					"TypeError",
+					"%s(): Argument #%d (%s) must be of type %s, string given",
+					zFunc,iArgNum,zParamName,zTypeStr
+					);
+			}
+			iVal = (sxi64)dVal;
+			if( (double)iVal != dVal ){
+				PH7_VmThrowDeprecatedFmt(pCtx->pVm,
+					"Implicit conversion from float-string \"%s\" to int loses precision",
+					zNum
+					);
+			}
+			*pOut = iVal;
+			return PH7_OK;
+		}
+		*pOut = ph7_value_to_int64(pArg);
+		return PH7_OK;
+	}
+	if( !ph7_value_is_int(pArg) && !ph7_value_is_bool(pArg) ){
+		/* Arrays, resources and objects: php names the class for objects */
+		const char *zType = ph7_type_name(pArg);
+		if( ph7_value_is_object(pArg) ){
+			ph7_class_instance *pInst = (ph7_class_instance *)pArg->x.pOther;
+			if( pInst && pInst->pClass ){
+				zType = SyStringData(&pInst->pClass->sName);
+			}
+		}
+		return PH7_VmThrowException(pCtx,
+			"TypeError",
+			"%s(): Argument #%d (%s) must be of type %s, %s given",
+			zFunc,iArgNum,zParamName,zTypeStr,zType
+			);
+	}
+	*pOut = ph7_value_to_int64(pArg);
+	return PH7_OK;
+}
+
 #ifndef PH7_DISABLE_BUILTIN_FUNC
 /* Forward decl: null-to-string ZPP deprecation notice (defined near the ZPP
  * helpers; both live inside the same DISABLE_BUILTIN_FUNC region as every
@@ -375,7 +477,14 @@ static int PH7_builtin_substr(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	}
 	nLen = nSrcLen; /* cc warning */
 	/* Extract the offset */
-	nOfft = ph7_value_to_int(apArg[1]);
+	{
+		sxi64 iTmp = 0;
+		sxi32 rcArg = PH7_IntArgResolve(pCtx,apArg[1],"substr",2,"$offset","int",&iTmp);
+		if( rcArg != PH7_OK ){
+			return rcArg;
+		}
+		nOfft = (int)iTmp;
+	}
 	if( nOfft < 0 ){
 		zOfft = &zSource[nSrcLen+nOfft];
 		if( zOfft < zSource ){
@@ -628,104 +737,6 @@ static sxi32 StrPredicateResolveArg(ph7_context *pCtx,ph7_value *pArg,const char
  * objects, non-numeric strings) is a TypeError naming zTypeStr (e.g. "int",
  * "array|int"). Returns PH7_OK with *pOut set, or the throw status.
  */
-static sxi32 IntArgResolve(
-	ph7_context *pCtx,
-	ph7_value *pArg,
-	const char *zFunc,
-	int iArgNum,
-	const char *zParamName,
-	const char *zTypeStr,
-	sxi64 *pOut
-){
-	if( ph7_value_is_null(pArg) ){
-		PH7_VmThrowDeprecatedFmt(pCtx->pVm,
-			"%s(): Passing null to parameter #%d (%s) of type %s is deprecated",
-			zFunc,iArgNum,zParamName,zTypeStr
-			);
-		*pOut = 0;
-		return PH7_OK;
-	}
-	if( ph7_value_is_float(pArg) ){
-		double dVal = ph7_value_to_double(pArg);
-		sxi64 iVal;
-		/* php: NAN/INF/out-of-int64-range floats fail ZPP outright */
-		if( dVal != dVal || dVal >= 9223372036854775808.0 || dVal < -9223372036854775808.0 ){
-			return PH7_VmThrowException(pCtx,
-				"TypeError",
-				"%s(): Argument #%d (%s) must be of type %s, float given",
-				zFunc,iArgNum,zParamName,zTypeStr
-				);
-		}
-		iVal = (sxi64)dVal;
-		if( (double)iVal != dVal ){
-			PH7_VmThrowDeprecatedFmt(pCtx->pVm,
-				"Implicit conversion from float %s to int loses precision",
-				ph7_value_to_string(pArg,0)
-				);
-		}
-		*pOut = iVal;
-		return PH7_OK;
-	}
-	if( ph7_value_is_string(pArg) ){
-		const char *zNum;
-		int nSlen;
-		int i,bFloat = 0;
-		if( !PH7_MemObjStringIsNumeric(pArg) ){
-			return PH7_VmThrowException(pCtx,
-				"TypeError",
-				"%s(): Argument #%d (%s) must be of type %s, string given",
-				zFunc,iArgNum,zParamName,zTypeStr
-				);
-		}
-		zNum = ph7_value_to_string(pArg,&nSlen);
-		for( i = 0 ; i < nSlen ; i++ ){
-			if( zNum[i] == '.' || zNum[i] == 'e' || zNum[i] == 'E' ){
-				bFloat = 1;
-				break;
-			}
-		}
-		if( bFloat ){
-			double dVal = 0;
-			sxi64 iVal;
-			SyStrToReal(zNum,(sxu32)nSlen,(void *)&dVal,0);
-			if( dVal != dVal || dVal >= 9223372036854775808.0 || dVal < -9223372036854775808.0 ){
-				return PH7_VmThrowException(pCtx,
-					"TypeError",
-					"%s(): Argument #%d (%s) must be of type %s, string given",
-					zFunc,iArgNum,zParamName,zTypeStr
-					);
-			}
-			iVal = (sxi64)dVal;
-			if( (double)iVal != dVal ){
-				PH7_VmThrowDeprecatedFmt(pCtx->pVm,
-					"Implicit conversion from float-string \"%s\" to int loses precision",
-					zNum
-					);
-			}
-			*pOut = iVal;
-			return PH7_OK;
-		}
-		*pOut = ph7_value_to_int64(pArg);
-		return PH7_OK;
-	}
-	if( !ph7_value_is_int(pArg) && !ph7_value_is_bool(pArg) ){
-		/* Arrays, resources and objects: php names the class for objects */
-		const char *zType = ph7_type_name(pArg);
-		if( ph7_value_is_object(pArg) ){
-			ph7_class_instance *pInst = (ph7_class_instance *)pArg->x.pOther;
-			if( pInst && pInst->pClass ){
-				zType = SyStringData(&pInst->pClass->sName);
-			}
-		}
-		return PH7_VmThrowException(pCtx,
-			"TypeError",
-			"%s(): Argument #%d (%s) must be of type %s, %s given",
-			zFunc,iArgNum,zParamName,zTypeStr,zType
-			);
-	}
-	*pOut = ph7_value_to_int64(pArg);
-	return PH7_OK;
-}
 /*
  * Normalize a substr_replace() offset/length pair against a string of nStrLen
  * bytes, exactly like PHP: a negative offset counts from the end (clamped to 0),
@@ -946,11 +957,11 @@ static int PH7_builtin_substr_replace(ph7_context *pCtx,int nArg,ph7_value **apA
 		if( rc != PH7_OK ) goto out;
 	}
 	if( !ph7_value_is_array(apArg[2]) ){
-		rc = IntArgResolve(pCtx,apArg[2],"substr_replace",3,"$offset","array|int",&f);
+		rc = PH7_IntArgResolve(pCtx,apArg[2],"substr_replace",3,"$offset","array|int",&f);
 		if( rc != PH7_OK ) goto out;
 	}
 	if( bLenGiven && !ph7_value_is_array(apArg[3]) ){
-		rc = IntArgResolve(pCtx,apArg[3],"substr_replace",4,"$length","array|int|null",&l);
+		rc = PH7_IntArgResolve(pCtx,apArg[3],"substr_replace",4,"$length","array|int|null",&l);
 		if( rc != PH7_OK ) goto out;
 	}
 	if( ph7_value_is_array(apArg[0]) ){
@@ -1124,7 +1135,7 @@ static int PH7_builtin_levenshtein(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	/* Optional integer costs */
 	for( i = 2 ; i < nArg && i < 5 ; i++ ){
 		sxi64 iVal;
-		rc = IntArgResolve(pCtx,apArg[i],"levenshtein",i+1,azParam[i-2],"int",&iVal);
+		rc = PH7_IntArgResolve(pCtx,apArg[i],"levenshtein",i+1,azParam[i-2],"int",&iVal);
 		if( rc != PH7_OK ) goto out;
 		if( i == 2 ){
 			iCostIns = iVal;
@@ -1327,7 +1338,7 @@ static int PH7_builtin_str_word_count(ph7_context *pCtx,int nArg,ph7_value **apA
 	if( rc != PH7_OK ) goto out;
 	if( nArg > 1 ){
 		sxi64 iVal;
-		rc = IntArgResolve(pCtx,apArg[1],"str_word_count",2,"$format","int",&iVal);
+		rc = PH7_IntArgResolve(pCtx,apArg[1],"str_word_count",2,"$format","int",&iVal);
 		if( rc != PH7_OK ) goto out;
 		if( iVal < 0 || iVal > 2 ){
 			rc = PH7_VmThrowException(pCtx,
@@ -3989,11 +4000,15 @@ static int PH7_builtin_str_repeat(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	}
 	/* Extract the target string */
 	zIn = ph7_value_to_string(apArg[0],&nLen);
-	/* Extract the multiplier as a 64-bit value (a 32-bit read would wrap a large
-	 * positive $times into a negative one and trip a spurious ValueError). PHP
-	 * validates $times regardless of the string contents: a negative count throws
-	 * a catchable ValueError. */
-	nMul = ph7_value_to_int64(apArg[1]);
+	/* Resolve $times through the shared ZPP helper so a lossy float / float-string
+	 * carries php's precision deprecation and NAN/INF/non-numeric fail with php's
+	 * TypeError — a bare ph7_value_to_int64() coerced them silently. */
+	{
+		sxi32 rcArg = PH7_IntArgResolve(pCtx,apArg[1],"str_repeat",2,"$times","int",&nMul);
+		if( rcArg != PH7_OK ){
+			return rcArg;
+		}
+	}
 	if( nMul < 0 ){
 		return PH7_VmThrowException(pCtx,"ValueError",
 			"str_repeat(): Argument #2 ($times) must be greater than or equal to 0");
@@ -7894,7 +7909,14 @@ static int PH7_builtin_str_pad(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	/* Extract the target string */
 	zIn = ph7_value_to_string(apArg[0],&iLen);
 	/* Padding length */
-	iRealPad = iPadlen = ph7_value_to_int(apArg[1]);
+	{
+		sxi64 iTmp = 0;
+		sxi32 rcArg = PH7_IntArgResolve(pCtx,apArg[1],"str_pad",2,"$length","int",&iTmp);
+		if( rcArg != PH7_OK ){
+			return rcArg;
+		}
+		iRealPad = iPadlen = (int)iTmp;
+	}
 	if( iPadlen > 0 ){
 		iPadlen -= iLen;
 	}

--- a/src/ph7/builtin_math.c
+++ b/src/ph7/builtin_math.c
@@ -1013,8 +1013,19 @@ PH7_PRIVATE int PH7_builtin_intdiv(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		}
 	}
 	/* Convert both arguments to int64 */
-	a = ph7_value_to_int64(apArg[0]);
-	b = ph7_value_to_int64(apArg[1]);
+	{
+		/* php's ZPP contract for the two int params (lossy float / float-string
+		 * deprecations); the manual type checks above already covered arrays,
+		 * objects and non-numeric strings with the same messages. */
+		sxi32 rcArg = PH7_IntArgResolve(pCtx,apArg[0],"intdiv",1,"$num1","int",&a);
+		if( rcArg != PH7_OK ){
+			return rcArg;
+		}
+		rcArg = PH7_IntArgResolve(pCtx,apArg[1],"intdiv",2,"$num2","int",&b);
+		if( rcArg != PH7_OK ){
+			return rcArg;
+		}
+	}
 	/* Check for division by zero */
 	if( b == 0 ){
 		return PH7_VmThrowException(pCtx,

--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -4524,7 +4524,14 @@ static int ph7_hashmap_slice(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	pSrc = (ph7_hashmap *)apArg[0]->x.pOther;
 	bPreserve = FALSE;
 	/* Get the offset */
-	iOfft = ph7_value_to_int(apArg[1]);
+	{
+		sxi64 iTmp = 0;
+		sxi32 rcArg = PH7_IntArgResolve(pCtx,apArg[1],"array_slice",2,"$offset","int",&iTmp);
+		if( rcArg != PH7_OK ){
+			return rcArg;
+		}
+		iOfft = (int)iTmp;
+	}
 	if( iOfft < 0 ){
 		iOfft = (int)pSrc->nEntry + iOfft;
 		if( iOfft < 0 ){

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -2241,6 +2241,12 @@ PH7_PRIVATE int PH7_builtin_mktime(ph7_context *pCtx,int nArg,ph7_value **apArg)
 PH7_PRIVATE int PH7_builtin_date_default_timezone_get(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE int PH7_builtin_date_default_timezone_set(ph7_context *pCtx,int nArg,ph7_value **apArg);
 /* builtin_mb.c (UTF-8-only mb_* family) */
+/* Shared ZPP helper: resolve an `int`-typed parameter with php's full contract
+ * (null deprecation, lossy float / float-string deprecations, TypeErrors for
+ * NAN/INF/non-numeric). Builtins with int params should use it instead of a
+ * bare ph7_value_to_int64(), which coerces silently. */
+PH7_PRIVATE sxi32 PH7_IntArgResolve(ph7_context *pCtx,ph7_value *pArg,const char *zFunc,
+	int iArgNum,const char *zParamName,const char *zTypeStr,sxi64 *pOut);
 PH7_PRIVATE int PH7_builtin_mb_strlen_f(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE int PH7_builtin_mb_substr_f(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE int PH7_builtin_mb_case_f(ph7_context *pCtx,int nArg,ph7_value **apArg);

--- a/tests/ph7/002-integration/function/zpp/int_param_float_coercion.phpt
+++ b/tests/ph7/002-integration/function/zpp/int_param_float_coercion.phpt
@@ -1,0 +1,42 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: builtin int parameters deprecate a lossy float (ZPP contract)
+--SKIPIF--
+skip: flaky
+--FILE--
+<?php
+// a fractional float truncates, carrying php's precision deprecation
+echo str_repeat('x', 2.7), "\n";
+echo intdiv(7.9, 2), "\n";
+echo substr('abcdef', 1.5), "\n";
+echo str_pad('x', 3.5), "\n";
+$a = [1, 2, 3];
+echo array_slice($a, 1.5)[0], "\n";
+// a float-STRING carries php's distinct float-string wording
+echo str_repeat('y', '2.5'), "\n";
+// an INTEGRAL float loses nothing, so it stays silent
+echo str_repeat('z', 3.0), "\n";
+echo substr('abcdef', 2.0), "\n";
+echo intdiv(7, 2), "\n";
+?>
+--EXPECTF--
+%AImplicit conversion from float 2.7 to int loses precision%A
+xx
+%AImplicit conversion from float 7.9 to int loses precision%A
+3
+%AImplicit conversion from float 1.5 to int loses precision%A
+bcdef
+%AImplicit conversion from float 3.5 to int loses precision%A
+x  
+%AImplicit conversion from float 1.5 to int loses precision%A
+2
+%AImplicit conversion from float-string "2.5" to int loses precision%A
+yy
+zzz
+cdef
+3
+--CLEAN--
+<?php
+unset($a);


### PR DESCRIPTION
str_repeat, intdiv, substr, str_pad and array_slice coerced a float argument with a bare ph7_value_to_int, truncating in silence where php deprecates the lossy conversion.

builtin.c already had the right abstraction: IntArgResolve implements php's full contract for an int parameter — the null deprecation, the lossy float and float-string deprecations, and TypeErrors for NAN, INF and non-numeric strings. Export it and have those five adopt it. An earlier attempt to check floats centrally at the call site, driven by a signature-derived bitmask, is not in this commit: it double-fired for the builtins already using the helper and still missed float-strings for the rest. The helper is the right altitude, not the call site.

The helper moves outside the disable-builtins guard because hashmap.c and builtin_math.c call it and both compile in the tiny build.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
