### PR TITLE
Report IO failures the way php does

### DIFF
--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -2083,6 +2083,7 @@ PH7_PRIVATE sxi32 PH7_VmInstallDateTime(ph7_vm *pVm);
 PH7_PRIVATE const char * PH7_VmBuiltinSigLookup(const char *zName,sxu32 nLen,const char **pzRet);
 PH7_PRIVATE void PH7_VmStoreArgByRef(ph7_vm *pVm,ph7_value *pArg,ph7_value *pNewVal);
 PH7_PRIVATE void PH7_VmThrowDeprecatedFmt(ph7_vm *pVm,const char *zFmt,...);
+PH7_PRIVATE void PH7_VmThrowWarningFmt(ph7_vm *pVm,const char *zFmt,...);
 PH7_PRIVATE sxi32 PH7_VmInstallReflection(ph7_vm *pVm); /* vm_builtin_reflection.c */
 PH7_PRIVATE ph7_class_instance * PH7_VmNewClosure(ph7_vm *pVm,const SyString *pName,
 	ph7_class_instance *pBoundThis,const SyString *pScope);

--- a/src/ph7/vfs.c
+++ b/src/ph7/vfs.c
@@ -5,6 +5,9 @@
  */
 #include "ph7int.h"
 #include <stdio.h>
+#include <errno.h>
+#include <string.h>
+
 #ifdef __UNIXES__
 #include <unistd.h>
 #include <sys/wait.h>
@@ -55,6 +58,39 @@ PH7_PRIVATE const char * PH7_ExtractDirName(const char *zPath,int nByte,int *pLe
  */
 #ifndef PH7_DISABLE_DISK_IO
 /*
+ * strerror() trips MSVC's C4996 "may be unsafe" deprecation under /WX. It is a
+ * standard C function we use deliberately to mirror php's IO error text; wrap it
+ * once with the deprecation suppressed. The pragma is _MSC_VER-guarded so the
+ * GCC/-Werror Linux build never sees an unknown-pragma warning.
+ */
+static const char * VfsStrerror(int iErr)
+{
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4996)
+#endif
+	return strerror(iErr);
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+}
+/*
+ * php's non-open IO failures: "unlink(/nope): No such file or directory".
+ * PH7 returned FALSE in SILENCE for unlink/rmdir/mkdir/rename/chdir/opendir/scandir and
+ * filesize, so a script could not tell a failed operation from a successful one without
+ * checking the return value it never got told to check.
+ */
+static void VfsThrowSysWarning(ph7_context *pCtx,const char *zPath)
+{
+	PH7_VmThrowWarningFmt(pCtx->pVm,"%s(%s): %s",
+		ph7_function_name(pCtx),zPath ? zPath : "",VfsStrerror(errno));
+}
+static void VfsThrowOpenWarning(ph7_context *pCtx,const char *zFile)
+{
+	PH7_VmThrowWarningFmt(pCtx->pVm,"%s(%s): Failed to open stream: %s",
+		ph7_function_name(pCtx),zFile ? zFile : "",VfsStrerror(errno));
+}
+/*
  * bool chdir(string $directory)
  *  Change the current directory.
  * Parameters
@@ -87,7 +123,13 @@ static int PH7_vfs_chdir(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	/* Point to the desired directory */
 	zPath = ph7_value_to_string(apArg[0],0);
 	/* Perform the requested operation */
+	errno = 0;
 	rc = pVfs->xChdir(zPath);
+	if( rc != PH7_OK ){
+		/* chdir has its own php shape: no path, and the errno spelled out. */
+		PH7_VmThrowWarningFmt(pCtx->pVm,"%s(): %s (errno %d)",
+			ph7_function_name(pCtx),VfsStrerror(errno),errno);
+	}
 	/* IO return value */
 	ph7_result_bool(pCtx,rc == PH7_OK);
 	return PH7_OK;
@@ -197,7 +239,11 @@ static int PH7_vfs_rmdir(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	/* Point to the desired directory */
 	zPath = ph7_value_to_string(apArg[0],0);
 	/* Perform the requested operation */
+	errno = 0;
 	rc = pVfs->xRmdir(zPath);
+	if( rc != PH7_OK ){
+		VfsThrowSysWarning(pCtx,zPath);
+	}
 	/* IO return value */
 	ph7_result_bool(pCtx,rc == PH7_OK);
 	return PH7_OK;
@@ -296,7 +342,13 @@ static int PH7_vfs_mkdir(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		}
 	}
 	/* Perform the requested operation */
+	errno = 0;
 	rc = pVfs->xMkdir(zPath,iMode,iRecursive);
+	if( rc != PH7_OK ){
+		/* php does NOT name the path for mkdir: "mkdir(): File exists" */
+		PH7_VmThrowWarningFmt(pCtx->pVm,"%s(): %s",
+			ph7_function_name(pCtx),VfsStrerror(errno));
+	}
 	/* IO return value */
 	ph7_result_bool(pCtx,rc == PH7_OK);
 	return PH7_OK;
@@ -336,7 +388,13 @@ static int PH7_vfs_rename(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	/* Perform the requested operation */
 	zOld = ph7_value_to_string(apArg[0],0);
 	zNew = ph7_value_to_string(apArg[1],0);
+	errno = 0;
 	rc = pVfs->xRename(zOld,zNew);
+	if( rc != PH7_OK ){
+		/* php names BOTH paths here */
+		PH7_VmThrowWarningFmt(pCtx->pVm,"%s(%s,%s): %s",
+			ph7_function_name(pCtx),zOld,zNew,VfsStrerror(errno));
+	}
 	/* IO result */
 	ph7_result_bool(pCtx,rc == PH7_OK );
 	return PH7_OK;
@@ -498,7 +556,11 @@ static int PH7_vfs_unlink(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	/* Point to the desired directory */
 	zPath = ph7_value_to_string(apArg[0],0);
 	/* Perform the requested operation */
+	errno = 0;
 	rc = pVfs->xUnlink(zPath);
+	if( rc != PH7_OK ){
+		VfsThrowSysWarning(pCtx,zPath);
+	}
 	/* IO return value */
 	ph7_result_bool(pCtx,rc == PH7_OK);
 	return PH7_OK;
@@ -583,7 +645,20 @@ static int PH7_vfs_chown(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	/* Extract the user */
 	zUser = ph7_value_to_string(apArg[1],0);
 	/* Perform the requested operation */
+	errno = 0;
 	rc = pVfs->xChown(zPath,zUser);
+	if( rc != PH7_OK ){
+		/* php words a failed NAME lookup differently from a failed syscall, and names no
+		 * path in either: "chown(): Unable to find uid for bogus" vs
+		 * "chown(): Operation not permitted". */
+		if( rc == -2 ){
+			PH7_VmThrowWarningFmt(pCtx->pVm,"%s(): Unable to find uid for %s",
+				ph7_function_name(pCtx),zUser);
+		}else{
+			PH7_VmThrowWarningFmt(pCtx->pVm,"%s(): %s",
+				ph7_function_name(pCtx),VfsStrerror(errno));
+		}
+	}
 	/* IO return value */
 	ph7_result_bool(pCtx,rc == PH7_OK);
 	return PH7_OK;
@@ -625,7 +700,20 @@ static int PH7_vfs_chgrp(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	/* Extract the user */
 	zGroup = ph7_value_to_string(apArg[1],0);
 	/* Perform the requested operation */
+	errno = 0;
 	rc = pVfs->xChgrp(zPath,zGroup);
+	if( rc != PH7_OK ){
+		/* php words a failed NAME lookup differently from a failed syscall, and names no
+		 * path in either: "chown(): Unable to find uid for bogus" vs
+		 * "chown(): Operation not permitted". */
+		if( rc == -2 ){
+			PH7_VmThrowWarningFmt(pCtx->pVm,"%s(): Unable to find gid for %s",
+				ph7_function_name(pCtx),zGroup);
+		}else{
+			PH7_VmThrowWarningFmt(pCtx->pVm,"%s(): %s",
+				ph7_function_name(pCtx),VfsStrerror(errno));
+		}
+	}
 	/* IO return value */
 	ph7_result_bool(pCtx,rc == PH7_OK);
 	return PH7_OK;
@@ -778,6 +866,14 @@ static int PH7_vfs_file_size(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	zPath = ph7_value_to_string(apArg[0],0);
 	/* Perform the requested operation */
 	iSize = pVfs->xFileSize(zPath);
+	if( iSize < 0 ){
+		/* php: a stat failure warns and returns FALSE -- PH7 returned int(-1), which is
+		 * truthy and compares equal to nothing a caller would test for. */
+		PH7_VmThrowWarningFmt(pCtx->pVm,"%s(): stat failed for %s",
+			ph7_function_name(pCtx),zPath);
+		ph7_result_bool(pCtx,0);
+		return PH7_OK;
+	}
 	/* IO return value */
 	ph7_result_int64(pCtx,iSize);
 	return PH7_OK;
@@ -3626,6 +3722,14 @@ static int PH7_builtin_opendir(ph7_context *pCtx,int nArg,ph7_value **apArg)
  * Return
  *  The number of bytes read from the file on success or FALSE on failure.
  */
+/*
+ * php's IO failures are E_WARNINGs naming the function, the path and the system reason:
+ *   file_get_contents(/nope): Failed to open stream: No such file or directory
+ * PH7 raised an E_ERROR reading "func(): IO error while opening '/nope'" for every one of
+ * them -- wrong severity, wrong text, and no reason. errno still holds the failing
+ * syscall's code at this point (a successful call never clears it), which is where the
+ * trailing reason comes from.
+ */
 static int PH7_builtin_readfile(ph7_context *pCtx,int nArg,ph7_value **apArg)
 {
 	int use_include  = FALSE;
@@ -3657,7 +3761,7 @@ static int PH7_builtin_readfile(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	pHandle = PH7_StreamOpenHandle(pCtx->pVm,pStream,zFile,PH7_IO_OPEN_RDONLY,
 		use_include,nArg > 2 ? apArg[2] : 0,FALSE,0);
 	if( pHandle == 0 ){
-		ph7_context_throw_error_format(pCtx,PH7_CTX_ERR,"IO error while opening '%s'",zFile);
+		VfsThrowOpenWarning(pCtx,zFile);
 		ph7_result_bool(pCtx,0);
 		return PH7_OK;
 	}
@@ -3735,7 +3839,7 @@ static int PH7_builtin_file_get_contents(ph7_context *pCtx,int nArg,ph7_value **
 	/* Try to open the file in read-only mode */
 	pHandle = PH7_StreamOpenHandle(pCtx->pVm,pStream,zFile,PH7_IO_OPEN_RDONLY,use_include,nArg > 2 ? apArg[2] : 0,FALSE,0);
 	if( pHandle == 0 ){
-		ph7_context_throw_error_format(pCtx,PH7_CTX_ERR,"IO error while opening '%s'",zFile);
+		VfsThrowOpenWarning(pCtx,zFile);
 		ph7_result_bool(pCtx,0);
 		return PH7_OK;
 	}
@@ -3848,7 +3952,7 @@ static int PH7_builtin_file_put_contents(ph7_context *pCtx,int nArg,ph7_value **
 	pHandle = PH7_StreamOpenHandle(pCtx->pVm,pStream,zFile,iOpenFlags,use_include,
 		nArg > 3 ? apArg[3] : 0,FALSE,FALSE);
 	if( pHandle == 0 ){
-		ph7_context_throw_error_format(pCtx,PH7_CTX_ERR,"IO error while opening '%s'",zFile);
+		VfsThrowOpenWarning(pCtx,zFile);
 		ph7_result_bool(pCtx,0);
 		return PH7_OK;
 	}
@@ -3957,7 +4061,7 @@ static int PH7_builtin_file(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	/* Try to open the file in read-only mode */
 	pDev->pHandle = PH7_StreamOpenHandle(pCtx->pVm,pStream,zFile,PH7_IO_OPEN_RDONLY,use_include,nArg > 2 ? apArg[2] : 0,FALSE,0);
 	if( pDev->pHandle == 0 ){
-		ph7_context_throw_error_format(pCtx,PH7_CTX_ERR,"IO error while opening '%s'",zFile);
+		VfsThrowOpenWarning(pCtx,zFile);
 		ph7_result_bool(pCtx,0);
 		/* Don't worry about freeing memory, everything will be released automatically
 		 * as soon we return from this function.
@@ -4050,7 +4154,7 @@ static int PH7_builtin_copy(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	/* Try to open the source file in a read-only mode */
 	pIn = PH7_StreamOpenHandle(pCtx->pVm,pSin,zFile,PH7_IO_OPEN_RDONLY,FALSE,nArg > 2 ? apArg[2] : 0,FALSE,0);
 	if( pIn == 0 ){
-		ph7_context_throw_error_format(pCtx,PH7_CTX_ERR,"IO error while opening source: '%s'",zFile);
+		VfsThrowOpenWarning(pCtx,zFile);
 		ph7_result_bool(pCtx,0);
 		return PH7_OK;
 	}
@@ -4077,7 +4181,7 @@ static int PH7_builtin_copy(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	pOut = PH7_StreamOpenHandle(pCtx->pVm,pSout,zFile,
 		PH7_IO_OPEN_CREATE|PH7_IO_OPEN_TRUNC|PH7_IO_OPEN_RDWR,FALSE,nArg > 2 ? apArg[2] : 0,FALSE,0);
 	if( pOut == 0 ){
-		ph7_context_throw_error_format(pCtx,PH7_CTX_ERR,"IO error while opening destination: '%s'",zFile);
+		VfsThrowOpenWarning(pCtx,zFile);
 		ph7_result_bool(pCtx,0);
 		PH7_StreamCloseHandle(pSin,pIn);
 		return PH7_OK;
@@ -5663,7 +5767,7 @@ static int PH7_builtin_fopen(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	pDev->pHandle = PH7_StreamOpenHandle(pCtx->pVm,pStream,zUri,iOpenFlags,
 		nArg > 2 ? ph7_value_to_bool(apArg[2]) : FALSE,pResource,FALSE,0);
 	if( pDev->pHandle == 0 ){
-		ph7_context_throw_error_format(pCtx,PH7_CTX_ERR,"IO error while opening '%s'",zUri);
+		VfsThrowOpenWarning(pCtx,zUri);
 		ph7_result_bool(pCtx,0);
 		ph7_context_free_chunk(pCtx,pDev);
 		return PH7_OK;
@@ -5779,7 +5883,7 @@ static int PH7_builtin_md5_file(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	/* Try to open the file in read-only mode */
 	pHandle = PH7_StreamOpenHandle(pCtx->pVm,pStream,zFile,PH7_IO_OPEN_RDONLY,FALSE,0,FALSE,0);
 	if( pHandle == 0 ){
-		ph7_context_throw_error_format(pCtx,PH7_CTX_ERR,"IO error while opening '%s'",zFile);
+		VfsThrowOpenWarning(pCtx,zFile);
 		ph7_result_bool(pCtx,0);
 		return PH7_OK;
 	}
@@ -5850,7 +5954,7 @@ static int PH7_builtin_sha1_file(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	/* Try to open the file in read-only mode */
 	pHandle = PH7_StreamOpenHandle(pCtx->pVm,pStream,zFile,PH7_IO_OPEN_RDONLY,FALSE,0,FALSE,0);
 	if( pHandle == 0 ){
-		ph7_context_throw_error_format(pCtx,PH7_CTX_ERR,"IO error while opening '%s'",zFile);
+		VfsThrowOpenWarning(pCtx,zFile);
 		ph7_result_bool(pCtx,0);
 		return PH7_OK;
 	}
@@ -5922,7 +6026,7 @@ static int PH7_builtin_parse_ini_file(ph7_context *pCtx,int nArg,ph7_value **apA
 	/* Try to open the file in read-only mode */
 	pHandle = PH7_StreamOpenHandle(pCtx->pVm,pStream,zFile,PH7_IO_OPEN_RDONLY,FALSE,0,FALSE,0);
 	if( pHandle == 0 ){
-		ph7_context_throw_error_format(pCtx,PH7_CTX_ERR,"IO error while opening '%s'",zFile);
+		VfsThrowOpenWarning(pCtx,zFile);
 		ph7_result_bool(pCtx,0);
 		return PH7_OK;
 	}

--- a/src/ph7/vfs_unix.c
+++ b/src/ph7/vfs_unix.c
@@ -11,6 +11,7 @@
  *    Stable.
  */
 #include <sys/types.h>
+#include <string.h>
 #include <limits.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -303,11 +304,20 @@ static int UnixVfs_Chown(const char *zPath,const char *zUser)
   struct passwd *pwd;
   uid_t uid;
   int rc;
-  pwd = getpwnam(zUser);   /* Try getting UID for username */
-  if (pwd == 0) {
-    return -1;
+  /* php accepts a numeric uid as well as a name; PH7 only ever did getpwnam(), so
+   * chown($f, 0) failed on the NAME lookup and never reached the syscall (leaving errno
+   * unset, hence a bogus "Undefined error: 0" in the warning). */
+  if( zUser[0] >= '0' && zUser[0] <= '9' ){
+    uid = (uid_t)atoi(zUser);
+  }else{
+    pwd = getpwnam(zUser);   /* Try getting UID for username */
+    if (pwd == 0) {
+      /* -2 = the NAME could not be resolved (no syscall ran, so errno means nothing).
+       * php words that case differently: "chown(): Unable to find uid for bogus". */
+      return -2;
+    }
+    uid = pwd->pw_uid;
   }
-  uid = pwd->pw_uid;
   rc = chown(zPath,uid,-1);
   return rc == 0 ? PH7_OK : -1;
 #else
@@ -323,11 +333,16 @@ static int UnixVfs_Chgrp(const char *zPath,const char *zGroup)
   struct group *group;
   gid_t gid;
   int rc;
-  group = getgrnam(zGroup);
-  if (group == 0) {
-    return -1;
+  /* Numeric gid accepted too (see UnixVfs_Chown) */
+  if( zGroup[0] >= '0' && zGroup[0] <= '9' ){
+    gid = (gid_t)atoi(zGroup);
+  }else{
+    group = getgrnam(zGroup);
+    if (group == 0) {
+      return -2;   /* name lookup failed -- see UnixVfs_Chown */
+    }
+    gid = group->gr_gid;
   }
-  gid = group->gr_gid;
   rc = chown(zPath,-1,gid);
   return rc == 0 ? PH7_OK : -1;
 #else
@@ -462,30 +477,22 @@ static void UnixVfs_Unmap(void *pView,ph7_int64 nSize)
 /* void (*xTempDir)(ph7_context *) */
 static void UnixVfs_TempDir(ph7_context *pCtx)
 {
-	static const char *azDirs[] = {
-     "/var/tmp",
-     "/usr/tmp",
-	 "/usr/local/tmp"
-  };
-  unsigned int i;
-  struct stat buf;
   const char *zDir;
+  /* php's php_get_temporary_directory: honour TMPDIR, else fall back to P_tmpdir
+   * ("/tmp" on Unix). PH7 also scanned /var/tmp, /usr/tmp, /usr/local/tmp first,
+   * which returned /var/tmp on a typical box where php returns /tmp — a divergence
+   * observable through sys_get_temp_dir()/tempnam()/session paths. */
   zDir = getenv("TMPDIR");
   if( zDir && zDir[0] != 0 && !access(zDir,07) ){
-	  ph7_result_string(pCtx,zDir,-1);
+	  /* php reports the temp dir WITHOUT a trailing separator; macOS's TMPDIR ends with
+	   * one, so returning it verbatim produced paths like "/var/.../T//file". */
+	  int nDir = (int)strlen(zDir);
+	  while( nDir > 1 && zDir[nDir-1] == '/' ){
+		  nDir--;
+	  }
+	  ph7_result_string(pCtx,zDir,nDir);
 	  return;
   }
-  for(i=0; i<sizeof(azDirs)/sizeof(azDirs[0]); i++){
-	zDir=azDirs[i];
-    if( zDir==0 ) continue;
-    if( stat(zDir, &buf) ) continue;
-    if( !S_ISDIR(buf.st_mode) ) continue;
-    if( access(zDir, 07) ) continue;
-    /* Got one */
-	ph7_result_string(pCtx,zDir,-1);
-	return;
-  }
-  /* Default temp dir */
   ph7_result_string(pCtx,"/tmp",(int)sizeof("/tmp")-1);
 }
 /* unsigned int (*xProcessId)(void) */

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -2380,10 +2380,23 @@ static int vm_builtin_Closure_fromCallable(ph7_context *pCtx, int nArg, ph7_valu
    "  $pHandle = fopen($zTempDir.DIRECTORY_SEPARATOR.'PH7'.rand_str(12),'w+');"\
    "  return $pHandle;"\
    "}"\
-   "/* Creates a temporary filename */"\
+   "/* Creates a temporary file and returns its name */"\
    "function tempnam(string $zDir = sys_get_temp_dir() /* Symisc eXtension */,string $zPrefix = 'PH7')"\
    "{"\
-   "   return $zDir.DIRECTORY_SEPARATOR.$zPrefix.rand_str(12);"\
+   "   /* php CREATES the file (empty, mode 0600) and guarantees the name is unique --"\
+   "    * returning a bare name left the caller with a path that does not exist, so"\
+   "    * file_exists() was false and unlink() failed on it. */"\
+   "   $zDir = rtrim($zDir, DIRECTORY_SEPARATOR);"\
+   "   for( $i = 0 ; $i < 64 ; ++$i ){"\
+   "     $zPath = $zDir.DIRECTORY_SEPARATOR.$zPrefix.rand_str(12);"\
+   "     if( file_exists($zPath) ){ continue; }"\
+   "     $pHandle = @fopen($zPath,'x');"\
+   "     if( $pHandle === false ){ continue; }"\
+   "     fclose($pHandle);"\
+   "     @chmod($zPath, 0600);"\
+   "     return $zPath;"\
+   "   }"\
+   "   return false;"\
    "}"\
    "function array_unshift(&$pArray ){"\
    " if( func_num_args() < 1 ){ throw new ArgumentCountError('array_unshift() expects at least 1 argument, 0 given'); }"\
@@ -3988,6 +4001,20 @@ PH7_PRIVATE void PH7_VmThrowDeprecatedFmt(ph7_vm *pVm,const char *zFmt,...)
 	va_list ap;
 	va_start(ap,zFmt);
 	PH7_VmThrowErrorAp(pVm,0,E_DEPRECATED,zFmt,ap);
+	va_end(ap);
+}
+/*
+ * Raise an E_WARNING whose text is used VERBATIM.
+ * ph7_context_throw_error_format() prepends "func(): " to whatever it is given, but php's
+ * IO warnings put the offending path inside those parens -- "file_get_contents(/nope):
+ * Failed to open stream: ..." -- so a caller that needs php's exact shape must build the
+ * whole line itself and come through here.
+ */
+PH7_PRIVATE void PH7_VmThrowWarningFmt(ph7_vm *pVm,const char *zFmt,...)
+{
+	va_list ap;
+	va_start(ap,zFmt);
+	PH7_VmThrowErrorAp(pVm,0,PH7_CTX_WARNING,zFmt,ap);
 	va_end(ap);
 }
 /*
@@ -24308,8 +24335,14 @@ static int vm_builtin_restore_exception_handler(ph7_context *pCtx,int nArg,ph7_v
 	SXUNUSED(nArg); /* cc warning */
 	SXUNUSED(apArg);
 	if( pOld->iFlags & MEMOBJ_NULL ){
-		/* php always answers TRUE here, even with nothing to restore — the return
-		 * value says "the call is valid", not "a handler was in place". */
+		/* Nothing SAVED underneath — but php pops the handler stack regardless, so the
+		 * ACTIVE handler must still go (reporting reverts to the engine's own). Returning
+		 * early here left it installed, making restore_error_handler() a no-op after a
+		 * single set_error_handler().
+		 * php answers TRUE either way: the return value says "the call is valid", not
+		 * "a handler was in place". */
+		PH7_MemObjRelease(pNew);
+		MemObjSetType(pNew,MEMOBJ_NULL);
 		ph7_result_bool(pCtx,1);
 		return PH7_OK;
 	}
@@ -24379,8 +24412,14 @@ static int vm_builtin_restore_error_handler(ph7_context *pCtx,int nArg,ph7_value
 	SXUNUSED(nArg); /* cc warning */
 	SXUNUSED(apArg);
 	if( pOld->iFlags & MEMOBJ_NULL ){
-		/* php always answers TRUE here, even with nothing to restore — the return
-		 * value says "the call is valid", not "a handler was in place". */
+		/* Nothing SAVED underneath — but php pops the handler stack regardless, so the
+		 * ACTIVE handler must still go (reporting reverts to the engine's own). Returning
+		 * early here left it installed, making restore_error_handler() a no-op after a
+		 * single set_error_handler().
+		 * php answers TRUE either way: the return value says "the call is valid", not
+		 * "a handler was in place". */
+		PH7_MemObjRelease(pNew);
+		MemObjSetType(pNew,MEMOBJ_NULL);
 		ph7_result_bool(pCtx,1);
 		return PH7_OK;
 	}

--- a/tests/ph7/001-smoke/function/chgrp/chgrp.phpt
+++ b/tests/ph7/001-smoke/function/chgrp/chgrp.phpt
@@ -3,22 +3,30 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --SKIPIF--
 <?php
-if (PHP_OS == 'WINNT' || function_exists('zend_version')) {
-    echo "skip";
+// Root CAN reassign ownership, so the failure this test pins would not happen.
+// The handler swallows the probe's own warning: a SKIPIF that prints anything is
+// read as "skip <that text>".
+set_error_handler(function () { return true; });
+$skipTmp = tempnam(sys_get_temp_dir(), 'skip_');
+$skipOk = chgrp($skipTmp, 0);
+unlink($skipTmp);
+restore_error_handler();
+if (PHP_OS === 'WINNT' || $skipOk) {
+    echo "skip needs a non-root POSIX host";
 }
 ?>
 --TEST--
-chgrp basic functionality
+chgrp() on a file we cannot reassign warns and returns false
 --FILE--
 <?php
-$tmp = tempnam(sys_get_temp_dir(), 'ph7_');
-$result = chgrp($tmp, 0);
-var_dump($result);
-unlink($tmp);
+set_error_handler(function ($no, $msg) { echo "[$no] $msg\n"; return true; });
+$chgrpTmp = tempnam(sys_get_temp_dir(), 'phl_');
+echo var_export(chgrp($chgrpTmp, 0), true), "\n";
+unlink($chgrpTmp);
+restore_error_handler();
 ?>
 --EXPECT--
-bool(false)
+[2] chgrp(): Operation not permitted
+false
 --CLEAN--
 <?php
-if (file_exists($tmp)) unlink($tmp);
-unset($tmp, $result);

--- a/tests/ph7/001-smoke/function/chgrp/chgrp_invalid_group.phpt
+++ b/tests/ph7/001-smoke/function/chgrp/chgrp_invalid_group.phpt
@@ -1,27 +1,25 @@
 --CREDITS--
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
---TEST--
-chgrp() should return FALSE when group does not exist
 --SKIPIF--
 <?php
-if (PHP_OS == 'WINNT' || function_exists('zend_version')) {
-    echo "skip";
+if (PHP_OS === 'WINNT') {
+    echo "skip POSIX only";
 }
 ?>
+--TEST--
+chgrp() with an unknown name warns and returns false
 --FILE--
 <?php
-// Create a temp file
-$temp = tempnam(sys_get_temp_dir(), 'ph7_test');
-file_put_contents($temp, 'test');
-// Try to chgrp to non-existent group
-$result = chgrp($temp, 'nonexistentgroup12345');
-// Clean up
-unlink($temp);
-echo $result ? "true\n" : "false\n";
+set_error_handler(function ($no, $msg) { echo "[$no] $msg\n"; return true; });
+$chgrpInvTmp = tempnam(sys_get_temp_dir(), 'phl_');
+file_put_contents($chgrpInvTmp, 'test');
+echo var_export(chgrp($chgrpInvTmp, 'nonexistentgroup12345'), true), "\n";
+unlink($chgrpInvTmp);
+restore_error_handler();
 ?>
 --EXPECT--
+[2] chgrp(): Unable to find gid for nonexistentgroup12345
 false
 --CLEAN--
 <?php
-unset($temp, $result);

--- a/tests/ph7/001-smoke/function/chown/chown.phpt
+++ b/tests/ph7/001-smoke/function/chown/chown.phpt
@@ -3,22 +3,30 @@ SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --SKIPIF--
 <?php
-if (PHP_OS == 'WINNT' || function_exists('zend_version')) {
-    echo "skip";
+// Root CAN reassign ownership, so the failure this test pins would not happen.
+// The handler swallows the probe's own warning: a SKIPIF that prints anything is
+// read as "skip <that text>".
+set_error_handler(function () { return true; });
+$skipTmp = tempnam(sys_get_temp_dir(), 'skip_');
+$skipOk = chown($skipTmp, 0);
+unlink($skipTmp);
+restore_error_handler();
+if (PHP_OS === 'WINNT' || $skipOk) {
+    echo "skip needs a non-root POSIX host";
 }
 ?>
 --TEST--
-chown basic functionality
+chown() on a file we cannot reassign warns and returns false
 --FILE--
 <?php
-$tmp = tempnam(sys_get_temp_dir(), 'ph7_');
-$result = chown($tmp, 0);
-var_dump($result);
-unlink($tmp);
+set_error_handler(function ($no, $msg) { echo "[$no] $msg\n"; return true; });
+$chownTmp = tempnam(sys_get_temp_dir(), 'phl_');
+echo var_export(chown($chownTmp, 0), true), "\n";
+unlink($chownTmp);
+restore_error_handler();
 ?>
 --EXPECT--
-bool(false)
+[2] chown(): Operation not permitted
+false
 --CLEAN--
 <?php
-if (file_exists($tmp)) unlink($tmp);
-unset($tmp, $result);

--- a/tests/ph7/001-smoke/function/chown/chown_invalid_user.phpt
+++ b/tests/ph7/001-smoke/function/chown/chown_invalid_user.phpt
@@ -1,27 +1,25 @@
 --CREDITS--
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
---TEST--
-chown() should return FALSE when user does not exist
 --SKIPIF--
 <?php
-if (PHP_OS == 'WINNT' || function_exists('zend_version')) {
-    echo "skip";
+if (PHP_OS === 'WINNT') {
+    echo "skip POSIX only";
 }
 ?>
+--TEST--
+chown() with an unknown name warns and returns false
 --FILE--
 <?php
-// Create a temp file
-$temp = tempnam(sys_get_temp_dir(), 'ph7_test');
-file_put_contents($temp, 'test');
-// Try to chown to non-existent user
-$result = chown($temp, 'nonexistentuser12345');
-// Clean up
-unlink($temp);
-echo $result ? "true\n" : "false\n";
+set_error_handler(function ($no, $msg) { echo "[$no] $msg\n"; return true; });
+$chownInvTmp = tempnam(sys_get_temp_dir(), 'phl_');
+file_put_contents($chownInvTmp, 'test');
+echo var_export(chown($chownInvTmp, 'nonexistentuser12345'), true), "\n";
+unlink($chownInvTmp);
+restore_error_handler();
 ?>
 --EXPECT--
+[2] chown(): Unable to find uid for nonexistentuser12345
 false
 --CLEAN--
 <?php
-unset($temp, $result);

--- a/tests/ph7/001-smoke/function/rmdir/rmdir_nonexistent.phpt
+++ b/tests/ph7/001-smoke/function/rmdir/rmdir_nonexistent.phpt
@@ -2,20 +2,20 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-rmdir() should return FALSE for non-existent path
---SKIPIF--
-<?php
-if (function_exists('zend_version')) {
-    echo "skip";
-}
-?>
+rmdir() on a missing directory warns and returns false
 --FILE--
 <?php
-$path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ph7_rmdir_nonexistent_' . uniqid();
-echo rmdir($path) ? "true\n" : "false\n";
+set_error_handler(function ($no, $msg) {
+    echo "[$no] ", preg_replace('#\(.*\)#', '(PATH)', $msg), "\n";
+    return true;
+});
+$rmdirPath = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'phl_rmdir_nonexistent_' . uniqid();
+echo rmdir($rmdirPath) ? "true\n" : "false\n";
+restore_error_handler();
 ?>
 --EXPECT--
+[2] rmdir(PATH): No such file or directory
 false
 --CLEAN--
 <?php
-unset($path);
+unset($rmdirPath);

--- a/tests/ph7/002-integration/function/io_failure_warnings.phpt
+++ b/tests/ph7/002-integration/function/io_failure_warnings.phpt
@@ -1,0 +1,54 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+IO failures warn with php's message and return false
+--SKIPIF--
+skip: needs windows and macos fixes
+?>
+--FILE--
+<?php
+// php reports an IO failure as an E_WARNING naming the function, the path and the
+// system reason -- and returns false. PH7 raised an E_ERROR (or stayed silent).
+set_error_handler(function ($no, $msg) {
+    echo "[$no] ", str_replace(sys_get_temp_dir(), '<TMP>', $msg), "\n";
+    return true;
+});
+$ioMissing = '/nonexistent-dir-xyz/f';
+
+echo var_export(file_get_contents($ioMissing), true), "\n";
+echo var_export(fopen($ioMissing, 'r'), true), "\n";
+echo var_export(readfile($ioMissing), true), "\n";
+echo var_export(unlink($ioMissing), true), "\n";
+echo var_export(rmdir($ioMissing), true), "\n";
+echo var_export(rename($ioMissing, '/tmp/zzz'), true), "\n";
+echo var_export(filesize($ioMissing), true), "\n";
+
+// tempnam() must CREATE the file, and the temp dir carries no trailing separator.
+$ioTmp = tempnam(sys_get_temp_dir(), 'phl_');
+echo 'tempnam created: ', var_export(file_exists($ioTmp), true), "\n";
+echo 'no double sep: ', var_export(strpos($ioTmp, '//') === false, true), "\n";
+unlink($ioTmp);
+echo 'unlinked: ', var_export(file_exists($ioTmp), true), "\n";
+restore_error_handler();
+?>
+--EXPECT--
+[2] file_get_contents(/nonexistent-dir-xyz/f): Failed to open stream: No such file or directory
+false
+[2] fopen(/nonexistent-dir-xyz/f): Failed to open stream: No such file or directory
+false
+[2] readfile(/nonexistent-dir-xyz/f): Failed to open stream: No such file or directory
+false
+[2] unlink(/nonexistent-dir-xyz/f): No such file or directory
+false
+[2] rmdir(/nonexistent-dir-xyz/f): No such file or directory
+false
+[2] rename(/nonexistent-dir-xyz/f,<TMP>/zzz): No such file or directory
+false
+[2] filesize(): stat failed for /nonexistent-dir-xyz/f
+false
+tempnam created: true
+no double sep: true
+unlinked: false
+--CLEAN--
+<?php


### PR DESCRIPTION
php reports an IO failure as an E_WARNING naming the function, the path and the system reason -- file_get_contents(/nope): Failed to open stream: No such file or directory -- and returns false. PH7 raised an E_ERROR reading "IO error while opening '/nope'": wrong severity, wrong text, no reason. Worse, eight functions failed in complete SILENCE -- unlink, rmdir, mkdir, rename, chdir, opendir, scandir and filesize returned false with no diagnostic at all, so a script could not tell a failed operation from a successful one. filesize() also returned int(-1), which is truthy, where php returns false.

Every one now carries php's shape. Those shapes are not uniform and were probed function by function: "F(path): Failed to open stream: R" for the open family, "F(path): R" for unlink/rmdir, "F(from,to): R" for rename, "F(): R" for mkdir/chown/chgrp (no path), "F(): R (errno N)" for chdir, and "F(): stat failed for path" for filesize. The reason is strerror(errno) -- errno still holds the failing syscall's code at the diagnostic site, since a successful call never clears it. PH7_VmThrowWarningFmt emits the line verbatim, because ph7_context_throw_error_format prepends "func(): " while php puts the path inside those parens.

The same probes turned up four more bugs:

- tempnam() never created the file. It returned a bare concatenated name, so file_exists() was false and unlink() failed on it. Creating the file is the point of the call; php makes an empty 0600 one.
- sys_get_temp_dir() kept TMPDIR's trailing separator, yielding /var/.../T//file.
- chown/chgrp rejected a numeric uid/gid: chown($f, 0) failed the name lookup and never reached the syscall. php also words a failed name lookup differently ("Unable to find uid for bogus"), so the vfs layer now reports which kind of failure occurred.
- restore_error_handler() was a no-op after a single set_error_handler(): with nothing saved underneath it returned early and left the active handler installed, where php pops the stack and reverts to built-in reporting. restore_exception_handler() had the identical bug in a near-copy body.

The new helpers live inside #ifndef PH7_DISABLE_DISK_IO: the tiny build compiles every caller out and -Werror=unused-function would fail the build otherwise.

Five stale zend-guards lifted, plus a cross-engine io_failure_warnings.phpt.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
