### PR TITLE
Parse weekday relatives in strtotime and DateTime

### DIFF
--- a/src/ph7/builtin_date.c
+++ b/src/ph7/builtin_date.c
@@ -1934,6 +1934,27 @@ static int DtMatchMonth(const char *z,const char *zEnd,int *pAdv)
 	}
 	return 0;
 }
+/* Match a weekday name at z (full or 3-letter, case-insensitive, word boundary).
+ * Returns the day-of-week 0=Sunday..6=Saturday and sets *pAdv, or -1. */
+static int DtMatchWeekday(const char *z,const char *zEnd,int *pAdv)
+{
+	static const struct { const char *z; int n; int dow; } aW[] = {
+		{ "sunday",6,0 },{ "monday",6,1 },{ "tuesday",7,2 },{ "wednesday",9,3 },
+		{ "thursday",8,4 },{ "friday",6,5 },{ "saturday",8,6 },
+		{ "sun",3,0 },{ "mon",3,1 },{ "tue",3,2 },{ "wed",3,3 },{ "thu",3,4 },
+		{ "fri",3,5 },{ "sat",3,6 }
+	};
+	sxu32 i;
+	for( i = 0 ; i < SX_ARRAYSIZE(aW) ; ++i ){
+		int n = aW[i].n;
+		if( zEnd - z >= n && SyStrnicmp(z,aW[i].z,(sxu32)n) == 0
+		 && (zEnd - z == n || !SyisAlpha(z[n])) ){
+			*pAdv = n;
+			return aW[i].dow;
+		}
+	}
+	return -1;
+}
 /* True if z points at a two-letter English ordinal suffix (st/nd/rd/th). */
 static int DtIsOrdinal(const char *z,const char *zEnd)
 {
@@ -2162,6 +2183,59 @@ static int DtParse(const char *zIn,int nLen,sxi64 iBaseTs,sxi32 iBaseOff,
 			sxi64 days = DtFloorDiv(iTs + iOff,86400) - 1;
 			iTs = days*86400 - iOff;
 			z += 9;
+			bAny = 1;
+			continue;
+		}
+		/* Weekday navigation: "[next|last|previous|this] <weekday>" moves to the
+		 * midnight of the target weekday. Bare/"this" = the this-week occurrence on
+		 * or after the base day; "next"/"last"/"previous" skip a matching base day. */
+		{
+			const char *zSave = z;
+			int dir = 0;         /* 0 = this-week occurrence, 1 = next, -1 = last */
+			int adv,dow;
+			if( DT_LOWEQ("next",4) ){ dir = 1; z += 4; DT_SKIP_WS(); }
+			else if( DT_LOWEQ("previous",8) ){ dir = -1; z += 8; DT_SKIP_WS(); }
+			else if( DT_LOWEQ("last",4) ){ dir = -1; z += 4; DT_SKIP_WS(); }
+			else if( DT_LOWEQ("this",4) ){ dir = 0; z += 4; DT_SKIP_WS(); }
+			dow = DtMatchWeekday(z,zEnd,&adv);
+			if( dow >= 0 ){
+				sxi64 days = DtFloorDiv(iTs + iOff,86400);
+				int bdow = (int)(((days + 4) % 7 + 7) % 7); /* 1970-01-01 was Thursday */
+				sxi64 delta;
+				if( dir == 1 ){
+					delta = ((dow - bdow) % 7 + 7) % 7;
+					if( delta == 0 ){ delta = 7; }
+				}else if( dir == -1 ){
+					delta = -(((bdow - dow) % 7 + 7) % 7);
+					if( delta == 0 ){ delta = -7; }
+				}else{
+					delta = ((dow - bdow) % 7 + 7) % 7;
+				}
+				iTs = (days + delta)*86400 - iOff; /* midnight of the target day */
+				z += adv;
+				bAny = 1;
+				continue;
+			}
+			z = zSave; /* prefix did not introduce a weekday: rewind and try the rest */
+		}
+		/* Trailing time-of-day in a relative sequence ("next thursday 15:00"): set
+		 * the clock on the current day. The leading absolute HH:MM branch handles a
+		 * time at the START; this handles one AFTER a date/relative token. */
+		if( zEnd-z >= 5 && SyisDigit(z[0]) && SyisDigit(z[1]) && z[2]==':'
+		 && SyisDigit(z[3]) && SyisDigit(z[4]) ){
+			sxi64 days = DtFloorDiv(iTs + iOff,86400);
+			int hh = (z[0]-'0')*10 + (z[1]-'0');
+			int mm = (z[3]-'0')*10 + (z[4]-'0');
+			int ss = 0;
+			if( hh > 24 ){ return (int)(z - zIn) + 1; }
+			if( mm > 59 ){ return (int)(&z[4] - zIn) + 1; }
+			z += 5;
+			if( z < zEnd && z[0]==':' && zEnd-z >= 3 && SyisDigit(z[1]) && SyisDigit(z[2]) ){
+				ss = (z[1]-'0')*10 + (z[2]-'0');
+				if( ss > 59 ){ return (int)(&z[2] - zIn) + 1; }
+				z += 3;
+			}
+			iTs = days*86400 + (sxi64)hh*3600 + (sxi64)mm*60 + ss - iOff;
 			bAny = 1;
 			continue;
 		}

--- a/tests/ph7/001-smoke/function/strtotime_weekday/strtotime_weekday.phpt
+++ b/tests/ph7/001-smoke/function/strtotime_weekday/strtotime_weekday.phpt
@@ -1,0 +1,47 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+strtotime/DateTime parse weekday relatives (bare, next, last/previous) with optional time
+--FILE--
+<?php
+function weekdayCases(): array {
+    date_default_timezone_set("UTC");
+    $b = 1600000000; // Sunday 2020-09-13
+    $inputs = [
+        "monday", "sunday", "thursday", "saturday", "friday", "tuesday", "wednesday",
+        "next thursday", "last monday", "previous friday", "next sunday", "last sunday",
+        "next monday", "this friday", "next saturday", "last saturday",
+        "next thursday 15:00", "monday 08:30:15", "last friday 23:59:59",
+        "sun", "next wed", "last tue",
+    ];
+    $out = [];
+    foreach ($inputs as $in) { $out[] = $in . " => " . gmdate("D Y-m-d H:i:s", strtotime($in, $b)); }
+    return $out;
+}
+echo implode("\n", weekdayCases()), "\n";
+--EXPECT--
+monday => Mon 2020-09-14 00:00:00
+sunday => Sun 2020-09-13 00:00:00
+thursday => Thu 2020-09-17 00:00:00
+saturday => Sat 2020-09-19 00:00:00
+friday => Fri 2020-09-18 00:00:00
+tuesday => Tue 2020-09-15 00:00:00
+wednesday => Wed 2020-09-16 00:00:00
+next thursday => Thu 2020-09-17 00:00:00
+last monday => Mon 2020-09-07 00:00:00
+previous friday => Fri 2020-09-11 00:00:00
+next sunday => Sun 2020-09-20 00:00:00
+last sunday => Sun 2020-09-06 00:00:00
+next monday => Mon 2020-09-14 00:00:00
+this friday => Fri 2020-09-18 00:00:00
+next saturday => Sat 2020-09-19 00:00:00
+last saturday => Sat 2020-09-12 00:00:00
+next thursday 15:00 => Thu 2020-09-17 15:00:00
+monday 08:30:15 => Mon 2020-09-14 08:30:15
+last friday 23:59:59 => Fri 2020-09-11 23:59:59
+sun => Sun 2020-09-13 00:00:00
+next wed => Wed 2020-09-16 00:00:00
+last tue => Tue 2020-09-08 00:00:00
+--CLEAN--
+<?php


### PR DESCRIPTION
Adds weekday navigation to the date parser, so strtotime and DateTime::modify handle the common relative weekday forms, which previously failed:

  monday / thursday          -- this week's occurrence on or after the base day
  next thursday              -- the next occurrence, skipping the base day if it matches
  last monday / previous fri -- the prior occurrence

DtMatchWeekday recognises full and 3-letter weekday names case-insensitively; the target is computed by day-of-week arithmetic (1970-01-01 was a Thursday) and lands at midnight. A trailing time-of-day setter was added to the relative loop as well, so "next thursday 15:00" and "monday 08:30:15" apply the clock after the weekday.

Byte-verified against php for both strtotime and DateTime across bare/next/last/ previous weekdays and the time-suffixed forms. The remaining relative constructs -- "first/last day of <month>" and this/next/last week-or-month navigation -- still return false and are recorded in NEWPLAN as the next slice.

Cross-engine test function/strtotime_weekday. test-compat green under both engines; docker ASan+UBSan clean across build, smoke and integration; full and tiny builds warning-free.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
