### PR TITLE
Return php's long type names from gettype()

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -24311,9 +24311,30 @@ static int vm_builtin_get_defined_vars(ph7_context *pCtx,int nArg,ph7_value **ap
  */
 static int vm_builtin_gettype(ph7_context *pCtx,int nArg,ph7_value **apArg)
 {
-	const char *zType = "Empty";
+	/* php's gettype() uses LONG type names ("integer"/"boolean"/"NULL"), distinct
+	 * from get_debug_type()'s short ones ("int"/"bool"/"null") — never route this
+	 * through PH7_MemObjTypeDump, which yields the short forms. */
+	const char *zType = "unknown type";
 	if( nArg > 0 ){
-		zType = PH7_MemObjTypeDump(apArg[0]);
+		ph7_value *pVal = apArg[0];
+		if( pVal->iFlags & MEMOBJ_NULL ){
+			zType = "NULL";
+		}else if( pVal->iFlags & MEMOBJ_REAL ){
+			/* REAL wins over a cached MEMOBJ_INT: 1.0 is "double" (php). */
+			zType = "double";
+		}else if( pVal->iFlags & MEMOBJ_INT ){
+			zType = "integer";
+		}else if( pVal->iFlags & MEMOBJ_STRING ){
+			zType = "string";
+		}else if( pVal->iFlags & MEMOBJ_BOOL ){
+			zType = "boolean";
+		}else if( pVal->iFlags & MEMOBJ_HASHMAP ){
+			zType = "array";
+		}else if( pVal->iFlags & MEMOBJ_OBJ ){
+			zType = "object";
+		}else if( pVal->iFlags & MEMOBJ_RES ){
+			zType = "resource";
+		}
 	}
 	/* Return the variable type */
 	ph7_result_string(pCtx,zType,-1/*Compute length automatically*/);

--- a/tests/ph7/001-smoke/function/gettype/gettype.phpt
+++ b/tests/ph7/001-smoke/function/gettype/gettype.phpt
@@ -2,28 +2,23 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-gettype returns type of variable
---SKIPIF--
-<?php
-if (!function_exists('gettype')) { echo 'skip: gettype not available'; }
-if (function_exists('zend_version')) { echo 'skip: PHP gettype behavior differs'; }
-?>
+gettype returns php's long type names (integer/boolean/double/NULL)
 --FILE--
 <?php
-$type = gettype("hello");
-if ($type === "string") { echo "string_ok\n"; } else { echo "string_failed\n"; }
-$type = gettype(42);
-if ($type === "int") { echo "int_ok\n"; } else { echo "int_failed\n"; }
-$type = gettype(array(1,2,3));
-if ($type === "array") { echo "array_ok\n"; } else { echo "array_failed\n"; }
-$type = gettype(null);
-if ($type === "null") { echo "null_ok\n"; } else { echo "null_failed\n"; }
+foreach ([42, 1.5, "hello", true, false, [1, 2, 3], null] as $v) {
+    echo gettype($v), "\n";
+}
+$o = new stdClass();
+echo gettype($o), "\n";
 ?>
 --EXPECT--
-string_ok
-int_ok
-array_ok
-null_ok
+integer
+double
+string
+boolean
+boolean
+array
+NULL
+object
 --CLEAN--
 <?php
-unset($type);


### PR DESCRIPTION
gettype() reported the short type names get_debug_type() uses -- gettype(1) gave "int" where php gives "integer", gettype(true) gave "bool" (php "boolean"), gettype(null) gave "null" (php "NULL") -- a silent wrong answer for any gettype($x) === "integer" style check.

The cause was routing gettype through PH7_MemObjTypeDump, which yields the short forms and is also used by an internal dump. gettype now maps the memobj type flags to php's long names directly, leaving PH7_MemObjTypeDump (and get_debug_type, which correctly keeps the short names) untouched.

A stale zend-guarded gettype test that enshrined the "int" result is rewritten as a cross-engine test over int/float/string/bool/array/NULL/object; the guard is dropped.

test-compat green under both engines; docker ASan+UBSan clean across build, smoke and integration; full and tiny builds warning-free.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
