### PR TITLE
Throw when printf is given too few arguments

### DIFF
--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -4336,6 +4336,90 @@ PH7_PRIVATE sxi32 PH7_FormatValidate(ph7_context *pCtx,const char *zFormat,int n
 	return PH7_OK;
 }
 /*
+ * Count the number of VALUE arguments a format string needs: the greater of the
+ * sequential (non-positional) conversion count and the highest positional index
+ * (`%N$`). `%%` consumes nothing. Mirrors FormatUnknownSpec's specifier walk.
+ */
+static int FormatRequiredArgs(const char *zIn,int nByte)
+{
+	const char *zEnd = &zIn[nByte];
+	int c,seq = 0,maxpos = 0;
+	while( zIn < zEnd ){
+		int numVal = 0,pos = 0;
+		if( zIn[0] != '%' ){
+			zIn++;
+			continue;
+		}
+		zIn++; /* jump the percent sign */
+		/* leading flags (incl. the "'<pad>'" custom-pad form) */
+		while( zIn < zEnd ){
+			c = zIn[0];
+			if( c=='-' || c=='+' || c==' ' || c=='0' ){ zIn++; continue; }
+			if( c=='\'' ){ zIn++; if( zIn < zEnd ){ zIn++; } continue; }
+			break;
+		}
+		/* leading number: a positional index when a '$' follows, else the width */
+		while( zIn < zEnd && zIn[0]>='0' && zIn[0]<='9' ){
+			numVal = numVal*10 + (zIn[0]-'0');
+			zIn++;
+		}
+		if( zIn < zEnd && zIn[0]=='$' ){
+			pos = numVal;
+			zIn++;
+			/* flags then width may follow the positional marker */
+			while( zIn < zEnd ){
+				c = zIn[0];
+				if( c=='-' || c=='+' || c==' ' || c=='0' ){ zIn++; continue; }
+				if( c=='\'' ){ zIn++; if( zIn < zEnd ){ zIn++; } continue; }
+				break;
+			}
+			while( zIn < zEnd && zIn[0]>='0' && zIn[0]<='9' ){ zIn++; }
+		}
+		/* precision */
+		if( zIn < zEnd && zIn[0]=='.' ){
+			zIn++;
+			while( zIn < zEnd && zIn[0]>='0' && zIn[0]<='9' ){ zIn++; }
+		}
+		/* a single 'l' length modifier (ignored, php compat) */
+		if( zIn < zEnd && zIn[0]=='l' ){ zIn++; }
+		if( zIn >= zEnd ){ break; }
+		c = zIn[0];
+		zIn++; /* jump the conversion specifier */
+		if( c == '%' ){ continue; } /* %% consumes no argument */
+		if( pos > 0 ){
+			if( pos > maxpos ){ maxpos = pos; }
+		}else{
+			seq++;
+		}
+	}
+	return seq > maxpos ? seq : maxpos;
+}
+/*
+ * PHP 8: a printf-family call with fewer VALUE arguments than the format needs
+ * throws BEFORE any output. The non-vararg family (sprintf/printf/fprintf) raises
+ * ArgumentCountError counting the format itself ("N arguments are required, M
+ * given"); the vararg family (vsprintf/vprintf/vfprintf) raises a ValueError over
+ * the values array ("The arguments array must contain N items, M given"). nValues
+ * is the count of value arguments actually supplied; nFixed is the number of
+ * fixed leading parameters counted in the ArgumentCountError totals (1 for the
+ * $format of sprintf/printf, 2 for fprintf's $stream + $format — the vararg
+ * ValueError counts only the array, so nFixed is ignored there). Returns PH7_OK
+ * when enough.
+ */
+PH7_PRIVATE sxi32 PH7_FormatCheckArgCount(ph7_context *pCtx,const char *zFormat,int nByte,int nValues,int nFixed,int bVararg)
+{
+	int required = FormatRequiredArgs(zFormat,nByte);
+	if( nValues < required ){
+		if( bVararg ){
+			return PH7_VmThrowException(pCtx,"ValueError",
+				"The arguments array must contain %d items, %d given",required,nValues);
+		}
+		return PH7_VmThrowException(pCtx,"ArgumentCountError",
+			"%d arguments are required, %d given",required+nFixed,nValues+nFixed);
+	}
+	return PH7_OK;
+}
+/*
  * PHP 8: a printf-family `$format` argument is a `string` parameter — scalars
  * (int/float/bool) and null coerce to a string, but an array/object/resource
  * raises a catchable TypeError. iArg is the 1-based argument position ($format
@@ -4881,6 +4965,11 @@ static int PH7_builtin_sprintf(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	if( rc != PH7_OK ){
 		return rc;
 	}
+	/* PHP 8: too few value arguments is a catchable ArgumentCountError before output. */
+	rc = PH7_FormatCheckArgCount(pCtx,zFormat,nLen,nArg-1,1,FALSE);
+	if( rc != PH7_OK ){
+		return rc;
+	}
 	/* Format the string; sprintfConsumer reports an allocation failure via &rc. */
 	PH7_InputFormat(sprintfConsumer,pCtx,zFormat,nLen,nArg,apArg,(void *)&rc,FALSE);
 	if( rc != SXRET_OK ){
@@ -4942,6 +5031,11 @@ static int PH7_builtin_printf(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		if( rcv != PH7_OK ){
 			return rcv;
 		}
+		/* PHP 8: too few value arguments is a catchable ArgumentCountError before output. */
+		rcv = PH7_FormatCheckArgCount(pCtx,zFormat,nLen,nArg-1,1,FALSE);
+		if( rcv != PH7_OK ){
+			return rcv;
+		}
 	}
 	/* Format the string */
 	PH7_InputFormat(printfConsumer,pCtx,zFormat,nLen,nArg,apArg,(void *)&nCounter,FALSE);
@@ -4998,6 +5092,12 @@ static int PH7_builtin_vprintf(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	}
 	/* Point to the hashmap */
 	pMap = (ph7_hashmap *)apArg[1]->x.pOther;
+	/* PHP 8: too few items in the $values array is a catchable ValueError before output.
+	 * Checked on the entry count before materialising the value set. */
+	rcFmt = PH7_FormatCheckArgCount(pCtx,zFormat,nLen,(int)pMap->nEntry,1,TRUE);
+	if( rcFmt != PH7_OK ){
+		return rcFmt;
+	}
 	/* Extract arguments from the hashmap */
 	n = PH7_HashmapValuesToSet(pMap,&sArg);
 	/* Format the string */
@@ -5057,6 +5157,11 @@ static int PH7_builtin_vsprintf(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	}
 	/* Point to hashmap */
 	pMap = (ph7_hashmap *)apArg[1]->x.pOther;
+	/* PHP 8: too few items in the $values array is a catchable ValueError before output. */
+	rcFmt = PH7_FormatCheckArgCount(pCtx,zFormat,nLen,(int)pMap->nEntry,1,TRUE);
+	if( rcFmt != PH7_OK ){
+		return rcFmt;
+	}
 	/* Extract arguments from the hashmap */
 	n = PH7_HashmapValuesToSet(pMap,&sArg);
 	/* Format the string; sprintfConsumer reports an allocation failure via &rc. */

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -2450,6 +2450,7 @@ PH7_PRIVATE int PH7_HashmapValuesToSet(ph7_hashmap *pMap,SySet *pOut);
 PH7_PRIVATE sxi32 PH7_InputFormat(int (*xConsumer)(ph7_context *,const char *,int,void *),
 	ph7_context *pCtx,const char *zIn,int nByte,int nArg,ph7_value **apArg,void *pUserData,int vf);
 PH7_PRIVATE sxi32 PH7_FormatValidate(ph7_context *pCtx,const char *zFormat,int nByte);
+PH7_PRIVATE sxi32 PH7_FormatCheckArgCount(ph7_context *pCtx,const char *zFormat,int nByte,int nValues,int nFixed,int bVararg);
 PH7_PRIVATE sxi32 PH7_FormatCheckFormatArg(ph7_context *pCtx,ph7_value *pArg,int iArg);
 PH7_PRIVATE sxi32 PH7_CheckStreamArg(ph7_context *pCtx,ph7_value *pArg,int iArg,const char *zName);
 PH7_PRIVATE sxi32 PH7_ProcessCsv(const char *zInput,int nByte,int delim,int encl,

--- a/src/ph7/vfs.c
+++ b/src/ph7/vfs.c
@@ -4699,6 +4699,12 @@ static int PH7_builtin_fprintf(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		if( rcv != PH7_OK ){
 			return rcv;
 		}
+		/* PHP 8: too few value arguments is a catchable ArgumentCountError before output.
+		 * fprintf's values start at apArg[2] (apArg[0]=stream, apArg[1]=format). */
+		rcv = PH7_FormatCheckArgCount(pCtx,zFormat,nLen,nArg - 2,2,FALSE);
+		if( rcv != PH7_OK ){
+			return rcv;
+		}
 	}
 	/* Prepare our private data */
 	sFdata.nCount = 0;
@@ -4791,6 +4797,13 @@ static int PH7_builtin_vfprintf(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	}
 	/* Point to hashmap */
 	pMap = (ph7_hashmap *)apArg[2]->x.pOther;
+	/* PHP 8: too few items in the $values array is a catchable ValueError before output. */
+	{
+		sxi32 rcc = PH7_FormatCheckArgCount(pCtx,zFormat,nLen,(int)pMap->nEntry,1,TRUE);
+		if( rcc != PH7_OK ){
+			return rcc;
+		}
+	}
 	/* Extract arguments from the hashmap */
 	n = PH7_HashmapValuesToSet(pMap,&sArg);
 	/* Prepare our private data */

--- a/tests/ph7/001-smoke/function/printf_argcount/printf_argcount.phpt
+++ b/tests/ph7/001-smoke/function/printf_argcount/printf_argcount.phpt
@@ -1,0 +1,47 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+printf family throws when given fewer value arguments than the format needs (PHP 8)
+--FILE--
+<?php
+function fmtArgCountCases(): array {
+    $catch = function (callable $fn): string {
+        try { $fn(); return "no-throw"; } catch (\Throwable $e) { return get_class($e) . ": " . $e->getMessage(); }
+    };
+    $mem = fopen("php://memory", "r+");
+    $out = [];
+    $out[] = $catch(fn() => sprintf("%d"));
+    $out[] = $catch(fn() => sprintf("%d-%d", 5));
+    $out[] = $catch(fn() => sprintf('%1$s %2$s', "a"));
+    $out[] = $catch(fn() => sprintf('%2$s', "a"));
+    $out[] = $catch(fn() => printf("%s%s", "a"));
+    $out[] = $catch(fn() => vsprintf("%d%d", [5]));
+    $out[] = $catch(fn() => vsprintf("%d", []));
+    $out[] = $catch(fn() => fprintf($mem, "%d-%d", 5));
+    $out[] = $catch(fn() => vfprintf($mem, "%d %d", [1]));
+    // valid cases must NOT throw
+    $out[] = sprintf("%d-%d", 5, 6);
+    $out[] = sprintf('%1$s %1$s', "a");
+    $out[] = sprintf("%% only");
+    $out[] = vsprintf("%s", ["a", "b", "c"]);
+    fclose($mem);
+    return $out;
+}
+echo implode("\n", fmtArgCountCases()), "\n";
+--EXPECT--
+ArgumentCountError: 2 arguments are required, 1 given
+ArgumentCountError: 3 arguments are required, 2 given
+ArgumentCountError: 3 arguments are required, 2 given
+ArgumentCountError: 3 arguments are required, 2 given
+ArgumentCountError: 3 arguments are required, 2 given
+ValueError: The arguments array must contain 2 items, 1 given
+ValueError: The arguments array must contain 1 items, 0 given
+ArgumentCountError: 4 arguments are required, 3 given
+ValueError: The arguments array must contain 2 items, 1 given
+5-6
+a a
+% only
+a
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/sprintf/sprintf_char_format.phpt
+++ b/tests/ph7/001-smoke/function/sprintf/sprintf_char_format.phpt
@@ -2,29 +2,19 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-sprintf with %c format specifier
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+sprintf with %c format specifier; a missing argument throws ArgumentCountError (PHP 8)
 --FILE--
 <?php
-$result1 = sprintf("%c", 65);
-if ($result1 === "A") {
-    echo "PASS_BASIC\n";
-} else {
-    echo "FAIL_BASIC: expected 'A', got " . var_export($result1, true) . "\n";
-}
-
-// Test with missing argument (should use 0 -> NUL)
-$result2 = sprintf("%c");
-if ($result2 === "\0") {
-    echo "PASS_MISSING_ARG\n";
-} else {
-    echo "FAIL_MISSING_ARG: expected NUL, got " . var_export($result2, true) . "\n";
+echo sprintf("%c", 65) === "A" ? "PASS_BASIC\n" : "FAIL_BASIC\n";
+try {
+    sprintf("%c");
+    echo "NO_THROW\n";
+} catch (\ArgumentCountError $e) {
+    echo $e->getMessage(), "\n";
 }
 ?>
 --EXPECT--
 PASS_BASIC
-PASS_MISSING_ARG
+2 arguments are required, 1 given
 --CLEAN--
 <?php
-unset($result1, $result2);


### PR DESCRIPTION
php raises before producing any output when a format string needs more values than were passed; PHL silently substituted 0/"" instead, so sprintf("%d-%d", 5) returned "5-0" where php throws. The existing ArgumentCountError tests only covered the zero-argument (missing-format) case, so this gap was unguarded.

A new FormatRequiredArgs scan computes the values a format needs -- the greater of the sequential conversion count and the highest positional (%N$) index, with %% consuming nothing -- and PH7_FormatCheckArgCount raises the right per-family error: ArgumentCountError "N arguments are required, M given" for the non-vararg sprintf/printf/fprintf (the totals count the fixed leading params, so fprintf includes its stream), and ValueError "The arguments array must contain N items, M given" for the vararg vsprintf/vprintf/vfprintf. The vararg sites check the array's entry count before materialising the value set, so nothing is allocated on the throw path. Byte-verified against php over positional, extra-argument, %% and stream cases.

A stale zend-guarded sprintf_char_format test asserted the old lenient sprintf("%c") -> NUL behaviour; it is rewritten as a cross-engine test of the %c specifier plus the ArgumentCountError, and the guard is dropped.

Cross-engine test function/printf_argcount. test-compat green under both engines; docker ASan+UBSan clean across build, smoke and integration; full and tiny builds warning-free.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
