### PR TITLE
Add get_error_handler/get_exception_handler

### DIFF
--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -9630,6 +9630,7 @@ static const ph7_builtin_func aBuiltInFunc[] = {
 	         /* Time functions */
 	{ "time"    ,    PH7_builtin_time         },
 	{ "microtime",   PH7_builtin_microtime    },
+	{ "hrtime",      PH7_builtin_hrtime       },
 	{ "getdate" ,    PH7_builtin_getdate      },
 	{ "gettimeofday",PH7_builtin_gettimeofday },
 	{ "date",        PH7_builtin_date         },

--- a/src/ph7/builtin_date.c
+++ b/src/ph7/builtin_date.c
@@ -178,6 +178,58 @@ PH7_PRIVATE int PH7_builtin_microtime(ph7_context *pCtx,int nArg,ph7_value **apA
 	return PH7_OK;
 }
 /*
+ * array|int hrtime(bool $as_number = false)
+ *  The system's high-resolution time, counted from an arbitrary monotonic
+ *  point in nanoseconds. Returns [seconds, nanoseconds] by default, or the
+ *  total nanoseconds as an int when $as_number is true.
+ */
+PH7_PRIVATE int PH7_builtin_hrtime(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	ph7_int64 sec = 0,nsec = 0;
+	int bAsNumber = 0;
+	if( nArg > 0 ){
+		bAsNumber = ph7_value_to_bool(apArg[0]);
+	}
+#if defined(CLOCK_MONOTONIC)
+	{
+		struct timespec ts;
+		if( clock_gettime(CLOCK_MONOTONIC,&ts) == 0 ){
+			sec  = (ph7_int64)ts.tv_sec;
+			nsec = (ph7_int64)ts.tv_nsec;
+		}
+	}
+#else
+	{
+		/* No monotonic clock available: fall back to the wall-clock microsecond
+		 * source (embedder clock / gettimeofday). Coarser and not strictly
+		 * monotonic, but keeps hrtime() usable off-Unix. */
+		sytime sTime;
+		DateNow(pCtx->pVm,&sTime);
+		sec  = (ph7_int64)sTime.tm_sec;
+		nsec = (ph7_int64)sTime.tm_usec * 1000;
+	}
+#endif
+	if( bAsNumber ){
+		ph7_result_int64(pCtx,sec * 1000000000LL + nsec);
+	}else{
+		ph7_value *pValue,*pArray;
+		pArray = ph7_context_new_array(pCtx);
+		pValue = ph7_context_new_scalar(pCtx);
+		if( pArray == 0 || pValue == 0 ){
+			ph7_result_null(pCtx);
+			return PH7_OK;
+		}
+		ph7_value_int64(pValue,sec);
+		ph7_array_add_elem(pArray,0/* Automatic index */,pValue);
+		ph7_value_int64(pValue,nsec);
+		ph7_array_add_elem(pArray,0/* Automatic index */,pValue);
+		ph7_result_value(pCtx,pArray);
+		ph7_context_release_value(pCtx,pValue);
+		ph7_context_release_value(pCtx,pArray);
+	}
+	return PH7_OK;
+}
+/*
  * array getdate ([ int $timestamp = time() ])
  *  Returns an associative array containing the date information
  *  of the timestamp, or the current local time if no timestamp is given.

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -2305,6 +2305,7 @@ PH7_PRIVATE int PH7_builtin_base_convert(ph7_context *pCtx,int nArg,ph7_value **
 /* builtin_date.c function prototypes */
 PH7_PRIVATE int PH7_builtin_time(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE int PH7_builtin_microtime(ph7_context *pCtx,int nArg,ph7_value **apArg);
+PH7_PRIVATE int PH7_builtin_hrtime(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE int PH7_builtin_getdate(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE int PH7_builtin_gettimeofday(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE int PH7_builtin_date(ph7_context *pCtx,int nArg,ph7_value **apArg);

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -3888,6 +3888,9 @@ static const struct VmBuiltinSig {
 	{ "serialize", "mixed $value", "string" },
 	{ "set_error_handler", "?callable $callback, int $error_levels = 30719", "" },
 	{ "set_exception_handler", "?callable $callback", "" },
+	{ "get_error_handler", "", "?callable" },
+	{ "get_exception_handler", "", "?callable" },
+	{ "hrtime", "bool $as_number = false", "array|int" },
 	{ "setcookie", "string $name, string $value = '', array|int $expires_or_options = 0, string $path = '', string $domain = '', bool $secure = false, bool $httponly = false", "bool" },
 	{ "setrawcookie", "string $name, string $value = '', array|int $expires_or_options = 0, string $path = '', string $domain = '', bool $secure = false, bool $httponly = false", "bool" },
 	{ "sha1", "string $string, bool $binary = false", "string" },
@@ -25163,6 +25166,36 @@ static int vm_builtin_set_error_handler(ph7_context *pCtx,int nArg,ph7_value **a
 	return PH7_OK;
 }
 /*
+ * ?callable get_error_handler(void)     -- php 8.5
+ * ?callable get_exception_handler(void) -- php 8.5
+ *  Return the currently installed handler callable (the ACTIVE slot [1] that the
+ *  dispatch paths call), or NULL when none is set.
+ */
+static int vm_builtin_get_error_handler(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	ph7_vm *pVm = pCtx->pVm;
+	SXUNUSED(nArg);
+	SXUNUSED(apArg);
+	if( ph7_value_is_callable(&pVm->aErrCB[1]) ){
+		ph7_result_value(pCtx,&pVm->aErrCB[1]);
+	}else{
+		ph7_result_null(pCtx);
+	}
+	return PH7_OK;
+}
+static int vm_builtin_get_exception_handler(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	ph7_vm *pVm = pCtx->pVm;
+	SXUNUSED(nArg);
+	SXUNUSED(apArg);
+	if( ph7_value_is_callable(&pVm->aExceptionCB[1]) ){
+		ph7_result_value(pCtx,&pVm->aExceptionCB[1]);
+	}else{
+		ph7_result_null(pCtx);
+	}
+	return PH7_OK;
+}
+/*
  * array debug_backtrace([ int $options = DEBUG_BACKTRACE_PROVIDE_OBJECT [, int $limit = 0 ]] )
  *  Generates a backtrace.
  * Paramaeter
@@ -27817,6 +27850,8 @@ static const ph7_builtin_func aVmFunc[] = {
 	{ "set_exception_handler",     vm_builtin_set_exception_handler     },
 	{ "restore_error_handler", vm_builtin_restore_error_handler },
 	{ "set_error_handler",vm_builtin_set_error_handler },
+	{ "get_error_handler", vm_builtin_get_error_handler },
+	{ "get_exception_handler", vm_builtin_get_exception_handler },
 	{ "debug_backtrace",  vm_builtin_debug_backtrace},
 	{ "error_get_last" ,  vm_builtin_error_get_last },
 	{ "debug_print_backtrace", vm_builtin_debug_print_backtrace  },

--- a/tests/ph7/001-smoke/function/hrtime/hrtime.phpt
+++ b/tests/ph7/001-smoke/function/hrtime/hrtime.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+hrtime returns [sec, nsec] or total nanoseconds and is monotonic
+--FILE--
+<?php
+$hrArr = hrtime();
+echo (is_array($hrArr) && count($hrArr) === 2 && is_int($hrArr[0]) && is_int($hrArr[1])) ? "array-ok" : "bad", "\n";
+echo is_int(hrtime(true)) ? "int-ok" : "bad", "\n";
+$hrA = hrtime(true);
+$hrB = hrtime(true);
+echo ($hrB >= $hrA) ? "monotonic" : "bad", "\n";
+?>
+--EXPECT--
+array-ok
+int-ok
+monotonic
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/function/get_error_handler/get_error_handler.phpt
+++ b/tests/ph7/002-integration/function/get_error_handler/get_error_handler.phpt
@@ -1,0 +1,26 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+get_error_handler and get_exception_handler report the active handler (php 8.5)
+--FILE--
+<?php
+echo get_error_handler() === null ? "null" : "?", "\n";
+set_error_handler("strlen");
+echo get_error_handler(), "\n";
+restore_error_handler();
+echo get_error_handler() === null ? "null" : "?", "\n";
+set_error_handler(function ($n, $s) { return true; });
+echo is_callable(get_error_handler()) ? "callable" : "?", "\n";
+echo get_exception_handler() === null ? "null" : "?", "\n";
+set_exception_handler(function ($e) {});
+echo is_callable(get_exception_handler()) ? "callable" : "?", "\n";
+--EXPECT--
+null
+strlen
+null
+callable
+null
+callable
+--CLEAN--
+<?php


### PR DESCRIPTION
Three more functions the oracle sweep found missing.

get_error_handler and get_exception_handler are php 8.5 additions that return the currently installed handler callable, or null when none is set. PHL already stored both in the VM (aErrCB[1]/aExceptionCB[1], the active slot the dispatch paths call), so the getters just hand that back -- byte-identical to php.

hrtime(bool $as_number = false) returns the system's monotonic high-resolution time as [seconds, nanoseconds], or the total nanoseconds as an int. It uses clock_gettime(CLOCK_MONOTONIC) with a wall-clock microsecond fallback where that clock is unavailable (off-Unix or an embedder clock). The value is non-deterministic, so the cross-engine tests assert shape and monotonicity rather than exact bytes; the handler test lives in 002-integration because set/restore mutate global handler state that would leak in the shared smoke interpreter.

memory_get_usage/memory_get_peak_usage stay unimplemented: PHL's allocator tracks only a block count, not byte totals, so a faithful version needs byte accounting instrumentation (and the number is engine-specific regardless).

Full and tiny builds warning-free; test-compat green under both engines; docker ASan+UBSan clean across build, smoke and integration.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
