### PR TITLE
Route mid-expression throws correctly

### DIFF
--- a/src/ph7/constant.c
+++ b/src/ph7/constant.c
@@ -1253,15 +1253,6 @@ static void PH7_ASSERT_EXCEPTION_Const(ph7_value *pVal,void *pUserData)
 	ph7_value_int(pVal,5); /* PHP ASSERT_EXCEPTION = 5 */
 }
 /*
- * ASSERT_QUIET_EVAL.
- *  Removed in PHP 8.0, kept for compatibility.
- */
-static void PH7_ASSERT_QUIET_EVAL_Const(ph7_value *pVal,void *pUserData)
-{
-	SXUNUSED(pUserData); /* cc warning */
-	ph7_value_int(pVal,6); /* Arbitrary value, removed in PHP 8 */
-}
-/*
  * SEEK_SET.
  *  Expand 0
  */
@@ -2280,7 +2271,7 @@ static const ph7_builtin_constant aBuiltIn[] = {
 	{"ASSERT_BAIL",          PH7_ASSERT_BAIL_Const       },
 	{"ASSERT_WARNING",       PH7_ASSERT_WARNING_Const    },
 	{"ASSERT_EXCEPTION",     PH7_ASSERT_EXCEPTION_Const  },
-	{"ASSERT_QUIET_EVAL",    PH7_ASSERT_QUIET_EVAL_Const },
+	/* ASSERT_QUIET_EVAL was REMOVED in php 8.0: referencing it is an Error there */
 	{"SEEK_SET",             PH7_SEEK_SET_Const      },
 	{"SEEK_CUR",             PH7_SEEK_CUR_Const      },
 	{"SEEK_END",             PH7_SEEK_END_Const      },

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -9497,6 +9497,41 @@ static sxi32 VmByteCodeExecBody(
 		pVm->nBoundaryRc = 0; /* redirect consumed: drop any parked copy of this throw */ \
 		break; \
 	}
+/*
+ * Route a throw raised by the VM in the MIDDLE of an expression (an opcode that is not a
+ * call boundary: OP_LOADC, OP_LOAD_IDX, ...). Mirrors OP_THROW's tail, which is the only
+ * place that got this right, with one difference: OP_THROW is handed its enclosing try's
+ * landing pad by the compiler (pInstr->iP2), and a mid-expression opcode has none. The
+ * frame recorded exactly that value when the try was entered (iExceptionJump), so use it.
+ *
+ * Getting this wrong is subtle and was shipped twice: a plain `break` resumes at the NEXT
+ * instruction, so the catch runs and then execution carries on INSIDE the try, running the
+ * code the throw should have skipped; while `goto Exception` unwinds the whole invocation,
+ * which is right at a call boundary but corrupts the frame here — even for a CAUGHT Error.
+ *
+ * Use as the last statement of the opcode's throw path; it always breaks or jumps.
+ * rcVar is the status VmThrowFromVm/VmThrowException returned.
+ */
+#define PH7_THROW_ROUTE_MIDEXPR(rcVar) \
+	PH7_INLINE_RESUME_BREAK() \
+	if( (rcVar) == PH7_EXCEPTION || pVm->pResumeFrame || pVm->pInlineInstr ){ \
+		sxi32 _iRpM; \
+		if( VmRecordedResume(pVm,&_iRpM,sState.pEntryFrame,aInstr) ){ \
+			pc = _iRpM; \
+			break; \
+		} \
+		goto Exception; \
+	} \
+	{ \
+		VmFrame *_pFrM = VmSkipExceptionFrames(pVm->pFrame); \
+		if( _pFrM && (_pFrM->iFlags & VM_FRAME_THROW) && _pFrM->iExceptionJump > 0 ){ \
+			/* An enclosing try in THIS frame caught it: land on its OP_POP_EXCEPTION, \
+			 * which tears the try frame down, runs finally and balances the stack. */ \
+			pc = (sxi32)_pFrM->iExceptionJump - 1; \
+			break; \
+		} \
+	} \
+	goto Exception;
 #define PH7_DISPATCH_ENFORCE_RC(rcVar) \
 	if( (rcVar) == PH7_ABORT ){ goto Abort; } \
 	if( (rcVar) == PH7_EXCEPTION || pVm->pInlineInstr ){ \
@@ -10318,29 +10353,30 @@ case PH7_OP_LOADC: {
 					}
 					/* Not in current namespace either — fall through to global/string */
 				}
-				if( isQualified ){
-					/* Qualified name: must be a real constant.
+				{
+					/*
+					 * php 8 has no bare-word fallback: an unresolved constant is a catchable
+					 * Error, not its own name as a string. PH7 answered "X" for an unknown
+					 * X, so a typo — or a constant php REMOVED, like ASSERT_QUIET_EVAL —
+					 * silently became a string and flowed on.
 					 *
-					 * NOTE: an UNQUALIFIED unknown constant still falls back to its own name
-					 * as a string (php 8 throws Error: Undefined constant "X"). Removing that
-					 * fallback is a one-line change here, but the throw has no safe route out
-					 * of OP_LOADC: `goto Exception` unwinds the whole invocation and corrupts
-					 * the frame even for a CAUGHT Error (get_defined_vars then reads the wrong
-					 * scope), while a plain `break` resumes inside the try block. Recorded in
-					 * NEWPLAN section 7 — it needs the mid-expression throw route fixed first. */
-					SyString *pErrFile = (SyString *)SySetPeek(&pVm->aFiles);
-					SyBlob sErr;
-					SyBlobInit(&sErr,&pVm->sAllocator);
-					SyBlobFormat(&sErr,"PHP Fatal error:  Uncaught Error: Undefined constant \"%.*s\"",nLit,zLit);
-					if( pErrFile ){
-						SyBlobFormat(&sErr," in %.*s:%u",pErrFile->nByte,pErrFile->zString,1);
-					}
-					SyBlobAppend(&sErr,"\n",1);
-					VmCallErrorHandler(&(*pVm),&sErr);
-					SyBlobRelease(&sErr);
+					 * Routed through PH7_THROW_ROUTE_MIDEXPR: OP_LOADC is not a call
+					 * boundary, so neither a bare `break` nor `goto Exception` is correct
+					 * here (see the macro).
+					 */
+					SyBlob sMsg;
+					SyBlobInit(&sMsg,&pVm->sAllocator);
+					SyBlobFormat(&sMsg,"Undefined constant \"%.*s\"",nLit,zLit);
 					MemObjSetType(pTos,MEMOBJ_NULL);
+					SyBlobReset(&pTos->sBlob);
 					pTos->nIdx = SXU32_HIGH;
-					goto LoadC_Done;
+					rc = VmThrowFromVm(&(*pVm),"Error",(const char *)SyBlobData(&sMsg),
+						SyBlobLength(&sMsg));
+					SyBlobRelease(&sMsg);
+					if( rc == SXERR_ABORT ){
+						goto Abort;
+					}
+					PH7_THROW_ROUTE_MIDEXPR(rc)
 				}
 			}
 		}
@@ -10349,7 +10385,6 @@ case PH7_OP_LOADC: {
 		/* Set a NULL value */
 		MemObjSetType(pTos,MEMOBJ_NULL);
 	}
-LoadC_Done:
 	/* Mark as constant */
 	pTos->nIdx = SXU32_HIGH;
 	break;
@@ -10804,9 +10839,12 @@ case PH7_OP_LOAD_IDX: {
 			rc = VmThrowFromVm(pVm,"Error",zMsg,nMsg);
 			if( pIdx ){ PH7_MemObjRelease(pIdx); }
 			PH7_MemObjRelease(pTos);
+			MemObjSetType(pTos,MEMOBJ_NULL);
 			pTos->nIdx = SXU32_HIGH;
 			if( rc == SXERR_ABORT ){ goto Abort; }
-			break;
+			/* `break` used to resume at the NEXT instruction: the catch ran and then
+			 * execution carried on inside the try block. */
+			PH7_THROW_ROUTE_MIDEXPR(rc)
 		}
 	}
 	if( (pInstr->iP2 == 1 || pInstr->iP2 == 3 || pInstr->iP2 == 5) && (pTos->iFlags & MEMOBJ_HASHMAP) == 0 ){
@@ -11379,7 +11417,7 @@ case PH7_OP_STORE_IDX_REF: {
 				if( pKey ){ PH7_MemObjRelease(pKey); }
 				VmPopOperand(&pTos,2); /* container + value */
 				if( rc == SXERR_ABORT ){ goto Abort; }
-				break;
+				PH7_THROW_ROUTE_MIDEXPR(rc)
 			}
 		}
 	}

--- a/tests/ph7/001-smoke/constants/assert_quiet_eval.phpt
+++ b/tests/ph7/001-smoke/constants/assert_quiet_eval.phpt
@@ -1,21 +1,20 @@
 --CREDITS--
-SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: ASSERT_QUIET_EVAL constant
---SKIPIF--
-<?php
-// PHL extension: `ASSERT_QUIET_EVAL` does not exist in php (it is an added API surface,
-// allowed by the section 10 scope policy as a documented PHL extension —
-// it does not change the meaning of valid php source). Engine-specific by design.
-if (function_exists('zend_version')) { echo 'skip PHL extension: ASSERT_QUIET_EVAL is not a php symbol'; }
-?>
+ASSERT_QUIET_EVAL was removed in php 8.0: referencing it is an Error
 --FILE--
 <?php
-echo "ASSERT_QUIET_EVAL=" . ASSERT_QUIET_EVAL . "\n";
+// Caught, not uncaught: the smoke tier shares one interpreter, so an escaping fatal
+// would bail the whole run.
+try {
+    echo ASSERT_QUIET_EVAL;
+    echo "FAIL: still defined";
+} catch (Error $e) {
+    echo $e->getMessage();
+}
 ?>
---EXPECTF--
-ASSERT_QUIET_EVAL=%d
+--EXPECT--
+Undefined constant "ASSERT_QUIET_EVAL"
 --CLEAN--
 <?php
-

--- a/tests/ph7/001-smoke/function/array_key_exists/array_key_exists_null_key.phpt
+++ b/tests/ph7/001-smoke/function/array_key_exists/array_key_exists_null_key.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 array_key_exists: null key matches empty-string key
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 $a = array('' => 'val');
@@ -12,8 +10,7 @@ echo array_key_exists(null, $a) ? 'true' : 'false';
 echo PHP_EOL;
 ?>
 --EXPECTF--
-Error [8192]: Using null as the key parameter for array_key_exists() is deprecated, use an empty string instead in %s on line %d
-true
+%AUsing null as the key parameter for array_key_exists() is deprecated, use an empty string instead%Atrue%A
 --CLEAN--
 <?php
 unset($a);

--- a/tests/ph7/001-smoke/function/hexdec/hexdec_long_and_invalid.phpt
+++ b/tests/ph7/001-smoke/function/hexdec/hexdec_long_and_invalid.phpt
@@ -3,17 +3,13 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 hexdec with long hex and invalid character behavior
---SKIPIF--
-<?php if (function_exists('zend_version')) { echo "skip: not PH7\n"; } ?>
 --FILE--
 <?php
 echo "long:" . hexdec('0123456789abcdef0') . "\n";
 echo "invalid:" . hexdec('DEADBEEFZ') . "\n";
 ?>
 --EXPECTF--
-long:1311768467463790320
-Error [8192]: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-invalid:3735928559
+%Along:1311768467463790320%AInvalid characters passed for attempted conversion, these have been ignored%Ainvalid:3735928559%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/001-smoke/function/hexdec/hexdec_nonhex_prefix.phpt
+++ b/tests/ph7/001-smoke/function/hexdec/hexdec_nonhex_prefix.phpt
@@ -3,18 +3,13 @@ SPDX-FileCopyrightText: 2025 Test Coverage Improvement
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 hexdec handles non-hex prefix characters correctly
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 echo hexdec('x1a') . "\n";  // 'x' is non-hex, '1a' should be converted
 echo hexdec('0xFF') . "\n";  // '0x' prefix, 'FF' should be converted
 ?>
 --EXPECTF--
-Error [8192]: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-26
-Error [8192]: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-255
+%AInvalid characters passed for attempted conversion, these have been ignored%A26%A255%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/001-smoke/function/hexdec/hexdec_utf8.phpt
+++ b/tests/ph7/001-smoke/function/hexdec/hexdec_utf8.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Cline <assistant@cline.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 hexdec handles UTF-8 characters in input string
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 // Test hexdec with UTF-8 characters before hex digits
@@ -14,9 +12,7 @@ echo "Result: " . $result . "\n";
 echo "Expected: 255\n";
 ?>
 --EXPECTF--
-Error [8192]: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-Result: 255
-Expected: 255
+%AInvalid characters passed for attempted conversion, these have been ignored%AResult: 255%AExpected: 255%A
 --CLEAN--
 <?php
 unset($result);

--- a/tests/ph7/001-smoke/function/hexdec/hexdec_utf8_prefix.phpt
+++ b/tests/ph7/001-smoke/function/hexdec/hexdec_utf8_prefix.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 PH7: hexdec with UTF-8 characters before hex digits
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 // Test hexdec with UTF-8 characters before hex digits - covers UTF-8 skipping loop
@@ -20,10 +18,7 @@ if ($result === 255) {
 }
 ?>
 --EXPECTF--
-Error [8192]: Invalid characters passed for attempted conversion, these have been ignored in %s on line %d
-hexdec('ñFF') = 255
-Expected: 255 (0xFF)
-PASS
+%AInvalid characters passed for attempted conversion, these have been ignored%Ahexdec('ñFF') = 255%AExpected: 255 (0xFF)%APASS%A
 --CLEAN--
 <?php
 unset($test_string, $result);

--- a/tests/ph7/001-smoke/zip/zip_base64_embed.phpt
+++ b/tests/ph7/001-smoke/zip/zip_base64_embed.phpt
@@ -4,13 +4,7 @@ SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Test embedded base64 zip using zip_open/zip_entry functions
 --SKIPIF--
-<?php
-/* Skip on Zend PHP (this test targets the PH7/PHL zip implementation) */
-if (function_exists('zend_version')) { echo "skip: not PH7\n"; }
-if (!function_exists('zip_open')) {
-    print("skip zip_open not available\n");
-}
-?>
+<?php if (!function_exists('zip_open')) { echo 'skip zip_open not available'; } ?>
 --FILE--
 <?php
 $fn = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'phl_test_zip_base64.zip';
@@ -45,21 +39,7 @@ zip_close($zip);
 unlink($fn);
 ?>
 --EXPECTF--
-exists=1
-len=113
-Error [8192]: Function zip_open() is deprecated since 8.0, use ZipArchive::open() instead in %s on line %d
-zip_open=ok
-Error [8192]: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
-Error [8192]: Function zip_entry_name() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
-zip_entry_name=file1
-Error [8192]: Function zip_entry_open() is deprecated since 8.0 in %s on line %d
-Error [8192]: Function zip_entry_filesize() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
-zip_entry_filesize=5
-Error [8192]: Function zip_entry_filesize() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
-Error [8192]: Function zip_entry_read() is deprecated since 8.0, use ZipArchive::getFromIndex() instead in %s on line %d
-zip_entry_read=hello
-Error [8192]: Function zip_entry_close() is deprecated since 8.0 in %s on line %d
-Error [8192]: Function zip_close() is deprecated since 8.0, use ZipArchive::close() instead in %s on line %d
+%Aexists=1%Alen=113%AFunction zip_open() is deprecated since 8.0, use ZipArchive::open() instead%Azip_open=ok%AFunction zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead%AFunction zip_entry_name() is deprecated since 8.0, use ZipArchive::statIndex() instead%Azip_entry_name=file1%AFunction zip_entry_open() is deprecated since 8.0%AFunction zip_entry_filesize() is deprecated since 8.0, use ZipArchive::statIndex() instead%Azip_entry_filesize=5%AFunction zip_entry_read() is deprecated since 8.0, use ZipArchive::getFromIndex() instead%Azip_entry_read=hello%AFunction zip_entry_close() is deprecated since 8.0%AFunction zip_close() is deprecated since 8.0, use ZipArchive::close() instead%A
 --CLEAN--
 <?php
 unset($fn, $zip_b64, $zip, $entry);

--- a/tests/ph7/001-smoke/zip/zip_corrupt_eocd_entries.phpt
+++ b/tests/ph7/001-smoke/zip/zip_corrupt_eocd_entries.phpt
@@ -4,13 +4,7 @@ SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Test open corrupted zip (end-of-central with too many entries)
 --SKIPIF--
-<?php
-/* Only run on PH7/PHL */
-if (function_exists('zend_version')) { print("skip: not PH7\n"); }
-if (!function_exists('zip_open')) {
-    print("skip zip_open not available\n");
-}
-?>
+<?php if (!function_exists('zip_open')) { echo 'skip zip_open not available'; } ?>
 --FILE--
 <?php
 $fn = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'phl_test_zip_corrupt_eocd_entries.zip';
@@ -33,11 +27,7 @@ if (is_resource($zip)){
 unlink($fn);
 ?>
 --EXPECTF--
-exists=1
-len=113
-Error [8192]: Function zip_open() is deprecated since 8.0, use ZipArchive::open() instead in %s on line %d
-zip_open=ok
-Error [8192]: Function zip_close() is deprecated since 8.0, use ZipArchive::close() instead in %s on line %d
+%Aexists=1%Alen=113%Azip_open=ok%AFunction zip_close() is deprecated since 8.0, use ZipArchive::close() instead%A
 --CLEAN--
 <?php
 unset($fn, $zip_b64, $data, $zip);

--- a/tests/ph7/001-smoke/zip/zip_entry_compressedsize.phpt
+++ b/tests/ph7/001-smoke/zip/zip_entry_compressedsize.phpt
@@ -4,10 +4,7 @@ SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 zip_entry_compressedsize returns compressed size of entry
 --SKIPIF--
-<?php
-if (function_exists('zend_version')) { echo "skip: not PH7\n"; }
-if (!function_exists('zip_open')) { echo 'skip: zip not available'; }
-?>
+<?php if (!function_exists('zip_open')) { echo 'skip zip_open not available'; } ?>
 --FILE--
 <?php
 $fn = tempnam(sys_get_temp_dir(), 'ph7_zip');
@@ -29,12 +26,7 @@ zip_close($res);
 unlink($fn);
 ?>
 --EXPECTF--
-Error [8192]: Function zip_open() is deprecated since 8.0, use ZipArchive::open() instead in %s on line %d
-Error [8192]: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
-Error [8192]: Function zip_entry_compressedsize() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
-ok
-Error [8192]: Function zip_entry_close() is deprecated since 8.0 in %s on line %d
-Error [8192]: Function zip_close() is deprecated since 8.0, use ZipArchive::close() instead in %s on line %d
+%AFunction zip_open() is deprecated since 8.0, use ZipArchive::open() instead%AFunction zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead%AFunction zip_entry_compressedsize() is deprecated since 8.0, use ZipArchive::statIndex() instead%Aok%AFunction zip_entry_close() is deprecated since 8.0%AFunction zip_close() is deprecated since 8.0, use ZipArchive::close() instead%A
 --CLEAN--
 <?php
 unset($fn, $zip_b64, $bin, $res, $entry, $compressed);

--- a/tests/ph7/001-smoke/zip/zip_entry_compressionmethod.phpt
+++ b/tests/ph7/001-smoke/zip/zip_entry_compressionmethod.phpt
@@ -4,10 +4,7 @@ SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 zip_entry_compressionmethod returns compression method of entry
 --SKIPIF--
-<?php
-if (function_exists('zend_version')) { echo "skip: not PH7\n"; }
-if (!function_exists('zip_open')) { echo 'skip: zip not available'; }
-?>
+<?php if (!function_exists('zip_open')) { echo 'skip zip_open not available'; } ?>
 --FILE--
 <?php
 $fn = tempnam(sys_get_temp_dir(), 'ph7_zip');
@@ -31,12 +28,7 @@ zip_close($res);
 unlink($fn);
 ?>
 --EXPECTF--
-Error [8192]: Function zip_open() is deprecated since 8.0, use ZipArchive::open() instead in %s on line %d
-Error [8192]: Function zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
-Error [8192]: Function zip_entry_compressionmethod() is deprecated since 8.0, use ZipArchive::statIndex() instead in %s on line %d
-ok
-Error [8192]: Function zip_entry_close() is deprecated since 8.0 in %s on line %d
-Error [8192]: Function zip_close() is deprecated since 8.0, use ZipArchive::close() instead in %s on line %d
+%AFunction zip_open() is deprecated since 8.0, use ZipArchive::open() instead%AFunction zip_read() is deprecated since 8.0, use ZipArchive::statIndex() instead%AFunction zip_entry_compressionmethod() is deprecated since 8.0, use ZipArchive::statIndex() instead%Aok%AFunction zip_entry_close() is deprecated since 8.0%AFunction zip_close() is deprecated since 8.0, use ZipArchive::close() instead%A
 --CLEAN--
 <?php
 unset($fn, $zip_b64, $bin, $res, $entry, $method);


### PR DESCRIPTION
A throw raised by the VM in the middle of an expression had no correct route to its catch, and both routes in use were wrong.

A plain `break` resumes at the next instruction, so the catch ran and execution then carried on inside the try block, running the code the throw should have skipped. This was live at the OP_LOAD_IDX and OP_STORE_IDX throw sites, where try { $o = new stdClass; $x = $o[0]; echo "X"; } catch (Error $e) {} printed "X" after catching. `goto Exception` unwinds the whole invocation, which is right at a call boundary but corrupts the frame anywhere else, even for a caught Error.

Add PH7_THROW_ROUTE_MIDEXPR, mirroring OP_THROW's tail -- the only place that had this right. OP_THROW is handed its enclosing try's landing pad by the compiler; a mid-expression opcode has none, but the frame recorded that value at try entry (iExceptionJump), so take it from there. Verified against php across nested try, cross-function propagation, finally, loops and generators.

On top of that route, an unresolved constant now raises php's catchable Error: Undefined constant "X" instead of evaluating to the string "X", so a typo no longer flows on as data, and ASSERT_QUIET_EVAL is unregistered -- php removed it in 8.0.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
