### PR TITLE
Reject an invalid callback with a TypeError

### DIFF
--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -2807,6 +2807,15 @@ static int ph7_hashmap_usort(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		ph7_result_bool(pCtx,0);
 		return PH7_OK;
 	}
+	if( nArg > 1 ){
+		/* php rejects an uncallable comparator with a TypeError, BEFORE touching the
+		 * array. PH7 handed it to the dispatcher, which answers NULL in silence -- so
+		 * usort() with a bogus comparator reordered the array anyway, by nothing. */
+		sxi32 rcCb = PH7_CheckCallbackArg(pCtx,apArg[1],2,"callback",0);
+		if( rcCb != PH7_OK ){
+			return rcCb;
+		}
+	}
 	/* Point to the internal representation of the input hashmap */
 	PH7_HashmapCowSeparate(pCtx->pVm, apArg[0]);
 	pMap = (ph7_hashmap *)apArg[0]->x.pOther;
@@ -2859,6 +2868,15 @@ static int ph7_hashmap_uasort(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		/* Missing/Invalid arguments,return FALSE */
 		ph7_result_bool(pCtx,0);
 		return PH7_OK;
+	}
+	if( nArg > 1 ){
+		/* php rejects an uncallable comparator with a TypeError, BEFORE touching the
+		 * array. PH7 handed it to the dispatcher, which answers NULL in silence -- so
+		 * usort() with a bogus comparator reordered the array anyway, by nothing. */
+		sxi32 rcCb = PH7_CheckCallbackArg(pCtx,apArg[1],2,"callback",0);
+		if( rcCb != PH7_OK ){
+			return rcCb;
+		}
 	}
 	/* Point to the internal representation of the input hashmap */
 	PH7_HashmapCowSeparate(pCtx->pVm, apArg[0]);
@@ -2914,6 +2932,15 @@ static int ph7_hashmap_uksort(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		/* Missing/Invalid arguments,return FALSE */
 		ph7_result_bool(pCtx,0);
 		return PH7_OK;
+	}
+	if( nArg > 1 ){
+		/* php rejects an uncallable comparator with a TypeError, BEFORE touching the
+		 * array. PH7 handed it to the dispatcher, which answers NULL in silence -- so
+		 * usort() with a bogus comparator reordered the array anyway, by nothing. */
+		sxi32 rcCb = PH7_CheckCallbackArg(pCtx,apArg[1],2,"callback",0);
+		if( rcCb != PH7_OK ){
+			return rcCb;
+		}
 	}
 	/* Point to the internal representation of the input hashmap */
 	PH7_HashmapCowSeparate(pCtx->pVm, apArg[0]);

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -2084,6 +2084,7 @@ PH7_PRIVATE const char * PH7_VmBuiltinSigLookup(const char *zName,sxu32 nLen,con
 PH7_PRIVATE void PH7_VmStoreArgByRef(ph7_vm *pVm,ph7_value *pArg,ph7_value *pNewVal);
 PH7_PRIVATE void PH7_VmThrowDeprecatedFmt(ph7_vm *pVm,const char *zFmt,...);
 PH7_PRIVATE void PH7_VmThrowWarningFmt(ph7_vm *pVm,const char *zFmt,...);
+PH7_PRIVATE sxi32 PH7_CheckCallbackArg(ph7_context *pCtx,ph7_value *pCb,int iArg,const char *zParam,int bNullable);
 PH7_PRIVATE sxi32 PH7_VmInstallReflection(ph7_vm *pVm); /* vm_builtin_reflection.c */
 PH7_PRIVATE ph7_class_instance * PH7_VmNewClosure(ph7_vm *pVm,const SyString *pName,
 	ph7_class_instance *pBoundThis,const SyString *pScope);

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -4010,6 +4010,62 @@ PH7_PRIVATE void PH7_VmThrowDeprecatedFmt(ph7_vm *pVm,const char *zFmt,...)
  * Failed to open stream: ..." -- so a caller that needs php's exact shape must build the
  * whole line itself and come through here.
  */
+/*
+ * Validate a callback argument and throw php's TypeError when it cannot be called.
+ *
+ * The shared dispatcher (PH7_VmCallUserFunctionWithMap) answers SXRET_OK with a NULL
+ * result for an unresolvable callable, so every caller that did not check first failed
+ * SILENTLY: call_user_func() returned NULL and usort() left the array sorted by nothing
+ * at all. php rejects the ARGUMENT up front, naming exactly why.
+ */
+PH7_PRIVATE sxi32 PH7_CheckCallbackArg(
+	ph7_context *pCtx,   /* Calling context (names the function in the message) */
+	ph7_value *pCb,      /* The callback argument */
+	int iArg,            /* Its 1-based position */
+	const char *zParam,  /* Its php parameter name, e.g. "callback" */
+	int bNullable        /* TRUE when php's text says "or null" */
+	)
+{
+	const char *zOrNull = bNullable ? " or null" : "";
+	if( ph7_value_is_callable(pCb) ){
+		return PH7_OK;
+	}
+	if( ph7_value_is_string(pCb) ){
+		int nLen;
+		const char *zName = ph7_value_to_string(pCb,&nLen);
+		return PH7_VmThrowException(pCtx,"TypeError",
+			"%s(): Argument #%d ($%s) must be a valid callback%s, function \"%.*s\" not found or invalid function name",
+			ph7_function_name(pCtx),iArg,zParam,zOrNull,nLen,zName);
+	}
+	if( ph7_value_is_array(pCb) ){
+		ph7_hashmap *pMap = (ph7_hashmap *)pCb->x.pOther;
+		if( pMap == 0 || pMap->nEntry != 2 ){
+			return PH7_VmThrowException(pCtx,"TypeError",
+				"%s(): Argument #%d ($%s) must be a valid callback%s, array callback must have exactly two members",
+				ph7_function_name(pCtx),iArg,zParam,zOrNull);
+		}else{
+			ph7_vm *pVm = pCtx->pVm;
+			ph7_value *pCls = (ph7_value *)SySetAt(&pVm->aMemObj,pMap->pFirst->nValIdx);
+			ph7_value *pMeth = (ph7_value *)SySetAt(&pVm->aMemObj,pMap->pFirst->pPrev->nValIdx);
+			ph7_class *pClass = pCls ? PH7_VmExtractClassFromValue(&(*pVm),pCls) : 0;
+			if( pClass == 0 ){
+				return PH7_VmThrowException(pCtx,"TypeError",
+					"%s(): Argument #%d ($%s) must be a valid callback%s, class \"%.*s\" not found",
+					ph7_function_name(pCtx),iArg,zParam,zOrNull,
+					pCls ? (int)SyBlobLength(&pCls->sBlob) : 0,
+					pCls ? (const char *)SyBlobData(&pCls->sBlob) : "");
+			}
+			return PH7_VmThrowException(pCtx,"TypeError",
+				"%s(): Argument #%d ($%s) must be a valid callback%s, class %z does not have a method \"%.*s\"",
+				ph7_function_name(pCtx),iArg,zParam,zOrNull,&pClass->sName,
+				pMeth ? (int)SyBlobLength(&pMeth->sBlob) : 0,
+				pMeth ? (const char *)SyBlobData(&pMeth->sBlob) : "");
+		}
+	}
+	return PH7_VmThrowException(pCtx,"TypeError",
+		"%s(): Argument #%d ($%s) must be a valid callback%s, no array or string given",
+		ph7_function_name(pCtx),iArg,zParam,zOrNull);
+}
 PH7_PRIVATE void PH7_VmThrowWarningFmt(ph7_vm *pVm,const char *zFmt,...)
 {
 	va_list ap;

--- a/src/ph7/vm_builtin_class.c
+++ b/src/ph7/vm_builtin_class.c
@@ -1103,6 +1103,14 @@ PH7_PRIVATE int vm_builtin_call_user_func(ph7_context *pCtx,int nArg,ph7_value *
 		ph7_result_bool(pCtx,0);
 		return PH7_OK;
 	}
+	{
+		/* php validates the callback BEFORE calling anything; the dispatcher below would
+		 * otherwise answer NULL in silence for an unresolvable one. */
+		sxi32 rcCb = PH7_CheckCallbackArg(pCtx,apArg[0],1,"callback",0);
+		if( rcCb != PH7_OK ){
+			return rcCb;
+		}
+	}
 	PH7_MemObjInit(pCtx->pVm,&sResult);
 	sResult.nIdx = SXU32_HIGH; /* Mark as constant */
 	/* php passes call_user_func()'s arguments BY VALUE: warn on a by-ref formal and copy */
@@ -1170,6 +1178,12 @@ PH7_PRIVATE int vm_builtin_call_user_func_array(ph7_context *pCtx,int nArg,ph7_v
 		/* Missing/Invalid arguments,return FALSE */
 		ph7_result_bool(pCtx,0);
 		return PH7_OK;
+	}
+	{
+		sxi32 rcCb = PH7_CheckCallbackArg(pCtx,apArg[0],1,"callback",0);
+		if( rcCb != PH7_OK ){
+			return rcCb;
+		}
 	}
 	PH7_MemObjInit(pCtx->pVm,&sResult);
 	sResult.nIdx = SXU32_HIGH; /* Mark as constant */

--- a/tests/ph7/001-smoke/function/call_user_func/callback_validation.phpt
+++ b/tests/ph7/001-smoke/function/call_user_func/callback_validation.phpt
@@ -1,0 +1,65 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+An invalid callback argument is a TypeError, not a silent no-op
+--FILE--
+<?php
+// php validates a callback ARGUMENT before calling anything. PH7 handed it to a
+// dispatcher that answers NULL in silence, so call_user_func() returned NULL and
+// usort() reordered the array by nothing at all.
+class CbC { public function m() { return 'm'; } }
+function cbTry($label, $fn)
+{
+    try {
+        echo $label, ' => ', var_export($fn(), true), "\n";
+    } catch (Throwable $e) {
+        echo $label, ' => ', get_class($e), ': ', $e->getMessage(), "\n";
+    }
+}
+cbTry('cuf missing',    fn() => call_user_func('cb_no_such_fn'));
+cbTry('cuf bad method', fn() => call_user_func([new CbC, 'nope']));
+cbTry('cuf bad class',  fn() => call_user_func(['CbNoCls', 'm']));
+cbTry('cuf one elem',   fn() => call_user_func([1]));
+cbTry('cuf int',        fn() => call_user_func(5));
+cbTry('cufa missing',   fn() => call_user_func_array('cb_no_such_fn', []));
+cbTry('usort bad',      function () { $a = [3, 1]; usort($a, 'cb_no_such_cmp'); return $a; });
+cbTry('uasort bad',     function () { $a = [3, 1]; uasort($a, 'cb_no_such_cmp'); return $a; });
+cbTry('uksort bad',     function () { $a = [3, 1]; uksort($a, 'cb_no_such_cmp'); return $a; });
+cbTry('array_walk bad', function () { $a = [1]; array_walk($a, 'cb_no_such_fn'); return $a; });
+cbTry('array_map bad',  fn() => array_map('cb_no_such_fn', [1]));
+
+// Valid callbacks, and the sort flags that are NOT callbacks, still work.
+cbTry('cuf ok',      fn() => call_user_func([new CbC, 'm']));
+cbTry('usort ok',    function () { $a = [3, 1, 2]; usort($a, fn($x, $y) => $x <=> $y); return $a; });
+cbTry('sort flags',  function () { $a = ['b', 'a']; sort($a, SORT_STRING); return $a; });
+cbTry('rsort flags', function () { $a = [1, 3]; rsort($a, SORT_NUMERIC); return $a; });
+?>
+--EXPECT--
+cuf missing => cuf missing => TypeError: call_user_func(): Argument #1 ($callback) must be a valid callback, function "cb_no_such_fn" not found or invalid function name
+cuf bad method => cuf bad method => TypeError: call_user_func(): Argument #1 ($callback) must be a valid callback, class CbC does not have a method "nope"
+cuf bad class => cuf bad class => TypeError: call_user_func(): Argument #1 ($callback) must be a valid callback, class "CbNoCls" not found
+cuf one elem => cuf one elem => TypeError: call_user_func(): Argument #1 ($callback) must be a valid callback, array callback must have exactly two members
+cuf int => cuf int => TypeError: call_user_func(): Argument #1 ($callback) must be a valid callback, no array or string given
+cufa missing => cufa missing => TypeError: call_user_func_array(): Argument #1 ($callback) must be a valid callback, function "cb_no_such_fn" not found or invalid function name
+usort bad => usort bad => TypeError: usort(): Argument #2 ($callback) must be a valid callback, function "cb_no_such_cmp" not found or invalid function name
+uasort bad => uasort bad => TypeError: uasort(): Argument #2 ($callback) must be a valid callback, function "cb_no_such_cmp" not found or invalid function name
+uksort bad => uksort bad => TypeError: uksort(): Argument #2 ($callback) must be a valid callback, function "cb_no_such_cmp" not found or invalid function name
+array_walk bad => array_walk bad => TypeError: array_walk(): Argument #2 ($callback) must be a valid callback, function "cb_no_such_fn" not found or invalid function name
+array_map bad => array_map bad => TypeError: array_map(): Argument #1 ($callback) must be a valid callback or null, function "cb_no_such_fn" not found or invalid function name
+cuf ok => 'm'
+usort ok => array (
+  0 => 1,
+  1 => 2,
+  2 => 3,
+)
+sort flags => array (
+  0 => 'a',
+  1 => 'b',
+)
+rsort flags => array (
+  0 => 3,
+  1 => 1,
+)
+--CLEAN--
+<?php


### PR DESCRIPTION
php validates a callback argument before it calls anything, and throws TypeError: f(): Argument #N ($callback) must be a valid callback, <why>. PHL passed it straight to the dispatcher, which answers SXRET_OK with a NULL result for anything it cannot resolve. So call_user_func('no_such_fn') quietly returned NULL, call_user_func(5) returned FALSE, and -- the one that matters -- usort($a, 'no_such_cmp') REORDERED THE ARRAY ANYWAY, comparing every pair by nothing at all and reporting success.

A shared PH7_CheckCallbackArg() reproduces php's "why" clauses exactly:

  function "f" not found or invalid function name
  class "C" not found
  class C does not have a method "m"
  array callback must have exactly two members
  no array or string given

and is wired into call_user_func, call_user_func_array, usort, uasort and uksort. array_map, array_filter and array_walk already validated, each with its own copy of the message. The dispatcher keeps its permissive contract -- call_user_func is not its only caller -- and validation happens at each entry point, as in php.

Note for whoever touches the sort family next: usort/uasort/uksort share their argument-guard text verbatim with sort/rsort/ksort/krsort/shuffle, whose second argument is a flags int rather than a callback. The check belongs only on the three that take a comparator.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
