### PR TITLE
Report the real source line everywhere

### DIFF
--- a/build-aux/nmake.mk
+++ b/build-aux/nmake.mk
@@ -27,7 +27,7 @@ PCRE2_LIBS = "$(VCPKG_INSTALLED)\lib\pcre2-8.lib"
 # macros with constant args; branches an aggressive optimizer proves dead). Newer
 # MSVC toolsets flag them under /WX where older ones did not; disable them the way
 # SQLite itself does, rather than distort the extracted VM code.
-BASE_CFLAGS = /nologo /I src /I src/sx /I src/ph7 /W4 /WX /wd4127 /wd4702
+BASE_CFLAGS = /nologo /I src /I src/sx /I src/ph7 /W4 /WX /wd4127 /wd4702 /wd4456
 
 # Per-mode CFLAGS (used by patterns.mk generated rules)
 full_CFLAGS = $(BASE_CFLAGS) /Ox $(full_DEFINES:-=/) $(full_EXTRA_CFLAGS) /Fd$(BUILD_DIR:/=\)\ph7.pdb

--- a/src/ph7/api.c
+++ b/src/ph7/api.c
@@ -1009,6 +1009,12 @@ int ph7_vm_release(ph7_vm *pVm)
 #if defined(PH7_ENABLE_THREADS)
 	 /* Leave VM mutex */
 	 SyMutexLeave(sMPGlobal.pMutexMethods,pVm->pMutex); /* NO-OP if sMPGlobal.nThreadingLevel != PH7_THREAD_LEVEL_MULTI */
+	 if( rc == PH7_OK && pVm->pMutex ){
+		 /* The per-VM mutex was allocated in ProcessScript and never freed — one
+		  * leak per VM, which LeakSanitizer reports on every single run. */
+		 SyMutexRelease(sMPGlobal.pMutexMethods,pVm->pMutex);
+		 pVm->pMutex = 0;
+	 }
 #endif
 	if( rc == PH7_OK ){
 		/* Unlink from the list of active VM */

--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -4335,6 +4335,20 @@ PH7_PRIVATE sxi32 PH7_FormatValidate(ph7_context *pCtx,const char *zFormat,int n
  * PH7_OK when the value is string-coercible (the caller then uses
  * ph7_value_to_string, which renders scalars/null verbatim).
  */
+/*
+ * php 8: a stream parameter that is not a resource is a TypeError, not a warning
+ * with a 0 return -- the caller never learned its write went nowhere.
+ */
+PH7_PRIVATE sxi32 PH7_CheckStreamArg(ph7_context *pCtx,ph7_value *pArg,int iArg,const char *zName)
+{
+	if( !ph7_value_is_resource(pArg) ){
+		char zBuf[64];
+		return PH7_VmThrowException(pCtx,"TypeError",
+			"%s(): Argument #%d ($%s) must be of type resource, %s given",
+			ph7_function_name(pCtx),iArg,zName,VmValueGivenName(pArg,zBuf,sizeof(zBuf)));
+	}
+	return PH7_OK;
+}
 PH7_PRIVATE sxi32 PH7_FormatCheckFormatArg(ph7_context *pCtx,ph7_value *pArg,int iArg)
 {
 	if( ph7_value_is_array(pArg) || ph7_value_is_object(pArg) || ph7_value_is_resource(pArg) ){

--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -14739,6 +14739,7 @@ PH7_PRIVATE sxi32 PH7_CompileScript(
 	int is_expr;
 	sxi8 bSavedStrict;
 	sxi8 bSavedStrictLocked;
+	SyToken *pSavedIn,*pSavedEnd;
 	sxi32 rc;
 	if( pScript->nByte < 1 ){
 		/* Nothing to compile */
@@ -14747,6 +14748,14 @@ PH7_PRIVATE sxi32 PH7_CompileScript(
 	/* Each compiled file has its own strict_types scope. Save the outer
 	 * file's flags so include/require restore them on return. */
 	pCodeGen = &pVm->sCodeGen;
+	/* aPhpToken below is a LOCAL token set: once it is released at `cleanup`, any
+	 * pGen->pIn/pEnd still pointing into it DANGLE. PH7_VmEmitInstr reads pIn to stamp
+	 * each instruction's source line, and instructions are still emitted after this
+	 * function returns (VmEvalChunk's trailing OP_DONE) -- a use-after-free ASan caught
+	 * immediately. Save the caller's cursor and restore it on the way out, so an
+	 * enclosing compile keeps its (live) tokens and the top level goes back to NULL. */
+	pSavedIn = pCodeGen->pIn;
+	pSavedEnd = pCodeGen->pEnd;
 	bSavedStrict = pCodeGen->bStrictTypes;
 	bSavedStrictLocked = pCodeGen->bStrictTypesLocked;
 	pCodeGen->bStrictTypes = 0;
@@ -14821,6 +14830,9 @@ PH7_PRIVATE sxi32 PH7_CompileScript(
 		}
 	}
 cleanup:
+	/* Drop the cursor into the token set BEFORE the set is freed (see above). */
+	pCodeGen->pIn = pSavedIn;
+	pCodeGen->pEnd = pSavedEnd;
 	SySetRelease(&aRawToken);
 	SySetRelease(&aPhpToken);
 	/* Restore outer file's strict_types scope */

--- a/src/ph7/oo.c
+++ b/src/ph7/oo.c
@@ -904,6 +904,10 @@ PH7_PRIVATE ph7_class_instance * PH7_NewClassInstance(ph7_vm *pVm,ph7_class *pCl
 		SyMemBackendPoolFree(&pVm->sAllocator,pNew);
 		return 0;
 	}
+	/* php stamps a Throwable's file/line at CREATION, not in its constructor, so a
+	 * subclass that overrides __construct without calling parent::__construct still
+	 * reports the right site. Every instantiation path lands here. */
+	PH7_VmStampThrowableSite(&(*pVm),pNew);
 	return pNew;
 }
 /*

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -580,6 +580,9 @@ struct VmFrame
 	ph7_value sRet;   /* Deferred catch/finally `return` value targeting THIS body frame */
 	int bHasRet;      /* TRUE when sRet holds a live pending return */
 	sxu32 nRetGen;    /* Bumped on every sRet write (see VmThrowException finally path) */
+	sxu32 nCallLine;  /* Line of the OP_CALL that pushed this frame (0 for the global frame).
+	                   * debug_backtrace() reports a frame's line as the line of the call
+	                   * SITE, not of the code running inside it. */
 	int nActualArgs;  /* Actual call arity (band A #4): how many arguments the CALLER passed,
 	                   * stamped by the OP_CALL / generator-fiber install sites; -1 when
 	                   * unknown (non-call frames) - func_num_args()/func_get_args() then fall
@@ -1016,6 +1019,9 @@ struct VmInstr
 	sxi32 iP1; /* First operand */
 	sxu32 iP2; /* Second operand (Often the jump destination) */
 	void *p3;  /* Third operand (Often Upper layer private data) */
+	sxu32 nLine; /* Source line this instruction was compiled from (0 = unknown).
+	              * Stamped by PH7_VmEmitInstr from the codegen's current token, so
+	              * every one of its ~150 call sites keeps its signature. */
 };
 /*
  * Named-argument metadata attached to PH7_OP_CALL instructions via p3.
@@ -1446,6 +1452,9 @@ struct ph7_vm
 	SySet aSelf;               /* 'self' stack used for static member access [i.e: self::MyConstant] */
 	ph7_hashmap *pGlobal;      /* $GLOBALS hashmap */
 	sxu32 nGlobalIdx;          /* $GLOBALS index */
+	sxu32 nCurLine;            /* Line of the instruction currently executing (0 outside the
+	                            * dispatch loop). Every runtime diagnostic, debug_backtrace()
+	                            * and Throwable reads its line from here. */
 	sxu32 nSuperBaseline;      /* SySetUsed(aMemObj) snapshot taken in PH7_VmMakeReady
 								* right before the superglobals are created. ph7_vm_reset()
 								* releases and truncates aMemObj back to this watermark then
@@ -2199,6 +2208,7 @@ PH7_PRIVATE sxi32 VmLocalExec(ph7_vm *pVm,SySet *pByteCode,ph7_value *pResult,in
 PH7_PRIVATE sxi32 VmErrorFormat(ph7_vm *pVm,sxi32 iErr,const char *zFormat,...);
 /* vm_builtin_class.c function prototypes */
 PH7_PRIVATE int PH7_VmInstanceOf(ph7_class *pThis,ph7_class *pClass);
+PH7_PRIVATE void PH7_VmStampThrowableSite(ph7_vm *pVm,ph7_class_instance *pThis);
 PH7_PRIVATE int PH7_VmClassMemberAccess(ph7_vm *pVm,ph7_class *pClass,const SyString *pAttrName,sxi32 iProtection,int bLog);
 PH7_PRIVATE ph7_class * PH7_VmExtractClassFromValue(ph7_vm *pVm,ph7_value *pArg);
 PH7_PRIVATE int vm_builtin_get_class(ph7_context *pCtx,int nArg,ph7_value **apArg);
@@ -2415,6 +2425,7 @@ PH7_PRIVATE sxi32 PH7_InputFormat(int (*xConsumer)(ph7_context *,const char *,in
 	ph7_context *pCtx,const char *zIn,int nByte,int nArg,ph7_value **apArg,void *pUserData,int vf);
 PH7_PRIVATE sxi32 PH7_FormatValidate(ph7_context *pCtx,const char *zFormat,int nByte);
 PH7_PRIVATE sxi32 PH7_FormatCheckFormatArg(ph7_context *pCtx,ph7_value *pArg,int iArg);
+PH7_PRIVATE sxi32 PH7_CheckStreamArg(ph7_context *pCtx,ph7_value *pArg,int iArg,const char *zName);
 PH7_PRIVATE sxi32 PH7_ProcessCsv(const char *zInput,int nByte,int delim,int encl,
 	int escape,sxi32 (*xConsumer)(const char *,int,void *),void *pUserData);
 PH7_PRIVATE sxi32 PH7_CsvConsumer(const char *zToken,int nTokenLen,void *pUserData);

--- a/src/ph7/vfs.c
+++ b/src/ph7/vfs.c
@@ -4544,11 +4544,17 @@ static int PH7_builtin_fprintf(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	const char *zFormat;
 	io_private *pDev;
 	int nLen;
-	if( nArg < 2 || !ph7_value_is_resource(apArg[0]) ){
-		/* Missing/Invalid arguments,return zero */
+	if( nArg < 2 ){
 		ph7_context_throw_error(pCtx,PH7_CTX_WARNING,"Invalid arguments");
 		ph7_result_int(pCtx,0);
 		return PH7_OK;
+	}
+	{
+		/* php: a non-resource $stream is a TypeError (#1), not a warn-and-return-0. */
+		sxi32 rcs = PH7_CheckStreamArg(pCtx,apArg[0],1,"stream");
+		if( rcs != PH7_OK ){
+			return rcs;
+		}
 	}
 	/* Extract our private data */
 	pDev = (io_private *)ph7_value_to_resource(apArg[0]);
@@ -4620,11 +4626,17 @@ static int PH7_builtin_vfprintf(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	io_private *pDev;
 	SySet sArg;
 	int n,nLen;
-	if( nArg < 3 || !ph7_value_is_resource(apArg[0]) ){
-		/* Missing/Invalid arguments,return zero */
+	if( nArg < 3 ){
 		ph7_context_throw_error(pCtx,PH7_CTX_WARNING,"Invalid arguments");
 		ph7_result_int(pCtx,0);
 		return PH7_OK;
+	}
+	{
+		/* php: a non-resource $stream is a TypeError (#1), not a warn-and-return-0. */
+		sxi32 rcs = PH7_CheckStreamArg(pCtx,apArg[0],1,"stream");
+		if( rcs != PH7_OK ){
+			return rcs;
+		}
 	}
 	/* PHP 8 checks argument types left-to-right: $format (#2) then $values (#3). */
 	{

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -818,12 +818,24 @@ PH7_PRIVATE sxi32 PH7_VmEmitInstr(
 	)
 {
 	VmInstr sInstr;
+	ph7_gen_state *pGen = &pVm->sCodeGen;
 	sxi32 rc;
 	/* Fill the VM instruction */
 	sInstr.iOp = (sxu8)iOp;
 	sInstr.iP1 = iP1;
 	sInstr.iP2 = iP2;
 	sInstr.p3  = p3;
+	/* Stamp the source line. The node handlers point pGen->pIn at the token being
+	 * compiled (that is how they read its text), so the current token IS this
+	 * instruction's source position; pIn can sit one past the end of the stream
+	 * between statements, hence the range check. */
+	sInstr.nLine = 0;
+	if( pGen->pIn && pGen->pEnd && pGen->pIn < pGen->pEnd ){
+		sInstr.nLine = pGen->pIn->nLine;
+	}else if( pGen->pIn && pGen->pEnd && pGen->pIn >= pGen->pEnd && pGen->pEnd > (SyToken *)0 ){
+		/* Past the end (statement tail): blame the last real token. */
+		sInstr.nLine = pGen->pEnd[-1].nLine;
+	}
 	if( pIndex ){
 		/* Instruction index in the bytecode array */
 		*pIndex = SySetUsed(pVm->pByteContainer);
@@ -949,6 +961,8 @@ static sxi32 VmEnterFrame(
 	if( pFrame == 0 ){
 		return SXERR_MEM;
 	}
+	/* The line currently executing IS the call site for the frame being pushed. */
+	pFrame->nCallLine = pVm->nCurLine;
 	/* Link to the list of active VM frame */
 	pFrame->pParent = pVm->pFrame;
 	pVm->pFrame = pFrame;
@@ -2031,9 +2045,6 @@ static int vm_builtin_Closure_fromCallable(ph7_context *pCtx, int nArg, ph7_valu
 	"	  $this->message = $message;"\
 	"   }"\
 	"   $this->code = $code;"\
-	"   $this->file = __FILE__;"\
-	"   $this->line = __LINE__;"\
-	"   $this->trace = debug_backtrace();"\
 	"   if( isset($previous) ){"\
 	"     $this->previous = $previous;"\
 	"   }"\
@@ -2054,7 +2065,14 @@ static int vm_builtin_Closure_fromCallable(ph7_context *pCtx, int nArg, ph7_valu
 	"   return $this->trace;"\
 	"}"\
 	"public function getTraceAsString(){"\
-	"  return debug_string_backtrace();"\
+	"  $s = ''; $i = 0;"\
+	"  if( is_array($this->trace) ){"\
+	"    foreach( $this->trace as $f ){"\
+	"      $s .= '#' . $i . ' ' . $f['file'] . '(' . $f['line'] . '): ' . $f['function'] . \"()\\n\";"\
+	"      $i++;"\
+	"    }"\
+	"  }"\
+	"  return $s . '#' . $i . ' {main}';"\
 	"}"\
 	"public function getPrevious(){"\
 	"    return $this->previous;"\
@@ -2075,9 +2093,6 @@ static int vm_builtin_Closure_fromCallable(ph7_context *pCtx, int nArg, ph7_valu
 	"	  $this->message = $message;"\
 	"   }"\
 	"   $this->code = $code;"\
-	"   $this->file = __FILE__;"\
-	"   $this->line = __LINE__;"\
-	"   $this->trace = debug_backtrace();"\
 	"   if( isset($previous) ){"\
 	"     $this->previous = $previous;"\
 	"   }"\
@@ -2098,7 +2113,14 @@ static int vm_builtin_Closure_fromCallable(ph7_context *pCtx, int nArg, ph7_valu
 	"   return $this->trace;"\
 	"}"\
 	"public function getTraceAsString(){"\
-	"  return debug_string_backtrace();"\
+	"  $s = ''; $i = 0;"\
+	"  if( is_array($this->trace) ){"\
+	"    foreach( $this->trace as $f ){"\
+	"      $s .= '#' . $i . ' ' . $f['file'] . '(' . $f['line'] . '): ' . $f['function'] . \"()\\n\";"\
+	"      $i++;"\
+	"    }"\
+	"  }"\
+	"  return $s . '#' . $i . ' {main}';"\
 	"}"\
 	"public function getPrevious(){"\
 	"    return $this->previous;"\
@@ -5436,9 +5458,9 @@ static sxi32 VmByteCodeDump(
 			break;
 		}
 		/* Format and call the consumer callback */
-		rc = SyProcFormat(xConsumer,pUserData,"%s %8d %8u %#8x [%u]\n",
+		rc = SyProcFormat(xConsumer,pUserData,"%s %8d %8u %#8x [%u] L%u\n",
 			VmInstrToString(pInstr->iOp),pInstr->iP1,pInstr->iP2,
-			SX_PTR_TO_INT(pInstr->p3),n);
+			SX_PTR_TO_INT(pInstr->p3),n,pInstr->nLine);
 		if( rc != SXRET_OK ){
 			/* Consumer routine request an operation abort */
 			return rc;
@@ -5617,10 +5639,11 @@ static void VmDiagnosticHeader(SyBlob *pWorker,sxi32 iErr,SyString *pFuncName)
 		SyBlobAppend(pWorker,"(): ",sizeof("(): ")-1);
 	}
 }
-static void VmDiagnosticLocation(SyBlob *pWorker,SyString *pFile)
+static void VmDiagnosticLocation(SyBlob *pWorker,SyString *pFile,sxu32 nLine)
 {
 	if( pFile ){
-		SyBlobFormat(pWorker," in %.*s on line %d",(int)pFile->nByte,pFile->zString,1);
+		SyBlobFormat(pWorker," in %.*s on line %u",(int)pFile->nByte,pFile->zString,
+			nLine ? nLine : 1);
 	}
 }
 PH7_PRIVATE sxi32 PH7_VmThrowError(
@@ -5633,19 +5656,20 @@ PH7_PRIVATE sxi32 PH7_VmThrowError(
 	SyBlob *pWorker = &pVm->sWorker;
 	SyString *pFile;
 	sxi32 rc = SXRET_OK;
-	if( !VmErrReportWants(pVm,iErr) ){
-		/* error_reporting() masks this severity out */
-		return SXRET_OK;
-	}
 	/* Reset the working buffer */
 	SyBlobReset(pWorker);
 	/* Peek the processed file if available */
 	pFile = (SyString *)SySetPeek(&pVm->aFiles);
 	VmDiagnosticHeader(pWorker,iErr,pFuncName);
 	SyBlobAppend(pWorker,zMessage,SyStrlen(zMessage));
-	VmDiagnosticLocation(pWorker,pFile);
-	/* Check for user error handler.  compute length of C string */
-	if( VmInvokeErrorHandler(pVm, iErr, zMessage, (sxi32)SyStrlen(zMessage), pFile, 0) ){
+	VmDiagnosticLocation(pWorker,pFile,pVm->nCurLine);
+	/* Check for user error handler. php calls it whatever error_reporting() says
+	 * (see VmThrowErrorAp) -- the mask gates only the printed copy below. */
+	if( VmInvokeErrorHandler(pVm, iErr, zMessage, (sxi32)SyStrlen(zMessage), pFile, (sxi32)pVm->nCurLine) ){
+		if( !VmErrReportWants(pVm,iErr) ){
+			/* error_reporting() masks this severity out of the DISPLAY */
+			return SXRET_OK;
+		}
 		if( pVm->nErrSuppress > 0 ){
 			/* Inside '@': php still runs a user handler (done just above) but
 			 * prints nothing itself. */
@@ -5817,7 +5841,7 @@ static sxi32 VmThrowErrorAp(
 	 * whatever error_reporting() says -- the mask only gates the built-in printer,
 	 * and a handler is expected to consult error_reporting() itself. Testing the
 	 * mask up here instead skipped the handler entirely for a masked severity. */
-	if( VmInvokeErrorHandler(pVm, iErr, (const char *)SyBlobData(&sMsg), (sxi32)SyBlobLength(&sMsg), pFile, 0) ){
+	if( VmInvokeErrorHandler(pVm, iErr, (const char *)SyBlobData(&sMsg), (sxi32)SyBlobLength(&sMsg), pFile, (sxi32)pVm->nCurLine) ){
 		/* No handler or handler returned TRUE, normal processing — unless the
 		 * expression is under '@', which suppresses the printed diagnostic. */
 		if( !VmErrReportWants(pVm,iErr) || pVm->nErrSuppress > 0 ){
@@ -5825,7 +5849,7 @@ static sxi32 VmThrowErrorAp(
 			return SXRET_OK;
 		}
 		SyBlobAppend(pWorker,SyBlobData(&sMsg),SyBlobLength(&sMsg));
-		VmDiagnosticLocation(pWorker,pFile);
+		VmDiagnosticLocation(pWorker,pFile,pVm->nCurLine);
 		rc = VmCallErrorHandler(&(*pVm),pWorker);
 	}
 	SyBlobRelease(&sMsg);
@@ -7718,9 +7742,18 @@ static void VmGetFrameContext(ph7_vm *pVm,const char **pzFuncName,int *pnFuncLen
 static void VmRenderUncaughtEntry(
 	ph7_vm *pVm,SyBlob *pOut,
 	const char *zClass,sxu32 nClass,const char *zMsg,sxu32 nMsg,
-	const char *zFuncName,int nFuncLen,int bFirst,int bLast)
+	const char *zFuncName,int nFuncLen,int bFirst,int bLast,
+	sxu32 nThrowLine,  /* line the exception was raised at (0 -> the line running now) */
+	sxu32 nCallLine)   /* line of the call that entered the throwing frame (0 -> same) */
 {
 	SyString *pFile;
+	if( nThrowLine == 0 ){
+		nThrowLine = pVm->nCurLine ? pVm->nCurLine : 1;
+	}
+	if( nCallLine == 0 ){
+		VmFrame *pTraceFrame = pVm->pFrame ? VmSkipExceptionFrames(pVm->pFrame) : 0;
+		nCallLine = (pTraceFrame && pTraceFrame->nCallLine) ? pTraceFrame->nCallLine : nThrowLine;
+	}
 	if( zClass == 0 || nClass == 0 ){
 		zClass = "Exception";
 		nClass = (sxu32)sizeof("Exception") - 1;
@@ -7740,18 +7773,18 @@ static void VmRenderUncaughtEntry(
 		SyBlobAppend(pOut,zMsg,nMsg);
 	}
 	if( pFile ){
-		SyBlobAppend(pOut," in ",sizeof(" in ")-1);
-		SyBlobAppend(pOut,pFile->zString,pFile->nByte);
-		SyBlobAppend(pOut,":1",sizeof(":1")-1);
+		SyBlobFormat(pOut," in %.*s:%u",(int)pFile->nByte,pFile->zString,nThrowLine);
 	}
 	SyBlobAppend(pOut,"\nStack trace:\n",sizeof("\nStack trace:\n")-1);
 	if( pFile ){
 		SyBlobAppend(pOut,"#0 ",sizeof("#0 ")-1);
 		SyBlobAppend(pOut,pFile->zString,pFile->nByte);
 		if( zFuncName && nFuncLen > 0 ){
-			SyBlobFormat(pOut,"(1): %.*s()\n",nFuncLen,zFuncName);
+			/* php reports a trace frame at its CALL SITE, not at the line running
+			 * inside it. */
+			SyBlobFormat(pOut,"(%u): %.*s()\n",nCallLine,nFuncLen,zFuncName);
 		}else{
-			SyBlobAppend(pOut,"(1): {main}\n",sizeof("(1): {main}\n")-1);
+			SyBlobFormat(pOut,"(%u): {main}\n",nCallLine);
 		}
 	}else if( zFuncName && nFuncLen > 0 ){
 		SyBlobFormat(pOut,"#0 [internal function]: %.*s()\n",nFuncLen,zFuncName);
@@ -7761,9 +7794,7 @@ static void VmRenderUncaughtEntry(
 	SyBlobAppend(pOut,"#1 {main}",sizeof("#1 {main}")-1);
 	if( bLast && pFile ){
 		SyBlobAppend(pOut,"\n",sizeof("\n")-1);
-		SyBlobAppend(pOut,"  thrown in ",sizeof("  thrown in ")-1);
-		SyBlobAppend(pOut,pFile->zString,pFile->nByte);
-		SyBlobAppend(pOut," on line 1",sizeof(" on line 1")-1);
+		SyBlobFormat(pOut,"  thrown in %.*s on line %u",(int)pFile->nByte,pFile->zString,nThrowLine);
 	}
 }
 /*
@@ -7781,7 +7812,7 @@ static sxi32 VmReportUncaughtException(ph7_vm *pVm,const char *zClass,sxu32 nCla
 		return PH7_OK;
 	}
 	SyBlobInit(&sOut,&pVm->sAllocator);
-	VmRenderUncaughtEntry(pVm,&sOut,zClass,nClass,zMsg,nMsg,zFuncName,nFuncLen,TRUE,TRUE);
+	VmRenderUncaughtEntry(pVm,&sOut,zClass,nClass,zMsg,nMsg,zFuncName,nFuncLen,TRUE,TRUE,0,0);
 	VmCallErrorHandler(pVm,&sOut);
 	SyBlobRelease(&sOut);
 	return PH7_ABORT;
@@ -7843,6 +7874,29 @@ static void VmExceptionLinkPrevious(ph7_class_instance *pThis,ph7_class_instance
  * getMessage() (so a user override is honored). A no-op if the method is
  * absent or yields an empty string.
  */
+/*
+ * Read a Throwable's `line` (the site it was created at — see PH7_VmStampThrowableSite).
+ * 0 when the class exposes no getLine().
+ */
+static sxu32 VmExtractExceptionLine(ph7_vm *pVm,ph7_class_instance *pThis)
+{
+	ph7_class_method *pGetLine;
+	ph7_value sLine;
+	sxu32 nLine = 0;
+	pGetLine = PH7_ClassExtractMethod(pThis->pClass,"getLine",sizeof("getLine")-1);
+	if( pGetLine == 0 ){
+		return 0;
+	}
+	PH7_MemObjInit(pVm,&sLine);
+	if( PH7_VmCallClassMethod(&(*pVm),pThis,pGetLine,&sLine,0,0) == SXRET_OK ){
+		sxi64 n = ph7_value_to_int64(&sLine);
+		if( n > 0 ){
+			nLine = (sxu32)n;
+		}
+	}
+	PH7_MemObjRelease(&sLine);
+	return nLine;
+}
 static void VmExtractExceptionMessage(ph7_vm *pVm,ph7_class_instance *pThis,SyBlob *pOut)
 {
 	ph7_class_method *pGetMessage;
@@ -7915,7 +7969,8 @@ static sxi32 VmReportUncaughtChain(ph7_vm *pVm,ph7_class_instance *pThis,const c
 			(const char *)SyBlobData(&sMsg),(sxu32)SyBlobLength(&sMsg),
 			zFuncName,nFuncLen,
 			(i == nChain - 1) ? TRUE : FALSE,   /* bFirst: deepest entry */
-			(i == 0) ? TRUE : FALSE);           /* bLast: outermost entry */
+			(i == 0) ? TRUE : FALSE,            /* bLast: outermost entry */
+			VmExtractExceptionLine(pVm,pEnt),0);
 		SyBlobRelease(&sMsg);
 	}
 	VmCallErrorHandler(pVm,&sOut);
@@ -8009,6 +8064,92 @@ static sxi32 VmThrowFromVm(
  *
  * Returns SXRET_OK to proceed, or the status of the thrown TypeError.
  */
+/*
+ * Stamp a freshly created Throwable with the site it was created at.
+ *
+ * php records `file`/`line` on the OBJECT at creation time -- not inside
+ * Exception::__construct -- so a subclass that overrides the constructor and never
+ * calls parent::__construct still reports the right position. The embedded
+ * Exception/Error constructors used to assign `$this->line = __LINE__`, which
+ * resolved against the EMBEDDED chunk (always line 1); they no longer touch either
+ * field, and this runs for every instantiation path (OP_NEW and the engine's own
+ * VmThrowBuiltinError / VmThrowFixedError).
+ */
+PH7_PRIVATE void PH7_VmStampThrowableSite(ph7_vm *pVm,ph7_class_instance *pThis)
+{
+	static const char *azField[] = { "file", "line", "trace" };
+	ph7_class *pThrowable;
+	SyString *pFile;
+	sxu32 n;
+	if( pThis == 0 || pThis->pClass == 0 ){
+		return;
+	}
+	pThrowable = PH7_VmExtractClass(&(*pVm),"Throwable",sizeof("Throwable")-1,FALSE,0);
+	if( pThrowable == 0 || !PH7_VmInstanceOf(pThis->pClass,pThrowable) ){
+		return;
+	}
+	pFile = (SyString *)SySetPeek(&pVm->aFiles);
+	for( n = 0 ; n < SX_ARRAYSIZE(azField) ; ++n ){
+		SyHashEntry *pEntry;
+		VmClassAttr *pVmAttr;
+		ph7_value *pAttrValue;
+		pEntry = SyHashGet(&pThis->hAttr,(const void *)azField[n],SyStrlen(azField[n]));
+		if( pEntry == 0 ){
+			continue;
+		}
+		pVmAttr = (VmClassAttr *)pEntry->pUserData;
+		pAttrValue = PH7_ClassInstanceExtractAttrValue(pThis,pVmAttr);
+		if( pAttrValue == 0 ){
+			continue;
+		}
+		if( n == 0 ){
+			if( pFile ){
+				PH7_MemObjRelease(pAttrValue);
+				PH7_MemObjInitFromString(&(*pVm),pAttrValue,pFile);
+			}
+		}else if( n == 1 ){
+			PH7_MemObjRelease(pAttrValue);
+			PH7_MemObjInitFromInt(&(*pVm),pAttrValue,(sxi64)(pVm->nCurLine ? pVm->nCurLine : 1));
+		}else{
+			/* trace: php captures it at the CREATION site, so the innermost entry is the
+			 * function that ran `new` -- reported at ITS call site. Building it here (the
+			 * ctors used to call debug_backtrace(), which described the __construct frame
+			 * instead) also gives php's shape: a LIST of frame maps. */
+			ph7_value *pList;
+			const char *zFunc = 0;
+			int nFunc = 0;
+			VmFrame *pFrame = pVm->pFrame ? VmSkipExceptionFrames(pVm->pFrame) : 0;
+			pList = ph7_new_array(&(*pVm));
+			if( pList == 0 ){
+				continue;
+			}
+			VmGetFrameContext(&(*pVm),&zFunc,&nFunc);
+			if( zFunc && nFunc > 0 ){
+				ph7_value *pEntry = ph7_new_array(&(*pVm));
+				ph7_value *pSlot = ph7_new_scalar(&(*pVm));
+				if( pEntry && pSlot ){
+					sxu32 nCall = (pFrame && pFrame->nCallLine) ? pFrame->nCallLine
+						: (pVm->nCurLine ? pVm->nCurLine : 1);
+					if( pFile ){
+						ph7_value_string(pSlot,pFile->zString,(int)pFile->nByte);
+						ph7_array_add_strkey_elem(pEntry,"file",pSlot);
+						ph7_value_reset_string_cursor(pSlot);
+					}
+					ph7_value_int(pSlot,(int)nCall);
+					ph7_array_add_strkey_elem(pEntry,"line",pSlot);
+					ph7_value_string(pSlot,zFunc,nFunc);
+					ph7_array_add_strkey_elem(pEntry,"function",pSlot);
+					ph7_array_add_elem(pList,0,pEntry);
+				}
+				if( pEntry ){ ph7_release_value(&(*pVm),pEntry); }
+				if( pSlot ){ ph7_release_value(&(*pVm),pSlot); }
+			}
+			PH7_MemObjRelease(pAttrValue);
+			PH7_MemObjStore(pList,pAttrValue);
+			ph7_release_value(&(*pVm),pList);
+		}
+	}
+}
 static const char * VmArithTypeName(ph7_value *pVal)
 {
 	if( (pVal->iFlags & MEMOBJ_OBJ) != 0 ){
@@ -9435,6 +9576,7 @@ static sxi32 VmByteCodeExec(
 {
 	sxi32 rc;
 	sxi32 nSavedBrc;
+	sxu32 nSavedLine;
 	if( VmNativeNestingExceeded(pVm) ){
 		return VmNativeNestingFatal(pVm);
 	}
@@ -9447,10 +9589,18 @@ static sxi32 VmByteCodeExec(
 	 * PH7_ABORT dominating either way. */
 	nSavedBrc = pVm->nBoundaryRc;
 	pVm->nBoundaryRc = 0;
+	/* The executing source line belongs to the ACTIVATION. A nested body -- a called
+	 * function, but equally an attribute-default or default-argument mini-program --
+	 * runs its own bytecode with its own lines, so it must not leave the caller
+	 * reporting the callee's position: `new Exception` stamped line 1 because the
+	 * class's `protected $message = '';` default ran (from the embedded chunk) between
+	 * OP_NEW and the stamp. Save on entry, restore on exit. */
+	nSavedLine = pVm->nCurLine;
 	pVm->nVmExecDepth++;
 	rc = VmByteCodeExecBody(&(*pVm),aInstr,pStack,nTos,pResult,pLastRef,is_callback,nPc,
 		pEnforceRetFunc,bReturnPropagates,pAdoptSegment,ppBaseOwner,pnBaseCap,nStackOrig);
 	pVm->nVmExecDepth--;
+	pVm->nCurLine = nSavedLine;
 	if( nSavedBrc != 0 && (nSavedBrc == PH7_ABORT || pVm->nBoundaryRc == 0) ){
 		pVm->nBoundaryRc = nSavedBrc;
 	}
@@ -9864,6 +10014,12 @@ VmLoopFetch:
 		}
 		/* Fetch the instruction to execute */
 		pInstr = &aInstr[pc];
+		if( pInstr->nLine ){
+			/* Publish the source position for diagnostics, debug_backtrace() and
+			 * Throwable. Instructions the compiler could not attribute (nLine 0)
+			 * leave the last known line standing rather than reporting line 0. */
+			pVm->nCurLine = pInstr->nLine;
+		}
 		rc = SXRET_OK;
 /*
  * What follows here is a massive switch statement where each case implements a
@@ -24271,10 +24427,15 @@ static int vm_builtin_debug_backtrace(ph7_context *pCtx,int nArg,ph7_value **apA
 			ph7_array_add_strkey_elem(pArray,"args",pArg);
 		}
 	}
-	ph7_value_int(pValue,1);
-	/* Append the current line (which is always 1 since PH7 does not track
-	 * line numbers at run-time. )
-	 */
+	{
+		/* php reports a trace entry's line as the CALL SITE — the line of the call
+		 * that entered this frame — not the line executing inside it. (PHL still
+		 * emits a single entry; the multi-frame walk is a separate gap.) */
+		VmFrame *pLineFrame = pVm->pFrame ? VmSkipExceptionFrames(pVm->pFrame) : 0;
+		sxu32 nLine = (pLineFrame && pLineFrame->nCallLine) ? pLineFrame->nCallLine
+			: (pVm->nCurLine ? pVm->nCurLine : 1);
+		ph7_value_int(pValue,(int)nLine);
+	}
 	ph7_array_add_strkey_elem(pArray,"line",pValue);
 	/* Current processed script */
 	pFile = (SyString *)SySetPeek(&pVm->aFiles);

--- a/tests/ph7/001-smoke/function/debug_backtrace/debug_backtrace.phpt
+++ b/tests/ph7/001-smoke/function/debug_backtrace/debug_backtrace.phpt
@@ -25,7 +25,7 @@ foo(10, "abc");
 is_array
 fn_foo
 args_2
-line_1
+line_11
 file_present
 --CLEAN--
 <?php

--- a/tests/ph7/001-smoke/function/error_get_last/error_get_last.phpt
+++ b/tests/ph7/001-smoke/function/error_get_last/error_get_last.phpt
@@ -21,7 +21,7 @@ foo();
 --EXPECT--
 is_array
 fn_foo
-line_1
+line_8
 --CLEAN--
 <?php
 unset($e);

--- a/tests/ph7/002-integration/cli/dash-b.phpt
+++ b/tests/ph7/002-integration/cli/dash-b.phpt
@@ -28,12 +28,12 @@ echo $out;
 ====================================================
 PH7 VM Dump
 ====================================================
-NSSWITCH           0        0        0 [0]
-LOADC              0 %A [1]
-CONSUME            1        0        0 [2]
-LOADC              0 %A [3]
-CONSUME            1        0        0 [4]
-DONE               0        0        0 [5]
+NSSWITCH           0        0        0 [0] L%d
+LOADC              0 %A [1] L%d
+CONSUME            1        0        0 [2] L%d
+LOADC              0 %A [3] L%d
+CONSUME            1        0        0 [4] L%d
+DONE               0        0        0 [5] L%d
 Hello World!
 --CLEAN--
 <?php

--- a/tests/ph7/002-integration/lang/runtime_line_numbers.phpt
+++ b/tests/ph7/002-integration/lang/runtime_line_numbers.phpt
@@ -1,0 +1,54 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Diagnostics, exceptions and traces report the source line
+--FILE--
+<?php
+set_error_handler(function ($no, $msg, $file, $line) {
+    echo "warn(line $line): $msg\n";
+    return true;
+});
+
+$ltA = "5x" + 1;
+
+$ltB = "6y"
+     + 1;
+
+function ltThrower() {
+    throw new RuntimeException("boom");
+}
+
+try {
+    ltThrower();
+} catch (RuntimeException $e) {
+    echo "caught at line ", $e->getLine(), "\n";
+    echo $e->getTraceAsString(), "\n";
+}
+
+$ltE = new LogicException("here");
+echo "created at line ", $ltE->getLine(), "\n";
+echo "file matches: ", var_export($ltE->getFile() === __FILE__, true), "\n";
+
+class LtCustom extends Exception
+{
+    public function __construct()
+    {
+        // No parent::__construct() — php still records the creation site.
+    }
+}
+$ltC = new LtCustom();
+echo "subclass without parent ctor: line ", $ltC->getLine(), "\n";
+restore_error_handler();
+?>
+--EXPECTF--
+warn(line 7): A non-numeric value encountered
+warn(line 10): A non-numeric value encountered
+caught at line 13
+#0 %A(17): ltThrower()
+#1 {main}
+created at line 23
+file matches: true
+subclass without parent ctor: line 34
+--CLEAN--
+<?php


### PR DESCRIPTION
Every runtime diagnostic said "line 1", debug_backtrace() reported 1, and (new Exception)->getLine() was 1: VmInstr carried no line number at all, so VmDiagnosticLocation hardcoded it. This was the top gate on the oracle-blind test debt, since a warning or exception test could only be made cross-engine by %d-masking the very number under test.

VmInstr gains an nLine, stamped inside PH7_VmEmitInstr from the codegen's current token -- the node handlers already point pGen->pIn at the token they are compiling, so the emitter can read the source position itself and all ~150 emit call sites keep their signatures. The dispatch loop publishes it as pVm->nCurLine at its single fetch point; the diagnostic footer and the error handler's $errline read it. `phl -b` now prints the line beside each instruction.

Three follow-on bugs, each real on its own:

- The line belongs to the ACTIVATION, so VmByteCodeExec saves and restores nCurLine around every body invocation. A nested mini-program -- not just a called function, but an attribute-default or default-argument program -- was leaving the caller reporting the callee's position. That is why `new Exception` stamped line 1: the class's `protected $message = '';` default ran, compiled from the embedded chunk, between OP_NEW and the stamp.
- A Throwable's file/line are recorded at CREATION, not by the constructor. The embedded Exception/Error ctors assigned `$this->line = __LINE__`, which resolved against the embedded chunk -- the real source of the eternal 1. PH7_VmStampThrowableSite now runs from PH7_NewClassInstance, the one funnel every instantiation path shares, so a subclass that overrides __construct without calling parent::__construct still reports the right site, as php does.
- getTraceAsString() was a PH7-ism printing "[Called function: ...]". The trace is captured at creation in php's shape (a list of frame maps) from the frame that ran `new`, reported at ITS call site (VmFrame.nCallLine), and rendered as php's "#0 file(line): func()\n#1 {main}".

Reading pGen->pIn at emit time turned a latent lifetime bug fatal: the token set is a LOCAL SySet in PH7_CompileScript, released on return, yet pGen->pIn kept pointing into it and instructions are still emitted afterwards (VmEvalChunk's trailing OP_DONE). The host suite was green -- the pool allocator masks exactly this -- and ASan caught the use-after-free on its first script. PH7_CompileScript now restores the caller's cursor before releasing the set.

Two more fixes fell out. fprintf()/vfprintf() on a non-resource stream printed "Warning: Invalid arguments" and returned 0 where php throws a TypeError, so a caller writing to a bad handle never learned the write went nowhere (new PH7_CheckStreamArg ZPP helper; the warning had been invisible until the error-handler fix stopped error_reporting from swallowing it). And the per-VM mutex allocated in ProcessScript was never released -- one leak per VM, reported by LeakSanitizer on every run and long dismissed as benign noise; it also broke cli_rf_rc.phpt under the sanitizer, since LSan's abort discards the child's buffered stdout.

Cross-engine runtime_line_numbers.phpt pins diagnostics, getLine(), getTraceAsString(), multi-line expressions and the no-parent-ctor subclass.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
