### PR TITLE
Reset the sprintf pad character between specifiers

### DIFF
--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -4438,6 +4438,10 @@ PH7_PRIVATE sxi32 PH7_InputFormat(
 		/* Find out what flags are present */
 		flag_leftjustify = flag_plussign = flag_blanksign =
 			flag_alternateform = flag_zeropad = 0;
+		/* Reset the pad buffer to spaces: a custom pad char ('X) — or the string
+		 * zero-pad below — from a PREVIOUS specifier must not bleed into this one.
+		 * php resets the pad character for every specifier. */
+		for( idx = 0 ; idx < etSPACESIZE ; ++idx ){ spaces[idx] = ' '; }
 		zIn++; /* Jump the precent sign */
 		do{
 			c = zIn[0];

--- a/tests/ph7/001-smoke/function/sprintf_pad/sprintf_pad.phpt
+++ b/tests/ph7/001-smoke/function/sprintf_pad/sprintf_pad.phpt
@@ -1,0 +1,31 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+sprintf resets the custom pad character per specifier (no bleed between fields)
+--FILE--
+<?php
+function sprintfPadCases(): array {
+    return [
+        sprintf("%'*10s|%10s", "a", "b"),
+        sprintf("%'*10s|%-10s", "a", "b"),
+        sprintf("%'x5s|%5s|%5s", "a", "b", "c"),
+        sprintf("%05s|%5s", "a", "b"),
+        sprintf("%'.10d|%10d", 1, 2),
+        sprintf("%-'*10s|%10s", "a", "b"),
+        sprintf("%1\$'*10s|%2\$10s", "a", "b"),
+        sprintf("%'*8s|%08.2f|%8s", "a", 3.14, "b"),
+    ];
+}
+echo implode("\n", sprintfPadCases()), "\n";
+--EXPECT--
+*********a|         b
+*********a|b         
+xxxxa|    b|    c
+0000a|    b
+.........1|         2
+a*********|         b
+*********a|         b
+*******a|00003.14|       b
+--CLEAN--
+<?php


### PR DESCRIPTION
A diff-probe against the oracle caught a silent wrong answer: after a specifier with a custom pad character (%'X) or a string zero-pad (%0...s), the next specifier reused that pad character instead of falling back to spaces. So

  sprintf("%'*10s|%10s", "a", "b")

padded the second field with '*' too, giving "*********a|*********b" where php
resets per specifier and yields "*********a|         b".

The cause is PH7_InputFormat's spaces[] buffer, which is overwritten in place when a custom pad or string zero-pad is parsed and never restored. Fixed by resetting it to blanks at the top of the per-specifier loop, matching php.

Discovered alongside a separate, still-open bug (recorded in NEWPLAN 2): the printf family accepts too few value arguments where php throws ArgumentCountError/ValueError -- addressed next.

Cross-engine test function/sprintf_pad. test-compat green under both engines; docker ASan+UBSan clean across build, smoke and integration; full and tiny builds warning-free.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
