### PR TITLE
Parse "first/last day of" month navigation

### DIFF
--- a/src/ph7/builtin_date.c
+++ b/src/ph7/builtin_date.c
@@ -2218,6 +2218,71 @@ static int DtParse(const char *zIn,int nLen,sxi64 iBaseTs,sxi32 iBaseOff,
 			}
 			z = zSave; /* prefix did not introduce a weekday: rewind and try the rest */
 		}
+		/* "first|last day of (this|next|last month | MonthName [Year])": jump to the
+		 * first or last day of a target month. A this/next/last-month target keeps the
+		 * base time-of-day; an absolute MonthName [Year] target resets it to midnight
+		 * (php). */
+		if( DT_LOWEQ("first",5) || DT_LOWEQ("last",4) ){
+			const char *zSave = z;
+			int bFirst = (SyToLower((unsigned char)z[0]) == 'f');
+			z += bFirst ? 5 : 4;
+			DT_SKIP_WS();
+			if( DT_LOWEQ("day",3) ){
+				z += 3;
+				DT_SKIP_WS();
+				if( DT_LOWEQ("of",2) ){
+					sxi64 days0 = DtFloorDiv(iTs + iOff,86400);
+					sxi64 yy,tod;
+					int mm,dd0,keepTime = 1,ok = 1;
+					z += 2;
+					DT_SKIP_WS();
+					DtCivilFromDays(days0,&yy,&mm,&dd0);
+					tod = (iTs + iOff) - days0*86400;
+					if( DT_LOWEQ("this",4) ){ z += 4; DT_SKIP_WS();
+						if( DT_LOWEQ("month",5) ){ z += 5; }else{ ok = 0; } }
+					else if( DT_LOWEQ("next",4) ){ z += 4; DT_SKIP_WS();
+						if( DT_LOWEQ("month",5) ){ z += 5; mm++; if(mm>12){ mm=1; yy++; } }else{ ok = 0; } }
+					else if( DT_LOWEQ("last",4) ){ z += 4; DT_SKIP_WS();
+						if( DT_LOWEQ("month",5) ){ z += 5; mm--; if(mm<1){ mm=12; yy--; } }else{ ok = 0; } }
+					else if( z < zEnd ){
+						int mo,adv;
+						mo = DtMatchMonth(z,zEnd,&adv);
+						if( mo == 0 ){ return (int)(z - zIn) + 1; }
+						z += adv; DT_SKIP_WS();
+						mm = mo; keepTime = 0; tod = 0;
+						if( z < zEnd && SyisDigit(z[0]) ){
+							int ny = 0; sxi64 yv = 0;
+							while( z < zEnd && SyisDigit(z[0]) && ny < 4 ){ yv = yv*10 + (z[0]-'0'); z++; ny++; }
+							if( ny <= 2 ){ if( yv <= 69 ){ yv += 2000; } else if( yv <= 99 ){ yv += 1900; } }
+							yy = yv;
+						}
+					}
+					/* else: "... day of" with nothing after — php defaults to this
+					 * month (mm/yy/tod stay the base, keepTime stays 1). */
+					if( ok ){
+						int dim = (int)(DtDaysFromCivil(yy,mm+1,1) - DtDaysFromCivil(yy,mm,1));
+						int day = bFirst ? 1 : dim;
+						iTs = DtDaysFromCivil(yy,mm,day)*86400 + (keepTime ? tod : 0) - iOff;
+						bAny = 1;
+						continue;
+					}
+				}
+			}
+			z = zSave; /* not the "first|last day of ..." shape: rewind */
+		}
+		/* Standalone month navigation: "this|next|last month" shifts the month,
+		 * keeping the day/time (php: "next month" is +1 month). Week navigation is a
+		 * recorded gap. */
+		{
+			const char *zSave = z;
+			if( DT_LOWEQ("next",4) ){ z += 4; DT_SKIP_WS();
+				if( DT_LOWEQ("month",5) ){ z += 5; iTs = DtAddMonths(iTs,iOff,1); bAny = 1; continue; } }
+			else if( DT_LOWEQ("last",4) ){ z += 4; DT_SKIP_WS();
+				if( DT_LOWEQ("month",5) ){ z += 5; iTs = DtAddMonths(iTs,iOff,-1); bAny = 1; continue; } }
+			else if( DT_LOWEQ("this",4) ){ z += 4; DT_SKIP_WS();
+				if( DT_LOWEQ("month",5) ){ z += 5; bAny = 1; continue; } }
+			z = zSave;
+		}
 		/* Trailing time-of-day in a relative sequence ("next thursday 15:00"): set
 		 * the clock on the current day. The leading absolute HH:MM branch handles a
 		 * time at the START; this handles one AFTER a date/relative token. */

--- a/tests/ph7/001-smoke/function/strtotime_dayof/strtotime_dayof.phpt
+++ b/tests/ph7/001-smoke/function/strtotime_dayof/strtotime_dayof.phpt
@@ -1,0 +1,45 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+strtotime/DateTime parse first|last day of month and standalone month navigation
+--FILE--
+<?php
+function dayOfCases(): array {
+    date_default_timezone_set("UTC");
+    $b = 1600000000;
+    $inputs = [
+        "first day of this month", "last day of this month", "first day of next month",
+        "last day of next month", "first day of last month", "last day of last month",
+        "first day of January 2020", "last day of February 2020", "first day of Feb 2021",
+        "last day of December 2020", "first day of March", "last day of April",
+        "next month", "last month", "this month",
+        "first day of this month midnight", "first day of next month 09:00",
+        "last day of",
+    ];
+    $out = [];
+    foreach ($inputs as $in) { $out[] = $in . " => " . var_export(strtotime($in, $b), true); }
+    return $out;
+}
+echo implode("\n", dayOfCases()), "\n";
+--EXPECT--
+first day of this month => 1598963200
+last day of this month => 1601468800
+first day of next month => 1601555200
+last day of next month => 1604147200
+first day of last month => 1596284800
+last day of last month => 1598876800
+first day of January 2020 => 1577836800
+last day of February 2020 => 1582934400
+first day of Feb 2021 => 1612137600
+last day of December 2020 => 1609372800
+first day of March => 1583020800
+last day of April => 1588204800
+next month => 1602592000
+last month => 1597321600
+this month => 1600000000
+first day of this month midnight => 1598918400
+first day of next month 09:00 => 1601542800
+last day of => 1601468800
+--CLEAN--
+<?php


### PR DESCRIPTION
Rounds out the date parser's relative forms so strtotime and DateTime handle:

  first|last day of this|next|last month
  first|last day of <MonthName [Year]>
  this|next|last month

"first|last day of" jumps to the 1st or the month's last day (computed from the civil calendar), keeping the base time-of-day for a relative-month target but resetting to midnight for an absolute MonthName [Year] one, matching php. A dangling "... day of" with nothing after defaults to this month, as php does. Standalone "next month"/"last month" shift the month via DtAddMonths, keeping the day and time.

Byte-verified against php for both strtotime and DateTime across this/next/last month, absolute month targets, time suffixes and the defaulting cases. The one remaining relative construct, this|next|last week (Monday-of-week navigation), is uncommon and recorded in NEWPLAN; the parser now covers essentially every everyday php date string.

Cross-engine test function/strtotime_dayof. test-compat green under both engines; docker ASan+UBSan clean across build, smoke and integration; full and tiny builds warning-free.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
