### PR TITLE
Honor the sort flags in array_unique

### DIFF
--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -2194,6 +2194,28 @@ static sxi32 HashmapScalarFlagCmp(ph7_value *pA,ph7_value *pB,int base,int bFold
 	return rc;
 }
 /*
+ * Are two live values equal under an array_unique() sort_flags? A non-mutating
+ * wrapper (works on private copies): base 0 = SORT_REGULAR loose comparison,
+ * explicit flags route through HashmapScalarFlagCmp. Used by array_unique.
+ */
+static int HashmapValueFlagEqual(ph7_vm *pVm,ph7_value *pA,ph7_value *pB,int base,int bFold)
+{
+	ph7_value sA,sB;
+	sxi32 rc;
+	PH7_MemObjInit(pVm,&sA);
+	PH7_MemObjInit(pVm,&sB);
+	PH7_MemObjStore(pA,&sA);
+	PH7_MemObjStore(pB,&sB);
+	if( base == 0 ){
+		rc = PH7_MemObjCmp(&sA,&sB,FALSE,0); /* SORT_REGULAR: loose comparison */
+	}else{
+		rc = HashmapScalarFlagCmp(&sA,&sB,base,bFold);
+	}
+	PH7_MemObjRelease(&sA);
+	PH7_MemObjRelease(&sB);
+	return rc == 0;
+}
+/*
  * Compare two node VALUES under php's sort_flags (base 0 = SORT_REGULAR uses the
  * standard value comparison; explicit flags route through HashmapScalarFlagCmp).
  */
@@ -6556,8 +6578,7 @@ static int ph7_hashmap_unique(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	ph7_value *pNeedle;
 	ph7_hashmap *pSrc;
 	ph7_value *pArray;
-	int bStrict;
-	sxi32 rc;
+	int iFlags,base,bFold;
 	sxu32 n;
 	if( nArg < 1 ){
 		/* Missing arguments, throw ArgumentCountError */
@@ -6583,7 +6604,11 @@ static int ph7_hashmap_unique(ph7_context *pCtx,int nArg,ph7_value **apArg)
 			ph7_type_name(apArg[0])
 			);
 	}
-	bStrict = FALSE;
+	/* php's default is SORT_STRING (2): elements compare as strings. Explicit
+	 * flags select numeric / natural / case-insensitive comparison. */
+	iFlags = nArg > 1 ? ph7_value_to_int(apArg[1]) : 2 /* SORT_STRING */;
+	base = iFlags & ~8;
+	bFold = (iFlags & 8) != 0;
 	/* Point to the internal representation of the input hashmap */
 	pSrc = (ph7_hashmap *)apArg[0]->x.pOther;
 	/* Create a new array */
@@ -6596,13 +6621,25 @@ static int ph7_hashmap_unique(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	pEntry = pSrc->pFirst;
 	for( n = 0 ; n < pSrc->nEntry ; n++ ){
 		pNeedle = HashmapExtractNodeValue(pEntry);
-		rc = SXERR_NOTFOUND;
 		if( pNeedle ){
-			rc = HashmapFindValue((ph7_hashmap *)pArray->x.pOther,pNeedle,0,bStrict);
-		}
-		if( rc != SXRET_OK ){
-			/* Perform the insertion */
-			HashmapInsertNode((ph7_hashmap *)pArray->x.pOther,pEntry,TRUE);
+			/* Keep this element unless a flag-equal one is already present. */
+			ph7_hashmap *pKept = (ph7_hashmap *)pArray->x.pOther;
+			ph7_hashmap_node *pK = pKept->pFirst;
+			int bDup = 0;
+			sxu32 i;
+			/* Forward iteration in this map uses the pPrev link (see the outer
+			 * loop over pSrc). */
+			for( i = 0 ; i < pKept->nEntry && pK ; ++i ){
+				ph7_value *pV = HashmapExtractNodeValue(pK);
+				if( pV && HashmapValueFlagEqual(pCtx->pVm,pNeedle,pV,base,bFold) ){
+					bDup = 1;
+					break;
+				}
+				pK = pK->pPrev;
+			}
+			if( !bDup ){
+				HashmapInsertNode(pKept,pEntry,TRUE);
+			}
 		}
 		/* Point to the next entry */
 		pEntry = pEntry->pPrev; /* Reverse link */

--- a/tests/ph7/001-smoke/function/array_unique_flags/array_unique_flags.phpt
+++ b/tests/ph7/001-smoke/function/array_unique_flags/array_unique_flags.phpt
@@ -1,0 +1,29 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+array_unique honors its sort flags (default SORT_STRING, numeric/regular/case/natural)
+--FILE--
+<?php
+function arrayUniqueFlagCases(): array {
+    $out = [];
+    $out[] = json_encode(array_unique(["1", 1, "1.0", 1.0]));
+    $out[] = json_encode(array_unique([1, "1", "1abc"], SORT_NUMERIC));
+    $out[] = json_encode(array_unique([1, "1", "1abc"], SORT_STRING));
+    $out[] = json_encode(array_unique([1, "1", 1.0, true], SORT_REGULAR));
+    $out[] = json_encode(array_unique(["FILE1", "file1", "File2"], SORT_STRING | SORT_FLAG_CASE));
+    $out[] = json_encode(array_unique(["x1", "x01", "x1"], SORT_NATURAL));
+    $out[] = json_encode(array_unique(["10", "9", "10", "9.0"], SORT_NUMERIC));
+    return $out;
+}
+echo implode("\n", arrayUniqueFlagCases()), "\n";
+--EXPECT--
+{"0":"1","2":"1.0"}
+[1]
+{"0":1,"2":"1abc"}
+[1]
+{"0":"FILE1","2":"File2"}
+["x1","x01"]
+["10","9"]
+--CLEAN--
+<?php


### PR DESCRIPTION
array_unique never read its $flags argument and always deduplicated with a loose value comparison, so even the DEFAULT SORT_STRING was wrong: array_unique(["1", 1, "1.0", 1.0]) returned ["1"] where php, comparing as strings, keeps {"0":"1","2":"1.0"}. SORT_NUMERIC and SORT_FLAG_CASE mis-deduplicated too.

It now reads the flag (default SORT_STRING) and tests membership with a new non-mutating HashmapValueFlagEqual wrapper over the shared HashmapScalarFlagCmp (base 0 = the loose SORT_REGULAR comparison).

The first cut walked the kept-list via pNode->pNext and hung on any array with two or more distinct elements: forward iteration in this hashmap follows the pPrev link (the enclosing loop over the source array already relied on that), so the scan now uses pPrev with a NULL guard.

Byte-verified against php for the SORT_STRING default and the numeric / regular / case-insensitive / natural flags. Cross-engine test function/array_unique_flags. test-compat green under both engines; docker ASan+UBSan clean across build, smoke and integration; full and tiny builds warning-free.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
