### PR TITLE
Parse textual-month dates in strtotime

### DIFF
--- a/src/ph7/builtin_date.c
+++ b/src/ph7/builtin_date.c
@@ -1908,6 +1908,124 @@ static int DtTryNumericDate(const char *z,const char *zEnd,const char **pzOut,
 	return 1;
 }
 /*
+ * Match a month name at z (full name or its distinct 3-letter abbreviation, plus
+ * "sept"), case-insensitively and only at a word boundary. Returns the month 1-12
+ * and sets *pAdv to the bytes consumed, or 0 when no month name is present.
+ */
+static int DtMatchMonth(const char *z,const char *zEnd,int *pAdv)
+{
+	static const struct { const char *z; int n; int mo; } aM[] = {
+		{ "january",7,1 },{ "february",8,2 },{ "march",5,3 },{ "april",5,4 },
+		{ "june",4,6 },{ "july",4,7 },{ "august",6,8 },{ "september",9,9 },
+		{ "sept",4,9 },{ "october",7,10 },{ "november",8,11 },{ "december",8,12 },
+		{ "may",3,5 },
+		{ "jan",3,1 },{ "feb",3,2 },{ "mar",3,3 },{ "apr",3,4 },{ "jun",3,6 },
+		{ "jul",3,7 },{ "aug",3,8 },{ "sep",3,9 },{ "oct",3,10 },{ "nov",3,11 },
+		{ "dec",3,12 }
+	};
+	sxu32 i;
+	for( i = 0 ; i < SX_ARRAYSIZE(aM) ; ++i ){
+		int n = aM[i].n;
+		if( zEnd - z >= n && SyStrnicmp(z,aM[i].z,(sxu32)n) == 0
+		 && (zEnd - z == n || !SyisAlpha(z[n])) ){
+			*pAdv = n;
+			return aM[i].mo;
+		}
+	}
+	return 0;
+}
+/* True if z points at a two-letter English ordinal suffix (st/nd/rd/th). */
+static int DtIsOrdinal(const char *z,const char *zEnd)
+{
+	if( zEnd - z < 2 ){ return 0; }
+	return SyStrnicmp(z,"st",2) == 0 || SyStrnicmp(z,"nd",2) == 0
+		|| SyStrnicmp(z,"rd",2) == 0 || SyStrnicmp(z,"th",2) == 0;
+}
+/*
+ * Try to read a textual-month date at z, in either order:
+ *   MonthName [Day] [Year]   ("Jan 15 2020", "January", "January 2020")
+ *   Day MonthName [Year]     ("15 January 2020", "15th Jan")
+ * A missing day defaults to 1, a missing year to the base timestamp's year (php).
+ * Day may carry an ordinal suffix, fields may be comma-separated, month names are
+ * case-insensitive, and an optional time-of-day suffix + trailing UTC/GMT is
+ * consumed. Returns 0 (not a month date — caller falls through, *pzOut untouched),
+ * 1 on success, or a DtParse error code (out-of-range day).
+ */
+static int DtTryMonthDate(const char *z,const char *zEnd,const char **pzOut,
+	sxi64 *pTs,sxi32 *pOff,int *pbOff,const char *zIn,sxi64 iBaseTs)
+{
+	int mo,d = 1,adv,haveDay = 0,haveYear = 0;
+	sxi64 y = 0;
+	int h = 0,mi = 0,s = 0;
+	sxi32 iOff = *pOff;
+	int rcT;
+#define MDSKIPWS() while( z < zEnd && (z[0]==' '||z[0]=='\t'||z[0]==',') ){ z++; }
+	if( (mo = DtMatchMonth(z,zEnd,&adv)) != 0 ){
+		/* MonthName [Day] [Year]. A 4-digit number here is the YEAR, not the day
+		 * ("January 2020" is month+year, day defaults); a 1-2 digit number is the day. */
+		z += adv;
+		MDSKIPWS();
+		if( z < zEnd && SyisDigit(z[0]) ){
+			int nrun = 0;
+			const char *zp = z;
+			while( zp < zEnd && SyisDigit(zp[0]) && nrun < 4 ){ zp++; nrun++; }
+			if( nrun < 4 ){
+				d = DtRead1or2(z,zEnd,&adv); z += adv;
+				if( DtIsOrdinal(z,zEnd) ){ z += 2; }
+				haveDay = 1;
+				MDSKIPWS();
+			}
+		}
+	}else if( SyisDigit(z[0]) ){
+		/* Day MonthName [Year] */
+		d = DtRead1or2(z,zEnd,&adv); z += adv;
+		if( DtIsOrdinal(z,zEnd) ){ z += 2; }
+		haveDay = 1;
+		MDSKIPWS();
+		if( (mo = DtMatchMonth(z,zEnd,&adv)) == 0 ){ return 0; }
+		z += adv;
+		MDSKIPWS();
+	}else{
+		return 0;
+	}
+	/* optional year */
+	if( z < zEnd && SyisDigit(z[0]) ){
+		int ny = 0;
+		y = 0;
+		while( z < zEnd && SyisDigit(z[0]) && ny < 4 ){ y = y*10 + (z[0]-'0'); z++; ny++; }
+		if( ny <= 2 ){
+			if( y >= 0 && y <= 69 ){ y += 2000; }
+			else if( y >= 70 && y <= 99 ){ y += 1900; }
+		}
+		haveYear = 1;
+	}
+	/* Default the unspecified fields from the base timestamp. php overlays: a
+	 * missing year takes the base year; a missing day is 1 when a year WAS given
+	 * ("January 2020" -> the 1st) but the base day when only the month was named
+	 * ("January" -> the base day). */
+	{
+		sxi64 by; int bm,bd;
+		DtCivilFromDays(DtFloorDiv(iBaseTs + *pOff,86400),&by,&bm,&bd);
+		if( !haveYear ){ y = by; }
+		if( !haveDay ){ d = haveYear ? 1 : bd; }
+	}
+	if( d > 31 ){ return (int)(z - zIn) + 1; }
+	/* optional time-of-day suffix */
+	rcT = DtTimeSuffix(&z,zEnd,zIn,&h,&mi,&s,&iOff,pbOff);
+	if( rcT != 0 ){ return rcT; }
+	/* optional trailing UTC/GMT zone name (PHL's default zone is already UTC) */
+	MDSKIPWS();
+	if( (zEnd-z >= 3 && SyStrnicmp(z,"utc",3) == 0 && (zEnd-z==3 || !SyisAlpha(z[3])))
+	 || (zEnd-z >= 3 && SyStrnicmp(z,"gmt",3) == 0 && (zEnd-z==3 || !SyisAlpha(z[3]))) ){
+		iOff = 0; z += 3;
+	}
+	*pTs = DtMakeTs(y,mo,d,h,mi,s,iOff);
+	*pOff = iOff;
+	*pzOut = z;
+	return 1;
+#undef MDSKIPWS
+}
+/*
  * Minimal php-datetime-string parser (slice 1): absolute forms
  * "now" | "@<ts>" | "YYYY-MM-DD[( |T)HH:MM[:SS]][Z|±HH[:MM]]" | "HH:MM[:SS]",
  * keywords today/midnight/noon/tomorrow/yesterday, and relative sequences
@@ -1923,7 +2041,7 @@ static int DtParse(const char *zIn,int nLen,sxi64 iBaseTs,sxi32 iBaseOff,
 	sxi32 iOff = iBaseOff;
 	int bOffSet = 0;
 	int bAny = 0;
-	int iNumRc;
+	int iNumRc,iMonRc;
 #define DT_SKIP_WS() while( z < zEnd && (z[0]==' '||z[0]=='\t'||z[0]==',') ){ z++; }
 #define DT_LOWEQ(zKw,nKw) (zEnd-z >= (nKw) && SyStrnicmp(z,zKw,nKw) == 0 \
 	&& (zEnd-z == (nKw) || !SyisAlpha(z[(nKw)])))
@@ -1982,6 +2100,12 @@ static int DtParse(const char *zIn,int nLen,sxi64 iBaseTs,sxi32 iBaseOff,
 		 * 1 is an error code in DtParse's own convention (positive position / negative
 		 * "double time"); propagate it verbatim. */
 		if( iNumRc != 1 ){ return iNumRc; }
+		bAny = 1;
+	}else if( (SyisAlpha(z[0]) || SyisDigit(z[0]))
+	 && (iMonRc = DtTryMonthDate(z,zEnd,&z,&iTs,&iOff,&bOffSet,zIn,iBaseTs)) != 0 ){
+		/* MonthName Day Year / Day MonthName Year, in any of php's spellings. As with
+		 * DtTryNumericDate, anything other than 1 is an error code to propagate. */
+		if( iMonRc != 1 ){ return iMonRc; }
 		bAny = 1;
 	}else if( zEnd-z >= 5 && SyisDigit(z[0]) && SyisDigit(z[1]) && z[2]==':'
 	 && SyisDigit(z[3]) && SyisDigit(z[4]) ){

--- a/tests/ph7/001-smoke/function/strtotime_monthname/strtotime_monthname.phpt
+++ b/tests/ph7/001-smoke/function/strtotime_monthname/strtotime_monthname.phpt
@@ -1,0 +1,55 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+strtotime/DateTime parse textual-month dates (MonthName Day Year and Day MonthName Year)
+--FILE--
+<?php
+function monthNameCases(): array {
+    date_default_timezone_set("UTC");
+    $inputs = [
+        "Jan 15 2020", "January 15 2020", "15 January 2020", "15 Jan 2020",
+        "January 15, 2020", "15th January 2020", "January 15th 2020",
+        "1 January 2020", "15 JANUARY 2020", "15 jan 2020",
+        "Jan 15 2020 14:30:00", "15 January 2020 08:00",
+        "January 2020", "Jan 2020", "15 January", "January 15",
+        "Feb 29 2020", "Feb 30 2020", "Xyz 15 2020", "15 Foo 2020",
+        "Sep 9 2001", "December 31 1999", "2020 Jan 15", "January 15 2020 UTC",
+        "sept 5 2020", "15 May 2020", "31st December 2020", "November 30th, 2019",
+    ];
+    $out = [];
+    foreach ($inputs as $in) { $out[] = $in . " => " . var_export(strtotime($in, 1600000000), true); }
+    return $out;
+}
+echo implode("\n", monthNameCases()), "\n";
+--EXPECT--
+Jan 15 2020 => 1579046400
+January 15 2020 => 1579046400
+15 January 2020 => 1579046400
+15 Jan 2020 => 1579046400
+January 15, 2020 => 1579046400
+15th January 2020 => 1579046400
+January 15th 2020 => 1579046400
+1 January 2020 => 1577836800
+15 JANUARY 2020 => 1579046400
+15 jan 2020 => 1579046400
+Jan 15 2020 14:30:00 => 1579098600
+15 January 2020 08:00 => 1579075200
+January 2020 => 1577836800
+Jan 2020 => 1577836800
+15 January => 1579046400
+January 15 => 1579046400
+Feb 29 2020 => 1582934400
+Feb 30 2020 => 1583020800
+Xyz 15 2020 => false
+15 Foo 2020 => false
+Sep 9 2001 => 999993600
+December 31 1999 => 946598400
+2020 Jan 15 => false
+January 15 2020 UTC => 1579046400
+sept 5 2020 => 1599264000
+15 May 2020 => 1589500800
+31st December 2020 => 1609372800
+November 30th, 2019 => 1575072000
+--CLEAN--
+<?php


### PR DESCRIPTION
Extends DtParse with month-name dates, so strtotime and DateTime accept the two textual orders php supports, which previously failed to parse:

  MonthName Day Year   ("Jan 15 2020", "January 15, 2020", "January 2020")
  Day MonthName Year   ("15 January 2020", "15th Jan", "31st December 2020")

New DtMatchMonth recognises full names and their 3-letter abbreviations (plus "sept"), case-insensitively at a word boundary. DtTryMonthDate handles ordinal day suffixes, comma separators, an optional time-of-day suffix and a trailing UTC/GMT, and reproduces php's field defaulting: a 4-digit number after the month is the year rather than the day ("January 2020" is the 1st); a missing year takes the base year; a missing day is 1 when a year was given but the base day when only the month was named ("January" keeps the base day -- php's overlay semantics). Day overflow normalises ("Feb 30" -> Mar 1); an unknown month, or a year-first spelling like "2020 Jan 15", is a parse failure.

Byte-verified against php across all twelve months, both orders, mixed case, ordinals and the edge cases, for both strtotime and DateTime. Cross-engine test function/strtotime_monthname. test-compat green under both engines; docker ASan+UBSan clean across build, smoke and integration; full and tiny builds warning-free.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
