### PR TITLE
Implement the query/URL/string builtins

### DIFF
--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -9358,12 +9358,36 @@ static int PH7_builtin_urlencode(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	/* Extract the input string */
 	zIn = ph7_value_to_string(apArg[0],&nLen);
 	if( nLen < 1 ){
-		/* Nothing to process,return FALSE */
-		ph7_result_bool(pCtx,0);
+		/* php returns an empty string for empty input, not FALSE */
+		ph7_result_string(pCtx,"",0);
 		return PH7_OK;
 	}
 	/* Perform the URL encoding */
 	SyUriEncode(zIn,(sxu32)nLen,Consumer,pCtx);
+	return PH7_OK;
+}
+/*
+ * string rawurlencode(string $str)
+ *  RFC 3986 URL encoding: spaces become %20 (not '+') and '~' is left intact.
+ */
+static int PH7_builtin_rawurlencode(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	const char *zIn;
+	int nLen;
+	if( nArg < 1 ){
+		/* Missing arguments,return FALSE */
+		ph7_result_bool(pCtx,0);
+		return PH7_OK;
+	}
+	/* Extract the input string */
+	zIn = ph7_value_to_string(apArg[0],&nLen);
+	if( nLen < 1 ){
+		/* php returns an empty string for empty input, not FALSE */
+		ph7_result_string(pCtx,"",0);
+		return PH7_OK;
+	}
+	/* Perform the RFC 3986 URL encoding */
+	SyUriEncodeRaw(zIn,(sxu32)nLen,Consumer,pCtx);
 	return PH7_OK;
 }
 /*
@@ -9388,8 +9412,8 @@ static int PH7_builtin_urldecode(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	/* Extract the input string */
 	zIn = ph7_value_to_string(apArg[0],&nLen);
 	if( nLen < 1 ){
-		/* Nothing to process,return FALSE */
-		ph7_result_bool(pCtx,0);
+		/* php returns an empty string for empty input, not FALSE */
+		ph7_result_string(pCtx,"",0);
 		return PH7_OK;
 	}
 	/* Perform the URL decoding */
@@ -9622,7 +9646,7 @@ static const ph7_builtin_func aBuiltInFunc[] = {
 	{ "convert_uudecode",PH7_builtin_base64_decode },
 	{ "urlencode",    PH7_builtin_urlencode },
 	{ "urldecode",    PH7_builtin_urldecode },
-	{ "rawurlencode", PH7_builtin_urlencode },
+	{ "rawurlencode", PH7_builtin_rawurlencode },
 	{ "rawurldecode", PH7_builtin_urldecode },
 #endif /* PH7_NEED_BUILTIN_REG */
 };

--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -13058,6 +13058,7 @@ static sxu32 GenStateByRefBuiltinMask(SyString *pName)
 		sxu32 nByte;
 		sxu32 mask;
 	} aByRef[] = {
+		{ "parse_str",              9, 1u<<1 },  /* &$result (apArg[1]) */
 		{ "preg_match",            10, 1u<<2 },  /* $matches (apArg[2]) */
 		{ "preg_match_all",        14, 1u<<2 },  /* $matches (apArg[2]) */
 		{ "preg_replace",          12, 1u<<4 },  /* &$count  (apArg[4]) */

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -2551,6 +2551,7 @@ PH7_PRIVATE const char *SyTimeGetDay(sxi32 iDay);
 PH7_PRIVATE sxi32 SyUriDecode(const char *zSrc,sxu32 nLen,ProcConsumer xConsumer,void *pUserData,int bUTF8);
 #ifndef PH7_DISABLE_BUILTIN_FUNC
 PH7_PRIVATE sxi32 SyUriEncode(const char *zSrc,sxu32 nLen,ProcConsumer xConsumer,void *pUserData);
+PH7_PRIVATE sxi32 SyUriEncodeRaw(const char *zSrc,sxu32 nLen,ProcConsumer xConsumer,void *pUserData);
 #endif
 PH7_PRIVATE sxi32 SyLexRelease(SyLex *pLex);
 PH7_PRIVATE sxi32 SyLexTokenizeInput(SyLex *pLex,const char *zInput,sxu32 nLen,void *pCtxData,ProcSort xSort,ProcCmp xCmp);

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -2580,6 +2580,131 @@ static int vm_builtin_Closure_fromCallable(ph7_context *pCtx, int nArg, ph7_valu
    "  }"\
    "  return $out;"\
    "}"\
+   "/* php's http_build_query() -- missing from PH7. Skips null values, casts"\
+   " * bool to 1/0, prefixes numeric top-level keys, urlencodes per RFC. */"\
+   "function __phl_hbq_enc($s, $enc){"\
+   "  return $enc == PHP_QUERY_RFC3986 ? rawurlencode((string)$s) : urlencode((string)$s);"\
+   "}"\
+   "function __phl_hbq(&$pairs, $data, $key_prefix, $numeric_prefix, $sep, $enc){"\
+   "  foreach( $data as $k => $v ){"\
+   "    if( $v === null ){ continue; }"\
+   "    if( $key_prefix === '' ){"\
+   "      $ek = is_int($k) ? __phl_hbq_enc($numeric_prefix . $k, $enc) : __phl_hbq_enc($k, $enc);"\
+   "    } else {"\
+   "      $ek = $key_prefix . '%5B' . __phl_hbq_enc($k, $enc) . '%5D';"\
+   "    }"\
+   "    if( is_array($v) ){"\
+   "      __phl_hbq($pairs, $v, $ek, $numeric_prefix, $sep, $enc);"\
+   "    } elseif( is_object($v) ){"\
+   "      __phl_hbq($pairs, get_object_vars($v), $ek, $numeric_prefix, $sep, $enc);"\
+   "    } else {"\
+   "      if( $v === true ){ $v = '1'; } elseif( $v === false ){ $v = '0'; }"\
+   "      $pairs[] = $ek . '=' . __phl_hbq_enc($v, $enc);"\
+   "    }"\
+   "  }"\
+   "}"\
+   "function http_build_query($data, $numeric_prefix = '', $arg_separator = null, $encoding_type = PHP_QUERY_RFC1738){"\
+   "  if( !is_array($data) && !is_object($data) ){"\
+   "    throw new TypeError('http_build_query(): Argument #1 ($data) must be of type array|object, ' . gettype($data) . ' given');"\
+   "  }"\
+   "  if( $arg_separator === null ){ $arg_separator = '&'; }"\
+   "  $pairs = array();"\
+   "  __phl_hbq($pairs, is_object($data) ? get_object_vars($data) : $data, '', (string)$numeric_prefix, $arg_separator, $encoding_type);"\
+   "  return implode($arg_separator, $pairs);"\
+   "}"\
+   "/* php's parse_str() -- missing from PH7. Mangles the base name ('.'/' ' -> '_'),"\
+   " * parses [key] nesting and [] appends, urldecodes keys and values. */"\
+   "function __phl_parsestr_assign(&$arr, $segments, $i, $val){"\
+   "  $seg = $segments[$i];"\
+   "  $last = ($i === count($segments) - 1);"\
+   "  if( $seg === '' ){"\
+   "    if( $last ){ $arr[] = $val; return; }"\
+   "    $arr[] = array();"\
+   "    $k = array_key_last($arr);"\
+   "    __phl_parsestr_assign($arr[$k], $segments, $i + 1, $val);"\
+   "  } else {"\
+   "    if( $last ){ $arr[$seg] = $val; return; }"\
+   "    if( !isset($arr[$seg]) || !is_array($arr[$seg]) ){ $arr[$seg] = array(); }"\
+   "    __phl_parsestr_assign($arr[$seg], $segments, $i + 1, $val);"\
+   "  }"\
+   "}"\
+   "function parse_str($string, &$result){"\
+   "  $result = array();"\
+   "  $string = (string)$string;"\
+   "  if( $string === '' ){ return; }"\
+   "  foreach( explode('&', $string) as $pair ){"\
+   "    if( $pair === '' ){ continue; }"\
+   "    $eq = strpos($pair, '=');"\
+   "    if( $eq === false ){ $rawkey = $pair; $val = ''; }"\
+   "    else { $rawkey = substr($pair, 0, $eq); $val = urldecode(substr($pair, $eq + 1)); }"\
+   "    if( $rawkey === '' ){ continue; }"\
+   "    $bpos = strpos($rawkey, '[');"\
+   "    if( $bpos === false ){ $base = $rawkey; $subs = array(); }"\
+   "    else {"\
+   "      $base = substr($rawkey, 0, $bpos);"\
+   "      preg_match_all('/\\[([^\\]]*)\\]/', substr($rawkey, $bpos), $m);"\
+   "      $subs = $m[1];"\
+   "    }"\
+   "    $base = str_replace(array(' ', '.'), '_', urldecode($base));"\
+   "    if( $base === '' ){ continue; }"\
+   "    $segs = array($base);"\
+   "    foreach( $subs as $s ){ $segs[] = urldecode($s); }"\
+   "    __phl_parsestr_assign($result, $segs, 0, $val);"\
+   "  }"\
+   "}"\
+   "/* php 8.3 str_increment(): Perl-style alphanumeric increment. */"\
+   "function str_increment($string){"\
+   "  $string = (string)$string;"\
+   "  if( $string === '' ){ throw new ValueError('str_increment(): Argument #1 ($string) must not be empty'); }"\
+   "  if( !ctype_alnum($string) ){ throw new ValueError('str_increment(): Argument #1 ($string) must be composed only of alphanumeric ASCII characters'); }"\
+   "  for( $i = strlen($string) - 1 ; $i >= 0 ; $i-- ){"\
+   "    $c = $string[$i];"\
+   "    if( $c === 'z' ){ $string[$i] = 'a'; }"\
+   "    elseif( $c === 'Z' ){ $string[$i] = 'A'; }"\
+   "    elseif( $c === '9' ){ $string[$i] = '0'; }"\
+   "    else { $string[$i] = chr(ord($c) + 1); return $string; }"\
+   "  }"\
+   "  $first = $string[0];"\
+   "  if( $first === '0' ){ return '1' . $string; }"\
+   "  if( $first === 'a' ){ return 'a' . $string; }"\
+   "  return 'A' . $string;"\
+   "}"\
+   "/* php 8.3 str_decrement(): inverse of str_increment(); throws out of range"\
+   " * at the bottom of the counting sequence. */"\
+   "function str_decrement($string){"\
+   "  $string = (string)$string;"\
+   "  if( $string === '' ){ throw new ValueError('str_decrement(): Argument #1 ($string) must not be empty'); }"\
+   "  if( !ctype_alnum($string) ){ throw new ValueError('str_decrement(): Argument #1 ($string) must be composed only of alphanumeric ASCII characters'); }"\
+   "  $orig = $string;"\
+   "  $borrowed = false;"\
+   "  for( $i = strlen($string) - 1 ; $i >= 0 ; $i-- ){"\
+   "    $c = $string[$i];"\
+   "    if( $c === 'a' ){ $string[$i] = 'z'; }"\
+   "    elseif( $c === 'A' ){ $string[$i] = 'Z'; }"\
+   "    elseif( $c === '0' ){ $string[$i] = '9'; }"\
+   "    else { $string[$i] = chr(ord($c) - 1); $borrowed = false; break; }"\
+   "    if( $i === 0 ){ $borrowed = true; }"\
+   "  }"\
+   "  if( $borrowed ){"\
+   "    if( $string[0] === '9' ){ throw new ValueError('str_decrement(): Argument #1 ($string) \"' . $orig . '\" is out of decrement range'); }"\
+   "    $string = substr($string, 1);"\
+   "    if( $string === '' ){ throw new ValueError('str_decrement(): Argument #1 ($string) \"' . $orig . '\" is out of decrement range'); }"\
+   "  } elseif( strlen($string) > 1 && $string[0] === '0' ){"\
+   "    $string = substr($string, 1);"\
+   "  }"\
+   "  return $string;"\
+   "}"\
+   "/* Permission bits via stat(); false + warning when stat fails, like php. */"\
+   "function fileperms($filename){"\
+   "  $s = @stat($filename);"\
+   "  if( $s === false ){"\
+   "    trigger_error('fileperms(): stat failed for ' . $filename, E_USER_WARNING);"\
+   "    return false;"\
+   "  }"\
+   "  return $s['mode'];"\
+   "}"\
+   "/* PH7 keeps no stat cache, so this is a no-op like php on a clean cache. */"\
+   "function clearstatcache($clear_realpath_cache = false, $filename = ''){}"\
    "/* Creates a temporary file and returns its name */"\
    "function tempnam(string $zDir = sys_get_temp_dir() /* Symisc eXtension */,string $zPrefix = 'PH7')"\
    "{"\

--- a/src/sx/sxlib.c
+++ b/src/sx/sxlib.c
@@ -237,8 +237,12 @@ PH7_PRIVATE sxi32 SyLexRelease(SyLex *pLex)
 	return rc;
 }
 #ifndef PH7_DISABLE_BUILTIN_FUNC
-#define SAFE_HTTP(C)	(SyisAlphaNum(c) || c == '_' || c == '-' || c == '$' || c == '.' )
-PH7_PRIVATE sxi32 SyUriEncode(const char *zSrc,sxu32 nLen,ProcConsumer xConsumer,void *pUserData)
+/* php's urlencode() keeps only alnum and -_. safe (space becomes '+'); rawurlencode()
+ * additionally keeps '~' and encodes space as %20 (RFC 3986). '$' is NOT safe in
+ * either -- php encodes it %24. */
+#define SAFE_URL(C)	(SyisAlphaNum(c) || c == '_' || c == '-' || c == '.' )
+#define SAFE_RAW(C)	(SyisAlphaNum(c) || c == '_' || c == '-' || c == '.' || c == '~' )
+static sxi32 SyUriEncodeInternal(const char *zSrc,sxu32 nLen,ProcConsumer xConsumer,void *pUserData,int bRaw)
 {
 	unsigned char *zIn = (unsigned char *)zSrc;
 	unsigned char zHex[3] = { '%',0,0 };
@@ -261,13 +265,13 @@ PH7_PRIVATE sxi32 SyUriEncode(const char *zSrc,sxu32 nLen,ProcConsumer xConsumer
 			break;
 		}
 		c = zCur[0];
-		if( SAFE_HTTP(c) ){
+		if( bRaw ? SAFE_RAW(c) : SAFE_URL(c) ){
 			zCur++; continue;
 		}
 		if( zCur != zIn && SXRET_OK != (rc = xConsumer(zIn,(sxu32)(zCur-zIn),pUserData))){
 			break;
 		}
-		if( c == ' ' ){
+		if( c == ' ' && !bRaw ){
 			zOut[0] = '+';
 			rc = xConsumer((const void *)zOut,sizeof(unsigned char),pUserData);
 		}else{
@@ -281,6 +285,14 @@ PH7_PRIVATE sxi32 SyUriEncode(const char *zSrc,sxu32 nLen,ProcConsumer xConsumer
 		zIn = &zCur[1]; zCur = zIn ;
 	}
 	return rc == SXRET_OK ? SXRET_OK : SXERR_ABORT;
+}
+PH7_PRIVATE sxi32 SyUriEncode(const char *zSrc,sxu32 nLen,ProcConsumer xConsumer,void *pUserData)
+{
+	return SyUriEncodeInternal(zSrc,nLen,xConsumer,pUserData,0);
+}
+PH7_PRIVATE sxi32 SyUriEncodeRaw(const char *zSrc,sxu32 nLen,ProcConsumer xConsumer,void *pUserData)
+{
+	return SyUriEncodeInternal(zSrc,nLen,xConsumer,pUserData,1);
 }
 #endif /* PH7_DISABLE_BUILTIN_FUNC */
 static sxi32 SyAsciiToHex(sxi32 c)

--- a/tests/ph7/001-smoke/function/fileperms/fileperms.phpt
+++ b/tests/ph7/001-smoke/function/fileperms/fileperms.phpt
@@ -1,0 +1,30 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+fileperms reports the stat mode bits; clearstatcache is a harmless no-op
+--SKIPIF--
+<?php
+// POSIX permission bits (0644/0600) cannot be reproduced on Windows, where chmod
+// only toggles the read-only attribute and stat reports 0666/0444 (php behaves
+// the same there). This assertion is inherently POSIX-only.
+if (DIRECTORY_SEPARATOR === '\\') { echo 'skip POSIX file mode bits are Windows-incompatible'; }
+?>
+--FILE--
+<?php
+$t = tempnam(sys_get_temp_dir(), "fp21");
+chmod($t, 0644);
+echo decoct(fileperms($t) & 0777), "\n";
+chmod($t, 0600);
+echo decoct(fileperms($t) & 0777), "\n";
+echo is_int(fileperms($t)) ? "int\n" : "?\n";
+echo (clearstatcache() === null) ? "clear:null\n" : "clear:?\n";
+unlink($t);
+?>
+--EXPECT--
+644
+600
+int
+clear:null
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/http_build_query/http_build_query.phpt
+++ b/tests/ph7/001-smoke/function/http_build_query/http_build_query.phpt
@@ -1,0 +1,34 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+http_build_query nests, prefixes numeric keys and honours the RFC encoding
+--FILE--
+<?php
+echo http_build_query(["a" => 1, "b" => ["c" => 2, "d" => 3], "e" => "x y&z"]), "\n";
+echo http_build_query(["a" => true, "b" => false, "c" => null, "d" => 1.5]), "\n";
+echo http_build_query(["a b" => "c"], "", null, PHP_QUERY_RFC3986), "\n";
+echo http_build_query([1 => "a", 2 => "b"], "pre_"), "\n";
+echo http_build_query(["foo" => ["a", "b"]]), "\n";
+echo http_build_query(["a" => ["x" => ["y" => 1]]]), "\n";
+echo http_build_query(["a" => [], "b" => 1]), "\n";
+echo http_build_query(["a" => 1, "b" => 2], "", "&amp;"), "\n";
+class Hbq21Obj { public $a = 1; public $b = 2; private $c = 3; }
+echo http_build_query(new Hbq21Obj()), "\n";
+echo http_build_query([["a", "b"]], "n"), "\n";
+echo "[", http_build_query([]), "]\n";
+?>
+--EXPECT--
+a=1&b%5Bc%5D=2&b%5Bd%5D=3&e=x+y%26z
+a=1&b=0&d=1.5
+a%20b=c
+pre_1=a&pre_2=b
+foo%5B0%5D=a&foo%5B1%5D=b
+a%5Bx%5D%5By%5D=1
+b=1
+a=1&amp;b=2
+a=1&b=2
+n0%5B0%5D=a&n0%5B1%5D=b
+[]
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/parse_str/parse_str.phpt
+++ b/tests/ph7/001-smoke/function/parse_str/parse_str.phpt
@@ -1,0 +1,29 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+parse_str vivifies its out-param and parses bracket nesting and appends
+--FILE--
+<?php
+parse_str("a=1&b[]=2&b[]=3&c[x]=9&d=x%20y", $r1);
+echo json_encode($r1), "\n";
+parse_str("a.b=1&c d=2&x[y][z]=3&flag", $r2);
+echo json_encode($r2), "\n";
+parse_str("user[name]=J+D&user[tags][]=php&user[tags][]=c&n=5", $r3);
+echo json_encode($r3), "\n";
+parse_str("a[b][c][d]=deep&list[]=1&list[]=2", $r4);
+echo json_encode($r4), "\n";
+parse_str("empty=&only", $r5);
+echo json_encode($r5), "\n";
+parse_str("", $r6);
+echo json_encode($r6), "\n";
+?>
+--EXPECT--
+{"a":"1","b":["2","3"],"c":{"x":"9"},"d":"x y"}
+{"a_b":"1","c_d":"2","x":{"y":{"z":"3"}},"flag":""}
+{"user":{"name":"J D","tags":["php","c"]},"n":"5"}
+{"a":{"b":{"c":{"d":"deep"}}},"list":["1","2"]}
+{"empty":"","only":""}
+[]
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/rawurlencode/rawurlencode.phpt
+++ b/tests/ph7/001-smoke/function/rawurlencode/rawurlencode.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+rawurlencode uses %20 and keeps ~; both encoders encode $; empty input is ""
+--FILE--
+<?php
+echo urlencode("a b"), "|", rawurlencode("a b"), "\n";
+echo urlencode("~"), "|", rawurlencode("~"), "\n";
+echo urlencode('a$b'), "|", rawurlencode('a$b'), "\n";
+echo "[", urlencode(""), "][", rawurlencode(""), "][", urldecode(""), "]\n";
+echo rawurldecode("a%20b"), "|", urldecode("a+b"), "\n";
+echo rawurlencode("hello world!"), "\n";
+?>
+--EXPECT--
+a+b|a%20b
+%7E|~
+a%24b|a%24b
+[][][]
+a b|a b
+hello%20world%21
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/str_increment/str_increment.phpt
+++ b/tests/ph7/001-smoke/function/str_increment/str_increment.phpt
@@ -1,0 +1,36 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+str_increment and str_decrement follow php's Perl-style alphanumeric counting
+--FILE--
+<?php
+$inc = [];
+foreach (["a", "z", "Z", "0", "9", "az", "zz", "ZZ", "99", "a0", "Zz9", "Az"] as $v) {
+    $inc[] = str_increment($v);
+}
+echo implode(" ", $inc), "\n";
+$dec = [];
+foreach (["b", "z", "Z", "1", "9", "ba", "zz", "b0", "Aa0", "10", "1000", "z0"] as $v) {
+    $dec[] = str_decrement($v);
+}
+echo implode(" ", $dec), "\n";
+foreach (["", "a b"] as $v) {
+    try { str_increment($v); } catch (\ValueError $e) { echo $e->getMessage(), "\n"; }
+}
+foreach (["", "0", "a", "00", "0a"] as $v) {
+    try { str_decrement($v); } catch (\ValueError $e) { echo $e->getMessage(), "\n"; }
+}
+?>
+--EXPECT--
+b aa AA 1 10 ba aaa AAA 100 a1 AAa0 Ba
+a y Y 0 8 az zy a9 z9 9 999 y9
+str_increment(): Argument #1 ($string) must not be empty
+str_increment(): Argument #1 ($string) must be composed only of alphanumeric ASCII characters
+str_decrement(): Argument #1 ($string) must not be empty
+str_decrement(): Argument #1 ($string) "0" is out of decrement range
+str_decrement(): Argument #1 ($string) "a" is out of decrement range
+str_decrement(): Argument #1 ($string) "00" is out of decrement range
+str_decrement(): Argument #1 ($string) "0a" is out of decrement range
+--CLEAN--
+<?php


### PR DESCRIPTION
Continuing the function_exists() sweep against the oracle, six everyday functions were missing: http_build_query, parse_str, str_increment/str_decrement (8.3), fileperms and clearstatcache. All are byte-identical to php 8.5.7.

http_build_query skips null values, casts bool to 1/0, prefixes only top-level numeric keys and honours PHP_QUERY_RFC1738/RFC3986. parse_str mangles the base name (dots and spaces to underscores), parses [key] nesting and [] appends via a by-reference recursion, and vivifies its undefined out-param. str_increment and str_decrement mirror php's Perl-style alphanumeric counting; the subtle part is str_decrement's out-of-range boundary (a leading digit borrowing out, or a single character at its class minimum) and the one-leading-zero strip.

Probing them uncovered four real pre-existing bugs, all fixed:

- rawurlencode was a plain alias of urlencode, so it wrongly encoded a space as '+' (must be %20) and encoded '~' (must be kept). It now has its own builtin over a new SyUriEncodeRaw; the shared encoder is a bRaw-flagged internal helper.
- Both encoders left '$' unencoded (SAFE_HTTP whitelisted it) where php encodes it %24. The fix also corrects setcookie/query-string building in vm_http_response.c, which share SyUriEncode.
- urlencode("") and urldecode("") returned false instead of "". This corrupted parse_str's empty-[] marker until fixed.
- Passing an undefined variable to a by-reference parameter did not vivify it: the argument loaded as a temp NULL and the by-ref install bound the callee's own slot, so parse_str($s, $undef) silently dropped the write-back. parse_str joins the compile-time GenStateByRefBuiltinMask table (the same one that vivifies preg_match's $matches), which emits a create-lvalue load for that argument.

escapeshellarg/escapeshellcmd stay unimplemented: php strips and rewrites high bytes through a locale mblen scan whose output differs between macOS and glibc, and mangling a UTF-8 filename would be a silent wrong answer -- they want a dedicated locale-aware C slice rather than embedded PHP.

Five cross-engine tests added. Full and tiny builds warning-free; test-compat green under both engines; docker ASan+UBSan clean across build, smoke and integration.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
