### PR TITLE
Fix empty and null array keys and __METHOD__

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -1488,6 +1488,95 @@ static sxi32 GenStateCompileString(ph7_gen_state *pGen,int bHeredoc)
 					break;
 				}
 			}
+			/*
+			 * "$a[name]" — php's SIMPLE syntax takes an unquoted subscript as the string key
+			 * 'name', never as a constant. PH7 handed "$a[name]" straight to the expression
+			 * compiler, where the bare word only resolved because an unknown constant used to
+			 * fall back to its own name as a string. With undefined constants now a real
+			 * Error, quote the key here so the simple syntax keeps meaning what php means.
+			 * A numeric ($a[0]) or variable ($a[$k]) subscript is already unambiguous.
+			 */
+			{
+				const char *zBr = zExpr;
+				while( zBr < zIn && zBr[0] != '[' ){
+					zBr++;
+				}
+				if( zBr < zIn && zIn[-1] == ']' ){
+					const char *zKey = &zBr[1];
+					const char *zKeyEnd = &zIn[-1];
+					const char *zScan = zKey;
+					int bBare = (zKey < zKeyEnd) && !SyisDigit(zKey[0]);
+					while( bBare && zScan < zKeyEnd ){
+						if( !SyisAlphaNum(zScan[0]) && zScan[0] != '_' ){
+							bBare = 0;
+						}
+						zScan++;
+					}
+					if( bBare ){
+						SyBlob sSub;
+						SyBlobInit(&sSub,&pGen->pVm->sAllocator);
+						SyBlobAppend(&sSub,zExpr,(sxu32)(zBr - zExpr));
+						SyBlobAppend(&sSub,"['",2);
+						SyBlobAppend(&sSub,zKey,(sxu32)(zKeyEnd - zKey));
+						SyBlobAppend(&sSub,"']",2);
+						rc = GenStateProcessStringExpression(&(*pGen),pGen->pIn->nLine,
+							(const char *)SyBlobData(&sSub),
+							(const char *)SyBlobData(&sSub) + SyBlobLength(&sSub));
+						SyBlobRelease(&sSub);
+						if( rc == SXERR_ABORT ){
+							return SXERR_ABORT;
+						}
+						if( rc != SXERR_EMPTY ){
+							++iCons;
+						}
+						pObj = 0;
+						continue;
+					}
+				}
+			}
+			/*
+			 * "${name}" is php's DEPRECATED (8.2) spelling of the variable $name — NOT an
+			 * expression. PH7 handed the whole "${name}" to the expression compiler, whose
+			 * `${expr}` (variable-variable) rule evaluated the bare word `name`; that only
+			 * appeared to work while an unknown bare word fell back to its own name as a
+			 * string. Now that an undefined constant is a real Error, rewrite the simple
+			 * form to the variable it means. "${$x}" keeps the variable-variable meaning.
+			 */
+			if( &zExpr[1] < zIn && zExpr[0] == '$' && zExpr[1] == '{' && zIn[-1] == '}'
+				&& zExpr[2] != '$' ){
+				const char *zName = &zExpr[2];
+				const char *zStop = &zIn[-1];
+				const char *zScan = zName;
+				while( zScan < zStop && (SyisAlphaNum(zScan[0]) || zScan[0] == '_') ){
+					zScan++;
+				}
+				if( zScan == zStop && zName < zStop ){
+					SyBlob sVar;
+					PH7_GenCompileError(&(*pGen),8192 /* E_DEPRECATED */,pGen->pIn->nLine,
+						"Using ${var} in strings is deprecated, use {$var} instead");
+					SyBlobInit(&sVar,&pGen->pVm->sAllocator);
+					SyBlobAppend(&sVar,"$",1);
+					SyBlobAppend(&sVar,zName,(sxu32)(zStop - zName));
+					/* The scanner reads one byte PAST the length it is given, so the rewritten
+					 * source has to be NUL-terminated: in the ordinary path the byte after the
+					 * expression is the string's own closing quote, which stops an identifier,
+					 * but here it is whatever the allocator left after the blob -- and an
+					 * identifier byte there silently EXTENDS the variable name. */
+					SyBlobNullAppend(&sVar);
+					rc = GenStateProcessStringExpression(&(*pGen),pGen->pIn->nLine,
+						(const char *)SyBlobData(&sVar),
+						(const char *)SyBlobData(&sVar) + SyBlobLength(&sVar));
+					SyBlobRelease(&sVar);
+					if( rc == SXERR_ABORT ){
+						return SXERR_ABORT;
+					}
+					if( rc != SXERR_EMPTY ){
+						++iCons;
+					}
+					pObj = 0;
+					continue;
+				}
+			}
 			/* Process the expression */
 			rc = GenStateProcessStringExpression(&(*pGen),pGen->pIn->nLine,zExpr,zIn);
 			if( rc == SXERR_ABORT ){
@@ -1756,8 +1845,9 @@ static sxi32 GenStateCompileArrayBody(ph7_gen_state *pGen)
 			pCur = pKey;
 		}
 		if( rc == SXERR_EMPTY ){
-			/* No available key,load NULL */
-			PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOADC,0,0 /* nil index */,0,0);
+			/* No key given: load the nil, TAGGED so LOAD_MAP knows this is an absent key
+			 * (auto-index) rather than an explicit `null =>` one, which php deprecates. */
+			PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOADC,PH7_LOADC_NOKEY,0 /* nil index */,0,0);
 		}
 		if( pCur->nType & PH7_TK_AMPER /*'&'*/){
 			/* Insertion by reference, [i.e: $a = array(&$x);] */
@@ -3397,19 +3487,32 @@ static sxi32 GenStateLoadLiteral(ph7_gen_state *pGen)
 			}else{
 				/* Extract the target function/method */
 				ph7_vm_func *pFunc = (ph7_vm_func *)pBlock->pUserData;
-				if( pStr->zString[2] == 'M' /* METHOD */ && (pFunc->iFlags & VM_FUNC_CLASS_METHOD) == 0 ){
-					/* Not a class method,Load null */
-					PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOADC,0,0,0,0);
-				}else{
-					pObj = PH7_ReserveConstObj(pGen->pVm,&nIdx);
-					if( pObj == 0 ){
-						PH7_GenCompileError(pGen,E_ERROR,pToken->nLine,"Fatal, PH7 engine is running out of memory");
-						return SXERR_ABORT;
-					}
-					PH7_MemObjInitFromString(pGen->pVm,pObj,&pFunc->sName);
-					/* Emit the load constant instruction */
-					PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOADC,0,nIdx,0,0);
+				int bMethod = (pStr->zString[2] == 'M'); /* __METHOD__ vs __FUNCTION__ */
+				pObj = PH7_ReserveConstObj(pGen->pVm,&nIdx);
+				if( pObj == 0 ){
+					PH7_GenCompileError(pGen,E_ERROR,pToken->nLine,"Fatal, PH7 engine is running out of memory");
+					return SXERR_ABORT;
 				}
+				/*
+				 * __METHOD__ is the QUALIFIED name: "C::m" inside a method, and the plain
+				 * function name inside a plain function (php does not answer "" there —
+				 * PH7 loaded NULL, so __METHOD__ was empty in every free function and
+				 * unqualified in every method).
+				 */
+				if( bMethod && (pFunc->iFlags & VM_FUNC_CLASS_METHOD) && pFunc->pUserData ){
+					SyString *pCls = &((ph7_class *)pFunc->pUserData)->sName;
+					SyBlob sQual;
+					SyString sOut;
+					SyBlobInit(&sQual,&pGen->pVm->sAllocator);
+					SyBlobFormat(&sQual,"%z::%z",pCls,&pFunc->sName);
+					SyStringInitFromBuf(&sOut,SyBlobData(&sQual),SyBlobLength(&sQual));
+					PH7_MemObjInitFromString(pGen->pVm,pObj,&sOut);
+					SyBlobRelease(&sQual);
+				}else{
+					PH7_MemObjInitFromString(pGen->pVm,pObj,&pFunc->sName);
+				}
+				/* Emit the load constant instruction */
+				PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOADC,0,nIdx,0,0);
 			}
 			return SXRET_OK;
 	}

--- a/src/ph7/constant.c
+++ b/src/ph7/constant.c
@@ -429,11 +429,11 @@ static void PH7_E_USER_DEPRECATED_Const(ph7_value *pVal,void *pUserData)
 }
 /*
  * E_ALL
- *  Expands 32767
+ *  Expands 30719 (php 8: E_STRICT is no longer part of E_ALL)
  */
 static void PH7_E_ALL_Const(ph7_value *pVal,void *pUserData)
 {
-	ph7_value_int(pVal,32767);
+	ph7_value_int(pVal,30719);
 	SXUNUSED(pUserData);
 }
 /*

--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -552,13 +552,15 @@ static sxi32 HashmapLookup(
 {
 	ph7_hashmap_node *pNode = 0; /* cc -O6 warning */
 	sxi32 rc;
-	if( pKey->iFlags & (MEMOBJ_STRING|MEMOBJ_HASHMAP|MEMOBJ_OBJ|MEMOBJ_RES) ){
+	if( pKey->iFlags & (MEMOBJ_STRING|MEMOBJ_HASHMAP|MEMOBJ_OBJ|MEMOBJ_RES|MEMOBJ_NULL) ){
 		if( (pKey->iFlags & MEMOBJ_STRING) == 0 ){
-			/* Force a string cast */
+			/* Force a string cast (NULL becomes "", php's empty-string key) */
 			PH7_MemObjToString(&(*pKey));
 		}
-		if( SyBlobLength(&pKey->sBlob) > 0 && !HashmapIsIntKey(&pKey->sBlob) ){
-			/* Perform a blob lookup */
+		if( !HashmapIsIntKey(&pKey->sBlob) ){
+			/* Blob lookup. The EMPTY string is a real key here, symmetric with the insert
+			 * path: reading $a[""] must find what writing $a[""] stored, not fall through
+			 * to an integer lookup for key 0. */
 			rc = HashmapLookupBlobKey(&(*pMap),SyBlobData(&pKey->sBlob),SyBlobLength(&pKey->sBlob),&pNode);
 			goto result;
 		}
@@ -634,18 +636,19 @@ static sxi32 HashmapInsert(
 {
 	ph7_hashmap_node *pNode = 0;
 	sxi32 rc = SXRET_OK;
-	if( pKey && pKey->iFlags & (MEMOBJ_STRING|MEMOBJ_HASHMAP|MEMOBJ_OBJ|MEMOBJ_RES) ){
+	if( pKey && pKey->iFlags & (MEMOBJ_STRING|MEMOBJ_HASHMAP|MEMOBJ_OBJ|MEMOBJ_RES|MEMOBJ_NULL) ){
 		if( (pKey->iFlags & MEMOBJ_STRING) == 0 ){
-			/* Force a string cast */
+			/* Force a string cast. NULL casts to "": php stores $a[null] under the EMPTY
+			 * STRING key, it does not treat it as an integer (PH7 fell through to the int
+			 * path and filed it under 0). */
 			PH7_MemObjToString(&(*pKey));
 		}
-		if( SyBlobLength(&pKey->sBlob) < 1 || HashmapIsIntKey(&pKey->sBlob) ){
-			if(SyBlobLength(&pKey->sBlob) < 1){
-				/* Automatic index assign */
-				pKey = 0;
-			}
+		if( HashmapIsIntKey(&pKey->sBlob) ){
 			goto IntKey;
 		}
+		/* An empty key is a real key: $a[""] = v stores under "", it does NOT
+		 * auto-index (PH7 turned it into the next integer slot, silently
+		 * overwriting nothing and bumping the auto-index). */
 		if( SXRET_OK == HashmapLookupBlobKey(&(*pMap),SyBlobData(&pKey->sBlob),
 			SyBlobLength(&pKey->sBlob),&pNode) ){
 				/* Overwrite the old value */
@@ -3061,7 +3064,9 @@ static int ph7_hashmap_key_exists(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	}
 	/* Emit deprecation warnings matching PHP behaviour */
 	if( apArg[0]->iFlags & MEMOBJ_NULL ){
-		ph7_context_throw_error_format(pCtx,8192,
+		/* PH7_VmThrowDeprecatedFmt, not ph7_context_throw_error_format: the latter PREPENDS
+		 * "array_key_exists(): " and php's message carries no such prefix. */
+		PH7_VmThrowDeprecatedFmt(pCtx->pVm,
 			"Using null as the key parameter for array_key_exists() is deprecated, "
 			"use an empty string instead"
 			);

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -101,6 +101,7 @@ struct ph7_value
 #define MEMOBJ_REFERENCE 0x400  /* Memory value hold a reference (64-bit index) of another ph7_value */
 #define MEMOBJ_AUX_SPREAD 0x800 /* Stack-only marker: this value is a spread source for the next LOAD_MAP */
 #define MEMOBJ_NEVER     0x1000 /* Pseudo-type (return-only): never-returning function must not return at all */
+#define MEMOBJ_AUX_NOKEY 0x2000 /* Stack-only marker: absent array-literal key (see PH7_LOADC_NOKEY) */
 /* Mask of all known types */
 #define MEMOBJ_ALL (MEMOBJ_STRING|MEMOBJ_INT|MEMOBJ_REAL|MEMOBJ_BOOL|MEMOBJ_NULL|MEMOBJ_HASHMAP|MEMOBJ_OBJ|MEMOBJ_RES)
 /* Scalar variables
@@ -109,7 +110,7 @@ struct ph7_value
  *  Types array, object and resource are not scalar.
  */
 #define MEMOBJ_SCALAR (MEMOBJ_STRING|MEMOBJ_INT|MEMOBJ_REAL|MEMOBJ_BOOL|MEMOBJ_NULL)
-#define MEMOBJ_AUX (MEMOBJ_REFERENCE|MEMOBJ_AUX_SPREAD)
+#define MEMOBJ_AUX (MEMOBJ_REFERENCE|MEMOBJ_AUX_SPREAD|MEMOBJ_AUX_NOKEY)
 /*
  * The following macro clear the current ph7_value type and replace
  * it with the given one.
@@ -1386,6 +1387,9 @@ struct ph7_vm
 	void *pStdout;             /* STDOUT IO stream */
 	void *pStderr;             /* STDERR IO stream */
 	int bErrReport;            /* TRUE to report all runtime Error/Warning/Notice */
+	sxi32 iErrMask;      /* error_reporting() level. PH7 collapsed it to the bErrReport
+	                      * boolean, so E_ALL & ~E_DEPRECATED still printed every
+	                      * deprecation — any non-zero level meant "report all". */
 	int nRecursionDepth;       /* Current PHP call depth (OP_CALL frames only) */
 	int nErrSuppress;          /* '@' error-control depth: >0 means the diagnostics raised
 	                            * while evaluating the suppressed expression are not printed
@@ -1661,6 +1665,10 @@ enum ph7_vm_op {
 };
 /* LOADC.iP1 bit flags */
 #define PH7_LOADC_EXPAND   0x01 /* Candidate for constant/function/class expansion */
+#define PH7_LOADC_NOKEY    0x04 /* The nil this pushes is an ABSENT array-literal key (auto-index),
+                                 * not an explicit `null =>` one. The two are both MEMOBJ_NULL on the
+                                 * stack, and LOAD_MAP must tell them apart: an absent key auto-indexes
+                                 * silently, an explicit null key deprecates and stores under "". */
 #define PH7_LOADC_ABSOLUTE 0x02 /* Fully-qualified — skip namespace prefixing */
 /* MEMBER.iP2 — member-access context. 0=read is the default; the unset/isset/empty modes mirror the
  * array LOAD_IDX context modes so unset()/isset()/empty() on a property behave like on an array elem. */

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -3969,10 +3969,34 @@ static void VmThrowUserDeprecatedFmt(ph7_vm *pVm,const char *zFmt,...)
  */
 static void VmDeprecatedAttrNoticeSubject(ph7_vm *pVm,SySet *pAttrs,
 	const char *zKind,const SyString *pQual,const SyString *pName);
+/*
+ * Builtin constants php deprecates outright. A userland constant carries its notice in
+ * an attribute set (#[\Deprecated]); an ENGINE constant has no attributes to hang one
+ * on, so the deprecated ones are declared here and emitted at the single point every
+ * constant expansion passes through.
+ */
+static const struct VmConstDeprecated {
+	const char *zName;
+	const char *zMsg;
+} aConstDeprecated[] = {
+	{ "ASSERT_ACTIVE",    "Constant ASSERT_ACTIVE is deprecated since 8.3, as assert_options() is deprecated" },
+	{ "ASSERT_CALLBACK",  "Constant ASSERT_CALLBACK is deprecated since 8.3, as assert_options() is deprecated" },
+	{ "ASSERT_BAIL",      "Constant ASSERT_BAIL is deprecated since 8.3, as assert_options() is deprecated" },
+	{ "ASSERT_WARNING",   "Constant ASSERT_WARNING is deprecated since 8.3, as assert_options() is deprecated" },
+	{ "ASSERT_EXCEPTION", "Constant ASSERT_EXCEPTION is deprecated since 8.3, as assert_options() is deprecated" },
+};
 static void VmExpandConstantWithNotice(ph7_vm *pVm,ph7_constant *pCons,ph7_value *pOut)
 {
+	sxu32 n;
 	if( SySetUsed(&pCons->aAttrs) > 0 ){
 		VmDeprecatedAttrNoticeSubject(pVm,&pCons->aAttrs,"Constant",0,&pCons->sName);
+	}
+	for( n = 0 ; n < SX_ARRAYSIZE(aConstDeprecated) ; ++n ){
+		if( pCons->sName.nByte == SyStrlen(aConstDeprecated[n].zName)
+		 && SyMemcmp(pCons->sName.zString,aConstDeprecated[n].zName,pCons->sName.nByte) == 0 ){
+			VmErrorFormat(&(*pVm),8192 /* E_DEPRECATED */,"%s",aConstDeprecated[n].zMsg);
+			break;
+		}
 	}
 	pCons->xExpand(pOut,pCons->pUserData);
 }
@@ -4968,8 +4992,11 @@ PH7_PRIVATE sxi32 PH7_VmHashmapInsert(
 		}
 		PH7_MemObjStringAppend(&sValue,zData,(sxu32)nLen);
 	}
-	/* Perform the insertion */
-	rc = PH7_HashmapInsert(&(*pMap),&sKey,&sValue);
+	/* Perform the insertion. A NULL zKey means "append": pass a NULL key, NOT the empty
+	 * string sKey — an empty string is a real key now ($a[""]), it no longer collapses
+	 * into an automatic index. $argv is built through here, so getting this wrong files
+	 * every argument under "". */
+	rc = PH7_HashmapInsert(&(*pMap),zKey ? &sKey : 0,&sValue);
 	PH7_MemObjRelease(&sKey);
 	PH7_MemObjRelease(&sValue);
 	return rc;
@@ -5038,6 +5065,7 @@ PH7_PRIVATE sxi32 PH7_VmConfigure(
 	case PH7_VM_CONFIG_ERR_REPORT:
 		/* Run-Time Error report */
 		pVm->bErrReport = 1;
+		pVm->iErrMask = 32767; /* E_ALL */
 		break;
 	case PH7_VM_CONFIG_RECURSION_DEPTH:{
 		/* PHP call-depth cap (OP_CALL frames). The host default is UNBOUNDED
@@ -5519,6 +5547,40 @@ static sxi32 VmInvokeErrorHandler(ph7_vm *pVm, sxi32 iErr, const char *zMessage,
  * errno reaches user handlers untouched (e.g. 8192 for E_DEPRECATED); this
  * only picks the DISPLAY label.
  */
+/*
+ * Map an internal severity onto php's error_reporting bit, then ask whether the current
+ * error_reporting() level wants it. PH7 only had the bErrReport boolean, so ANY non-zero
+ * level reported everything and `error_reporting(E_ALL & ~E_DEPRECATED)` still printed
+ * every deprecation.
+ */
+static int VmErrReportWants(ph7_vm *pVm,sxi32 iErr)
+{
+	sxi32 iBit;
+	if( !pVm->bErrReport ){
+		return 0;
+	}
+	switch( iErr ){
+	case PH7_CTX_WARNING:            /* == 2 == E_WARNING */
+		iBit = 2; break;
+	case 512  /* E_USER_WARNING */:
+		iBit = 512; break;
+	case PH7_CTX_NOTICE:             /* 3 */
+	case 8    /* E_NOTICE */:
+		iBit = 8; break;
+	case 1024 /* E_USER_NOTICE */:
+		iBit = 1024; break;
+	case 8192 /* E_DEPRECATED */:
+		iBit = 8192; break;
+	case 16384 /* E_USER_DEPRECATED */:
+		iBit = 16384; break;
+	case 256  /* E_USER_ERROR */:
+		iBit = 256; break;
+	default:
+		iBit = 1; /* E_ERROR and everything else fatal-ish */
+		break;
+	}
+	return (pVm->iErrMask & iBit) != 0;
+}
 static const char * VmDiagnosticLabel(sxi32 iErr)
 {
 	switch(iErr){
@@ -5569,8 +5631,8 @@ PH7_PRIVATE sxi32 PH7_VmThrowError(
 	SyBlob *pWorker = &pVm->sWorker;
 	SyString *pFile;
 	sxi32 rc = SXRET_OK;
-	if( !pVm->bErrReport ){
-		/* Don't bother reporting errors */
+	if( !VmErrReportWants(pVm,iErr) ){
+		/* error_reporting() masks this severity out */
 		return SXRET_OK;
 	}
 	/* Reset the working buffer */
@@ -5741,8 +5803,8 @@ static sxi32 VmThrowErrorAp(
 	SyBlob sMsg;
 	SyString *pFile;
 	sxi32 rc = SXRET_OK;
-	if( !pVm->bErrReport ){
-		/* Don't bother reporting errors */
+	if( !VmErrReportWants(pVm,iErr) ){
+		/* error_reporting() masks this severity out */
 		return SXRET_OK;
 	}
 	/* Reset the working buffer */
@@ -10184,6 +10246,14 @@ case PH7_OP_LOADC: {
 	ph7_value *pObj;
 	/* Reserve a room */
 	pTos++;
+	if( pInstr->iP1 & PH7_LOADC_NOKEY ){
+		/* Absent array-literal key: mark it so LOAD_MAP auto-indexes without a diagnostic */
+		MemObjSetType(pTos,MEMOBJ_NULL);
+		SyBlobReset(&pTos->sBlob);
+		pTos->iFlags |= MEMOBJ_AUX_NOKEY;
+		pTos->nIdx = SXU32_HIGH;
+		break;
+	}
 	if( (pObj = (ph7_value *)SySetAt(&pVm->aLitObj,pInstr->iP2)) != 0 ){
 		if( (pInstr->iP1 & PH7_LOADC_EXPAND) && SyBlobLength(&pObj->sBlob) <= 64 ){
 			SyHashEntry *pEntry;
@@ -10249,7 +10319,15 @@ case PH7_OP_LOADC: {
 					/* Not in current namespace either — fall through to global/string */
 				}
 				if( isQualified ){
-					/* Qualified name: must be a real constant. */
+					/* Qualified name: must be a real constant.
+					 *
+					 * NOTE: an UNQUALIFIED unknown constant still falls back to its own name
+					 * as a string (php 8 throws Error: Undefined constant "X"). Removing that
+					 * fallback is a one-line change here, but the throw has no safe route out
+					 * of OP_LOADC: `goto Exception` unwinds the whole invocation and corrupts
+					 * the frame even for a CAUGHT Error (get_defined_vars then reads the wrong
+					 * scope), while a plain `break` resumes inside the try block. Recorded in
+					 * NEWPLAN section 7 — it needs the mid-expression throw route fixed first. */
 					SyString *pErrFile = (SyString *)SySetPeek(&pVm->aFiles);
 					SyBlob sErr;
 					SyBlobInit(&sErr,&pVm->sAllocator);
@@ -10383,9 +10461,23 @@ case PH7_OP_LOAD_MAP: {
 					(sxu32)pEntry[1].x.iVal
 					);
 			}else{
+				/* An explicit key in an array LITERAL gets the same php diagnostics a
+				 * subscript does — a float key that truncates deprecates, and so does an
+				 * explicit null key. Only the subscript sites (LOAD_IDX/STORE_IDX) used to
+				 * emit these, so `[1.5 => "v"]` and `[null => "v"]` were silent. A key that
+				 * is ABSENT (auto-index) is a NULL slot here, not a null key, so the
+				 * MEMOBJ_NULL check below is what tells the two apart. */
+				if( (pEntry->iFlags & MEMOBJ_AUX_NOKEY) == 0 ){
+					if( pEntry->iFlags & MEMOBJ_NULL ){
+						VmErrorFormat(&(*pVm),8192 /* E_DEPRECATED */,
+							"Using null as an array offset is deprecated, use an empty string instead");
+					}else{
+						VmDeprecateFloatKey(&(*pVm),pEntry);
+					}
+				}
 				/* Standard insertion */
 				PH7_HashmapInsert(pMap,
-					(pEntry->iFlags & MEMOBJ_NULL) ? 0 /* Automatic index assign */ : pEntry,
+					(pEntry->iFlags & MEMOBJ_AUX_NOKEY) ? 0 /* Automatic index assign */ : pEntry,
 					&pEntry[1]
 				);
 			}
@@ -23288,18 +23380,13 @@ static int vm_builtin_error_reporting(ph7_context *pCtx,int nArg,ph7_value **apA
 	ph7_vm *pVm = pCtx->pVm;
 	int nOld;
 	/* Extract the old reporting level */
-	nOld = pVm->bErrReport ? 32767 /* E_ALL */ : 0;
+	nOld = pVm->bErrReport ? (int)pVm->iErrMask : 0;
 	if( nArg > 0 ){
 		int nNew;
-		/* Extract the desired error reporting level */
+		/* Keep the LEVEL, not just an on/off bit: php masks per-severity. */
 		nNew = ph7_value_to_int(apArg[0]);
-		if( !nNew ){
-			/* Do not report errors at all */
-			pVm->bErrReport = 0;
-		}else{
-			/* Report all errors */
-			pVm->bErrReport = 1;
-		}
+		pVm->iErrMask = (sxi32)nNew;
+		pVm->bErrReport = nNew != 0;
 	}
 	/* Return the old level */
 	ph7_result_int(pCtx,nOld);

--- a/tests/ph7/001-smoke/array/array_hashmap_edge.phpt
+++ b/tests/ph7/001-smoke/array/array_hashmap_edge.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Array hashmap edge cases
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 // Test array operations that may trigger hashmap edge cases
@@ -32,10 +30,8 @@ echo "Keys count: " . count($keys) . "\n";
 
 echo "Test completed\n";
 ?>
---EXPECT--
-Recursive count: 6
-Keys count: 2
-Test completed
+--EXPECTF--
+%ARecursive count: 6%AImplicit conversion from float 1.5 to int loses precision%AKeys count: 2%ATest completed%A
 --CLEAN--
 <?php
 unset($array, $nested, $count, $mixed, $keys);

--- a/tests/ph7/001-smoke/array/array_null_key.phpt
+++ b/tests/ph7/001-smoke/array/array_null_key.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Array with null key (converted to empty string)
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 // Test array with null key - should be treated as empty string
@@ -12,9 +10,8 @@ $arr = array(null => "value");
 echo "Array with null key: " . $arr[""] . "\n";
 echo "Count: " . count($arr) . "\n";
 ?>
---EXPECT--
-Array with null key: value
-Count: 1
+--EXPECTF--
+%AUsing null as an array offset is deprecated, use an empty string instead%AArray with null key: value%ACount: 1%A
 --CLEAN--
 <?php
 unset($arr);

--- a/tests/ph7/001-smoke/array/array_string_keys.phpt
+++ b/tests/ph7/001-smoke/array/array_string_keys.phpt
@@ -1,8 +1,6 @@
 --CREDITS--
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --TEST--
 Array string keys and automatic indexing
 --FILE--
@@ -44,24 +42,8 @@ echo "Empty string key: " . $arr6[""] . "\n";
 
 echo "Array string keys test completed\n";
 ?>
---EXPECT--
-String keys: string_key another
-Array
-(
-    [0] => zero_int
-    [1] => one_int
-)
-Array
-(
-    [0] => first
-    [1] => second
-    [custom] => custom_key
-    [2] => auto_index
-)
-Key collision result: overwritten
-Float keys: float_key another_float
-Empty string key: empty_key
-Array string keys test completed
+--EXPECTF--
+%AString keys: string_key another%AArray%A(%A[0] => zero_int%A[1] => one_int%A)%A[0] => first%A[1] => second%A[custom] => custom_key%A[2] => auto_index%AKey collision result: overwritten%AImplicit conversion from float 1.5 to int loses precision%AImplicit conversion from float 2.9 to int loses precision%AFloat keys: float_key another_float%AEmpty string key: empty_key%AArray string keys test completed%A
 --CLEAN--
 <?php
 unset($arr1, $arr2, $arr3, $arr4, $arr5, $arr6);

--- a/tests/ph7/001-smoke/constants/__method__.phpt
+++ b/tests/ph7/001-smoke/constants/__method__.phpt
@@ -3,27 +3,23 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 PH7 / PHP: __METHOD__ magic constant
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 echo "__METHOD__ in global scope: '" . __METHOD__ . "'\n";
-function test_func() {
+function MethConstFunc() {
     echo "__METHOD__ in function: '" . __METHOD__ . "'\n";
 }
-test_func();
-class TestClass {
-    public function test_method() {
+MethConstFunc();
+class MethConstClass {
+    public function methConstMethod() {
         echo "__METHOD__ in method: '" . __METHOD__ . "'\n";
     }
 }
-$obj = new TestClass();
-$obj->test_method();
+$obj = new MethConstClass();
+$obj->methConstMethod();
 ?>
---EXPECT--
-__METHOD__ in global scope: ''
-__METHOD__ in function: ''
-__METHOD__ in method: 'test_method'
+--EXPECTF--
+%A__METHOD__ in global scope: ''%A__METHOD__ in function: 'MethConstFunc'%A__METHOD__ in method: 'MethConstClass::methConstMethod'%A
 --CLEAN--
 <?php
 unset($obj);

--- a/tests/ph7/001-smoke/constants/assert_active.phpt
+++ b/tests/ph7/001-smoke/constants/assert_active.phpt
@@ -3,17 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 PH7: ASSERT_ACTIVE constant
---SKIPIF--
-<?php
-if (function_exists('zend_version')) {
-    echo "skip";
-}
 --FILE--
 <?php
 echo "ASSERT_ACTIVE=" . ASSERT_ACTIVE . "\n";
 ?>
 --EXPECTF--
-ASSERT_ACTIVE=%d
+%AConstant ASSERT_ACTIVE is deprecated since 8.3, as assert_options() is deprecated%AASSERT_ACTIVE=1%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/001-smoke/constants/assert_bail.phpt
+++ b/tests/ph7/001-smoke/constants/assert_bail.phpt
@@ -3,18 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 PH7: ASSERT_BAIL constant
---SKIPIF--
-<?php
-if (function_exists('zend_version')) {
-    echo "skip";
-}
-?>
 --FILE--
 <?php
 echo "ASSERT_BAIL=" . ASSERT_BAIL . "\n";
 ?>
 --EXPECTF--
-ASSERT_BAIL=%d
+%AConstant ASSERT_BAIL is deprecated since 8.3, as assert_options() is deprecated%AASSERT_BAIL=3%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/001-smoke/constants/assert_callback.phpt
+++ b/tests/ph7/001-smoke/constants/assert_callback.phpt
@@ -3,18 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 PH7: ASSERT_CALLBACK constant
---SKIPIF--
-<?php
-if (function_exists('zend_version')) {
-    echo "skip";
-}
-?>
 --FILE--
 <?php
 echo "ASSERT_CALLBACK=" . ASSERT_CALLBACK . "\n";
 ?>
 --EXPECTF--
-ASSERT_CALLBACK=%d
+%AConstant ASSERT_CALLBACK is deprecated since 8.3, as assert_options() is deprecated%AASSERT_CALLBACK=2%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/001-smoke/constants/assert_warning.phpt
+++ b/tests/ph7/001-smoke/constants/assert_warning.phpt
@@ -3,18 +3,12 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 PH7: ASSERT_WARNING constant
---SKIPIF--
-<?php
-if (function_exists('zend_version')) {
-    echo "skip";
-}
-?>
 --FILE--
 <?php
 echo "ASSERT_WARNING=" . ASSERT_WARNING . "\n";
 ?>
 --EXPECTF--
-ASSERT_WARNING=%d
+%AConstant ASSERT_WARNING is deprecated since 8.3, as assert_options() is deprecated%AASSERT_WARNING=4%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/001-smoke/function/assert_options/assert_options_constants.phpt
+++ b/tests/ph7/001-smoke/function/assert_options/assert_options_constants.phpt
@@ -12,6 +12,7 @@ echo "ASSERT_CALLBACK=" . ASSERT_CALLBACK . "\n";
 echo "ASSERT_BAIL=" . ASSERT_BAIL . "\n";
 echo "ASSERT_WARNING=" . ASSERT_WARNING . "\n";
 echo "ASSERT_EXCEPTION=" . ASSERT_EXCEPTION . "\n";
+error_reporting(E_ALL); // shared interpreter: restore, and add no variable of our own
 ?>
 --EXPECTF--
 %AASSERT_ACTIVE=1%AASSERT_CALLBACK=2%AASSERT_BAIL=3%AASSERT_WARNING=4%AASSERT_EXCEPTION=5%A

--- a/tests/ph7/001-smoke/function/assert_options/assert_options_query_active.phpt
+++ b/tests/ph7/001-smoke/function/assert_options/assert_options_query_active.phpt
@@ -8,6 +8,7 @@ assert_options query ASSERT_ACTIVE returns 1 by default
 <?php
 error_reporting(E_ALL & ~E_DEPRECATED);
 echo assert_options(ASSERT_ACTIVE) === 1 ? "OK" : "FAIL";
+error_reporting(E_ALL); // shared interpreter: restore, and add no variable of our own
 ?>
 --EXPECTF--
 %AOK%A


### PR DESCRIPTION
The empty-string key did not exist: $a[""] = v was filed under the next integer slot, because the insert path read an empty blob as "assign an automatic index", and reading $a[""] then looked up integer 0. A null key rode the same path onto 0, where php stores it under "". Fix both the insert and the lookup -- they have to move together, or reads cannot find what writes stored.

Emit the null-key and lossy-float-key deprecations for array LITERAL keys, which were silent while the subscript forms already reported them. Telling an absent key from an explicit null one needs a marker, since both arrive as a NULL on the stack, so tag the nil the compiler loads for a missing key.

__METHOD__ was empty in every free function and unqualified inside a method; php answers the function name and Class::method.

error_reporting() was a boolean: any non-zero level meant "report everything", so E_ALL & ~E_DEPRECATED still printed every deprecation. Keep the level and consult it per severity. E_ALL was 32767; php 8's is 30719.

Give the ASSERT_* constants php 8.3's deprecation, emitted where every constant expansion passes.

Compile "${name}" as the variable it means (with php's 8.2 deprecation) and "$a[name]" as the string key, instead of handing both to the expression compiler, where they only resolved via the bare-word fallback.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
