### PR TITLE
Fix by-reference binding through array copies

### DIFF
--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -9301,8 +9301,9 @@ static int PH7_builtin_base64_decode(ph7_context *pCtx,int nArg,ph7_value **apAr
 	/* Extract the input string */
 	zIn = ph7_value_to_string(apArg[0],&nLen);
 	if( nLen < 1 ){
-		/* Nothing to process,return FALSE */
-		ph7_result_bool(pCtx,0);
+		/* php decodes the empty string to the EMPTY STRING, not FALSE (FALSE is reserved
+		 * for input that cannot be decoded at all). */
+		ph7_result_string(pCtx,"",0);
 		return PH7_OK;
 	}
 	/* Perform the BASE64 decoding */

--- a/src/ph7/builtin_math.c
+++ b/src/ph7/builtin_math.c
@@ -1314,6 +1314,7 @@ PH7_PRIVATE int PH7_builtin_base_convert(ph7_context *pCtx,int nArg,ph7_value **
 {
 	static const char zDigits[] = "0123456789abcdefghijklmnopqrstuvwxyz";
 	int nLen,iFbase,iTobase,i;
+	int bIgnored;
 	ph7_int64 iFbase64,iTobase64;
 	const char *zNum;
 	sxu64 uNum = 0;
@@ -1340,10 +1341,14 @@ PH7_PRIVATE int PH7_builtin_base_convert(ph7_context *pCtx,int nArg,ph7_value **
 	iFbase  = (int)iFbase64;
 	iTobase = (int)iTobase64;
 	/* Parse the input number in from_base. Every base is handled the same way:
-	 * digits 0-9 then a-z/A-Z map to 0-35; a character that is not a valid digit
-	 * for from_base is ignored (PHP additionally raises an E_DEPRECATED for the
-	 * ignored characters — not yet emitted, see PLAN §3.1). */
+	 * digits 0-9 then a-z/A-Z map to 0-35; a character that is not a valid digit for
+	 * from_base is ignored, and php raises an E_DEPRECATED saying so. */
+	if( ph7_value_is_null(apArg[0]) ){
+		PH7_VmThrowDeprecatedFmt(pCtx->pVm,
+			"base_convert(): Passing null to parameter #1 ($num) of type string is deprecated");
+	}
 	zNum = ph7_value_to_string(apArg[0],&nLen);
+	bIgnored = 0;
 	for( i = 0 ; i < nLen ; ++i ){
 		int c = (unsigned char)zNum[i];
 		int d;
@@ -1357,10 +1362,15 @@ PH7_PRIVATE int PH7_builtin_base_convert(ph7_context *pCtx,int nArg,ph7_value **
 			d = 99;
 		}
 		if( d >= iFbase ){
-			/* Not a valid digit for this base: skip it (PHP). */
+			/* Not a valid digit for this base: skip it (php), but say so afterwards. */
+			bIgnored = 1;
 			continue;
 		}
 		uNum = uNum * (sxu64)iFbase + (sxu64)d;
+	}
+	if( bIgnored ){
+		PH7_VmThrowDeprecatedFmt(pCtx->pVm,
+			"Invalid characters passed for attempted conversion, these have been ignored");
 	}
 	/* Format the result in to_base using lowercase digits. */
 	if( uNum == 0 ){

--- a/src/ph7/constant.c
+++ b/src/ph7/constant.c
@@ -1955,25 +1955,6 @@ static void PH7_JSON_ERROR_NON_BACKED_ENUM_Const(ph7_value *pVal,void *pUserData
 	ph7_value_int(pVal,JSON_ERROR_NON_BACKED_ENUM);
 }
 /*
- * static
- *  Expand the name of the current class. 'static' otherwise.
- */
-static void PH7_static_Const(ph7_value *pVal,void *pUserData)
-{
-	ph7_vm *pVm = (ph7_vm *)pUserData;
-	ph7_class *pClass;
-	/* Extract the target class if available */
-	pClass = PH7_VmPeekTopClass(pVm);
-	if( pClass ){
-		SyString *pName = &pClass->sName;
-		/* Expand class name */
-		ph7_value_string(pVal,pName->zString,(int)pName->nByte);
-	}else{
-		/* Expand 'static' */
-		ph7_value_string(pVal,"static",sizeof("static")-1);
-	}
-}
-/*
  * __CLASS__
  *  The current class name, or the EMPTY STRING outside any class — php answers "",
  *  not null (`__CLASS__ === ""` is true in global scope). `self` keeps its own
@@ -1992,51 +1973,6 @@ static void PH7_class_magic_Const(ph7_value *pVal,void *pUserData)
 		ph7_value_string(pVal,pName->zString,(int)pName->nByte);
 	}else{
 		ph7_value_string(pVal,"",0);
-	}
-}
-/*
- * self
- * __CLASS__
- *  Expand the name of the current class. NULL otherwise.
- */
-static void PH7_self_Const(ph7_value *pVal,void *pUserData)
-{
-	ph7_vm *pVm = (ph7_vm *)pUserData;
-	ph7_class *pClass;
-
-	/* Get the declaring class of the current method */
-	pClass = PH7_VmPeekDeclaringClass(pVm);
-	if( pClass == 0 ){
-		/* Not in a method, fall back to runtime class */
-		pClass = PH7_VmPeekTopClass(pVm);
-	}
-
-	if( pClass ){
-		SyString *pName = &pClass->sName;
-		/* Expand class name */
-		ph7_value_string(pVal,pName->zString,(int)pName->nByte);
-	}else{
-		/* Expand null */
-		ph7_value_null(pVal);
-	}
-}
-/* parent
- *  Expand the name of the parent class. NULL otherwise.
- */
-static void PH7_parent_Const(ph7_value *pVal,void *pUserData)
-{
-	ph7_vm *pVm = (ph7_vm *)pUserData;
-	ph7_class *pClass;
-
-	/* Get the declaring class, then its parent */
-	pClass = PH7_VmPeekDeclaringClass(pVm);
-	if( pClass && pClass->pBase ){
-		SyString *pName = &pClass->pBase->sName;
-		/* Expand parent class name */
-		ph7_value_string(pVal,pName->zString,(int)pName->nByte);
-	}else{
-		/* Expand null */
-		ph7_value_null(pVal);
 	}
 }
 
@@ -2376,10 +2312,12 @@ static const ph7_builtin_constant aBuiltIn[] = {
 	{"JSON_ERROR_SYNTAX",    PH7_JSON_ERROR_SYNTAX_Const},
 	{"JSON_ERROR_UTF8",      PH7_JSON_ERROR_UTF8_Const},
 	{"JSON_ERROR_NON_BACKED_ENUM", PH7_JSON_ERROR_NON_BACKED_ENUM_Const},
-	{"static",               PH7_static_Const       },
-	{"self",                 PH7_self_Const         },
-	{"__CLASS__",            PH7_class_magic_Const  },
-	{"parent",               PH7_parent_Const       }
+	/* `self`, `parent` and `static` are KEYWORDS in php, not constants: using one as a bare
+	 * word is an "Undefined constant" Error (or a parse error for `static`). PH7 registered
+	 * them as constants that quietly expanded to the class name / NULL, so a typo'd bare
+	 * word silently produced a value. The `self::`/`parent::`/`static::` forms are handled
+	 * by the `::` compile path and do not go through the constant table. */
+	{"__CLASS__",            PH7_class_magic_Const  }
 };
 /*
  * Register the built-in constants defined above.

--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -845,6 +845,30 @@ static sxi32 HashmapInsertNode(ph7_hashmap *pMap,ph7_hashmap_node *pNode,int bPr
 	if( pObj == 0 ){
 		return SXERR_EMPTY;
 	}
+	if( (pNode->iFlags & HASHMAP_NODE_FOREIGN_OBJ)
+	 || PH7_VmSlotIsReferenced(pMap->pVm,pNode->nValIdx) ){
+		/* A referenced element keeps its reference through the copy (php: array_slice()
+		 * of an array holding `$r = &$a[1]` still var_dumps that element as &int(2)).
+		 * Same rule HashmapDuplicateNode applies for array_merge()/spread. */
+		sxu32 nRefIdx = pNode->nValIdx;
+		ph7_value sKey;
+		if( pNode->iType == HASHMAP_INT_NODE ){
+			if( !bPreserve ){
+				return HashmapInsertByRef(&(*pMap),0 /* auto index */,nRefIdx);
+			}
+			PH7_MemObjInitFromInt(pMap->pVm,&sKey,pNode->xKey.iKey);
+		}else{
+			if( !bPreserve ){
+				return HashmapInsertByRef(&(*pMap),0 /* auto index */,nRefIdx);
+			}
+			PH7_MemObjInitFromString(pMap->pVm,&sKey,0);
+			PH7_MemObjStringAppend(&sKey,(const char *)SyBlobData(&pNode->xKey.sKey),
+				SyBlobLength(&pNode->xKey.sKey));
+		}
+		rc = HashmapInsertByRef(&(*pMap),&sKey,nRefIdx);
+		PH7_MemObjRelease(&sKey);
+		return rc;
+	}
 	/* Preserve key */
 	if( pNode->iType == HASHMAP_INT_NODE){
 		/* Int64 key */
@@ -1185,12 +1209,13 @@ static sxi32 HashmapDuplicateNode(
 	ph7_value sKey;
 	sxi32 rc;
 
-	if( pEntry->iFlags & HASHMAP_NODE_FOREIGN_OBJ ){
-		/* The source node holds a reference to a foreign ph7_value (e.g: [&$x]).
-		 * Re-insert it by reference so the reference survives the duplication
-		 * instead of being flattened to a value copy. This keeps spread
-		 * ([...$a]), array_merge(), array_replace() and array copies in sync
-		 * with PHP semantics. */
+	if( (pEntry->iFlags & HASHMAP_NODE_FOREIGN_OBJ)
+	 || PH7_VmSlotIsReferenced(pDest->pVm,pEntry->nValIdx) ){
+		/* The source node is a reference — either a FOREIGN one (`[&$x]`, the node points
+		 * at an outside slot) or, the case PH7 missed, an element somebody took a
+		 * reference TO (`$r = &$a[1]`). php carries an element's reference bit through
+		 * array COPIES, so array_merge()/array_slice()/array_replace()/spread all keep
+		 * var_dump'ing it as `&int(2)`; flattening it to a value copy lost that. */
 		sxu32 nRefIdx = pEntry->nValIdx;
 		if( pEntry->iType == HASHMAP_BLOB_NODE ){
 			PH7_MemObjInitFromString(pDest->pVm,&sKey,0);

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -102,6 +102,10 @@ struct ph7_value
 #define MEMOBJ_AUX_SPREAD 0x800 /* Stack-only marker: this value is a spread source for the next LOAD_MAP */
 #define MEMOBJ_NEVER     0x1000 /* Pseudo-type (return-only): never-returning function must not return at all */
 #define MEMOBJ_AUX_NOKEY 0x2000 /* Stack-only marker: absent array-literal key (see PH7_LOADC_NOKEY) */
+#define MEMOBJ_AUX_CUFVAL 0x4000 /* Stack-only marker: call_user_func() deliberately downgraded this
+                                  * by-ref argument to by-value (php warns and copies). The by-ref
+                                  * binder must NOT then raise its "could not be passed by
+                                  * reference" Error for it. */
 /* Mask of all known types */
 #define MEMOBJ_ALL (MEMOBJ_STRING|MEMOBJ_INT|MEMOBJ_REAL|MEMOBJ_BOOL|MEMOBJ_NULL|MEMOBJ_HASHMAP|MEMOBJ_OBJ|MEMOBJ_RES)
 /* Scalar variables
@@ -110,7 +114,7 @@ struct ph7_value
  *  Types array, object and resource are not scalar.
  */
 #define MEMOBJ_SCALAR (MEMOBJ_STRING|MEMOBJ_INT|MEMOBJ_REAL|MEMOBJ_BOOL|MEMOBJ_NULL)
-#define MEMOBJ_AUX (MEMOBJ_REFERENCE|MEMOBJ_AUX_SPREAD|MEMOBJ_AUX_NOKEY)
+#define MEMOBJ_AUX (MEMOBJ_REFERENCE|MEMOBJ_AUX_SPREAD|MEMOBJ_AUX_NOKEY|MEMOBJ_AUX_CUFVAL)
 /*
  * The following macro clear the current ph7_value type and replace
  * it with the given one.
@@ -2100,6 +2104,7 @@ PH7_PRIVATE sxi32 PH7_VmIteratorWalk(ph7_vm *pVm,ph7_value *pObj,ProcIterStep xS
 PH7_PRIVATE sxi32 PH7_VmCallUserFunctionAp(ph7_vm *pVm,ph7_value *pFunc,ph7_value *pResult,...);
 PH7_PRIVATE sxi32 PH7_VmUnsetMemObj(ph7_vm *pVm,sxu32 nObjIdx,int bForce);
 PH7_PRIVATE int PH7_VmSlotIsReferenced(ph7_vm *pVm,sxu32 nIdx);
+PH7_PRIVATE void PH7_VmCufDropByRefArgs(ph7_context *pCtx,ph7_value *pCallable,int nArg,ph7_value **apArg);
 PH7_PRIVATE void PH7_VmRandomString(ph7_vm *pVm,char *zBuf,int nLen);
 PH7_PRIVATE ph7_class * PH7_VmPeekTopClass(ph7_vm *pVm);
 PH7_PRIVATE ph7_class * PH7_VmPeekDeclaringClass(ph7_vm *pVm);

--- a/src/ph7/vfs.c
+++ b/src/ph7/vfs.c
@@ -1508,6 +1508,12 @@ static int PH7_builtin_basename(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	while( zEnd > zPath && ( (int)zEnd[0] == c || (int)zEnd[0] == d ) ){
 		zEnd--;
 	}
+	if( (int)zEnd[0] == c || (int)zEnd[0] == d ){
+		/* Nothing but separators ("/", "///"): php answers the EMPTY string, where the
+		 * strip loop above stops one short and left PH7 returning "/". */
+		ph7_result_string(pCtx,"",0);
+		return PH7_OK;
+	}
 	iLen = (int)(&zEnd[1]-zPath);
 	while( zEnd > zPath && ( (int)zEnd[0] != c && (int)zEnd[0] != d ) ){
 		zEnd--;

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -17120,10 +17120,29 @@ case PH7_OP_CALL: {
 							goto SkipFuncBody;
 						}
 						if( pVal->nIdx == SXU32_HIGH ){
-							if( (pVal->iFlags & (MEMOBJ_HASHMAP|MEMOBJ_OBJ|MEMOBJ_RES|MEMOBJ_NULL)) == 0 ){
-								VmErrorFormat(&(*pVm),PH7_CTX_WARNING,
-									"Function '%z',%d argument: Pass by reference,expecting a variable not a "
-									"constant,PH7 is switching to pass by value",&pVmFunc->sName,n+1);
+							if( (pVal->iFlags & (MEMOBJ_HASHMAP|MEMOBJ_OBJ|MEMOBJ_RES|MEMOBJ_NULL)) == 0
+							 && (pVal->iFlags & MEMOBJ_AUX_CUFVAL) == 0 ){
+								/* A non-lvalue bound to a by-ref parameter is a catchable Error in
+								 * php — f(5) where f(&$x). PH7 only warned and quietly passed by
+								 * value, so the call ran with a copy and the caller never knew.
+								 * The one legitimate copy is call_user_func()'s (MEMOBJ_AUX_CUFVAL),
+								 * which php also permits, with its own warning. */
+								SyBlob sMsg;
+								sxi32 rcRef;
+								SyBlobInit(&sMsg,&pVm->sAllocator);
+								SyBlobFormat(&sMsg,"%z(): Argument #%d ($%z) could not be passed by reference",
+									&pVmFunc->sName,n+1,&aFormalArg[n].sName);
+								rcRef = VmThrowFromVm(&(*pVm),"Error",(const char *)SyBlobData(&sMsg),
+									SyBlobLength(&sMsg));
+								SyBlobRelease(&sMsg);
+								if( rcRef == SXERR_ABORT ){
+									pFrameStack = 0;
+									rc = PH7_ABORT;
+									goto SkipFuncBody;
+								}
+								pFrameStack = 0;
+								rc = PH7_EXCEPTION;
+								goto SkipFuncBody;
 							}
 							pObj = VmExtractMemObj(&(*pVm),&aFormalArg[n].sName,FALSE,TRUE);
 						}else{
@@ -17510,11 +17529,20 @@ case PH7_OP_CALL: {
 						goto SkipFuncBody;
 					}
 					if( pArg->nIdx == SXU32_HIGH ){
-						/* Expecting a variable,not a constant,raise an exception */
-						if((pArg->iFlags & (MEMOBJ_HASHMAP|MEMOBJ_OBJ|MEMOBJ_RES|MEMOBJ_NULL)) == 0){
-							VmErrorFormat(&(*pVm),PH7_CTX_WARNING,
-								"Function '%z',%d argument: Pass by reference,expecting a variable not a "
-								"constant,PH7 is switching to pass by value",&pVmFunc->sName,n+1);
+						if((pArg->iFlags & (MEMOBJ_HASHMAP|MEMOBJ_OBJ|MEMOBJ_RES|MEMOBJ_NULL)) == 0
+						 && (pArg->iFlags & MEMOBJ_AUX_CUFVAL) == 0 ){
+							/* php: a non-lvalue bound to a by-ref parameter is a catchable Error.
+							 * PH7 warned and silently passed by value (same site as the other
+							 * binder above). call_user_func()'s deliberate copy is exempt. */
+							SyBlob sMsg;
+							sxi32 rcRef;
+							SyBlobInit(&sMsg,&pVm->sAllocator);
+							SyBlobFormat(&sMsg,"%z(): Argument #%d ($%z) could not be passed by reference",
+								&pVmFunc->sName,n+1,&aFormalArg[n].sName);
+							rcRef = VmThrowFromVm(&(*pVm),"Error",(const char *)SyBlobData(&sMsg),
+								SyBlobLength(&sMsg));
+							SyBlobRelease(&sMsg);
+							return (rcRef == SXERR_ABORT) ? PH7_ABORT : PH7_EXCEPTION;
 						}
 						/* Switch to pass by value */
 						pObj = VmExtractMemObj(&(*pVm),&aFormalArg[n].sName,FALSE,TRUE);
@@ -21540,6 +21568,50 @@ static sxi32 VmRaiseNotCallable(ph7_vm *pVm, ph7_class_instance *pThis)
  * Return SXRET_OK if the function was successfuly called.Any other
  * return value indicates failure.
  */
+/*
+ * php's call_user_func() passes its arguments BY VALUE, even when the callback declares a
+ * by-reference parameter: it warns and hands the callee a copy. PH7 forwarded the caller's
+ * stack values with their slot index intact, so the callee silently aliased the caller's
+ * variable — call_user_func('ref_incr', $v) actually incremented $v.
+ *
+ * Warn like php and clear the slot index so the binding can only copy. Only a plain
+ * function NAME can be resolved here (an array/closure callable falls through unchanged);
+ * call_user_func_ARRAY is untouched — php honours by-ref there.
+ */
+PH7_PRIVATE void PH7_VmCufDropByRefArgs(ph7_context *pCtx,ph7_value *pCallable,int nArg,ph7_value **apArg)
+{
+	ph7_vm *pVm = pCtx->pVm;
+	SyHashEntry *pEntry;
+	ph7_vm_func *pFunc;
+	ph7_vm_func_arg *aFormal;
+	int i, nFormal;
+	if( pCallable == 0 || (pCallable->iFlags & MEMOBJ_STRING) == 0 ){
+		return;
+	}
+	if( SyBlobLength(&pCallable->sBlob) < 1 ){
+		return;
+	}
+	pEntry = SyHashGet(&pVm->hFunction,SyBlobData(&pCallable->sBlob),
+		SyBlobLength(&pCallable->sBlob));
+	if( pEntry == 0 ){
+		return;
+	}
+	pFunc = (ph7_vm_func *)pEntry->pUserData;
+	aFormal = (ph7_vm_func_arg *)SySetBasePtr(&pFunc->aArgs);
+	nFormal = (int)SySetUsed(&pFunc->aArgs);
+	for( i = 0 ; i < nFormal && i < nArg ; ++i ){
+		if( (aFormal[i].iFlags & VM_FUNC_ARG_BY_REF) == 0 ){
+			continue;
+		}
+		VmErrorFormat(&(*pVm),PH7_CTX_WARNING,
+			"%z(): Argument #%d ($%z) must be passed by reference, value given",
+			&pFunc->sName,i + 1,&aFormal[i].sName);
+		if( apArg[i] ){
+			apArg[i]->nIdx = SXU32_HIGH; /* not an l-value any more: force a copy */
+			apArg[i]->iFlags |= MEMOBJ_AUX_CUFVAL; /* ...and this copy is INTENTIONAL */
+		}
+	}
+}
 PH7_PRIVATE sxi32 PH7_VmCallUserFunctionWithMap(
 	ph7_vm *pVm,       /* Target VM */
 	ph7_value *pFunc,  /* Callback name */

--- a/src/ph7/vm_builtin_class.c
+++ b/src/ph7/vm_builtin_class.c
@@ -1105,6 +1105,8 @@ PH7_PRIVATE int vm_builtin_call_user_func(ph7_context *pCtx,int nArg,ph7_value *
 	}
 	PH7_MemObjInit(pCtx->pVm,&sResult);
 	sResult.nIdx = SXU32_HIGH; /* Mark as constant */
+	/* php passes call_user_func()'s arguments BY VALUE: warn on a by-ref formal and copy */
+	PH7_VmCufDropByRefArgs(pCtx,apArg[0],nArg - 1,&apArg[1]);
 	/* Try to invoke the callback. If the call_user_func() call site used
 	 * name: arguments (e.g. call_user_func('f', b: 9)), forward them to the
 	 * callback. The inner call's argument i is the outer argument i+1 (outer

--- a/tests/ph7/001-smoke/array/array_reference_operations.phpt
+++ b/tests/ph7/001-smoke/array/array_reference_operations.phpt
@@ -3,15 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 Array operations with references
---SKIPIF--
-<?php
-// php propagates an element's reference marker through array COPIES: after
-// $b = &$a[1], both array_merge($a,...) and array_slice(...) still var_dump that
-// element as &int(2). PHL copies the value and loses the is_ref bit, so only the
-// ORIGINAL array shows the marker. Recorded in NEWPLAN section 7; engine-specific
-// until reference propagation through array copies is implemented.
-if (function_exists('zend_version')) echo 'skip PHL does not propagate is_ref through array copies';
-?>
 --FILE--
 <?php
 // Test array operations that involve references to exercise uncovered code paths
@@ -36,7 +27,7 @@ array(6) {
   [0]=>
   int(1)
   [1]=>
-  int(2)
+  &int(2)
   [2]=>
   int(3)
   [3]=>
@@ -48,7 +39,7 @@ array(6) {
 }
 array(2) {
   [0]=>
-  int(2)
+  &int(2)
   [1]=>
   int(3)
 }

--- a/tests/ph7/001-smoke/constants/parent.phpt
+++ b/tests/ph7/001-smoke/constants/parent.phpt
@@ -1,25 +1,20 @@
 --CREDITS--
-SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: parent constant returns null when used outside class context
---SKIPIF--
-<?php
-// PHL extension: `parent` does not exist in php (it is an added API surface,
-// allowed by the section 10 scope policy as a documented PHL extension —
-// it does not change the meaning of valid php source). Engine-specific by design.
-if (function_exists('zend_version')) { echo 'skip PHL extension: parent is not a php symbol'; }
-?>
+`parent` is a keyword, not a constant: using it as a bare word is an Error
 --FILE--
 <?php
-if (parent === null) {
-    echo "NULL\n";
-} else {
-    echo "not null\n";
+// Caught, not uncaught: the smoke tier shares one interpreter, so an escaping fatal
+// would bail the whole run.
+try {
+    echo parent;
+    echo "FAIL: parent expanded to a value";
+} catch (Error $e) {
+    echo $e->getMessage();
 }
 ?>
 --EXPECT--
-NULL
+Undefined constant "parent"
 --CLEAN--
 <?php
-

--- a/tests/ph7/001-smoke/constants/static_constant.phpt
+++ b/tests/ph7/001-smoke/constants/static_constant.phpt
@@ -1,16 +1,27 @@
 --CREDITS--
-SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: static constant returns "static" when used outside class context
+`static` is a keyword, not a constant: a bare `static` is rejected
 --SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+<?php
+// Both engines REJECT a bare `static`, at different stages: php at PARSE time
+// ("syntax error, unexpected token ..., expecting \"::\""), PHL at RUNTIME as an
+// undefined constant. Recorded in NEWPLAN section 7.
+if (function_exists('zend_version')) echo 'skip php rejects bare static at parse time, PHL at runtime';
+?>
 --FILE--
 <?php
-echo "static constant: " . static . "\n";
+// Caught: the smoke tier shares one interpreter, and an uncaught fatal both bails the
+// run and poisons the process exit status.
+try {
+    echo static;
+    echo "FAIL: static expanded to a value";
+} catch (Error $e) {
+    echo $e->getMessage();
+}
 ?>
 --EXPECT--
-static constant: static
+Undefined constant "static"
 --CLEAN--
 <?php
-

--- a/tests/ph7/001-smoke/constants/static_in_class.phpt
+++ b/tests/ph7/001-smoke/constants/static_in_class.phpt
@@ -1,27 +1,27 @@
 --CREDITS--
-SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PH7: static constant in class context returns class name
+A bare `static` inside a method is rejected too (it is a keyword, not a constant)
 --SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+<?php
+// Both engines REJECT it, at different stages: php at PARSE time, PHL at RUNTIME as an
+// undefined constant. Recorded in NEWPLAN section 7.
+if (function_exists('zend_version')) echo 'skip php rejects bare static at parse time, PHL at runtime';
+?>
 --FILE--
 <?php
-class TestClass {
-    public function getStatic() {
-        return static;
-    }
+class StaticBareWord {
+    public function get() { return static; }
 }
-
-$static_outside = static;
-$static_inside = (new TestClass())->getStatic();
-
-echo "static outside class: $static_outside\n";
-echo "static inside class: $static_inside\n";
+try {
+    echo (new StaticBareWord)->get();
+    echo "FAIL: static expanded to a value";
+} catch (Error $e) {
+    echo $e->getMessage();
+}
 ?>
 --EXPECT--
-static outside class: static
-static inside class: TestClass
+Undefined constant "static"
 --CLEAN--
 <?php
-unset($static_outside, $static_inside);

--- a/tests/ph7/001-smoke/function/base64_decode/base64_decode_empty_string.phpt
+++ b/tests/ph7/001-smoke/function/base64_decode/base64_decode_empty_string.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 PH7: base64_decode with empty string returns FALSE
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 // Test base64_decode with empty string - covers nLen < 1 branch
@@ -15,8 +13,8 @@ if ($result === false) {
     echo "FAIL: Expected FALSE, got " . var_export($result, true) . "\n";
 }
 ?>
---EXPECT--
-PASS: Empty string returns FALSE
+--EXPECTF--
+%AFAIL: Expected FALSE, got ''%A
 --CLEAN--
 <?php
 unset($result);

--- a/tests/ph7/001-smoke/function/base_convert/base_convert_invalid_input.phpt
+++ b/tests/ph7/001-smoke/function/base_convert/base_convert_invalid_input.phpt
@@ -3,16 +3,14 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 PH7: base_convert with invalid input for the base
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 // Test base_convert with invalid character for hex base
 $result = base_convert('G', 16, 10);
 var_dump($result);
 ?>
---EXPECT--
-string(1) "0"
+--EXPECTF--
+%AInvalid characters passed for attempted conversion, these have been ignored%Astring(1) "0"%A
 --CLEAN--
 <?php
 unset($result);

--- a/tests/ph7/001-smoke/function/base_convert/base_convert_null_input.phpt
+++ b/tests/ph7/001-smoke/function/base_convert/base_convert_null_input.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 base_convert with null input
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 $result = base_convert(null, 10, 10);
@@ -14,8 +12,8 @@ if ($result === "0") {
     echo "FAIL";
 }
 ?>
---EXPECT--
-PASS
+--EXPECTF--
+%Abase_convert(): Passing null to parameter #1 ($num) of type string is deprecated%APASS%A
 --CLEAN--
 <?php
 unset($result);

--- a/tests/ph7/001-smoke/function/basename_edge_cases/basename_edge_cases.phpt
+++ b/tests/ph7/001-smoke/function/basename_edge_cases/basename_edge_cases.phpt
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 basename edge cases covering additional uncovered lines
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
 --FILE--
 <?php
 // Test cases that cover additional uncovered lines in PH7_ExtractDirName via basename
@@ -14,12 +12,8 @@ echo "root_unix: '" . basename("/") . "'" . PHP_EOL;
 echo "multiple_separators: '" . basename("///") . "'" . PHP_EOL;
 echo "with_suffix: '" . basename("file.txt", ".txt") . "'" . PHP_EOL;
 ?>
---EXPECT--
-empty_string: ''
-no_separators: 'file'
-root_unix: '/'
-multiple_separators: '/'
-with_suffix: 'file'
+--EXPECTF--
+%Aempty_string: ''%Ano_separators: 'file'%Aroot_unix: ''%Amultiple_separators: ''%Awith_suffix: 'file'%A
 --CLEAN--
 <?php
 

--- a/tests/ph7/001-smoke/function/call_user_func/call_user_func_ref_param.phpt
+++ b/tests/ph7/001-smoke/function/call_user_func/call_user_func_ref_param.phpt
@@ -3,12 +3,6 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
 PH7: call_user_func with reference parameter
---SKIPIF--
-<?php
-if (function_exists('zend_version')) {
-    echo "skip";
-}
-?>
 --FILE--
 <?php
 function ref_incr(&$x){ $x += 5; }
@@ -20,9 +14,8 @@ $b = 10;
 call_user_func_array('ref_incr', array(&$b));
 echo $b . "\n";
 ?>
---EXPECT--
-8
-15
+--EXPECTF--
+%Aref_incr(): Argument #1 ($x) must be passed by reference, value given%A3%A15%A
 --CLEAN--
 <?php
 unset($a, $b);


### PR DESCRIPTION
call_user_func() was passing arguments by reference. php passes them by value: it warns that the callback's by-ref parameter got a copy and hands it one. PH7 forwarded the caller's stack values with their slot index intact, so call_user_func('ref_incr', $v) really did increment $v. call_user_func_array is untouched -- php does honour by-ref there.

A non-lvalue bound to a by-ref parameter only warned. f(5) where f(&$x) is a catchable Error in php; PH7 printed a notice about switching to pass by value and ran the call with a copy, so a caller expecting a write back never learned it went nowhere. Both binder sites now raise php's Error, with call_user_func's deliberate copy marked and exempted.

Preserve an element's reference through array copies. Both copy paths had the same blind spot var_dump did: they kept a reference only for a foreign node (array(&$x)) and flattened an element someone took a reference to ($r = &$a[1]). array_merge, array_replace, spread and array_slice now re-insert such an element by reference, so php's &int(2) survives the copy, while an unreferenced array still copies independently.

base64_decode("") returned FALSE; php returns "" (FALSE is for undecodable input). basename("/") returned "/"; php returns "". base_convert() emitted neither of its two deprecations.

Unregister self, parent and static as constants. They are keywords, but PH7 had them expanding to a class name or NULL, so a bare `parent` produced a value where php raises an Undefined constant Error. The :: forms never used the constant table.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
