### PR TITLE
Implement strtotime over the DateTime parser

### DIFF
--- a/src/ph7/builtin_date.c
+++ b/src/ph7/builtin_date.c
@@ -3112,6 +3112,18 @@ static const char zDateTimeLib[] =
 "}"
 "function timezone_name_get($object){ return $object->getName(); }"
 "function timezone_offset_get($object, $datetime){ return $object->getOffset($datetime); }"
+/* int|false strtotime(string $datetime, ?int $baseTimestamp = null). Rides the
+ * same DtParse the DateTime constructor uses, so its format coverage is identical.
+ * php: the EMPTY string is false, but whitespace-only is 'now'; a parse failure is
+ * false (never an exception). The default timezone is treated as offset 0, exactly
+ * as the DateTime constructor does for a null $timezone. */
+"function strtotime($datetime, $baseTimestamp = null){"
+" $s = (string)$datetime;"
+" if( $s === '' ){ return false; }"
+" $base = $baseTimestamp === null ? __dt_now() : (int)$baseTimestamp;"
+" $r = __dt_parse($s, $base, 0);"
+" return is_string($r) ? false : $r[0];"
+"}"
 ;
 /*
  * Install the DateTime family: thunks first, then the chunk. Called from

--- a/tests/ph7/001-smoke/function/strtotime/strtotime.phpt
+++ b/tests/ph7/001-smoke/function/strtotime/strtotime.phpt
@@ -1,0 +1,55 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+strtotime parses absolute, epoch, time-only and relative forms against a base timestamp
+--FILE--
+<?php
+function strtotimeCases(): array {
+    date_default_timezone_set("UTC");
+    $base = 1600000000;
+    $inputs = [
+        "", "   ", "now", "@1500000000", "@0", "@-100",
+        "2020-01-15 14:30:45", "2020-01-15", "2020-01-15T14:30:45+02:00", "2020-01-15T14:30:45Z",
+        "14:30:45", "14:30", "garbage", "2020-13-01", "2020-01-32",
+        "+1 day", "+1 week", "-3 hours", "+1 month", "+1 year", "-2 weeks",
+        "tomorrow", "yesterday", "midnight", "noon", "today",
+        "2020-01-31 +1 month", "+90 minutes", "+2 fortnights",
+    ];
+    $out = [];
+    foreach ($inputs as $in) { $out[] = $in . " => " . var_export(strtotime($in, $base), true); }
+    return $out;
+}
+echo implode("\n", strtotimeCases()), "\n";
+--EXPECT--
+ => false
+    => 1600000000
+now => 1600000000
+@1500000000 => 1500000000
+@0 => 0
+@-100 => -100
+2020-01-15 14:30:45 => 1579098645
+2020-01-15 => 1579046400
+2020-01-15T14:30:45+02:00 => 1579091445
+2020-01-15T14:30:45Z => 1579098645
+14:30:45 => 1600007445
+14:30 => 1600007400
+garbage => false
+2020-13-01 => false
+2020-01-32 => false
++1 day => 1600086400
++1 week => 1600604800
+-3 hours => 1599989200
++1 month => 1602592000
++1 year => 1631536000
+-2 weeks => 1598790400
+tomorrow => 1600041600
+yesterday => 1599868800
+midnight => 1599955200
+noon => 1599998400
+today => 1599955200
+2020-01-31 +1 month => 1583107200
++90 minutes => 1600005400
++2 fortnights => 1602419200
+--CLEAN--
+<?php


### PR DESCRIPTION
strtotime was missing entirely -- a fatal "Call to undefined function" for one of the most common date functions. It is now a thin wrapper over the same __dt_parse (DtParse) the DateTime constructor uses, so its format coverage is identical to DateTime's: ISO datetimes, @epoch, HH:MM[:SS], the +/-N unit relative forms, and now/today/tomorrow/yesterday/midnight/noon.

php's contract is matched: the empty string returns false while a whitespace-only string is "now"; a parse failure returns false (never an exception); an explicit base timestamp seeds the relative parts; and the default timezone is treated as offset 0, exactly as the DateTime constructor does for a null $timezone.

Verified byte-identical to php across 29 absolute, epoch, time-only, invalid and relative inputs. The parser's remaining gaps -- DD-MM-YYYY, slash dates, month names, and weekday/ordinal relatives -- are recorded in NEWPLAN as the next iterative slices; extending DtParse will lift them for both strtotime and DateTime at once.

Cross-engine test function/strtotime. test-compat green under both engines; docker ASan+UBSan clean across build, smoke and integration; full and tiny builds warning-free.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
