### PR TITLE
Fix the SORT_* values and wire natural sorts

### DIFF
--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -2052,6 +2052,12 @@ static int PH7_builtin_strcmp(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	ph7_result_int(pCtx,res);
 	return PH7_OK;
 }
+#endif /* PH7_DISABLE_BUILTIN_FUNC */
+/*
+ * The natural-order comparison core lives OUTSIDE the PH7_DISABLE_BUILTIN_FUNC
+ * guard: hashmap.c's SORT_NATURAL path (always compiled) calls PH7_StrNatCmp, so
+ * it must exist in the tiny build too. [[tiny-build-disk-io-guard-fragility]]
+ */
 /*
  * Natural-order comparison core (Martin Pool's natcompare as adapted by php's
  * ext/standard/strnatcmp.c): digit runs compare numerically — the longer run
@@ -2087,7 +2093,7 @@ static int StrNatCompareLeft(const char **pa,const char *aEnd,const char **pb,co
 		(*pb)++;
 	}
 }
-static int StrNatCmpCore(const char *zA,int nA,const char *zB,int nB,int bFold)
+PH7_PRIVATE int PH7_StrNatCmp(const char *zA,int nA,const char *zB,int nB,int bFold)
 {
 	const char *a = zA,*aEnd = &zA[nA];
 	const char *b = zB,*bEnd = &zB[nB];
@@ -2115,6 +2121,7 @@ static int StrNatCmpCore(const char *zA,int nA,const char *zB,int nB,int bFold)
 		b++;
 	}
 }
+#ifndef PH7_DISABLE_BUILTIN_FUNC
 /*
  * int strnatcmp(string $string1, string $string2)
  * int strnatcasecmp(string $string1, string $string2)
@@ -2133,7 +2140,7 @@ static int PH7_builtin_strnatcmp(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	bFold = zFunc[sizeof("strnat")-1] == 'c'; /* strnatCasecmp */
 	z1 = ph7_value_to_string(apArg[0],&n1);
 	z2 = ph7_value_to_string(apArg[1],&n2);
-	ph7_result_int(pCtx,StrNatCmpCore(z1,n1,z2,n2,bFold));
+	ph7_result_int(pCtx,PH7_StrNatCmp(z1,n1,z2,n2,bFold));
 	return PH7_OK;
 }
 /*

--- a/src/ph7/constant.c
+++ b/src/ph7/constant.c
@@ -506,48 +506,51 @@ static void PH7_COUNT_RECURSIVE_Const(ph7_value *pVal,void *pUserData)
 	SXUNUSED(pUserData);
 }
 /*
- * SORT_ASC
- *  Expands 1.
+ * php's sort-flag constants. The VALUES must match php exactly: they are a
+ * public ABI (code passes literal ints, dumps them, and OR-combines the base
+ * type with SORT_FLAG_CASE). SORT_ASC/SORT_DESC are the array_multisort
+ * direction flags.
+ * SORT_REGULAR 0 · SORT_NUMERIC 1 · SORT_STRING 2 · SORT_DESC 3 · SORT_ASC 4 ·
+ * SORT_LOCALE_STRING 5 · SORT_NATURAL 6 · SORT_FLAG_CASE 8
  */
 static void PH7_SORT_ASC_Const(ph7_value *pVal,void *pUserData)
-{
-	ph7_value_int(pVal,1);
-	SXUNUSED(pUserData);
-}
-/*
- * SORT_DESC
- *  Expands 2.
- */
-static void PH7_SORT_DESC_Const(ph7_value *pVal,void *pUserData)
-{
-	ph7_value_int(pVal,2);
-	SXUNUSED(pUserData);
-}
-/*
- * SORT_REGULAR
- *  Expands 3.
- */
-static void PH7_SORT_REG_Const(ph7_value *pVal,void *pUserData)
-{
-	ph7_value_int(pVal,3);
-	SXUNUSED(pUserData);
-}
-/*
- * SORT_NUMERIC
- *  Expands 4.
- */
-static void PH7_SORT_NUMERIC_Const(ph7_value *pVal,void *pUserData)
 {
 	ph7_value_int(pVal,4);
 	SXUNUSED(pUserData);
 }
-/*
- * SORT_STRING
- *  Expands 5.
- */
+static void PH7_SORT_DESC_Const(ph7_value *pVal,void *pUserData)
+{
+	ph7_value_int(pVal,3);
+	SXUNUSED(pUserData);
+}
+static void PH7_SORT_REG_Const(ph7_value *pVal,void *pUserData)
+{
+	ph7_value_int(pVal,0);
+	SXUNUSED(pUserData);
+}
+static void PH7_SORT_NUMERIC_Const(ph7_value *pVal,void *pUserData)
+{
+	ph7_value_int(pVal,1);
+	SXUNUSED(pUserData);
+}
 static void PH7_SORT_STRING_Const(ph7_value *pVal,void *pUserData)
 {
+	ph7_value_int(pVal,2);
+	SXUNUSED(pUserData);
+}
+static void PH7_SORT_LOCALE_STRING_Const(ph7_value *pVal,void *pUserData)
+{
 	ph7_value_int(pVal,5);
+	SXUNUSED(pUserData);
+}
+static void PH7_SORT_NATURAL_Const(ph7_value *pVal,void *pUserData)
+{
+	ph7_value_int(pVal,6);
+	SXUNUSED(pUserData);
+}
+static void PH7_SORT_FLAG_CASE_Const(ph7_value *pVal,void *pUserData)
+{
+	ph7_value_int(pVal,8);
 	SXUNUSED(pUserData);
 }
 /*
@@ -2159,6 +2162,9 @@ static const ph7_builtin_constant aBuiltIn[] = {
 	{"SORT_REGULAR",         PH7_SORT_REG_Const     },
 	{"SORT_NUMERIC",         PH7_SORT_NUMERIC_Const },
 	{"SORT_STRING",          PH7_SORT_STRING_Const  },
+	{"SORT_LOCALE_STRING",   PH7_SORT_LOCALE_STRING_Const },
+	{"SORT_NATURAL",         PH7_SORT_NATURAL_Const },
+	{"SORT_FLAG_CASE",       PH7_SORT_FLAG_CASE_Const },
 	{"PHP_ROUND_HALF_DOWN",  PH7_PHP_ROUND_HALF_DOWN_Const },
 	{"PHP_ROUND_HALF_EVEN",  PH7_PHP_ROUND_HALF_EVEN_Const },
 	{"PHP_ROUND_HALF_UP",    PH7_PHP_ROUND_HALF_UP_Const   },

--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -2147,52 +2147,71 @@ static sxi32 HashmapMergeSort(ph7_hashmap *pMap,ProcNodeCmp xCmp,void *pCmpData)
  * Node comparison callback.
  * used-by: [sort(),asort(),...]
  */
-static sxi32 HashmapCmpCallback1(ph7_hashmap_node *pA,ph7_hashmap_node *pB,void *pCmpData)
+/*
+ * Compare two node VALUES under php's sort_flags. The flag carries a base type
+ * in its low bits and the optional SORT_FLAG_CASE (8) modifier:
+ *   SORT_REGULAR 0 · SORT_NUMERIC 1 · SORT_STRING 2 · SORT_LOCALE_STRING 5 ·
+ *   SORT_NATURAL 6   (| SORT_FLAG_CASE for a case-insensitive string/natural sort)
+ * PHL has no locale tables, so SORT_LOCALE_STRING behaves like SORT_STRING.
+ */
+static sxi32 HashmapFlagValueCmp(ph7_hashmap_node *pA,ph7_hashmap_node *pB,sxi32 iFlags)
 {
 	ph7_value sA,sB;
-	sxi32 iFlags;
-	int rc;
-	if( pCmpData == 0 ){
-		/* Perform a standard comparison */
-		rc = HashmapNodeCmp(pA,pB,FALSE);
-		return rc;
+	int base = iFlags & ~8;      /* strip SORT_FLAG_CASE */
+	int bFold = (iFlags & 8) != 0;
+	sxi32 rc;
+	if( base == 0 ){
+		/* SORT_REGULAR */
+		return HashmapNodeCmp(pA,pB,FALSE);
 	}
-	iFlags = SX_PTR_TO_INT(pCmpData);
-	/* Duplicate node values */
 	PH7_MemObjInit(pA->pMap->pVm,&sA);
 	PH7_MemObjInit(pA->pMap->pVm,&sB);
 	PH7_HashmapExtractNodeValue(pA,&sA,FALSE);
 	PH7_HashmapExtractNodeValue(pB,&sB,FALSE);
-	if( iFlags == 5 ){
-		/* String cast */
+	if( base == 1 ){
+		/* SORT_NUMERIC */
+		PH7_MemObjToNumeric(&sA);
+		PH7_MemObjToNumeric(&sB);
+		rc = PH7_MemObjCmp(&sA,&sB,FALSE,0);
+	}else{
+		/* SORT_STRING (2) / SORT_LOCALE_STRING (5) / SORT_NATURAL (6) */
 		const char *zA,*zB;
-		sxu32 nA,nB,nMin;
-		if( (sA.iFlags & MEMOBJ_STRING) == 0 ){
-			PH7_MemObjToString(&sA);
-		}
-		if( (sB.iFlags & MEMOBJ_STRING) == 0 ){
-			PH7_MemObjToString(&sB);
-		}
-		/* Lexicographic string comparison to avoid numeric string coercion */
+		sxu32 nA,nB,nMin,i;
+		if( (sA.iFlags & MEMOBJ_STRING) == 0 ){ PH7_MemObjToString(&sA); }
+		if( (sB.iFlags & MEMOBJ_STRING) == 0 ){ PH7_MemObjToString(&sB); }
 		zA = (const char *)SyBlobData(&sA.sBlob);
 		zB = (const char *)SyBlobData(&sB.sBlob);
 		nA = SyBlobLength(&sA.sBlob);
 		nB = SyBlobLength(&sB.sBlob);
-		nMin = nA < nB ? nA : nB;
-		rc = SyMemcmp(zA,zB,nMin);
-		if( rc == 0 ){
-			if( nA < nB ) rc = -1;
-			else if( nA > nB ) rc = 1;
+		if( base == 6 ){
+			rc = PH7_StrNatCmp(zA,(int)nA,zB,(int)nB,bFold);
+		}else{
+			/* Lexicographic comparison (binary-safe), case-folded on request. */
+			nMin = nA < nB ? nA : nB;
+			rc = 0;
+			for( i = 0 ; i < nMin ; ++i ){
+				int ca = (unsigned char)zA[i];
+				int cb = (unsigned char)zB[i];
+				if( bFold ){ ca = SyToLower(ca); cb = SyToLower(cb); }
+				if( ca != cb ){ rc = ca < cb ? -1 : 1; break; }
+			}
+			if( rc == 0 ){
+				if( nA < nB ) rc = -1;
+				else if( nA > nB ) rc = 1;
+			}
 		}
-	}else{
-		/* Numeric cast */
-		PH7_MemObjToNumeric(&sA);
-		PH7_MemObjToNumeric(&sB);
-		rc = PH7_MemObjCmp(&sA,&sB,FALSE,0);
 	}
 	PH7_MemObjRelease(&sA);
 	PH7_MemObjRelease(&sB);
 	return rc;
+}
+static sxi32 HashmapCmpCallback1(ph7_hashmap_node *pA,ph7_hashmap_node *pB,void *pCmpData)
+{
+	if( pCmpData == 0 ){
+		/* SORT_REGULAR fast path */
+		return HashmapNodeCmp(pA,pB,FALSE);
+	}
+	return HashmapFlagValueCmp(pA,pB,SX_PTR_TO_INT(pCmpData));
 }
 /*
  * Shared key comparison for ksort()/krsort(): php 8 semantics. Two string
@@ -2282,50 +2301,11 @@ static sxi32 HashmapCmpCallback2(ph7_hashmap_node *pA,ph7_hashmap_node *pB,void 
  */
 static sxi32 HashmapCmpCallback3(ph7_hashmap_node *pA,ph7_hashmap_node *pB,void *pCmpData)
 {
-	ph7_value sA,sB;
-	sxi32 iFlags;
-	int rc;
 	if( pCmpData == 0 ){
-		/* Perform a standard comparison */
-		rc = HashmapNodeCmp(pA,pB,FALSE);
-		return -rc;
+		/* SORT_REGULAR fast path, reversed */
+		return -HashmapNodeCmp(pA,pB,FALSE);
 	}
-	iFlags = SX_PTR_TO_INT(pCmpData);
-	/* Duplicate node values */
-	PH7_MemObjInit(pA->pMap->pVm,&sA);
-	PH7_MemObjInit(pA->pMap->pVm,&sB);
-	PH7_HashmapExtractNodeValue(pA,&sA,FALSE);
-	PH7_HashmapExtractNodeValue(pB,&sB,FALSE);
-	if( iFlags == 5 ){
-		/* String cast */
-		const char *zA,*zB;
-		sxu32 nA,nB,nMin;
-		if( (sA.iFlags & MEMOBJ_STRING) == 0 ){
-			PH7_MemObjToString(&sA);
-		}
-		if( (sB.iFlags & MEMOBJ_STRING) == 0 ){
-			PH7_MemObjToString(&sB);
-		}
-		/* Lexicographic string comparison to avoid numeric string coercion */
-		zA = (const char *)SyBlobData(&sA.sBlob);
-		zB = (const char *)SyBlobData(&sB.sBlob);
-		nA = SyBlobLength(&sA.sBlob);
-		nB = SyBlobLength(&sB.sBlob);
-		nMin = nA < nB ? nA : nB;
-		rc = SyMemcmp(zA,zB,nMin);
-		if( rc == 0 ){
-			if( nA < nB ) rc = -1;
-			else if( nA > nB ) rc = 1;
-		}
-	}else{
-		/* Numeric cast */
-		PH7_MemObjToNumeric(&sA);
-		PH7_MemObjToNumeric(&sB);
-		rc = PH7_MemObjCmp(&sA,&sB,FALSE,0);
-	}
-	PH7_MemObjRelease(&sA);
-	PH7_MemObjRelease(&sB);
-	return -rc;
+	return -HashmapFlagValueCmp(pA,pB,SX_PTR_TO_INT(pCmpData));
 }
 /*
  * Node comparison callback: Invoke an user-defined callback for the purpose of node comparison.
@@ -2520,9 +2500,6 @@ static int ph7_hashmap_sort(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		if( nArg > 1 ){
 			/* Extract comparison flags */
 			iCmpFlags = ph7_value_to_int(apArg[1]);
-			if( iCmpFlags == 3 /* SORT_REGULAR */ ){
-				iCmpFlags = 0; /* Standard comparison */
-			}
 		}
 		/* Do the merge sort */
 		HashmapMergeSort(pMap,HashmapCmpCallback1,SX_INT_TO_PTR(iCmpFlags));
@@ -2574,9 +2551,6 @@ static int ph7_hashmap_asort(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		if( nArg > 1 ){
 			/* Extract comparison flags */
 			iCmpFlags = ph7_value_to_int(apArg[1]);
-			if( iCmpFlags == 3 /* SORT_REGULAR */ ){
-				iCmpFlags = 0; /* Standard comparison */
-			}
 		}
 		/* Do the merge sort */
 		HashmapMergeSort(pMap,HashmapCmpCallback1,SX_INT_TO_PTR(iCmpFlags));
@@ -2630,9 +2604,6 @@ static int ph7_hashmap_arsort(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		if( nArg > 1 ){
 			/* Extract comparison flags */
 			iCmpFlags = ph7_value_to_int(apArg[1]);
-			if( iCmpFlags == 3 /* SORT_REGULAR */ ){
-				iCmpFlags = 0; /* Standard comparison */
-			}
 		}
 		/* Do the merge sort */
 		HashmapMergeSort(pMap,HashmapCmpCallback3,SX_INT_TO_PTR(iCmpFlags));
@@ -2677,9 +2648,6 @@ static int ph7_hashmap_ksort(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		if( nArg > 1 ){
 			/* Extract comparison flags */
 			iCmpFlags = ph7_value_to_int(apArg[1]);
-			if( iCmpFlags == 3 /* SORT_REGULAR */ ){
-				iCmpFlags = 0; /* Standard comparison */
-			}
 		}
 		/* Do the merge sort */
 		HashmapMergeSort(pMap,HashmapCmpCallback2,SX_INT_TO_PTR(iCmpFlags));
@@ -2724,9 +2692,6 @@ static int ph7_hashmap_krsort(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		if( nArg > 1 ){
 			/* Extract comparison flags */
 			iCmpFlags = ph7_value_to_int(apArg[1]);
-			if( iCmpFlags == 3 /* SORT_REGULAR */ ){
-				iCmpFlags = 0; /* Standard comparison */
-			}
 		}
 		/* Do the merge sort */
 		HashmapMergeSort(pMap,HashmapCmpCallback5,SX_INT_TO_PTR(iCmpFlags));
@@ -2771,9 +2736,6 @@ static int ph7_hashmap_rsort(ph7_context *pCtx,int nArg,ph7_value **apArg)
 		if( nArg > 1 ){
 			/* Extract comparison flags */
 			iCmpFlags = ph7_value_to_int(apArg[1]);
-			if( iCmpFlags == 3 /* SORT_REGULAR */ ){
-				iCmpFlags = 0; /* Standard comparison */
-			}
 		}
 		/* Do the merge sort */
 		HashmapMergeSort(pMap,HashmapCmpCallback3,SX_INT_TO_PTR(iCmpFlags));

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -2459,6 +2459,9 @@ PH7_PRIVATE sxi32 PH7_CsvConsumer(const char *zToken,int nTokenLen,void *pUserDa
 PH7_PRIVATE sxi32 PH7_StripTagsFromString(ph7_context *pCtx,const char *zIn,int nByte,const char *zTaglist,int nTaglen);
 PH7_PRIVATE sxi32 PH7_ParseIniString(ph7_context *pCtx,const char *zIn,sxu32 nByte,int bProcessSection);
 #endif /* PH7_DISABLE_BUILTIN_FUNC || PH7_DISABLE_DISK_IO */
+/* Natural-order compare: unguarded because hashmap.c's SORT_NATURAL path (always
+ * compiled) uses it, even in the tiny build. [[tiny-build-disk-io-guard-fragility]] */
+PH7_PRIVATE int PH7_StrNatCmp(const char *zA,int nA,const char *zB,int nB,int bFold);
 /* oo.c function prototypes */
 PH7_PRIVATE ph7_class * PH7_NewRawClass(ph7_vm *pVm,const SyString *pName,sxu32 nLine);
 PH7_PRIVATE ph7_class_attr * PH7_NewClassAttr(ph7_vm *pVm,const SyString *pName,sxu32 nLine,sxi32 iProtection,sxi32 iFlags);

--- a/tests/ph7/001-smoke/function/sort_flags/sort_flags.phpt
+++ b/tests/ph7/001-smoke/function/sort_flags/sort_flags.phpt
@@ -1,0 +1,33 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+SORT_* flag constants match php and drive numeric/string/natural/case-insensitive sorts
+--FILE--
+<?php
+function sortFlagCases(): array {
+    $out = [];
+    $out[] = implode(",", [SORT_REGULAR, SORT_NUMERIC, SORT_STRING, SORT_DESC, SORT_ASC, SORT_LOCALE_STRING, SORT_NATURAL, SORT_FLAG_CASE]);
+    $a = [3, 1, 2, 10, 20]; sort($a, SORT_STRING); $out[] = json_encode($a);
+    $a = [3, 1, 2, 10, 20]; sort($a, SORT_NUMERIC); $out[] = json_encode($a);
+    $a = ["img10", "img1", "img2", "img12"]; sort($a, SORT_NATURAL); $out[] = json_encode($a);
+    $a = ["IMG10", "img1", "Img2"]; sort($a, SORT_NATURAL | SORT_FLAG_CASE); $out[] = json_encode($a);
+    $a = ["Banana", "apple", "Cherry"]; sort($a, SORT_STRING | SORT_FLAG_CASE); $out[] = json_encode($a);
+    $a = ["b" => 10, "a" => 2, "c" => 1]; arsort($a, SORT_NUMERIC); $out[] = json_encode($a);
+    $a = ["x2", "x10", "x1"]; asort($a, SORT_NATURAL); $out[] = json_encode($a);
+    $a = [3, 1, 2, 10]; rsort($a, SORT_STRING); $out[] = json_encode($a);
+    return $out;
+}
+echo implode("\n", sortFlagCases()), "\n";
+--EXPECT--
+0,1,2,3,4,5,6,8
+[1,10,2,20,3]
+[1,2,3,10,20]
+["img1","img2","img10","img12"]
+["img1","Img2","IMG10"]
+["apple","Banana","Cherry"]
+{"b":10,"a":2,"c":1}
+{"2":"x1","0":"x2","1":"x10"}
+[3,2,10,1]
+--CLEAN--
+<?php


### PR DESCRIPTION
A sort-flag probe against the oracle found that every SORT_* constant carried the wrong value: SORT_REGULAR/NUMERIC/STRING/DESC/ASC were 3/4/5/2/1 where php uses 0/1/2/3/4, and SORT_LOCALE_STRING (5), SORT_NATURAL (6) and SORT_FLAG_CASE (8) did not exist at all. The sort behaviour was internally consistent -- each sort mapped its own constant -- so this stayed hidden until a script passed a literal flag, dumped or serialised a constant, or OR-combined a base type with SORT_FLAG_CASE. Those all produced silent wrong answers, and sort($a, SORT_NATURAL) was a fatal "undefined constant".

constant.c now defines php's exact values plus the three missing constants. The value-sort dispatch is reworked around a shared HashmapFlagValueCmp that strips the SORT_FLAG_CASE bit and routes the base type to numeric, binary-safe lexicographic (case-folded on request), or natural comparison. SORT_NATURAL reuses the natural comparison core, promoted from builtin.c as PH7_StrNatCmp. The six now-incorrect "iCmpFlags == 3 -> SORT_REGULAR" remaps are gone, since 0 now means regular directly.

Byte-verified against php across every flag including SORT_NATURAL | SORT_FLAG_CASE; the sort/rsort/asort/arsort/ksort/krsort suites stay green. Separate pre-existing gaps are recorded in NEWPLAN, not addressed here: ksort/krsort ignore their $flags argument, array_unique ignores SORT_FLAG_CASE, and array_multisort is still missing.

Cross-engine test function/sort_flags. test-compat green under both engines; docker ASan+UBSan clean across build, smoke and integration; full and tiny builds warning-free.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
