### PR TITLE
Emit php's parse errors; fix goto/label rules

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -39,6 +39,7 @@ struct Label
 	sxu32 nJumpDest;     /* Jump destination */
 	SyString sName;      /* Label name */
 	sxu32 nLine;         /* Line number this label occurs */
+	sxu32 nLoopId;       /* Innermost loop/switch enclosing this label (0 = none) */
 	sxu8 bRef;           /* True if the label was referenced */
 };
 /*
@@ -57,6 +58,7 @@ struct JumpFixup
 	SyString sLabel;    /* Label name */
 	ph7_vm_func *pFunc; /* Compiled function inside which the goto was emitted. NULL otherwise */
 	sxu32 nLine;        /* Track line number */
+	sxu32 nLoopId;      /* Innermost loop/switch enclosing this goto (0 = none) */
 };
 /*
  * Each language construct is represented by an instance
@@ -205,6 +207,16 @@ static sxi32 GenStateEnterBlock(
 	GenStateInitBlock(&(*pGen),pBlock,iType,nFirstInstr,pUserData);
 	/* Link to the parent block */
 	pBlock->pParent = pGen->pCurrent;
+	/* A loop or switch gets an id, and remembers the loop it nests inside, so a goto's
+	 * and a label's positions can be compared after compilation (see aLoopParent). */
+	if( iType & (GEN_BLOCK_LOOP|GEN_BLOCK_SWITCH) ){
+		sxu32 nParent = pGen->nCurLoopId;
+		pGen->nLoopId++;
+		SySetPut(&pGen->aLoopParent,(const void *)&nParent);
+		pBlock->nLoopId = pGen->nLoopId;
+		pBlock->nOuterLoopId = nParent;
+		pGen->nCurLoopId = pGen->nLoopId;
+	}
 	/* Mark as the current block */
 	pGen->pCurrent = pBlock;
 	if( ppBlock ){
@@ -240,6 +252,9 @@ static sxi32 GenStateLeaveBlock(ph7_gen_state *pGen,GenBlock **ppBlock)
 	if( pBlock == 0 ){
 		/* No more block to pop */
 		return SXERR_EMPTY;
+	}
+	if( pBlock->iFlags & (GEN_BLOCK_LOOP|GEN_BLOCK_SWITCH) ){
+		pGen->nCurLoopId = pBlock->nOuterLoopId;
 	}
 	/* Point to the upper block */
 	pGen->pCurrent = pBlock->pParent;
@@ -324,7 +339,7 @@ static sxu32 GenStateFixJumps(GenBlock *pBlock,sxi32 nJumpType,sxu32 nJumpDest)
 static sxi32 GenStateFixGoto(ph7_gen_state *pGen,sxu32 nOfft)
 {
 	JumpFixup *pJump,*aJumps;
-	Label *pLabel,*aLabel;
+	Label *pLabel;
 	VmInstr *pInstr;
 	sxi32 rc;
 	sxu32 n;
@@ -337,15 +352,39 @@ static sxi32 GenStateFixGoto(ph7_gen_state *pGen,sxu32 nOfft)
 		rc = GenStateGetLabel(&(*pGen),&pJump->sLabel,&pLabel);
 		if( rc != SXRET_OK ){
 			/* No such label */
-			rc = PH7_GenCompileError(&(*pGen),E_ERROR,pJump->nLine,"Label '%z' was referenced but not defined",&pJump->sLabel);
+			rc = PH7_GenCompileError(&(*pGen),E_ERROR,pJump->nLine,"'goto' to undefined label '%z'",&pJump->sLabel);
 			if( rc == SXERR_ABORT ){
 				return SXERR_ABORT;
 			}
 			continue;
 		}
+		/* php's one goto restriction: you may not jump INTO a loop or a switch. The label
+		 * is inside one exactly when it carries a loop id; that is legal only if the same
+		 * loop also encloses the goto, i.e. the label's loop is the goto's loop or one of
+		 * its ancestors. Walk up from the goto's loop looking for the label's. */
+		if( pLabel->nLoopId != 0 ){
+			sxu32 *aParent = (sxu32 *)SySetBasePtr(&pGen->aLoopParent);
+			sxu32 nCur = pJump->nLoopId;
+			int bInside = 0;
+			while( nCur != 0 ){
+				if( nCur == pLabel->nLoopId ){
+					bInside = 1;
+					break;
+				}
+				nCur = (nCur <= SySetUsed(&pGen->aLoopParent)) ? aParent[nCur - 1] : 0;
+			}
+			if( !bInside ){
+				rc = PH7_GenCompileError(&(*pGen),E_ERROR,pJump->nLine,
+					"'goto' into loop or switch statement is disallowed");
+				if( rc == SXERR_ABORT ){
+					return SXERR_ABORT;
+				}
+				continue;
+			}
+		}
 		/* Make sure the target label is reachable */
 		if( pLabel->pFunc != pJump->pFunc ){
-			rc = PH7_GenCompileError(&(*pGen),E_ERROR,pJump->nLine,"Label '%z' is unreachable",&pJump->sLabel);
+			rc = PH7_GenCompileError(&(*pGen),E_ERROR,pJump->nLine,"'goto' to undefined label '%z'",&pJump->sLabel);
 			if( rc == SXERR_ABORT ){
 				return SXERR_ABORT;
 			}
@@ -356,14 +395,8 @@ static sxi32 GenStateFixGoto(ph7_gen_state *pGen,sxu32 nOfft)
 			pInstr->iP2 = pLabel->nJumpDest;
 		}
 	}
-	aLabel = (Label *)SySetBasePtr(&pGen->aLabel);
-	for( n = 0 ; n < SySetUsed(&pGen->aLabel) ; ++n ){
-		if( aLabel[n].bRef == FALSE ){
-			/* Emit a warning */
-			PH7_GenCompileError(&(*pGen),E_WARNING,aLabel[n].nLine,
-				"Label '%z' is defined but not referenced",&aLabel[n].sName);
-		}
-	}
+	/* php says nothing about a label nobody jumps to — the old "defined but not
+	 * referenced" warning was a PH7-ism with no counterpart in the oracle. */
 	return SXRET_OK;
 }
 /*
@@ -1562,16 +1595,14 @@ static sxi32 GenStateArrayNodeValidator(ph7_gen_state *pGen,ph7_expr_node *pRoot
 			pRoot->pOp->iOp != EXPR_OP_FUNC_CALL /* function() [Symisc extension: i.e: array(&foo())] */
 			&& pRoot->pOp->iOp != EXPR_OP_ARROW /* -> */ && pRoot->pOp->iOp != EXPR_OP_DC /* :: */){
 			/* Unexpected expression */
-			rc = PH7_GenCompileError(&(*pGen),E_ERROR,pRoot->pStart? pRoot->pStart->nLine : 0,
-				"array(): Expecting a variable/array member/function call after reference operator '&'");
+			rc = PH7_GenSyntaxError(&(*pGen),pRoot->pStart,"\"->\" or \"?->\" or \"[\"");
 			if( rc != SXERR_ABORT ){
 				rc = SXERR_INVALID;
 			}
 		}
 	}else if( pRoot->xCode != PH7_CompileVariable ){
 		/* Unexpected expression */
-		rc = PH7_GenCompileError(&(*pGen),E_ERROR,pRoot->pStart? pRoot->pStart->nLine : 0,
-			"array(): Expecting a variable after reference operator '&'");
+		rc = PH7_GenSyntaxError(&(*pGen),pRoot->pStart,0);
 		if( rc != SXERR_ABORT ){
 			rc = SXERR_INVALID;
 		}
@@ -1703,7 +1734,7 @@ static sxi32 GenStateCompileArrayBody(ph7_gen_state *pGen)
 		if( pCur < pGen->pIn ){
 			if( &pCur[1] >= pGen->pIn ){
 				/* Missing value */
-				rc = PH7_GenCompileError(&(*pGen),E_ERROR,pCur->nLine,"array(): Missing entry value");
+				rc = PH7_GenSyntaxError(&(*pGen),pCur,0);
 				if( rc == SXERR_ABORT ){
 					return SXERR_ABORT;
 				}
@@ -1927,7 +1958,7 @@ static sxi32 GenStateListNodeValidator(ph7_gen_state *pGen,ph7_expr_node *pRoot)
 			&& pRoot->pOp->iOp != EXPR_OP_DC /* :: */ ){
 				/* Unexpected expression */
 				rc = PH7_GenCompileError(&(*pGen),E_ERROR,pRoot->pStart? pRoot->pStart->nLine : 0,
-					"list(): Expecting a variable not an expression");
+					"Assignments can only happen to writable values");
 				if( rc != SXERR_ABORT ){
 					rc = SXERR_INVALID;
 				}
@@ -1935,7 +1966,7 @@ static sxi32 GenStateListNodeValidator(ph7_gen_state *pGen,ph7_expr_node *pRoot)
 	}else if( pRoot->xCode != PH7_CompileVariable ){
 		/* Unexpected expression */
 		rc = PH7_GenCompileError(&(*pGen),E_ERROR,pRoot->pStart? pRoot->pStart->nLine : 0,
-			"list(): Expecting a variable not an expression");
+			"Assignments can only happen to writable values");
 		if( rc != SXERR_ABORT ){
 			rc = SXERR_INVALID;
 		}
@@ -3204,7 +3235,7 @@ PH7_PRIVATE sxi32 PH7_CompileVariable(ph7_gen_state *pGen,sxi32 iCompileFlag)
 	}
 	if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & (PH7_TK_ID|PH7_TK_KEYWORD|PH7_TK_OCB/*'{'*/)) == 0 ){
 		/* Invalid variable name */
-		rc = PH7_GenCompileError(pGen,E_ERROR,nLineLocal,"Invalid variable name");
+		rc = PH7_GenSyntaxError(pGen,pGen->pIn < pGen->pEnd ? pGen->pIn : 0,"variable or \"{\" or \"$\"");
 		if( rc == SXERR_ABORT ){
 			/* Error count limit reached,abort immediately */
 			return SXERR_ABORT;
@@ -3218,7 +3249,13 @@ PH7_PRIVATE sxi32 PH7_CompileVariable(ph7_gen_state *pGen,sxi32 iCompileFlag)
 		pGen->pEnd--; /* Ignore the trailing curly */
 		if( pGen->pIn >= pGen->pEnd ){
 			/* Empty expression */
-			PH7_GenCompileError(&(*pGen),E_ERROR,nLineLocal,"Invalid variable name");
+			{
+			/* php names the offending token and, for an empty "${}", stops there:
+			 * the "expecting" tail only appears when something could still follow. */
+			SyToken *pBad = pGen->pIn < pGen->pEnd ? pGen->pIn : 0;
+			PH7_GenSyntaxError(&(*pGen),pBad,
+				(pBad && (pBad->nType & PH7_TK_CCB)) ? 0 : "variable or \"{\" or \"$\"");
+			}
 			return SXRET_OK;
 		}
 		/* Compile the expression holding the variable name */
@@ -3226,7 +3263,7 @@ PH7_PRIVATE sxi32 PH7_CompileVariable(ph7_gen_state *pGen,sxi32 iCompileFlag)
 		if( rc == SXERR_ABORT ){
 			return SXERR_ABORT;
 		}else if( rc == SXERR_EMPTY ){
-			PH7_GenCompileError(&(*pGen),E_ERROR,nLineLocal,"Missing variable name");
+			PH7_GenSyntaxError(&(*pGen),pGen->pIn < pGen->pEnd ? pGen->pIn : 0,0);
 			return SXRET_OK;
 		}
 	}else{
@@ -3534,7 +3571,7 @@ static sxi32 PH7_CompileConstant(ph7_gen_state *pGen)
 	pGen->pIn++; /* Jump the 'const' keyword */
 	if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & (PH7_TK_SSTR|PH7_TK_DSTR|PH7_TK_ID|PH7_TK_KEYWORD)) == 0 ){
 		/* Invalid constant name */
-		rc = PH7_GenCompileError(pGen,E_ERROR,nLineLocal,"const: Invalid constant name");
+		rc = PH7_GenSyntaxError(pGen,pGen->pIn < pGen->pEnd ? pGen->pIn : 0,"identifier");
 		if( rc == SXERR_ABORT ){
 			/* Error count limit reached,abort immediately */
 			return SXERR_ABORT;
@@ -3546,7 +3583,7 @@ static sxi32 PH7_CompileConstant(ph7_gen_state *pGen)
 	/* Make sure the constant name isn't reserved */
 	if( GenStateIsReservedConstant(pName) ){
 		/* Reserved constant */
-		rc = PH7_GenCompileError(pGen,E_ERROR,nLineLocal,"const: Cannot redeclare a reserved constant '%z'",pName);
+		rc = PH7_GenCompileError(pGen,E_ERROR,nLineLocal,"Cannot redeclare constant '%z'",pName);
 		if( rc == SXERR_ABORT ){
 			/* Error count limit reached,abort immediately */
 			return SXERR_ABORT;
@@ -3556,7 +3593,7 @@ static sxi32 PH7_CompileConstant(ph7_gen_state *pGen)
 	pGen->pIn++;
 	if(pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_EQUAL /* '=' */) == 0 ){
 		/* Invalid statement*/
-		rc = PH7_GenCompileError(pGen,E_ERROR,nLineLocal,"const: Expected '=' after constant name");
+		rc = PH7_GenSyntaxError(pGen,pGen->pIn < pGen->pEnd ? pGen->pIn : 0,"\"=\"");
 		if( rc == SXERR_ABORT ){
 			/* Error count limit reached,abort immediately */
 			return SXERR_ABORT;
@@ -3707,7 +3744,7 @@ static sxi32 PH7_CompileContinue(ph7_gen_state *pGen)
 	pLoop = GenStateFetchBlock(pGen->pCurrent,GEN_BLOCK_LOOP,iLevel);
 	if( pLoop == 0 ){
 		/* Illegal continue */
-		rc = PH7_GenCompileError(pGen,E_ERROR,nLineLocal,"A 'continue' statement may only be used within a loop or switch");
+		rc = PH7_GenCompileError(pGen,E_ERROR,nLineLocal,"'continue' not in the 'loop' or 'switch' context");
 		if( rc == SXERR_ABORT ){
 			/* Error count limit reached,abort immediately */
 			return SXERR_ABORT;
@@ -3793,7 +3830,7 @@ static sxi32 PH7_CompileBreak(ph7_gen_state *pGen)
 	pLoop = GenStateFetchBlock(pGen->pCurrent,GEN_BLOCK_LOOP,iLevel);
 	if( pLoop == 0 ){
 		/* Illegal break */
-		rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,"A 'break' statement may only be used within a loop or switch");
+		rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,"'break' not in the 'loop' or 'switch' context");
 		if( rc == SXERR_ABORT ){
 			/* Error count limit reached,abort immediately */
 			return SXERR_ABORT;
@@ -3829,16 +3866,11 @@ static sxi32 PH7_CompileLabel(ph7_gen_state *pGen)
 {
 	GenBlock *pBlock;
 	Label sLabel;
-	/* Make sure the label does not occur inside a loop or a try{}catch(); block */
-	pBlock = GenStateFetchBlock(pGen->pCurrent,GEN_BLOCK_LOOP|GEN_BLOCK_EXCEPTION,0);
-	if( pBlock ){
-		sxi32 rc;
-		rc = PH7_GenCompileError(&(*pGen),E_ERROR,pGen->pIn->nLine,
-			"Label '%z' inside loop or try/catch block is disallowed",&pGen->pIn->sData);
-		if( rc == SXERR_ABORT ){
-			return SXERR_ABORT;
-		}
-	}else{
+	/* php places NO restriction on where a label may be DEFINED — inside a loop, a switch
+	 * or a try{} is all fine. The only rule is on the jump: you may not goto INTO a loop
+	 * or switch from outside it, which is checked once the labels are all known (see
+	 * GenStateFixJumps). Record the loop this label sits in so that check can run. */
+	{
 		SyString *pTarget = &pGen->pIn->sData;
 		char *zDup;
 		/* Initialize label fields */
@@ -3852,6 +3884,7 @@ static sxi32 PH7_CompileLabel(ph7_gen_state *pGen)
 		SyStringInitFromBuf(&sLabel.sName,zDup,pTarget->nByte);
 		sLabel.bRef  = FALSE;
 		sLabel.nLine = pGen->pIn->nLine;
+		sLabel.nLoopId = pGen->nCurLoopId;
 		pBlock = pGen->pCurrent;
 		while( pBlock ){
 			if( pBlock->iFlags & (GEN_BLOCK_FUNC|GEN_BLOCK_EXCEPTION) ){
@@ -3900,7 +3933,7 @@ static sxi32 PH7_CompileGoto(ph7_gen_state *pGen)
 		return SXRET_OK;
 	}
 	if( (pGen->pIn->nType & (PH7_TK_KEYWORD|PH7_TK_ID)) == 0 ){
-		rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,"goto: Invalid label name: '%z'",&pGen->pIn->sData);
+		rc = PH7_GenSyntaxError(pGen,pGen->pIn,"identifier");
 		if( rc == SXERR_ABORT ){
 			/* Error count limit reached,abort immediately */
 			return SXERR_ABORT;
@@ -3919,20 +3952,17 @@ static sxi32 PH7_CompileGoto(ph7_gen_state *pGen)
 			return SXERR_ABORT;
 		}
 		SyStringInitFromBuf(&sJump.sLabel,zDup,pTarget->nByte);
+		/* The loop/switch this goto sits in, for the "goto into a loop" check later. */
+		sJump.nLoopId = pGen->nCurLoopId;
+		/* A goto inside a try{}/catch{} is legal php (jumping OUT of the block is fine);
+		 * only the owning function matters here, since a goto may not cross functions. */
 		pBlock = pGen->pCurrent;
 		while( pBlock ){
-			if( pBlock->iFlags & (GEN_BLOCK_FUNC|GEN_BLOCK_EXCEPTION) ){
+			if( pBlock->iFlags & GEN_BLOCK_FUNC ){
 				break;
 			}
 			/* Point to the upper block */
 			pBlock = pBlock->pParent;
-		}
-		if( pBlock && pBlock->iFlags & GEN_BLOCK_EXCEPTION ){
-			rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,"goto inside try/catch block is disallowed");
-			if( rc == SXERR_ABORT ){
-				/* Error count limit reached,abort immediately */
-				return SXERR_ABORT;
-			}
 		}
 		if( pBlock && (pBlock->iFlags & GEN_BLOCK_FUNC)){
 			sJump.pFunc = (ph7_vm_func *)pBlock->pUserData;
@@ -4048,8 +4078,9 @@ static sxi32 PH7_CompileBlock(
 			 	   return SXERR_ABORT;
 				}
 				if( rc == SXERR_EOF ){
-					/* No more token to process. Missing closing braces */
-					PH7_GenCompileError(&(*pGen),E_ERROR,nLine,"Missing closing braces '}'");
+					/* No more token to process: the block was never closed. php reports
+					 * the line the '{' was opened on, not where the input ran out. */
+					PH7_GenCompileError(&(*pGen),E_PARSE,nLine,"Unclosed '{' on line %u",nLine);
 					break;
 				}
 			}
@@ -4186,7 +4217,7 @@ static sxi32 PH7_CompileWhile(ph7_gen_state *pGen)
 	}
 	/* Update token stream */
 	while(pGen->pIn < pEnd ){
-		rc = PH7_GenCompileError(&(*pGen),E_ERROR,pGen->pIn->nLine,"Unexpected token '%z'",&pGen->pIn->sData);
+		rc = PH7_GenSyntaxError(&(*pGen),pGen->pIn,0);
 		if( rc == SXERR_ABORT ){
 			return SXERR_ABORT;
 		}
@@ -4323,7 +4354,7 @@ static sxi32 PH7_CompileDoWhile(ph7_gen_state *pGen)
 	}
 	/* Update token stream */
 	while(pGen->pIn < pEnd ){
-		rc = PH7_GenCompileError(&(*pGen),E_ERROR,pGen->pIn->nLine,"Unexpected token '%z'",&pGen->pIn->sData);
+		rc = PH7_GenSyntaxError(&(*pGen),pGen->pIn,0);
 		if( rc == SXERR_ABORT ){
 			return SXERR_ABORT;
 		}
@@ -4424,8 +4455,7 @@ static sxi32 PH7_CompileFor(ph7_gen_state *pGen)
 	}
 	if( (pGen->pIn->nType & PH7_TK_SEMI) == 0 ){
 		/* Syntax error */
-		rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,
-			"for: Expected ';' after initialization expressions");
+		rc = PH7_GenSyntaxError(pGen,pGen->pIn < pGen->pEnd ? pGen->pIn : 0,"\";\"");
 		if( rc == SXERR_ABORT ){
 			/* Error count limit reached,abort immediately */
 			return SXERR_ABORT;
@@ -4454,8 +4484,7 @@ static sxi32 PH7_CompileFor(ph7_gen_state *pGen)
 	}
 	if( (pGen->pIn->nType & PH7_TK_SEMI) == 0 ){
 		/* Syntax error */
-		rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,
-			"for: Expected ';' after conditionals expressions");
+		rc = PH7_GenSyntaxError(pGen,pGen->pIn < pGen->pEnd ? pGen->pIn : 0,"\";\"");
 		if( rc == SXERR_ABORT ){
 			/* Error count limit reached,abort immediately */
 			return SXERR_ABORT;
@@ -4947,7 +4976,7 @@ static sxi32 PH7_CompileIf(ph7_gen_state *pGen)
 		rc = PH7_CompileExpr(&(*pGen),0,0);
 		/* Update token stream */
 		while(pGen->pIn < pEnd ){
-			PH7_GenCompileError(&(*pGen),E_ERROR,pGen->pIn->nLine,"Unexpected token '%z'",&pGen->pIn->sData);
+			PH7_GenSyntaxError(&(*pGen),pGen->pIn,0);
 			pGen->pIn++;
 		}
 		pGen->pIn  = &pEnd[1];
@@ -5897,7 +5926,7 @@ static sxi32 PH7_CompileDeclare(ph7_gen_state *pGen)
 	sxi32 rc;
 	pGen->pIn++; /* Jump the 'declare' keyword */
 	if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_LPAREN) == 0 /*'('*/ ){
-		rc = PH7_GenCompileError(pGen,E_ERROR,nLine,"declare: Expecting opening parenthesis '('");
+		rc = PH7_GenSyntaxError(pGen,pGen->pIn < pGen->pEnd ? pGen->pIn : 0,"\"(\"");
 		if( rc == SXERR_ABORT ){
 			return SXERR_ABORT;
 		}
@@ -7475,7 +7504,8 @@ static sxi32 GenStateCompileFunc(
 	PH7_DelimitNestedTokens(pGen->pIn,pGen->pEnd,PH7_TK_LPAREN /* '(' */,PH7_TK_RPAREN /* ')' */,&pEnd);
 	if( pEnd >= pGen->pEnd ){
 		/* Syntax error */
-		rc = PH7_GenCompileError(pGen,E_ERROR,nLine,"Missing ')' after function '%z' signature",pName);
+		rc = PH7_GenSyntaxError(pGen,pGen->pIn < pGen->pEnd ? pGen->pIn : 0,"variable");
+		(void)pName;
 		if( rc == SXERR_ABORT ){
 			/* Error count limit reached,abort immediately */
 			return SXERR_ABORT;
@@ -7694,7 +7724,7 @@ static sxi32 PH7_CompileFunction(ph7_gen_state *pGen)
 	}
 	if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & (PH7_TK_ID|PH7_TK_KEYWORD)) == 0 ){
 		/* Invalid function name */
-		rc = PH7_GenCompileError(&(*pGen),E_ERROR,nLine,"Invalid function name");
+		rc = PH7_GenSyntaxError(&(*pGen),pGen->pIn < pGen->pEnd ? pGen->pIn : 0,"\"(\"");
 		if( rc == SXERR_ABORT ){
 			return SXERR_ABORT;
 		}
@@ -7710,7 +7740,7 @@ static sxi32 PH7_CompileFunction(ph7_gen_state *pGen)
 	pGen->pIn++;
 	if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_LPAREN) == 0 ){
 		/* Syntax error */
-		rc = PH7_GenCompileError(pGen,E_ERROR,nLine,"Expected '(' after function name '%z'",pName);
+		rc = PH7_GenSyntaxError(pGen,pGen->pIn < pGen->pEnd ? pGen->pIn : 0,"\"(\"");
 		if( rc == SXERR_ABORT ){
 			/* Error count limit reached,abort immediately */
 			return SXERR_ABORT;
@@ -12484,7 +12514,7 @@ static sxi32 GenStateCompileSwitchBlock(ph7_gen_state *pGen,sxu32 iTokenDelim,sx
 	sxi32 rc = SXRET_OK;
 	while( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & (PH7_TK_SEMI/*';'*/|PH7_TK_COLON/*':'*/)) == 0 ){
 		/* Unexpected token */
-		rc = PH7_GenCompileError(&(*pGen),E_ERROR,pGen->pIn->nLine,"Unexpected token '%z'",&pGen->pIn->sData);
+		rc = PH7_GenSyntaxError(&(*pGen),pGen->pIn,0);
 		if( rc == SXERR_ABORT ){
 			return SXERR_ABORT;
 		}
@@ -14634,6 +14664,8 @@ PH7_PRIVATE sxi32 PH7_InitCodeGenerator(
 	pGen->pErrData = pErrData;
 	SySetInit(&pGen->aLabel,&pVm->sAllocator,sizeof(Label));
 	SySetInit(&pGen->aGoto,&pVm->sAllocator,sizeof(JumpFixup));
+	SySetInit(&pGen->aLoopParent,&pVm->sAllocator,sizeof(sxu32));
+	pGen->nLoopId = pGen->nCurLoopId = 0;
 	SySetInit(&pGen->aNullsafeJmp,&pVm->sAllocator,sizeof(sxu32));
 	SySetInit(&pGen->aTrivia,&pVm->sAllocator,sizeof(ph7_trivia));
 	SySetInit(&pGen->aPendingAttrs,&pVm->sAllocator,sizeof(ph7_trivia));
@@ -14704,6 +14736,66 @@ PH7_PRIVATE sxi32 PH7_ResetCodeGenerator(
 	return SXRET_OK;
 }
 /*
+ * Raise php's parse error for an unexpected token: E_PARSE with the exact text
+ * php's parser prints, e.g.
+ *
+ *   syntax error, unexpected token ";", expecting "{"
+ *   syntax error, unexpected identifier "invalid", expecting "("
+ *   syntax error, unexpected end of file
+ *
+ * php names the token by CLASS, not just by text: an identifier, a variable and
+ * a number each get their own noun, while everything else (keywords, operators,
+ * punctuation) is a "token". zExpecting is the optional ", expecting ..." tail
+ * — pass NULL when the site cannot say what it wanted (php often can't either).
+ * pTok == NULL means the input ran out: "unexpected end of file".
+ *
+ * PHL's hand-written recursive-descent parser has no bison expectation sets, so
+ * a site can only claim an "expecting" clause it genuinely knows; every clause
+ * emitted here was verified against php 8.5.7 for the construct in question.
+ */
+PH7_PRIVATE sxi32 PH7_GenSyntaxError(
+	ph7_gen_state *pGen,   /* Code generator state */
+	SyToken *pTok,         /* Offending token, or NULL for end of file */
+	const char *zExpecting /* ", expecting <this>" tail, or NULL */
+	)
+{
+	const char *zNoun = "token";
+	sxu32 nLine;
+	if( pTok == 0 && pGen->pTokenSet ){
+		/* The caller ran out of tokens inside its own slice — but a statement's slice stops
+		 * BEFORE its terminator, so the token php actually names (typically the ';') is the
+		 * one sitting just past the slice, still inside the chunk's token stream. Reach for
+		 * it before concluding "end of file". */
+		SyToken *pBase = (SyToken *)SySetBasePtr(pGen->pTokenSet);
+		SyToken *pStreamEnd = &pBase[SySetUsed(pGen->pTokenSet)];
+		if( pGen->pEnd >= pBase && pGen->pEnd < pStreamEnd ){
+			pTok = pGen->pEnd;
+		}
+	}
+	nLine = pTok ? pTok->nLine : (pGen->pIn > (SyToken *)SySetBasePtr(pGen->pTokenSet) ? pGen->pIn[-1].nLine : 1);
+	if( pTok == 0 ){
+		return PH7_GenCompileError(pGen,E_PARSE,nLine,
+			zExpecting ? "syntax error, unexpected end of file, expecting %s"
+			           : "syntax error, unexpected end of file",
+			zExpecting);
+	}
+	if( pTok->nType & PH7_TK_ID ){
+		zNoun = "identifier";
+	}else if( pTok->nType & PH7_TK_DOLLAR ){
+		zNoun = "variable";
+	}else if( pTok->nType & PH7_TK_INTEGER ){
+		zNoun = "integer";
+	}else if( pTok->nType & PH7_TK_REAL ){
+		zNoun = "float";
+	}
+	if( zExpecting ){
+		return PH7_GenCompileError(pGen,E_PARSE,nLine,
+			"syntax error, unexpected %s \"%z\", expecting %s",zNoun,&pTok->sData,zExpecting);
+	}
+	return PH7_GenCompileError(pGen,E_PARSE,nLine,
+		"syntax error, unexpected %s \"%z\"",zNoun,&pTok->sData);
+}
+/*
  * Generate a compile-time error message.
  * If the error count limit is reached (usually 15 error message)
  * this function return SXERR_ABORT.In that case upper-layers must
@@ -14720,8 +14812,11 @@ PH7_PRIVATE sxi32 PH7_GenCompileError(ph7_gen_state *pGen,sxi32 nErrType,sxu32 n
 	SyBlobReset(pWorker);
 	/* Peek the processed file path if available */
 	pFile = (SyString *)SySetPeek(&pGen->pVm->aFiles);
-	if( nErrType == E_ERROR ){
-		/* Increment the error counter */
+	if( nErrType == E_ERROR || nErrType == E_PARSE ){
+		/* Increment the error counter. A PARSE error is every bit as fatal as an
+		 * E_ERROR one: php compiles nothing, runs nothing and exits 255. Counting
+		 * only E_ERROR let a parse error print its diagnostic and then fall through
+		 * into execution with a 0 exit status. */
 		pGen->nErr++;
 		if( pGen->nErr > 15 ){
 			/* Error count limit reached */

--- a/src/ph7/oo.c
+++ b/src/ph7/oo.c
@@ -525,10 +525,11 @@ PH7_PRIVATE sxi32 PH7_ClassInherit(ph7_gen_state *pGen,ph7_class *pSub,ph7_class
 		pName = &pMeth->sFunc.sName;
 		if( (pEntry = SyHashGet(&pSub->hMethod,(const void *)pName->zString,pName->nByte)) != 0 ){
 			 if( pMeth->iFlags & PH7_CLASS_ATTR_FINAL ){
-				/* Cannot Overwrite final method */
+				/* php: "Cannot override final method A::test()" */
 				rc = PH7_GenCompileError(&(*pGen),E_ERROR,((ph7_class_method *)pEntry->pUserData)->nLine,
-					"Cannot Overwrite final method '%z:%z' inside child class '%z'",
-					&pBase->sName,pName,&pSub->sName);
+					"Cannot override final method %z::%z()",
+					&pBase->sName,pName);
+				(void)pSub;
 				if( rc == SXERR_ABORT ){
 					return SXERR_ABORT;
 				}

--- a/src/ph7/parse.c
+++ b/src/ph7/parse.c
@@ -403,7 +403,7 @@ static sxi32 ExprVerifyNodes(ph7_gen_state *pGen,ph7_expr_node **apNode,sxi32 nN
 			iParen++;
 		}else if( apNode[i]->pStart->nType & PH7_TK_RPAREN/*')*/){
 			if( iParen <= 0 ){
-				rc = PH7_GenCompileError(&(*pGen),E_ERROR,apNode[i]->pStart->nLine,"Syntax error: Unexpected token ')'");
+				rc = PH7_GenCompileError(&(*pGen),E_PARSE,apNode[i]->pStart->nLine,"Unmatched ')'");
 				if( rc != SXERR_ABORT ){
 					rc = SXERR_SYNTAX;
 				}
@@ -414,7 +414,7 @@ static sxi32 ExprVerifyNodes(ph7_gen_state *pGen,ph7_expr_node **apNode,sxi32 nN
 			iSquare++;
 		}else if (apNode[i]->pStart->nType & PH7_TK_CSB /*']'*/){
 			if( iSquare <= 0 ){
-				rc = PH7_GenCompileError(&(*pGen),E_ERROR,apNode[i]->pStart->nLine,"Syntax error: Unexpected token ']'");
+				rc = PH7_GenCompileError(&(*pGen),E_PARSE,apNode[i]->pStart->nLine,"Unmatched ']'");
 				if( rc != SXERR_ABORT ){
 					rc = SXERR_SYNTAX;
 				}
@@ -470,7 +470,7 @@ static sxi32 ExprVerifyNodes(ph7_gen_state *pGen,ph7_expr_node **apNode,sxi32 nN
 			}
 		}else if (apNode[i]->pStart->nType & PH7_TK_CCB /*'}'*/){
 			if( iBraces <= 0 ){
-				rc = PH7_GenCompileError(&(*pGen),E_ERROR,apNode[i]->pStart->nLine,"Syntax error: Unexpected token '}'");
+				rc = PH7_GenCompileError(&(*pGen),E_PARSE,apNode[i]->pStart->nLine,"Unmatched '}'");
 				if( rc != SXERR_ABORT ){
 					rc = SXERR_SYNTAX;
 				}
@@ -517,7 +517,7 @@ static sxi32 ExprVerifyNodes(ph7_gen_state *pGen,ph7_expr_node **apNode,sxi32 nN
 		}
 	}
 	if( iParen != 0 || iSquare != 0 || iQuesty != 0 || iBraces != 0){
-		rc = PH7_GenCompileError(&(*pGen),E_ERROR,apNode[0]->pStart->nLine,"Syntax error,mismatched '(','[','{' or '?'");
+		rc = PH7_GenSyntaxError(&(*pGen),0,0);
 		if( rc != SXERR_ABORT ){
 			rc = SXERR_SYNTAX;
 		}
@@ -639,17 +639,20 @@ static void ExprSkipReturnType(SyToken **ppIn,SyToken *pEnd)
 static sxi32 ExprAssembleAnnon(ph7_gen_state *pGen,SyToken **ppCur,SyToken *pEnd)
 {
 	SyToken *pIn = *ppCur;
-	sxu32 nLine;
 	sxi32 rc;
-	/* Jump the 'function' keyword */
-	nLine = pIn->nLine;
+	/* Jump the leading keyword. The caller may hand us either `function (...)` or
+	 * `static function (...)`, so a 'function' keyword still sitting here belongs to
+	 * the static form and is jumped too. An IDENTIFIER, on the other hand, is not a
+	 * name to skip over — a closure is anonymous, so that is precisely the syntax
+	 * error php reports ("unexpected identifier, expecting \"(\"") . */
 	pIn++;
-	if( pIn < pEnd && (pIn->nType & (PH7_TK_ID|PH7_TK_KEYWORD)) ){
+	if( pIn < pEnd && (pIn->nType & PH7_TK_KEYWORD)
+		&& SX_PTR_TO_INT(pIn->pUserData) == PH7_TKWRD_FUNCTION ){
 		pIn++;
 	}
 	if( pIn >= pEnd || (pIn->nType & PH7_TK_LPAREN) == 0 ){
 		/* Syntax error */
-		rc = PH7_GenCompileError(&(*pGen),E_ERROR,nLine,"Missing opening parenthesis '(' while declaring annonymous function");
+		rc = PH7_GenSyntaxError(&(*pGen),pIn < pEnd ? pIn : 0,"\"(\"");
 		if( rc != SXERR_ABORT ){
 			rc = SXERR_SYNTAX;
 		}
@@ -658,8 +661,11 @@ static sxi32 ExprAssembleAnnon(ph7_gen_state *pGen,SyToken **ppCur,SyToken *pEnd
 	pIn++; /* Jump the leading parenthesis '(' */
 	PH7_DelimitNestedTokens(pIn,pEnd,PH7_TK_LPAREN/*'('*/,PH7_TK_RPAREN/*')'*/,&pIn);
 	if( pIn >= pEnd || &pIn[1] >= pEnd ){
-		/* Syntax error */
-		rc = PH7_GenCompileError(&(*pGen),E_ERROR,nLine,"Syntax error while declaring annonymous function");
+		/* Nothing follows the parameter list inside our slice: the body is missing.
+		 * php names the token that actually comes next (it lives just past the
+		 * expression slice, still in the raw stream) and says it wanted the '{'. */
+		SyToken *pBad = pEnd < pGen->pEnd ? pEnd : 0;
+		rc = PH7_GenSyntaxError(&(*pGen),pBad,"\"{\"");
 		if( rc != SXERR_ABORT ){
 			rc = SXERR_SYNTAX;
 		}
@@ -675,7 +681,7 @@ static sxi32 ExprAssembleAnnon(ph7_gen_state *pGen,SyToken **ppCur,SyToken *pEnd
 			pIn++; /* Jump the 'use' keyword */
 			if( pIn >= pEnd || (pIn->nType & PH7_TK_LPAREN) == 0 ){
 				/* Syntax error */
-				rc = PH7_GenCompileError(&(*pGen),E_ERROR,nLine,"Syntax error while declaring annonymous function");
+				rc = PH7_GenSyntaxError(&(*pGen),pIn < pEnd ? pIn : 0,"\"(\"");
 				if( rc != SXERR_ABORT ){
 					rc = SXERR_SYNTAX;
 				}
@@ -685,7 +691,7 @@ static sxi32 ExprAssembleAnnon(ph7_gen_state *pGen,SyToken **ppCur,SyToken *pEnd
 			PH7_DelimitNestedTokens(pIn,pEnd,PH7_TK_LPAREN/*'('*/,PH7_TK_RPAREN/*')'*/,&pIn);
 			if( pIn >= pEnd || &pIn[1] >= pEnd ){
 				/* Syntax error */
-				rc = PH7_GenCompileError(&(*pGen),E_ERROR,nLine,"Syntax error while declaring annonymous function");
+				rc = PH7_GenSyntaxError(&(*pGen),0 /* ran off the end */,0);
 				if( rc != SXERR_ABORT ){
 					rc = SXERR_SYNTAX;
 				}
@@ -697,7 +703,7 @@ static sxi32 ExprAssembleAnnon(ph7_gen_state *pGen,SyToken **ppCur,SyToken *pEnd
 			ExprSkipReturnType(&pIn,pEnd);
 		}else{
 			/* Syntax error */
-			rc = PH7_GenCompileError(&(*pGen),E_ERROR,nLine,"Syntax error while declaring annonymous function");
+			rc = PH7_GenSyntaxError(&(*pGen),pIn < pEnd ? pIn : 0,"\"{\"");
 			if( rc != SXERR_ABORT ){
 				rc = SXERR_SYNTAX;
 			}
@@ -714,8 +720,12 @@ static sxi32 ExprAssembleAnnon(ph7_gen_state *pGen,SyToken **ppCur,SyToken *pEnd
 			pIn++;
 		}
 	}else{
-		/* Syntax error */
-		rc = PH7_GenCompileError(&(*pGen),E_ERROR,nLine,"Syntax error while declaring annonymous function,missing '{'");
+		/* Syntax error. The closure's token range stops at the expression end, so on
+		 * `$f = function() ;` the '{' is missing and pIn has already reached pEnd —
+		 * php names the token that actually follows (the ';'), which is still in the
+		 * raw stream just past our slice. Peek at it rather than claiming EOF. */
+		SyToken *pBad = pIn < pEnd ? pIn : (pEnd < pGen->pEnd ? pEnd : 0);
+		rc = PH7_GenSyntaxError(&(*pGen),pBad,"\"{\"");
 		if( rc == SXERR_ABORT ){
 			return SXERR_ABORT;
 		}
@@ -1023,7 +1033,7 @@ static sxi32 ExprExtractNode(ph7_gen_state *pGen,ph7_expr_node **ppNode,int iLas
 				if( pCur < pGen->pEnd ){
 					pCur++;
 				}else{
-					rc = PH7_GenCompileError(pGen,E_ERROR,pNode->pStart->nLine,"Syntax error: Missing closing brace '}'");
+					rc = PH7_GenSyntaxError(pGen,pNode->pStart,0);
 					if( rc != SXERR_ABORT ){
 						rc = SXERR_SYNTAX;
 					}
@@ -1069,7 +1079,7 @@ static sxi32 ExprExtractNode(ph7_gen_state *pGen,ph7_expr_node **ppNode,int iLas
 					 ph7_expr_op *pOp = (pCur < pGen->pEnd) ? (ph7_expr_op *)pCur->pUserData : 0;
 					 if( pCur >= pGen->pEnd || (pCur->nType & PH7_TK_OP) == 0  || pOp == 0 || pOp->iVmOp != PH7_OP_STORE /*'='*/){
 						 /* Syntax error */
-						 rc = PH7_GenCompileError(pGen,E_ERROR,pNode->pStart->nLine,"list(): expecting '=' after construct");
+						 rc = PH7_GenSyntaxError(pGen,pNode->pStart,"\"=\"");
 						 if( rc != SXERR_ABORT ){
 							 rc = SXERR_SYNTAX;
 						 }
@@ -1164,7 +1174,7 @@ static sxi32 ExprExtractNode(ph7_gen_state *pGen,ph7_expr_node **ppNode,int iLas
 			 /* Point to the code generator routine */
 			 pNode->xCode = PH7_GetNodeHandler(pCur->nType);
 			 if( pNode->xCode == 0 ){
-				 rc = PH7_GenCompileError(pGen,E_ERROR,pNode->pStart->nLine,"Syntax error: Unexpected token '%z'",&pNode->pStart->sData);
+				 rc = PH7_GenSyntaxError(pGen,pNode->pStart,0);
 				 if( rc != SXERR_ABORT ){
 					 rc = SXERR_SYNTAX;
 				 }
@@ -1870,7 +1880,7 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 					  if( pNode->pLeft && pNode->pLeft->pOp && pNode->pLeft->pOp->iPrec > 4 ){
 						  if( pNode->pLeft->pLeft == 0 || pNode->pLeft->pRight == 0 ){
 							   /* Syntax error */
-							  rc = PH7_GenCompileError(pGen,E_ERROR,pNode->pLeft->pStart->nLine,"'%z': Missing operand",&pNode->pLeft->pOp->sOp);
+							  rc = PH7_GenSyntaxError(pGen,0,0);
 							  if( rc != SXERR_ABORT ){
 								  rc = SXERR_SYNTAX;
 							  }
@@ -1879,7 +1889,7 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 					  }
 				  }else{
 					  /* Syntax error */
-					  rc = PH7_GenCompileError(pGen,E_ERROR,pNode->pStart->nLine,"'%z': Missing operand",&pNode->pOp->sOp);
+					  rc = PH7_GenSyntaxError(pGen,0,0);
 					  if( rc != SXERR_ABORT ){
 						  rc = SXERR_SYNTAX;
 					  }
@@ -1918,8 +1928,7 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 				 }
 			 }
 			 if( iR < 0 || iL < 0 || !NODE_ISTERM(iR) || !NODE_ISTERM(iL) ){
-				 rc = PH7_GenCompileError(pGen,E_ERROR,pNode->pStart->nLine,
-					 "'%z': Missing/Invalid operand",&pNode->pOp->sOp);
+				 rc = PH7_GenSyntaxError(pGen,0,0);
 				 if( rc != SXERR_ABORT ){
 					 rc = SXERR_SYNTAX;
 				 }
@@ -1978,7 +1987,7 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 				 }
 				 if( iRight >= nToken || iLeft < 0 || !NODE_ISTERM(iRight) || !NODE_ISTERM(iLeft) ){
 					 /* Syntax error */
-					 rc = PH7_GenCompileError(pGen,E_ERROR,pNode->pStart->nLine,"'%z': Missing/Invalid operand",&pNode->pOp->sOp);
+					 rc = PH7_GenSyntaxError(pGen,0,0);
 					 if( rc != SXERR_ABORT ){
 						 rc = SXERR_SYNTAX;
 					 }
@@ -2047,7 +2056,7 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 			  sxi32 iNest = 1;
 			  if( iLeft < 0 || !NODE_ISTERM(iLeft) ){
 				  /* Missing condition */
-				  rc = PH7_GenCompileError(pGen,E_ERROR,pNode->pStart->nLine,"'%z': Syntax error",&pNode->pOp->sOp);
+				  rc = PH7_GenSyntaxError(pGen,pNode->pStart,0);
 				  if( rc != SXERR_ABORT ){
 					  rc = SXERR_SYNTAX;
 				  }
@@ -2129,7 +2138,7 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 					 rc = PH7_GenCompileError(pGen,E_PARSE,pNode->pStart->nLine,
 						 "syntax error, unexpected token \"%z\"",&pNode->pOp->sOp);
 				 }else{
-					 rc = PH7_GenCompileError(pGen,E_ERROR,pNode->pStart->nLine,"'%z': Missing/Invalid operand",&pNode->pOp->sOp);
+					 rc = PH7_GenSyntaxError(pGen,0,0);
 				 }
 				 if( rc != SXERR_ABORT ){
 					 rc = SXERR_SYNTAX;
@@ -2208,7 +2217,7 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 				 }
 				 if( iRight >= nToken || iLeft < 0 || !NODE_ISTERM(iRight) || !NODE_ISTERM(iLeft) ){
 					 /* Syntax error */
-					 rc = PH7_GenCompileError(pGen,E_ERROR,pNode->pStart->nLine,"'%z': Missing/Invalid operand",&pNode->pOp->sOp);
+					 rc = PH7_GenSyntaxError(pGen,0,0);
 					 if( rc != SXERR_ABORT ){
 						 rc = SXERR_SYNTAX;
 					 }
@@ -2226,7 +2235,7 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 	 for( iCur = 1 ; iCur < nToken ; ++iCur ){
 		 if( apNode[iCur] ){
 			 if( (apNode[iCur]->pOp || apNode[iCur]->xCode ) && apNode[0] != 0){
-				 rc = PH7_GenCompileError(pGen,E_ERROR,apNode[iCur]->pStart->nLine,"Unexpected token '%z'",&apNode[iCur]->pStart->sData);
+				 rc = PH7_GenSyntaxError(pGen,apNode[iCur]->pStart,pGen->nCommaExprOk > 0 ? "\";\"" : 0);
 				  if( rc != SXERR_ABORT ){
 					  rc = SXERR_SYNTAX;
 				  }

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -479,6 +479,8 @@ struct GenBlock
 	sxi32 iFlags;         /* Block control flags (see below) */
 	SySet aJumpFix;       /* Jump fixup (JumpFixup instance) */
 	void *pUserData;      /* Upper layer private data */
+	sxu32 nLoopId;        /* This block's loop/switch id (0 when it is neither) */
+	sxu32 nOuterLoopId;   /* Loop/switch that was innermost when this one was entered */
 	/* The following two fields are used only when compiling
 	 * the 'do..while()' language construct.
 	 */
@@ -510,6 +512,14 @@ struct ph7_gen_state
 	int nCommaExprOk;    /* > 0 while compiling a for() clause, the ONLY place php's grammar
 	                      * allows a comma-separated expression list (PH7's comma OPERATOR
 	                      * is otherwise a PH7-ism php rejects — §10) */
+	sxu32 nLoopId;       /* Monotonic id handed to each loop/switch block as it is entered */
+	sxu32 nCurLoopId;    /* Innermost loop/switch currently open (0 = none) */
+	SySet aLoopParent;   /* aLoopParent[id-1] = enclosing loop id, so the ancestry of any loop
+	                      * can be walked after compilation. php's only goto restriction is
+	                      * "'goto' into loop or switch statement is disallowed": a jump is
+	                      * illegal exactly when the LABEL sits in a loop that does not also
+	                      * enclose the GOTO. Both ends record their loop id; the fixup pass
+	                      * walks up from the goto's to look for the label's. */
 	SyBlob sWorker;      /* General purpose working buffer */
 	SyBlob sErrBuf;      /* Error buffer */
 	SyBlob sNamespace;   /* Current namespace path (e.g. "App\\Models") */
@@ -2329,6 +2339,7 @@ PH7_PRIVATE sxi32 PH7_CompileThrowExpr(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_InitCodeGenerator(ph7_vm *pVm,ProcConsumer xErr,void *pErrData);
 PH7_PRIVATE sxi32 PH7_ResetCodeGenerator(ph7_vm *pVm,ProcConsumer xErr,void *pErrData);
 PH7_PRIVATE sxi32 PH7_GenCompileError(ph7_gen_state *pGen,sxi32 nErrType,sxu32 nLine,const char *zFormat,...);
+PH7_PRIVATE sxi32 PH7_GenSyntaxError(ph7_gen_state *pGen,SyToken *pTok,const char *zExpecting);
 PH7_PRIVATE sxi32 PH7_CompileScript(ph7_vm *pVm,SyString *pScript,sxi32 iFlags);
 /* constant.c function prototypes */
 PH7_PRIVATE void PH7_RegisterBuiltInConstant(ph7_vm *pVm);

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -17726,8 +17726,13 @@ SkipFuncBody:
 					break;
 				}
 			}
-			/* Call to undefined function */
-			VmErrorFormat(&(*pVm),PH7_CTX_WARNING,"Call to undefined function '%z',NULL will be returned",&sName);
+			/* Call to an undefined function is a catchable Error in php 8 — it does
+			 * NOT warn and hand back null and carry on, which is what PH7 did (and
+			 * which quietly turned a typo into a null-propagating program). */
+			{
+			SyBlob sMsg;
+			SyBlobInit(&sMsg,&pVm->sAllocator);
+			SyBlobFormat(&sMsg,"Call to undefined function %z()",&sName);
 			/* Consume this call's captured spread runs so they don't leak into a
 			 * later call (this path never reaches VmBuildEffectiveArgMap). */
 			if( pInstr->iP2 ){
@@ -17740,9 +17745,15 @@ SkipFuncBody:
 			if( nCallArgs > 0 ){
 				VmPopOperand(&pTos,nCallArgs);
 			}
-			/* Assume a null return value so that the program continue it's execution normally */
 			PH7_MemObjRelease(pTos);
-			break;
+			rc = VmThrowFromVm(&(*pVm),"Error",(const char *)SyBlobData(&sMsg),
+				SyBlobLength(&sMsg));
+			SyBlobRelease(&sMsg);
+			if( rc == SXERR_ABORT ){
+				goto Abort;
+			}
+			goto Exception;
+			}
 		}
 		pFunc = (ph7_user_func *)pEntry->pUserData;
 		/* Host function (builtin): build the effective spread-key map so the

--- a/src/phl/phl.c
+++ b/src/phl/phl.c
@@ -61,6 +61,16 @@ static void Fatal(const char *zMsg)
 	FatalCode(zMsg,255);
 }
 /*
+ * Exit 255 without printing anything: used when the diagnostic has already been
+ * emitted by the error consumer (a compile/parse error), which is exactly what
+ * php does — it prints the parse error and nothing more.
+ */
+static void FatalSilent(void)
+{
+	ph7_lib_shutdown();
+	exit(255);
+}
+/*
  * Display the banner,a help message and exit.
  */
 static void Help(void)
@@ -562,8 +572,9 @@ int main(int argc,char **argv)
 			if( rc == PH7_VM_ERR ){
 				Fatal("VM initialization error");
 			}else{
-				/* Compile-time error, your output (STDOUT) should display the error messages */
-				Fatal("Compile error");
+				/* Compile-time error. The diagnostic has already been printed by the
+				 * error consumer; php adds nothing else, it just exits 255. */
+				FatalSilent();
 			}
 		}
 	}else{
@@ -579,8 +590,9 @@ int main(int argc,char **argv)
 			}else if( rc == PH7_VM_ERR ){
 				Fatal("VM initialization error");
 			}else{
-				/* Compile-time error, your output (STDOUT) should display the error messages */
-				Fatal("Compile error");
+				/* Compile-time error. The diagnostic has already been printed by the
+				 * error consumer; php prints nothing further and exits 255. */
+				FatalSilent();
 			}
 		}
 	}

--- a/tests/ph7/002-integration/array/array_invalid_reference.phpt
+++ b/tests/ph7/002-integration/array/array_invalid_reference.phpt
@@ -3,15 +3,13 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 array() with invalid reference expression
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 $a = array(&$b + $c);
 echo "Should not reach here\n";
 ?>
 --EXPECTF--
-%s Fatal error:  array(): Expecting a variable/array member/function call after reference operator '&' %s
+%AParse error:%Asyntax error, unexpected token "+", expecting "->" or "?->" or "["%A
 --CLEAN--
 <?php
 unset($a);

--- a/tests/ph7/002-integration/array/array_missing_entry_value.phpt
+++ b/tests/ph7/002-integration/array/array_missing_entry_value.phpt
@@ -10,7 +10,7 @@ array with missing entry value
 $a = array(key => );
 ?>
 --EXPECTF--
-%s Fatal error:  array(): Missing entry value %s
+%AParse error:%Asyntax error, unexpected token "=>"%A
 --CLEAN--
 <?php
 unset($a);

--- a/tests/ph7/002-integration/array/array_missing_value.phpt
+++ b/tests/ph7/002-integration/array/array_missing_value.phpt
@@ -10,7 +10,7 @@ PHL: array() with missing entry value should produce a compile error
 $x = array(1 => );
 ?>
 --EXPECTF--
-%s Fatal error:  array(): Missing entry value %s
+%AParse error:%Asyntax error, unexpected token "=>"%A
 --CLEAN--
 <?php
 unset($x);

--- a/tests/ph7/002-integration/error/anonymous_function_missing_brace.phpt
+++ b/tests/ph7/002-integration/error/anonymous_function_missing_brace.phpt
@@ -3,14 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Syntax error: Missing opening brace in anonymous function
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 $f = function();
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error while declaring annonymous function %s
+%AParse error:%Asyntax error, unexpected token ";", expecting "{"%A
 --CLEAN--
 <?php
 unset($f);

--- a/tests/ph7/002-integration/error/anonymous_function_missing_params.phpt
+++ b/tests/ph7/002-integration/error/anonymous_function_missing_params.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 PHL: Syntax error while declaring anonymous function
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 $f = function {
@@ -12,7 +10,7 @@ $f = function {
 };
 ?>
 --EXPECTF--
-%s Fatal error:  Missing opening parenthesis '(' while declaring annonymous function %s
+%AParse error:%Asyntax error, unexpected token "{", expecting "("%A
 --CLEAN--
 <?php
 unset($f);

--- a/tests/ph7/002-integration/error/anonymous_function_syntax.phpt
+++ b/tests/ph7/002-integration/error/anonymous_function_syntax.phpt
@@ -3,14 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Syntax error: Missing opening parenthesis in anonymous function
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 $f = function echo 1;
 ?>
 --EXPECTF--
-%s Fatal error:  Missing opening parenthesis '(' while declaring annonymous function %s
+%AParse error:%Asyntax error, unexpected token "echo", expecting "("%A
 --CLEAN--
 <?php
 unset($f);

--- a/tests/ph7/002-integration/error/anonymous_function_syntax_use.phpt
+++ b/tests/ph7/002-integration/error/anonymous_function_syntax_use.phpt
@@ -3,14 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Syntax error: Invalid token after 'use' in anonymous function
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 $f = function() use invalid { };
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error while declaring annonymous function %s
+%AParse error:%Asyntax error, unexpected identifier "invalid", expecting "("%A
 --CLEAN--
 <?php
 unset($f);

--- a/tests/ph7/002-integration/error/array_invalid_reference_assignment.phpt
+++ b/tests/ph7/002-integration/error/array_invalid_reference_assignment.phpt
@@ -3,14 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 PHL: array with invalid reference to assignment
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 $a = array(&$b = 1);
 ?>
 --EXPECTF--
-%s Fatal error:  array(): Expecting a variable/array member/function call after reference operator '&' %s
+%AParse error:%Asyntax error, unexpected token "=", expecting "->" or "?->" or "["%A
 --CLEAN--
 <?php
 unset($a);

--- a/tests/ph7/002-integration/error/array_invalid_reference_expression.phpt
+++ b/tests/ph7/002-integration/error/array_invalid_reference_expression.phpt
@@ -3,14 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 PHL: array with invalid reference to expression
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 $a = array(&$b + 1);
 ?>
 --EXPECTF--
-%s Fatal error:  array(): Expecting a variable/array member/function call after reference operator '&' %s
+%AParse error:%Asyntax error, unexpected token "+", expecting "->" or "?->" or "["%A
 --CLEAN--
 <?php
 unset($a);

--- a/tests/ph7/002-integration/error/array_invalid_reference_literal.phpt
+++ b/tests/ph7/002-integration/error/array_invalid_reference_literal.phpt
@@ -3,14 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 PHL: array with invalid reference to literal
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 $a = array(&1);
 ?>
 --EXPECTF--
-%s Fatal error:  array(): Expecting a variable after reference operator '&' %s
+%AParse error:%Asyntax error, unexpected integer "1"%A
 --CLEAN--
 <?php
 unset($a);

--- a/tests/ph7/002-integration/error/constant_invalid_name.phpt
+++ b/tests/ph7/002-integration/error/constant_invalid_name.phpt
@@ -3,14 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 const: Invalid constant name
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 const 123 = 5;
 ?>
 --EXPECTF--
-%s Fatal error:  const: Invalid constant name %s
+%AParse error:%Asyntax error, unexpected integer "123", expecting identifier%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/error/declare_invalid.phpt
+++ b/tests/ph7/002-integration/error/declare_invalid.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 PHL: declare statement with invalid syntax (missing opening parenthesis)
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 declare ticks=1) {
@@ -12,7 +10,7 @@ declare ticks=1) {
 }
 ?>
 --EXPECTF--
-%s Fatal error:  declare: Expecting opening parenthesis '(' %s
+%AParse error:%Asyntax error, unexpected identifier "ticks", expecting "("%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/error/final_method_overwrite.phpt
+++ b/tests/ph7/002-integration/error/final_method_overwrite.phpt
@@ -15,7 +15,7 @@ class B extends A {
 }
 ?>
 --EXPECTF--
-%s Fatal error:  Cannot Overwrite final method 'A:test' inside child class 'B' %s
+%AFatal error:%ACannot override final method A::test()%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/error/for_missing_condition_semicolon.phpt
+++ b/tests/ph7/002-integration/error/for_missing_condition_semicolon.phpt
@@ -11,7 +11,7 @@ for($i=0; $i<10 $i++) {
 }
 ?>
 --EXPECTF--
-%s Fatal error:  Unexpected token '++' %s
+%AParse error:%Asyntax error, unexpected token "++", expecting ";"%AParse error:%Asyntax error, unexpected token ")", expecting ";"%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/error/for_missing_init_semicolon.phpt
+++ b/tests/ph7/002-integration/error/for_missing_init_semicolon.phpt
@@ -11,7 +11,7 @@ for($i=0$i<10; $i++) {
 }
 ?>
 --EXPECTF--
-%s Fatal error:  Unexpected token '<' %s
+%AParse error:%Asyntax error, unexpected token "<", expecting ";"%AParse error:%Asyntax error, unexpected token ")", expecting ";"%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/error/function_invalid_name.phpt
+++ b/tests/ph7/002-integration/error/function_invalid_name.phpt
@@ -3,14 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Invalid function name
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 function 123() {}
 ?>
 --EXPECTF--
-%s Fatal error:  Invalid function name %s
+%AParse error:%Asyntax error, unexpected integer "123", expecting "("%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/error/function_missing_lparen.phpt
+++ b/tests/ph7/002-integration/error/function_missing_lparen.phpt
@@ -3,14 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Expected '(' after function name
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 function foo {}
 ?>
 --EXPECTF--
-%s Fatal error:  Expected '(' after function name 'foo' %s
+%AParse error:%Asyntax error, unexpected token "{", expecting "("%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/error/goto_different_function.phpt
+++ b/tests/ph7/002-integration/error/goto_different_function.phpt
@@ -13,7 +13,7 @@ goto label;
 label:
 echo "hello";
 --EXPECTF--
-%s Fatal error:  Label 'label' was referenced but not defined %s
+%AFatal error:%A'goto' to undefined label 'label'%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/error/goto_error.phpt
+++ b/tests/ph7/002-integration/error/goto_error.phpt
@@ -14,7 +14,7 @@ global_label:
 goto undefined;
 undefined_label:
 --EXPECTF--
-%s Fatal error:  Label 'global_label' was referenced but not defined %s
+%AFatal error:%A'goto' to undefined label 'global_label'%AFatal error:%A'goto' to undefined label 'undefined'%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/error/goto_in_try_catch.phpt
+++ b/tests/ph7/002-integration/error/goto_in_try_catch.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 PHL: goto statement inside try/catch block is disallowed
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 try {
@@ -16,7 +14,7 @@ label:
 echo "Should not reach here\n";
 ?>
 --EXPECTF--
-%s Fatal error:  goto inside try/catch block is disallowed %s
+%AShould not reach here%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/error/goto_invalid_label.phpt
+++ b/tests/ph7/002-integration/error/goto_invalid_label.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Goto with invalid label name
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 goto 123;
@@ -12,7 +10,7 @@ label:
 echo "done";
 ?>
 --EXPECTF--
-%s Fatal error:  goto: Invalid label name: '123' %s
+%AParse error:%Asyntax error, unexpected integer "123", expecting identifier%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/error/goto_unreachable_label_different_function.phpt
+++ b/tests/ph7/002-integration/error/goto_unreachable_label_different_function.phpt
@@ -16,7 +16,7 @@ goto bar;
 }
 ?>
 --EXPECTF--
-%s Warning:  Label 'bar' is defined but not referenced %s
+%AFatal error:%A'goto' to undefined label 'bar'%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/error/illegal_break.phpt
+++ b/tests/ph7/002-integration/error/illegal_break.phpt
@@ -10,7 +10,7 @@ PHL: break statement outside loop or switch
 break;
 ?>
 --EXPECTF--
-%s Fatal error:  A 'break' statement may only be used within a loop or switch %s
+%AFatal error:%A'break' not in the 'loop' or 'switch' context%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/error/illegal_continue.phpt
+++ b/tests/ph7/002-integration/error/illegal_continue.phpt
@@ -10,7 +10,7 @@ PHL: continue statement outside loop
 continue;
 ?>
 --EXPECTF--
-%s Fatal error:  A 'continue' statement may only be used within a loop or switch %s
+%AFatal error:%A'continue' not in the 'loop' or 'switch' context%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/error/invalid_array_syntax.phpt
+++ b/tests/ph7/002-integration/error/invalid_array_syntax.phpt
@@ -12,7 +12,7 @@ $a = array(1, 2, 3 => );
 echo "Should not reach here";
 ?>
 --EXPECTF--
-%s Fatal error:  array(): Missing entry value %s
+%AParse error:%Asyntax error, unexpected token "=>"%A
 --CLEAN--
 <?php
 unset($a);

--- a/tests/ph7/002-integration/error/invalid_goto.phpt
+++ b/tests/ph7/002-integration/error/invalid_goto.phpt
@@ -21,7 +21,7 @@ inside_try:
 echo "Done\n";
 ?>
 --EXPECTF--
-%s Fatal error:  goto inside try/catch block is disallowed %s
+%AFatal error:%A'goto' to undefined label 'nonexistent_label'%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/error/invalid_variable_name.phpt
+++ b/tests/ph7/002-integration/error/invalid_variable_name.phpt
@@ -11,7 +11,7 @@ $result = $(;
 echo "Result: $result\n";
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error,mismatched '(','[','{' or '?' %s
+%AParse error:%Asyntax error, unexpected token ";"%A
 --CLEAN--
 <?php
 unset($result);

--- a/tests/ph7/002-integration/error/label_inside_loop.phpt
+++ b/tests/ph7/002-integration/error/label_inside_loop.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Label inside loop construct error
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 // This should trigger a compile error: "Label 'label' inside loop or try/catch block is disallowed"
@@ -14,7 +12,7 @@ for ($i = 0; $i < 1; $i++) {
 }
 ?>
 --EXPECTF--
-%s Fatal error:  Label 'label' inside loop or try/catch block is disallowed %s
+%Atest%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/error/label_inside_try.phpt
+++ b/tests/ph7/002-integration/error/label_inside_try.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Label inside try/catch construct error
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 // This should trigger a compile error: "Label 'label' inside loop or try/catch block is disallowed"
@@ -16,7 +14,7 @@ try {
 }
 ?>
 --EXPECTF--
-%s Fatal error:  Label 'label' inside loop or try/catch block is disallowed %s
+%Atest%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/error/label_unused.phpt
+++ b/tests/ph7/002-integration/error/label_unused.phpt
@@ -3,15 +3,13 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 PHL: unused label warning
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 unused_label:
 echo "test";
 ?>
 --EXPECTF--
-%s Warning:  Label 'unused_label' is defined but not referenced %s
+%Atest%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/error/list_invalid_expression.phpt
+++ b/tests/ph7/002-integration/error/list_invalid_expression.phpt
@@ -11,7 +11,7 @@ list() construct with invalid expression error
 list(1) = array(1);
 ?>
 --EXPECTF--
-%s Fatal error:  list(): Expecting a variable not an expression %s
+%AFatal error:%AAssignments can only happen to writable values%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/error/list_missing_assignment.phpt
+++ b/tests/ph7/002-integration/error/list_missing_assignment.phpt
@@ -11,7 +11,7 @@ list() construct missing assignment operator error
 list();
 ?>
 --EXPECTF--
-%s Fatal error:  list(): expecting '=' after construct %s
+%AParse error:%Asyntax error, unexpected token "list", expecting "="%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/error/missing_closing_brace.phpt
+++ b/tests/ph7/002-integration/error/missing_closing_brace.phpt
@@ -10,7 +10,7 @@ Syntax error: Missing closing brace in variable name
 $var = ${unclosed;
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error: Missing closing brace '}' %s
+%AParse error:%Asyntax error, unexpected variable "$"%A
 --CLEAN--
 <?php
 unset($var);

--- a/tests/ph7/002-integration/error/missing_var_name.phpt
+++ b/tests/ph7/002-integration/error/missing_var_name.phpt
@@ -10,7 +10,7 @@ PHL: missing variable name
 $a = ${};
 ?>
 --EXPECTF--
-%s Fatal error:  Invalid variable name %s
+%AParse error:%Asyntax error, unexpected token "}", expecting variable or "{" or "$"%A
 --CLEAN--
 <?php
 unset($a);

--- a/tests/ph7/002-integration/error/missing_variable_name.phpt
+++ b/tests/ph7/002-integration/error/missing_variable_name.phpt
@@ -3,15 +3,13 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 PHL: Missing variable name in dynamic variable syntax
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 $result = ${;};
 echo "Result: $result\n";
 ?>
 --EXPECTF--
-%s Fatal error:  Missing variable name %s
+%AParse error:%Asyntax error, unexpected token ";"%A
 --CLEAN--
 <?php
 unset($result);

--- a/tests/ph7/002-integration/error/parse_error.phpt
+++ b/tests/ph7/002-integration/error/parse_error.phpt
@@ -3,19 +3,13 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 PHL: Parser reports a parse error for malformed code
---SKIPIF--
-<?php
-if (function_exists('zend_version')) {
-    echo "skip";
-}
-?>
 --FILE--
 <?php
 function broken( { // syntax error: missing ) brace
     echo "should never print\n";
 ?>
 --EXPECTF--
-%s Fatal error:  Missing ')' after function 'broken' signature %s
+%AParse error:%Asyntax error, unexpected token "{", expecting variable%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/error/undefined_function_call.phpt
+++ b/tests/ph7/002-integration/error/undefined_function_call.phpt
@@ -10,7 +10,7 @@ undefined function call warning
 nonexistent_function();
 ?>
 --EXPECTF--
-Warning: Call to undefined function 'nonexistent_function',NULL will be returned in %s on line %d
+%AFatal error:%AUncaught Error: Call to undefined function nonexistent_function()%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/error/unexpected_closing_brace.phpt
+++ b/tests/ph7/002-integration/error/unexpected_closing_brace.phpt
@@ -3,14 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 PH7: Syntax error for unexpected closing brace '}'
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 if (true) { echo 1; } }
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error: Unexpected token '}' %s
+%AParse error:%AUnmatched '}'%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/error/unexpected_closing_paren.phpt
+++ b/tests/ph7/002-integration/error/unexpected_closing_paren.phpt
@@ -10,7 +10,7 @@ PH7: Syntax error for unexpected closing parenthesis ')'
 echo 1 + );
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error: Unexpected token ')' %s
+%AParse error:%AUnmatched ')'%AParse error:%Asyntax error, unexpected token ";"%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/error/unmatched_closing_bracket.phpt
+++ b/tests/ph7/002-integration/error/unmatched_closing_bracket.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Unmatched closing bracket should produce syntax error
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 // Test unmatched closing bracket
@@ -12,7 +10,7 @@ echo "test";
 ]
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error: Unexpected token ']' %s
+%AParse error:%AUnmatched ']'%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/function/echo/echo_invalid_syntax.phpt
+++ b/tests/ph7/002-integration/function/echo/echo_invalid_syntax.phpt
@@ -10,7 +10,7 @@ PHL: echo with invalid syntax triggers unexpected token error
 echo 1 2;
 ?>
 --EXPECTF--
-%s Fatal error:  Unexpected token '2' %s
+%AParse error:%Asyntax error, unexpected integer "2"%AParse error:%Asyntax error, unexpected token ";"%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/anonymous_function_invalid_after_params.phpt
+++ b/tests/ph7/002-integration/lang/anonymous_function_invalid_after_params.phpt
@@ -3,14 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 PH7: Syntax error in anonymous function declaration - invalid token after parameters
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 $func = function() if { };
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error while declaring annonymous function %s
+%AParse error:%Asyntax error, unexpected token "if", expecting "{"%A
 --CLEAN--
 <?php
 unset($func);

--- a/tests/ph7/002-integration/lang/anonymous_function_missing_body_after_use.phpt
+++ b/tests/ph7/002-integration/lang/anonymous_function_missing_body_after_use.phpt
@@ -10,7 +10,7 @@ PH7: Syntax error in anonymous function declaration - missing body after use
 $func = function() use ($x) ;
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error while declaring annonymous function %s
+%AParse error:%Asyntax error, unexpected token ";"%A
 --CLEAN--
 <?php
 unset($func);

--- a/tests/ph7/002-integration/lang/anonymous_function_missing_brace.phpt
+++ b/tests/ph7/002-integration/lang/anonymous_function_missing_brace.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Syntax error in anonymous function with malformed body
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 // Test malformed anonymous function syntax that triggers parsing error
@@ -13,7 +11,7 @@ Syntax error in anonymous function with malformed body
 $func = function() echo 'test';
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error while declaring annonymous function %s
+%AParse error:%Asyntax error, unexpected token "echo", expecting "{"%A
 --CLEAN--
 <?php
 unset($func);

--- a/tests/ph7/002-integration/lang/anonymous_function_missing_brace_after_params.phpt
+++ b/tests/ph7/002-integration/lang/anonymous_function_missing_brace_after_params.phpt
@@ -3,15 +3,13 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Anonymous function syntax error: missing brace after parameters
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 $func = function($x, $y)
 echo "test";
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error while declaring annonymous function %s
+%AParse error:%Asyntax error, unexpected token "echo", expecting "{"%A
 --CLEAN--
 <?php
 unset($func);

--- a/tests/ph7/002-integration/lang/anonymous_function_missing_brace_params.phpt
+++ b/tests/ph7/002-integration/lang/anonymous_function_missing_brace_params.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Syntax error in anonymous function with parameters but missing opening brace '{'
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 // Test malformed anonymous function syntax that triggers parsing error for missing '{'
@@ -12,7 +10,7 @@ Syntax error in anonymous function with parameters but missing opening brace '{'
 $func = function($x) ;
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error while declaring annonymous function %s
+%AParse error:%Asyntax error, unexpected token ";", expecting "{"%A
 --CLEAN--
 <?php
 unset($func);

--- a/tests/ph7/002-integration/lang/anonymous_function_missing_parenthesis.phpt
+++ b/tests/ph7/002-integration/lang/anonymous_function_missing_parenthesis.phpt
@@ -10,7 +10,7 @@ PH7: Syntax error - unexpected token ')'
 echo ) 1;
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error: Unexpected token ')' %s
+%AParse error:%AUnmatched ')'%AParse error:%Asyntax error, unexpected token ";"%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/anonymous_function_syntax_error.phpt
+++ b/tests/ph7/002-integration/lang/anonymous_function_syntax_error.phpt
@@ -10,7 +10,7 @@ PH7: Syntax error in anonymous function declaration
 $func = function() use ($x { };
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error while declaring annonymous function %s
+%AParse error:%Asyntax error, unexpected token ";"%A
 --CLEAN--
 <?php
 unset($func);

--- a/tests/ph7/002-integration/lang/anonymous_function_syntax_error_missing_use_paren.phpt
+++ b/tests/ph7/002-integration/lang/anonymous_function_syntax_error_missing_use_paren.phpt
@@ -10,7 +10,7 @@ PH7: Syntax error in anonymous function declaration - missing use paren
 $func = function() use $x { };
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error while declaring annonymous function %s
+%AParse error:%Asyntax error, unexpected variable "$", expecting "("%A
 --CLEAN--
 <?php
 unset($func);

--- a/tests/ph7/002-integration/lang/array_missing_entry_value.phpt
+++ b/tests/ph7/002-integration/lang/array_missing_entry_value.phpt
@@ -14,7 +14,7 @@ if (function_exists('zend_version')) {
 $x = array(0 => );
 ?>
 --EXPECTF--
-%s Fatal error:  array(): Missing entry value %s
+%AParse error:%Asyntax error, unexpected token "=>"%A
 --CLEAN--
 <?php
 unset($x);

--- a/tests/ph7/002-integration/lang/break_invalid_level.phpt
+++ b/tests/ph7/002-integration/lang/break_invalid_level.phpt
@@ -21,7 +21,7 @@ $result .= "end";
 echo $result;
 ?>
 --EXPECTF--
-%s Fatal error:  A 'break' statement may only be used within a loop or switch %s
+%AFatal error:%A'break' not in the 'loop' or 'switch' context%A
 --CLEAN--
 <?php
 unset($result);

--- a/tests/ph7/002-integration/lang/break_outside_loop.phpt
+++ b/tests/ph7/002-integration/lang/break_outside_loop.phpt
@@ -12,7 +12,7 @@ break;
 echo "After break\n";
 ?>
 --EXPECTF--
-%s Fatal error:  A 'break' statement may only be used within a loop or switch %s
+%AFatal error:%A'break' not in the 'loop' or 'switch' context%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/compilation_error_recovery.phpt
+++ b/tests/ph7/002-integration/lang/compilation_error_recovery.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Test compilation error recovery paths to cover uncovered error handling
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 // Test error recovery during compilation to cover uncovered paths
@@ -21,7 +19,7 @@ function test_error_recovery() {
 test_error_recovery();
 ?>
 --EXPECTF--
-%s Fatal error:  '=': Missing/Invalid operand %s
+%AParse error:%Asyntax error, unexpected token ";"%A
 --CLEAN--
 <?php
 unset($invalid_syntax);

--- a/tests/ph7/002-integration/lang/const_invalid_name.phpt
+++ b/tests/ph7/002-integration/lang/const_invalid_name.phpt
@@ -3,14 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 PHL: Invalid constant name in const declaration
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 const 123;
 ?>
 --EXPECTF--
-%s Fatal error:  const: Invalid constant name %s
+%AParse error:%Asyntax error, unexpected integer "123", expecting identifier%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/const_missing_equal.phpt
+++ b/tests/ph7/002-integration/lang/const_missing_equal.phpt
@@ -3,14 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 PHL: Missing '=' in const declaration
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 const FOO;
 ?>
 --EXPECTF--
-%s Fatal error:  const: Expected '=' after constant name %s
+%AParse error:%Asyntax error, unexpected token ";", expecting "="%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/const_missing_equals.phpt
+++ b/tests/ph7/002-integration/lang/const_missing_equals.phpt
@@ -3,14 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 const without equals (covers compile.c lines 492,494)
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 const MYCONST;
 ?>
 --EXPECTF--
-%s Fatal error:  const: Expected '=' after constant name %s
+%AParse error:%Asyntax error, unexpected token ";", expecting "="%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/const_reserved_name.phpt
+++ b/tests/ph7/002-integration/lang/const_reserved_name.phpt
@@ -14,7 +14,7 @@ if (function_exists('zend_version')) {
 const true = 1;
 ?>
 --EXPECTF--
-%s Fatal error:  const: Cannot redeclare a reserved constant 'true' %s
+%AFatal error:%ACannot redeclare constant 'true'%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/continue_outside_loop.phpt
+++ b/tests/ph7/002-integration/lang/continue_outside_loop.phpt
@@ -12,7 +12,7 @@ continue;
 echo "After continue\n";
 ?>
 --EXPECTF--
-%s Fatal error:  A 'continue' statement may only be used within a loop or switch %s
+%AFatal error:%A'continue' not in the 'loop' or 'switch' context%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/declare_invalid_syntax.phpt
+++ b/tests/ph7/002-integration/lang/declare_invalid_syntax.phpt
@@ -3,15 +3,13 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Declare statement with invalid syntax
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 declare invalid;
 echo "should not reach here\n";
 ?>
 --EXPECTF--
-%s Fatal error:  declare: Expecting opening parenthesis '(' %s
+%AParse error:%Asyntax error, unexpected identifier "invalid", expecting "("%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/empty_function_argument.phpt
+++ b/tests/ph7/002-integration/lang/empty_function_argument.phpt
@@ -3,14 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 PH7: Syntax error - mismatched parentheses
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 echo ( 1 ;
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error,mismatched '(','[','{' or '?' %s
+%AParse error:%Asyntax error, unexpected token ";"%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/goto_inside_try.phpt
+++ b/tests/ph7/002-integration/lang/goto_inside_try.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Goto inside try/catch block results in compile-time error
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 try {
@@ -17,7 +15,7 @@ label:
 echo "label\n";
 ?>
 --EXPECTF--
-%s Fatal error:  goto inside try/catch block is disallowed %s
+%Alabel%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/goto_many_missing.phpt
+++ b/tests/ph7/002-integration/lang/goto_many_missing.phpt
@@ -25,7 +25,7 @@ goto label15;
 goto label16;
 ?>
 --EXPECTF--
-%s Fatal error:  Label 'label1' was referenced but not defined %s
+%AFatal error:%A'goto' to undefined label 'label1'%AFatal error:%A'goto' to undefined label 'label2'%AFatal error:%A'goto' to undefined label 'label3'%AFatal error:%A'goto' to undefined label 'label4'%AFatal error:%A'goto' to undefined label 'label5'%AFatal error:%A'goto' to undefined label 'label6'%AFatal error:%A'goto' to undefined label 'label7'%AFatal error:%A'goto' to undefined label 'label8'%AFatal error:%A'goto' to undefined label 'label9'%AFatal error:%A'goto' to undefined label 'label10'%AFatal error:%A'goto' to undefined label 'label11'%AFatal error:%A'goto' to undefined label 'label12'%AFatal error:%A'goto' to undefined label 'label13'%AFatal error:%A'goto' to undefined label 'label14'%AFatal error:%A'goto' to undefined label 'label15'%AFatal error:%AError count limit reached,PH7 is aborting compilation%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/goto_missing_label.phpt
+++ b/tests/ph7/002-integration/lang/goto_missing_label.phpt
@@ -10,7 +10,7 @@ Goto a missing label results in compile-time error
 goto missing_label;
 ?>
 --EXPECTF--
-%s Fatal error:  Label 'missing_label' was referenced but not defined %s
+%AFatal error:%A'goto' to undefined label 'missing_label'%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/goto_undefined.phpt
+++ b/tests/ph7/002-integration/lang/goto_undefined.phpt
@@ -13,7 +13,7 @@ UNDEFINED_LABEL:
 echo "Defined label\n";
 ?>
 --EXPECTF--
-%s Fatal error:  Label 'MISSING_LABEL' was referenced but not defined %s
+%AFatal error:%A'goto' to undefined label 'MISSING_LABEL'%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/goto_unreachable.phpt
+++ b/tests/ph7/002-integration/lang/goto_unreachable.phpt
@@ -14,7 +14,7 @@ function foo() {
 echo "ok";
 ?>
 --EXPECTF--
-%s Fatal error:  Label 'bar' is unreachable %s
+%AFatal error:%A'goto' to undefined label 'bar'%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/goto_unreachable_label.phpt
+++ b/tests/ph7/002-integration/lang/goto_unreachable_label.phpt
@@ -15,7 +15,7 @@ function foo() {
 }
 ?>
 --EXPECTF--
-%s Warning:  Label 'bar' is defined but not referenced %s
+%AFatal error:%A'goto' to undefined label 'bar'%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/heredoc_unclosed.phpt
+++ b/tests/ph7/002-integration/lang/heredoc_unclosed.phpt
@@ -3,10 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Unterminated heredoc must produce a compiler parse error (PH7 only)
---SKIPIF--
-<?php
-if (function_exists('zend_version')) { echo "skip"; }
-?>
 --FILE--
 <?php
 if (true) {
@@ -16,7 +12,7 @@ unterminated
 }
 ?>
 --EXPECTF--
-%s Fatal error:  Missing closing braces '}' %s
+%AParse error:%AUnclosed '{' on line 2%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/invalid_hex_literal.phpt
+++ b/tests/ph7/002-integration/lang/invalid_hex_literal.phpt
@@ -11,7 +11,7 @@ $a = 0xG;
 echo "Should not reach here\n";
 ?>
 --EXPECTF--
-%s Fatal error:  Unexpected token 'G' %s
+%AParse error:%Asyntax error, unexpected identifier "G"%A
 --CLEAN--
 <?php
 unset($a);

--- a/tests/ph7/002-integration/lang/invalid_variable_name.phpt
+++ b/tests/ph7/002-integration/lang/invalid_variable_name.phpt
@@ -11,7 +11,7 @@ $a = $1;
 echo "Should not reach here\n";
 ?>
 --EXPECTF--
-%s Fatal error:  Unexpected token '1' %s
+%AParse error:%Asyntax error, unexpected integer "1"%A
 --CLEAN--
 <?php
 unset($a);

--- a/tests/ph7/002-integration/lang/label_not_referenced.phpt
+++ b/tests/ph7/002-integration/lang/label_not_referenced.phpt
@@ -2,22 +2,16 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PHL: Label defined but not referenced should emit a warning
---SKIPIF--
-<?php
-if (function_exists('zend_version')) {
-    echo "skip";
-}
-?>
+A label nobody jumps to is silent (php has no "defined but not referenced" warning)
 --FILE--
 <?php
 function foo() {
     label_unreferenced:
     echo "hello";
 }
+echo "no-diagnostic";
 ?>
---EXPECTF--
-%s Warning:  Label 'label_unreferenced' is defined but not referenced %s
+--EXPECT--
+no-diagnostic
 --CLEAN--
 <?php
-

--- a/tests/ph7/002-integration/lang/label_unreferenced.phpt
+++ b/tests/ph7/002-integration/lang/label_unreferenced.phpt
@@ -3,15 +3,13 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Unreferenced label emits warning
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 my_label:
 echo "test\n";
 ?>
 --EXPECTF--
-%s Warning:  Label 'my_label' is defined but not referenced %s
+%Atest%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/lang_goto_nonexistent.phpt
+++ b/tests/ph7/002-integration/lang/lang_goto_nonexistent.phpt
@@ -11,7 +11,7 @@ goto nonexistent;
 echo "this should not be reached\n";
 ?>
 --EXPECTF--
-%s Fatal error:  Label 'nonexistent' was referenced but not defined %s
+%AFatal error:%A'goto' to undefined label 'nonexistent'%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/mismatched_parentheses.phpt
+++ b/tests/ph7/002-integration/lang/mismatched_parentheses.phpt
@@ -3,14 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Mismatched parentheses
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 echo 1 + (2 + 3 ;
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error,mismatched '(','[','{' or '?' %s
+%AParse error:%Asyntax error, unexpected token ";"%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/missing_closing_parenthesis.phpt
+++ b/tests/ph7/002-integration/lang/missing_closing_parenthesis.phpt
@@ -3,14 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Missing closing parenthesis in expression
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 echo (1 + 2;
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error,mismatched '(','[','{' or '?' %s
+%AParse error:%Asyntax error, unexpected token ";"%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/missing_math_operand.phpt
+++ b/tests/ph7/002-integration/lang/missing_math_operand.phpt
@@ -3,14 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 PHL: invalid expression syntax triggers parse error
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 $a = 1 + ;
 ?>
 --EXPECTF--
-%s Fatal error:  '+': Missing/Invalid operand %s
+%AParse error:%Asyntax error, unexpected token ";"%A
 --CLEAN--
 <?php
 unset($a);

--- a/tests/ph7/002-integration/lang/missing_variable_value.phpt
+++ b/tests/ph7/002-integration/lang/missing_variable_value.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Invalid expressions
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 // Test invalid syntax that triggers compile error
@@ -13,7 +11,7 @@ $var = ;
 echo "Should not reach here\n";
 ?>
 --EXPECTF--
-%s Fatal error:  '=': Missing/Invalid operand %s
+%AParse error:%Asyntax error, unexpected token ";"%A
 --CLEAN--
 <?php
 unset($var);

--- a/tests/ph7/002-integration/lang/runtime_error_handling.phpt
+++ b/tests/ph7/002-integration/lang/runtime_error_handling.phpt
@@ -15,8 +15,7 @@ $result = nonexistent_function_12345();
 echo "Test completed\n";
 ?>
 --EXPECTF--
-Warning: Call to undefined function 'nonexistent_function_12345',NULL will be returned in %s on line %d
-Test completed
+%AFatal error:%AUncaught Error: Call to undefined function nonexistent_function_12345()%A
 --CLEAN--
 <?php
 unset($result);

--- a/tests/ph7/002-integration/lang/unexpected_closing_brace.phpt
+++ b/tests/ph7/002-integration/lang/unexpected_closing_brace.phpt
@@ -3,15 +3,13 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Unexpected closing brace
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 echo 1;
 }
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error: Unexpected token '}' %s
+%AParse error:%AUnmatched '}'%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/unexpected_closing_parenthesis.phpt
+++ b/tests/ph7/002-integration/lang/unexpected_closing_parenthesis.phpt
@@ -10,7 +10,7 @@ Unexpected closing parenthesis
 echo (1 + 2));
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error: Unexpected token ')' %s
+%AParse error:%AUnmatched ')'%AParse error:%Asyntax error, unexpected token ";"%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/unexpected_token.phpt
+++ b/tests/ph7/002-integration/lang/unexpected_token.phpt
@@ -12,7 +12,7 @@ if (function_exists('zend_version')) echo 'skip';
 echo 1 + * 2;
 ?>
 --EXPECTF--
-%s Fatal error:  '*': Missing/Invalid operand %s
+%AParse error:%Asyntax error, unexpected token ";"%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/unknown_operator.phpt
+++ b/tests/ph7/002-integration/lang/unknown_operator.phpt
@@ -3,14 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Test unknown operator parsing
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 $a @@ $b;
 ?>
 --EXPECTF--
-%s Fatal error:  Unexpected token '@' %s
+%AParse error:%Asyntax error, unexpected token "@"%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/lang/var_assignment_array_missing_entry_value.phpt
+++ b/tests/ph7/002-integration/lang/var_assignment_array_missing_entry_value.phpt
@@ -12,7 +12,7 @@ Var assignment on array with key but missing value generates compile error
 array(1 =>);
 ?>
 --EXPECTF--
-%s Fatal error:  array(): Missing entry value %s
+%AParse error:%Asyntax error, unexpected token "=>"%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/oo/final_method_override.phpt
+++ b/tests/ph7/002-integration/oo/final_method_override.phpt
@@ -19,7 +19,7 @@ class B extends A {
 }
 ?>
 --EXPECTF--
-%s Fatal error:  Cannot Overwrite final method 'A:f' inside child class 'B' %s
+%AFatal error:%ACannot override final method A::f()%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/parse/anonymous_function_missing_brace.phpt
+++ b/tests/ph7/002-integration/parse/anonymous_function_missing_brace.phpt
@@ -3,14 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Anonymous function syntax error: missing '{'
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 $func = function() echo "test";
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error while declaring annonymous function %s
+%AParse error:%Asyntax error, unexpected token "echo", expecting "{"%A
 --CLEAN--
 <?php
 unset($func);

--- a/tests/ph7/002-integration/parse/array_invalid_reference_extended.phpt
+++ b/tests/ph7/002-integration/parse/array_invalid_reference_extended.phpt
@@ -13,7 +13,7 @@ $a = array(&$e + $f);
 echo "Should not reach here\n";
 ?>
 --EXPECTF--
-%s Fatal error:  array(): Expecting a variable/array member/function call after reference operator '&' %s
+%AParse error:%Asyntax error, unexpected token "++", expecting "->" or "?->" or "["%AParse error:%Asyntax error, unexpected token "+", expecting "->" or "?->" or "["%A
 --CLEAN--
 <?php
 unset($a);

--- a/tests/ph7/002-integration/parse/block_nesting_edge_cases.phpt
+++ b/tests/ph7/002-integration/parse/block_nesting_edge_cases.phpt
@@ -53,7 +53,7 @@ $obj->test_method();
 
 ?>
 --EXPECTF--
-%s Fatal error:  A 'break' statement may only be used within a loop or switch %s
+%AFatal error:%A'break' not in the 'loop' or 'switch' context%AFatal error:%A'continue' not in the 'loop' or 'switch' context%A
 --CLEAN--
 <?php
 unset($obj);

--- a/tests/ph7/002-integration/parse/compilation_boundary_conditions.phpt
+++ b/tests/ph7/002-integration/parse/compilation_boundary_conditions.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 compilation boundary conditions and syntax error edge cases
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 // Test various compilation boundary conditions and syntax errors
@@ -75,7 +73,7 @@ class Child extends Parent implements {
 
 ?>
 --EXPECTF--
-%s Fatal error:  Missing ')' after function 'invalid_func' signature %s
+%AParse error:%Asyntax error, unexpected token "{", expecting variable%A
 --CLEAN--
 <?php
 unset($empty, $bad);

--- a/tests/ph7/002-integration/parse/compile_error_deep_nesting.phpt
+++ b/tests/ph7/002-integration/parse/compile_error_deep_nesting.phpt
@@ -102,7 +102,7 @@ echo "deep";
 }
 ?>
 --EXPECTF--
-%s Fatal error:  Missing closing braces '}' %s
+%AParse error:%AUnclosed '{' on line 11%AParse error:%AUnclosed '{' on line 10%AParse error:%AUnclosed '{' on line 9%AParse error:%AUnclosed '{' on line 8%AParse error:%AUnclosed '{' on line 7%AParse error:%AUnclosed '{' on line 6%AParse error:%AUnclosed '{' on line 5%AParse error:%AUnclosed '{' on line 4%AParse error:%AUnclosed '{' on line 3%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/parse/compile_error_edge_cases.phpt
+++ b/tests/ph7/002-integration/parse/compile_error_edge_cases.phpt
@@ -46,7 +46,7 @@ class InvalidClass {
 }
 ?>
 --EXPECTF--
-%s Fatal error:  '=': Missing/Invalid operand %s
+%AParse error:%Asyntax error, unexpected token ";"%AParse error:%Asyntax error, unexpected token ";", expecting variable%A
 --CLEAN--
 <?php
 unset($a, $arr, $result, $value);

--- a/tests/ph7/002-integration/parse/compile_error_many_errors.phpt
+++ b/tests/ph7/002-integration/parse/compile_error_many_errors.phpt
@@ -30,7 +30,7 @@ $s = ;
 $t = ;
 ?>
 --EXPECTF--
-%s Fatal error:  '=': Missing/Invalid operand %s
+%AParse error:%Asyntax error, unexpected token ";"%AFatal error:%AError count limit reached,PH7 is aborting compilation%A
 --CLEAN--
 <?php
 unset($a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, $n, $o, $p, $q, $r, $s, $t);

--- a/tests/ph7/002-integration/parse/const_reserved_names.phpt
+++ b/tests/ph7/002-integration/parse/const_reserved_names.phpt
@@ -13,7 +13,7 @@ const false = 3;
 echo "Should not reach here\n";
 ?>
 --EXPECTF--
-%s Fatal error:  const: Cannot redeclare a reserved constant 'null' %s
+%AFatal error:%ACannot redeclare constant 'null'%AFatal error:%ACannot redeclare constant 'true'%AFatal error:%ACannot redeclare constant 'false'%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/parse/expression_compile_errors.phpt
+++ b/tests/ph7/002-integration/parse/expression_compile_errors.phpt
@@ -45,7 +45,7 @@ INVALID;
 
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error,mismatched '(','[','{' or '?' %s
+%AParse error:%Asyntax error, unexpected token ";"%AFatal error:%A'->': Missing/Invalid member name%AFatal error:%A'::': Missing/Invalid member name%A
 --CLEAN--
 <?php
 unset($var, $array, $result, $obj);

--- a/tests/ph7/002-integration/parse/goto_cross_function_error.phpt
+++ b/tests/ph7/002-integration/parse/goto_cross_function_error.phpt
@@ -15,7 +15,7 @@ function foo() {
 goto LABEL;
 ?>
 --EXPECTF--
-%s Warning:  Label 'LABEL' is defined but not referenced %s
+%AFatal error:%A'goto' to undefined label 'LABEL'%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/parse/goto_edge_cases.phpt
+++ b/tests/ph7/002-integration/parse/goto_edge_cases.phpt
@@ -37,7 +37,7 @@ outer_function();
 
 ?>
 --EXPECTF--
-%s Fatal error:  Label 'NONEXISTENT_LABEL' was referenced but not defined %s
+%AFatal error:%A'goto' to undefined label 'NONEXISTENT_LABEL'%AFatal error:%A'goto' to undefined label 'MISSING_LABEL'%AFatal error:%A'goto' to undefined label 'INNER_MISSING'%AFatal error:%A'goto' to undefined label 'GLOBAL_MISSING_LABEL'%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/parse/goto_undefined_label.phpt
+++ b/tests/ph7/002-integration/parse/goto_undefined_label.phpt
@@ -10,7 +10,7 @@ goto undefined label
 goto LABEL;
 ?>
 --EXPECTF--
-%s Fatal error:  Label 'LABEL' was referenced but not defined %s
+%AFatal error:%A'goto' to undefined label 'LABEL'%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/parse/invalid_function_const_names.phpt
+++ b/tests/ph7/002-integration/parse/invalid_function_const_names.phpt
@@ -12,7 +12,7 @@ const 456 = 789;
 echo "Should not reach here\n";
 ?>
 --EXPECTF--
-%s Fatal error:  Invalid function name %s
+%AParse error:%Asyntax error, unexpected integer "123", expecting "("%AParse error:%Asyntax error, unexpected integer "456", expecting identifier%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/parse/invalid_operator.phpt
+++ b/tests/ph7/002-integration/parse/invalid_operator.phpt
@@ -3,14 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Invalid operator parsing to cover uncovered lines in PH7_ExprExtractOperator
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 $a invalid_op $b;
 ?>
 --EXPECTF--
-%s Fatal error:  Unexpected token 'invalid_op' %s
+%AParse error:%Asyntax error, unexpected identifier "invalid_op"%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/parse/mismatched_parenthesis.phpt
+++ b/tests/ph7/002-integration/parse/mismatched_parenthesis.phpt
@@ -3,14 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 mismatched parenthesis
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 echo (1 + 2;
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error,mismatched '(','[','{' or '?' %s
+%AParse error:%Asyntax error, unexpected token ";"%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/parse/missing_operand.phpt
+++ b/tests/ph7/002-integration/parse/missing_operand.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Test missing operand error in expression parsing
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 // Test missing operand after unary operator
@@ -17,7 +15,7 @@ $result2 = 5 + ;
 $result3 = (2 * ) + 3;
 ?>
 --EXPECTF--
-%s Fatal error:  '+': Missing operand %s
+%AParse error:%Asyntax error, unexpected token ";"%A
 --CLEAN--
 <?php
 unset($result, $result2, $result3);

--- a/tests/ph7/002-integration/parse/parse_block_error.phpt
+++ b/tests/ph7/002-integration/parse/parse_block_error.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Block mismatch error
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 function test() {
@@ -13,7 +11,7 @@ function test() {
 echo "test";
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error: Unexpected token '}' %s
+%AParse error:%AUnmatched '}'%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/parse/parse_string_interp_error.phpt
+++ b/tests/ph7/002-integration/parse/parse_string_interp_error.phpt
@@ -11,7 +11,7 @@ $a = "${1+";
 echo "test";
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error: Missing closing brace '}' %s
+%AParse error:%Asyntax error, unexpected variable "$"%A
 --CLEAN--
 <?php
 unset($a);

--- a/tests/ph7/002-integration/parse/parser_error_handling.phpt
+++ b/tests/ph7/002-integration/parse/parser_error_handling.phpt
@@ -58,7 +58,7 @@ try {
 
 ?>
 --EXPECTF--
-%s Fatal error:  goto: Invalid label name: ';' %s
+%AParse error:%Asyntax error, unexpected token ";", expecting identifier%AFatal error:%AExpected semi-colon ';' after 'goto' statement%AFatal error:%ASyntax error: Unexpected token ':'%AFatal error:%ASyntax error: Unexpected keyword 'interface'%AFatal error:%ASyntax error: Unexpected keyword 'trait'%AFatal error:%ASyntax error: Unexpected keyword 'abstract'%AFatal error:%ASyntax error: Unexpected keyword 'final'%AFatal error:%AMissing argument default value%AFatal error:%AEmpty constant 'CONSTANT' value%AFatal error:%AMissing ')' after method 'method' declaration%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/parse/ternary_missing_condition.phpt
+++ b/tests/ph7/002-integration/parse/ternary_missing_condition.phpt
@@ -3,15 +3,13 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Test ternary operator missing condition syntax error
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 // Test ternary operator without condition (should trigger syntax error)
 $result = ? "true" : "false";
 ?>
 --EXPECTF--
-%s Fatal error:  '?': Syntax error %s
+%AParse error:%Asyntax error, unexpected token "?"%A
 --CLEAN--
 <?php
 unset($result);

--- a/tests/ph7/002-integration/parse/ternary_missing_else.phpt
+++ b/tests/ph7/002-integration/parse/ternary_missing_else.phpt
@@ -3,15 +3,13 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Test ternary operator missing else syntax error
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 // Test ternary operator without else part (should trigger syntax error)
 $result = true ? "true";
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error,mismatched '(','[','{' or '?' %s
+%AParse error:%Asyntax error, unexpected token ";"%A
 --CLEAN--
 <?php
 unset($result);

--- a/tests/ph7/002-integration/parse/unexpected_closing_curly_brace.phpt
+++ b/tests/ph7/002-integration/parse/unexpected_closing_curly_brace.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 unexpected closing curly brace
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 if (true) {
@@ -14,7 +12,7 @@ echo 2;
 }
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error: Unexpected token '}' %s
+%AParse error:%AUnmatched '}'%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/parse/unexpected_closing_paren.phpt
+++ b/tests/ph7/002-integration/parse/unexpected_closing_paren.phpt
@@ -10,7 +10,7 @@ unexpected closing parenthesis
 echo 1);
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error: Unexpected token ')' %s
+%AParse error:%AUnmatched ')'%AParse error:%Asyntax error, unexpected token ";"%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/002-integration/parse/unexpected_closing_square_bracket.phpt
+++ b/tests/ph7/002-integration/parse/unexpected_closing_square_bracket.phpt
@@ -10,7 +10,7 @@ unexpected closing square bracket
 echo $a];
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error: Unexpected token ']' %s
+%AParse error:%AUnmatched ']'%AParse error:%Asyntax error, unexpected token ";"%A
 --CLEAN--
 <?php
 unset($a);

--- a/tests/ph7/002-integration/parse/unexpected_token.phpt
+++ b/tests/ph7/002-integration/parse/unexpected_token.phpt
@@ -31,7 +31,7 @@ foreach ([1,2] as $val) {
 
 ?>
 --EXPECTF--
-%s Fatal error:  Syntax error: Unexpected token '}' %s
+%AParse error:%AUnmatched '}'%AParse error:%AUnmatched ']'%AParse error:%Asyntax error, unexpected token ";"%A
 --CLEAN--
 <?php
 unset($a, $array, $func, $x);


### PR DESCRIPTION
Replace PH7's bespoke syntax-error sentences with php's wording via a shared PH7_GenSyntaxError(): php names a token by class -- identifier "x", variable "$i", integer "123", otherwise token ";" -- with an optional ", expecting ..." tail. Around thirty sites in compile.c and parse.c now use it, so 56 of the 67 guarded parse/error tests emit php's text byte-for-byte. A statement's token slice stops before its terminator, so the helper reaches one token past the slice to name the ';' php blames rather than claiming end of file.

E_PARSE did not count as a compile error: a parse error printed its diagnostic and then fell through into execution with exit status 0. It now fails the compile, and the CLI no longer prints an extra "Compile error" line -- php prints the diagnostic and exits 255.

The goto/label rules were inverted. PHL rejected a label defined inside a loop or try{}, rejected goto inside try{}, and warned about an unreferenced label; php allows all three and warns about none. php's actual rule is the opposite: 'goto' into loop or switch statement is disallowed. Each loop/switch now takes an id and records its parent, labels and gotos record the loop they sit in, and the fixup pass walks up from the goto's loop looking for the label's.

Calling an undefined function warned and returned null, quietly turning a typo into a null-propagating program; it now raises php's catchable Error.

Regenerate the affected expectations, un-guarding the 49 that now agree with the oracle, and rewrite label_not_referenced, which asserted the deleted unused-label warning.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
