### PR TITLE
Parse this/next/last week navigation

### DIFF
--- a/src/ph7/builtin_date.c
+++ b/src/ph7/builtin_date.c
@@ -2270,17 +2270,35 @@ static int DtParse(const char *zIn,int nLen,sxi64 iBaseTs,sxi32 iBaseOff,
 			}
 			z = zSave; /* not the "first|last day of ..." shape: rewind */
 		}
-		/* Standalone month navigation: "this|next|last month" shifts the month,
-		 * keeping the day/time (php: "next month" is +1 month). Week navigation is a
-		 * recorded gap. */
+		/* Standalone "this|next|last (month|week)": month shifts by ±1 keeping the
+		 * day/time; week moves to the Monday of this/next/last ISO week keeping the
+		 * time-of-day (php: weeks start on Monday). */
 		{
 			const char *zSave = z;
-			if( DT_LOWEQ("next",4) ){ z += 4; DT_SKIP_WS();
-				if( DT_LOWEQ("month",5) ){ z += 5; iTs = DtAddMonths(iTs,iOff,1); bAny = 1; continue; } }
-			else if( DT_LOWEQ("last",4) ){ z += 4; DT_SKIP_WS();
-				if( DT_LOWEQ("month",5) ){ z += 5; iTs = DtAddMonths(iTs,iOff,-1); bAny = 1; continue; } }
-			else if( DT_LOWEQ("this",4) ){ z += 4; DT_SKIP_WS();
-				if( DT_LOWEQ("month",5) ){ z += 5; bAny = 1; continue; } }
+			int dir = 2; /* 2 = no prefix */
+			if( DT_LOWEQ("next",4) ){ dir = 1; z += 4; }
+			else if( DT_LOWEQ("last",4) ){ dir = -1; z += 4; }
+			else if( DT_LOWEQ("this",4) ){ dir = 0; z += 4; }
+			if( dir != 2 ){
+				DT_SKIP_WS();
+				if( DT_LOWEQ("month",5) ){
+					z += 5;
+					iTs = DtAddMonths(iTs,iOff,dir);
+					bAny = 1;
+					continue;
+				}
+				if( DT_LOWEQ("week",4) ){
+					sxi64 days0 = DtFloorDiv(iTs + iOff,86400);
+					sxi64 tod = (iTs + iOff) - days0*86400;
+					int bdow = (int)(((days0 + 4) % 7 + 7) % 7);
+					sxi64 monday = days0 - ((bdow + 6) % 7); /* Monday of the base week */
+					z += 4;
+					monday += (sxi64)dir * 7;
+					iTs = monday*86400 + tod - iOff;
+					bAny = 1;
+					continue;
+				}
+			}
 			z = zSave;
 		}
 		/* Trailing time-of-day in a relative sequence ("next thursday 15:00"): set

--- a/tests/ph7/001-smoke/function/strtotime_week/strtotime_week.phpt
+++ b/tests/ph7/001-smoke/function/strtotime_week/strtotime_week.phpt
@@ -1,0 +1,32 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+strtotime/DateTime parse this|next|last week (Monday-of-week) navigation
+--FILE--
+<?php
+function weekNavCases(): array {
+    date_default_timezone_set("UTC");
+    $b = 1600000000; // Sunday 2020-09-13 12:26:40
+    $inputs = [
+        "this week", "next week", "last week",
+        "next week 09:00", "this week midnight", "last week 23:00",
+        "this month", "next month", "last month",
+    ];
+    $out = [];
+    foreach ($inputs as $in) { $out[] = $in . " => " . gmdate("D Y-m-d H:i:s", strtotime($in, $b)); }
+    return $out;
+}
+echo implode("\n", weekNavCases()), "\n";
+--EXPECT--
+this week => Mon 2020-09-07 12:26:40
+next week => Mon 2020-09-14 12:26:40
+last week => Mon 2020-08-31 12:26:40
+next week 09:00 => Mon 2020-09-14 09:00:00
+this week midnight => Mon 2020-09-07 00:00:00
+last week 23:00 => Mon 2020-08-31 23:00:00
+this month => Sun 2020-09-13 12:26:40
+next month => Tue 2020-10-13 12:26:40
+last month => Thu 2020-08-13 12:26:40
+--CLEAN--
+<?php


### PR DESCRIPTION
Completes the relative date forms: "this week", "next week" and "last week" move to the Monday of the current, next or previous ISO week (weeks start on Monday), keeping the time-of-day -- matching php. This folds into the standalone month/week navigation block alongside "next month" etc.

Byte-verified against php for both strtotime and DateTime across this/next/last week (with and without a trailing time). One divergence is recorded in NEWPLAN, not fixed: the weekday+week COMBO "monday next week" -- php's timelib accumulates the relative offsets and applies them to the base once, yielding "Monday of next week", whereas PHL's sequential left-to-right parser resolves "monday" to a date and then shifts a week, double-counting. A faithful fix needs the accumulate-then-apply relative model, a parser rework.

The strtotime/DateTime string parser now covers essentially every everyday php date string.

Cross-engine test function/strtotime_week. test-compat green under both engines; docker ASan+UBSan clean across build, smoke and integration; full and tiny builds warning-free.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
