### PR TITLE
Fix string offsets; stop scalars becoming arrays

### DIFF
--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -2334,6 +2334,14 @@ static int PH7_builtin_implode(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	imp_data.rc = SXRET_OK;
 	if( !ph7_value_is_array(apArg[0]) ){
 		imp_data.zSep = ph7_value_to_string(apArg[0],&imp_data.nSeplen);
+		if( nArg > 1 && !ph7_value_is_array(apArg[1]) && !ph7_value_is_null(apArg[1]) ){
+			/* php: implode($glue, $pieces) requires an ARRAY. PH7 stringified whatever it
+			 * was handed, so implode(",", 5) quietly returned "5". */
+			char zBuf[64];
+			return PH7_VmThrowException(pCtx,"TypeError",
+				"implode(): Argument #2 ($array) must be of type ?array, %s given",
+				VmValueGivenName(apArg[1],zBuf,sizeof(zBuf)));
+		}
 	}else{
 		imp_data.zSep = 0;
 		imp_data.nSeplen = 0;

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -11092,18 +11092,38 @@ case PH7_OP_LOAD_IDX: {
 	if( pTos->iFlags & MEMOBJ_STRING ){
 		/* String access */
 		if( pIdx ){
-			sxu32 nOfft;
+			sxi64 iOfft;
+			sxi64 nLen = (sxi64)SyBlobLength(&pTos->sBlob);
 			if( (pIdx->iFlags & MEMOBJ_INT) == 0 ){
 				/* Force an int cast */
 				PH7_MemObjToInteger(pIdx);
 			}
-			nOfft = (sxu32)pIdx->x.iVal;
-			if( nOfft >= SyBlobLength(&pTos->sBlob) ){
-				/* Invalid offset,load null */
+			iOfft = pIdx->x.iVal;
+			/* php 7.1: a NEGATIVE offset counts back from the end ($s[-1] is the last
+			 * character). The offset used to be cast to UNSIGNED, so -1 became a huge
+			 * number, ran past the end and quietly produced NULL. */
+			if( iOfft < 0 ){
+				iOfft += nLen;
+			}
+			if( iOfft < 0 || iOfft >= nLen ){
+				/* Out of range. In an isset()/empty() lookup php answers FALSE, so load
+				 * NULL there; everywhere else it WARNS and yields the empty string (PH7
+				 * silently produced NULL in both cases). */
+				/* LOAD_IDX carries its OWN iP2 codes, which do NOT line up with the
+				 * PH7_MEMBER_* ones: 4 = isset, 5 = unset, 6 = empty. All three are
+				 * lookups and must stay silent. */
+				int bQuiet = pInstr->iP2 == 4 || pInstr->iP2 == 5 || pInstr->iP2 == 6;
 				PH7_MemObjRelease(pTos);
+				if( bQuiet ){
+					MemObjSetType(pTos,MEMOBJ_NULL);
+				}else{
+					MemObjSetType(pTos,MEMOBJ_STRING);
+					VmErrorFormat(&(*pVm),PH7_CTX_WARNING,"Uninitialized string offset %qd",
+						pIdx->x.iVal);
+				}
 			}else{
 				const char *zData = (const char *)SyBlobData(&pTos->sBlob);
-				int c = zData[nOfft];
+				int c = zData[iOfft];
 				PH7_MemObjRelease(pTos);
 				MemObjSetType(pTos,MEMOBJ_STRING);
 				SyBlobAppend(&pTos->sBlob,(const void *)&c,sizeof(char));
@@ -11413,6 +11433,13 @@ case PH7_OP_LOAD_IDX: {
 		SyBlobNullAppend(&sMsg);
 		PH7_VmThrowError(&(*pVm),0,PH7_CTX_WARNING,(const char *)SyBlobData(&sMsg));
 		SyBlobRelease(&sMsg);
+	}
+	if( (pTos->iFlags & (MEMOBJ_HASHMAP|MEMOBJ_STRING|MEMOBJ_OBJ)) == 0
+	 && (pInstr->iP2 == 0 || pInstr->iP2 == 2) ){
+		/* Subscripting a scalar base is a WARNING in php ("Trying to access array offset
+		 * on int") that yields NULL. PH7 yielded NULL in silence. */
+		VmErrorFormat(&(*pVm),PH7_CTX_WARNING,"Trying to access array offset on %s",
+			VmArithTypeName(pTos));
 	}
 	if( pIdx ){
 		PH7_MemObjRelease(pIdx);
@@ -11910,20 +11937,42 @@ case PH7_OP_STORE_IDX_REF: {
 					SyBlobAppend(&pObj->sBlob,SyBlobData(&pTos->sBlob),SyBlobLength(&pTos->sBlob));
 				}
 			}else{
-				sxu32 nOfft;
-				if((pKey->iFlags & MEMOBJ_INT)){
+				sxi64 iOfft;
+				sxi64 nLen;
+				if((pKey->iFlags & MEMOBJ_INT) == 0 ){
 					/* Force an int cast */
 					PH7_MemObjToInteger(pKey);
 				}
-				nOfft = (sxu32)pKey->x.iVal;
-				if( nOfft < SyBlobLength(&pObj->sBlob) && SyBlobLength(&pTos->sBlob) > 0 ){
+				iOfft = pKey->x.iVal;
+				nLen = (sxi64)SyBlobLength(&pObj->sBlob);
+				if( iOfft < 0 ){
+					/* php 7.1: a negative offset writes back from the end. */
+					iOfft += nLen;
+					if( iOfft < 0 ){
+						VmErrorFormat(&(*pVm),PH7_CTX_WARNING,"Illegal string offset %qd",
+							pKey->x.iVal);
+						PH7_MemObjRelease(pKey);
+						break;
+					}
+				}
+				if( SyBlobLength(&pTos->sBlob) > 0 ){
 					const char *zBlob = (const char *)SyBlobData(&pTos->sBlob);
-					char *zData = (char *)SyBlobData(&pObj->sBlob);
-					zData[nOfft] = zBlob[0];
-				}else{
-					if( SyBlobLength(&pTos->sBlob) >= sizeof(char) ){
-						/* Perform an append operation */
-						SyBlobAppend(&pObj->sBlob,SyBlobData(&pTos->sBlob),sizeof(char));
+					if( SyBlobLength(&pTos->sBlob) > 1 ){
+						VmErrorFormat(&(*pVm),PH7_CTX_WARNING,
+							"Only the first byte will be assigned to the string offset");
+					}
+					if( iOfft >= nLen ){
+						/* php PADS WITH SPACES up to the offset. PH7 simply appended the
+						 * byte, so "abc" with [6]="Z" became "abcZ" rather than "abc   Z"
+						 * -- a silently wrong string. */
+						sxi64 nPad;
+						for( nPad = nLen ; nPad < iOfft ; ++nPad ){
+							SyBlobAppend(&pObj->sBlob," ",sizeof(char));
+						}
+						SyBlobAppend(&pObj->sBlob,(const void *)zBlob,sizeof(char));
+					}else{
+						char *zData = (char *)SyBlobData(&pObj->sBlob);
+						zData[iOfft] = zBlob[0];
 					}
 				}
 			}
@@ -11932,6 +11981,28 @@ case PH7_OP_STORE_IDX_REF: {
 			}
 			break;
 		}else if( (pObj->iFlags & MEMOBJ_HASHMAP) == 0 ){
+			/* php: only NULL and FALSE auto-vivify into an array. Writing an index into an
+			 * int/float/resource/TRUE is a catchable Error -- PH7 quietly REPLACED the value
+			 * with an array, destroying it ($x = 5; $x[0] = 1; left $x === [1]). */
+			int bScalar = (pObj->iFlags & (MEMOBJ_INT|MEMOBJ_REAL|MEMOBJ_RES)) != 0
+				|| ((pObj->iFlags & MEMOBJ_BOOL) != 0 && pObj->x.iVal != 0);
+			if( bScalar ){
+				sxi32 rcSc;
+				if( pKey ){
+					PH7_MemObjRelease(pKey);
+				}
+				VmPopOperand(&pTos,1);
+				rcSc = VmThrowFromVm(&(*pVm),"Error","Cannot use a scalar value as an array",
+					sizeof("Cannot use a scalar value as an array")-1);
+				if( rcSc == SXERR_ABORT ){ goto Abort; }
+				rc = rcSc;
+				PH7_THROW_ROUTE_MIDEXPR(rc)
+			}
+			if( (pObj->iFlags & MEMOBJ_BOOL) != 0 ){
+				/* php 8.1 deprecates auto-vivifying FALSE. */
+				VmErrorFormat(&(*pVm),8192 /* E_DEPRECATED */,
+					"Automatic conversion of false to array is deprecated");
+			}
 			/* Force a hashmap cast  */
 			rc = PH7_MemObjToHashmap(pObj);
 			if( rc != SXRET_OK ){
@@ -14635,8 +14706,11 @@ case PH7_OP_FOREACH_INIT: {
 	/* Make sure we are dealing with a hashmap aka 'array' or an object */
 	if( (pTos->iFlags & (MEMOBJ_HASHMAP|MEMOBJ_OBJ)) == 0 || SyStringLength(&pInfo->sValue) < 1 ){
 		/* Jump out of the loop */
-		if( (pTos->iFlags & MEMOBJ_NULL) == 0 ){
-			PH7_VmThrowError(&(*pVm),0,PH7_CTX_WARNING,"Invalid argument supplied for the foreach statement,expecting array or class instance");
+		if( SyStringLength(&pInfo->sValue) > 0 ){
+			/* php warns for EVERY non-iterable, null included (PH7 exempted null). */
+			VmErrorFormat(&(*pVm),PH7_CTX_WARNING,
+				"foreach() argument must be of type array|object, %s given",
+				VmArithTypeName(pTos));
 		}
 		pc = pInstr->iP2 - 1;
 	}else{

--- a/tests/ph7/001-smoke/lang/string_offsets.phpt
+++ b/tests/ph7/001-smoke/lang/string_offsets.phpt
@@ -1,0 +1,90 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+String offsets (negative, padding) and subscripting a scalar
+--FILE--
+<?php
+// String offsets, and what happens when a scalar is subscripted. PH7 silently
+// produced wrong VALUES here: $s[-1] was NULL, $s[6]="Z" grew "abc" to "abcZ"
+// instead of padding, and $x=5; $x[0]=1 replaced the int with an array.
+function soTry($label, $fn)
+{
+    try {
+        echo $label, ' => ', var_export($fn(), true), "\n";
+    } catch (Throwable $e) {
+        echo $label, ' => ', get_class($e), ': ', $e->getMessage(), "\n";
+    }
+}
+set_error_handler(function ($no, $msg) { echo "  [$no] $msg\n"; return true; });
+
+// Reads: negative offsets count back from the end; out of range warns and gives "".
+soTry('read 1',       function () { $s = 'abc'; return $s[1]; });
+soTry('read -1',      function () { $s = 'abc'; return $s[-1]; });
+soTry('read -3',      function () { $s = 'abc'; return $s[-3]; });
+soTry('read oob',     function () { $s = 'abc'; return $s[10]; });
+soTry('isset oob',    function () { $s = 'abc'; return isset($s[10]); });
+soTry('isset -1',     function () { $s = 'abc'; return isset($s[-1]); });
+soTry('empty oob',    function () { $s = 'abc'; return empty($s[10]); });
+
+// Writes: negative offsets, space padding, first byte only.
+soTry('write 1',      function () { $s = 'abc'; $s[1] = 'Z'; return $s; });
+soTry('write -1',     function () { $s = 'abc'; $s[-1] = 'Z'; return $s; });
+soTry('write -9',     function () { $s = 'abc'; $s[-9] = 'Z'; return $s; });
+soTry('write pad',    function () { $s = 'abc'; $s[6] = 'Z'; return $s; });
+soTry('write 2 bytes', function () { $s = 'abc'; $s[1] = 'XY'; return $s; });
+
+// Subscripting a scalar.
+soTry('null vivify',  function () { $x = null; $x[0] = 1; return $x; });
+soTry('false vivify', function () { $x = false; $x[0] = 1; return $x; });
+soTry('true write',   function () { $x = true; $x[0] = 1; return $x; });
+soTry('int write',    function () { $x = 5; $x[0] = 1; return $x; });
+soTry('int read',     function () { $x = 5; return $x[0]; });
+soTry('null read',    function () { $x = null; return $x[0]; });
+
+// foreach over a non-iterable, and implode's array argument.
+soTry('foreach int',  function () { $o = []; foreach (5 as $v) { $o[] = $v; } return $o; });
+soTry('foreach null', function () { $o = []; foreach (null as $v) { $o[] = $v; } return $o; });
+soTry('implode int',  fn() => implode(',', 5));
+soTry('implode ok',   fn() => implode(',', [1, 2]));
+restore_error_handler();
+?>
+--EXPECT--
+read 1 => 'b'
+read -1 => 'c'
+read -3 => 'a'
+read oob =>   [2] Uninitialized string offset 10
+''
+isset oob => false
+isset -1 => true
+empty oob => true
+write 1 => 'aZc'
+write -1 => 'abZ'
+write -9 =>   [2] Illegal string offset -9
+'abc'
+write pad => 'abc   Z'
+write 2 bytes =>   [2] Only the first byte will be assigned to the string offset
+'aXc'
+null vivify => array (
+  0 => 1,
+)
+false vivify =>   [8192] Automatic conversion of false to array is deprecated
+array (
+  0 => 1,
+)
+true write => true write => Error: Cannot use a scalar value as an array
+int write => int write => Error: Cannot use a scalar value as an array
+int read =>   [2] Trying to access array offset on int
+NULL
+null read =>   [2] Trying to access array offset on null
+NULL
+foreach int =>   [2] foreach() argument must be of type array|object, int given
+array (
+)
+foreach null =>   [2] foreach() argument must be of type array|object, null given
+array (
+)
+implode int => implode int => TypeError: implode(): Argument #2 ($array) must be of type ?array, int given
+implode ok => '1,2'
+--CLEAN--
+<?php


### PR DESCRIPTION
These were wrong VALUES, not wrong diagnostics, in ordinary code.

$s[-1] returned NULL: php 7.1's negative string offsets were never implemented. The offset was cast to unsigned, so -1 became a huge number, ran past the end and quietly produced nothing -- reading the last character of a string silently gave NULL. Writing was equally wrong: $s[-1] = 'Z' appended instead of replacing.

$s[6] = 'Z' on "abc" produced "abcZ". php pads with spaces up to the offset
("abc   Z"); PH7 appended the byte and built a different string.

$x = 5; $x[0] = 1; REPLACED the int with an array, destroying the value. php raises a catchable Error: Cannot use a scalar value as an array. null and false still auto-vivify (false with php 8.1's deprecation).

The quieter siblings, all previously silent:

- an out-of-range read now warns "Uninitialized string offset N" and yields "", where PH7 produced NULL
- subscripting a scalar warns "Trying to access array offset on int"
- foreach over a non-iterable uses php's wording and no longer exempts null
- implode(",", 5) throws php's TypeError instead of returning '5'

Note for anyone touching OP_LOAD_IDX: it carries its OWN iP2 codes (4 = isset, 5 = unset, 6 = empty), which do not line up with the PH7_MEMBER_* constants (ISSET 3, EMPTY 4). Reusing VmMemberCtxIsLookup() there silences isset but not empty, which then warns where php does not.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
