### PR TITLE
Add the date_create_from_format procedural aliases

### DIFF
--- a/src/ph7/builtin_date.c
+++ b/src/ph7/builtin_date.c
@@ -3315,6 +3315,14 @@ static const char zDateTimeLib[] =
 "function date_create_immutable($datetime = 'now', $timezone = null){"
 " try { return new DateTimeImmutable($datetime, $timezone); } catch (Exception $e) { return false; }"
 "}"
+/* Procedural aliases of the createFromFormat statics: same (format, datetime,
+ * ?timezone) order, returning false on failure like php. */
+"function date_create_from_format($format, $datetime, $timezone = null){"
+" return DateTime::createFromFormat($format, $datetime, $timezone);"
+"}"
+"function date_create_immutable_from_format($format, $datetime, $timezone = null){"
+" return DateTimeImmutable::createFromFormat($format, $datetime, $timezone);"
+"}"
 "class DateInterval {"
 " public $y = 0;"
 " public $m = 0;"

--- a/tests/ph7/001-smoke/function/date_create_from_format/date_create_from_format.phpt
+++ b/tests/ph7/001-smoke/function/date_create_from_format/date_create_from_format.phpt
@@ -1,0 +1,31 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+date_create_from_format and date_create_immutable_from_format procedural aliases
+--FILE--
+<?php
+function dcffCases(): array {
+    date_default_timezone_set("UTC");
+    $out = [];
+    $d = date_create_from_format("Y-m-d", "2020-06-15");
+    $out[] = ($d instanceof DateTime ? "DT" : "?") . " " . $d->format("Y-m-d");
+    $i = date_create_immutable_from_format("d/m/Y", "15/06/2020");
+    $out[] = ($i instanceof DateTimeImmutable ? "DTI" : "?") . " " . $i->format("Y-m-d");
+    $out[] = var_export(date_create_from_format("Y-m-d", "garbage"), true);
+    $t = date_create_from_format("Y-m-d H:i", "2020-01-01 12:00", new DateTimeZone("UTC"));
+    $out[] = $t->format("Y-m-d H:i:s");
+    $out[] = date_create_from_format("!Y-m-d", "2021-03-04")->format("Y-m-d H:i:s");
+    $out[] = date_create_immutable_from_format("!d-m-Y H:i", "04-03-2021 08:30")->format("Y-m-d H:i:s");
+    return $out;
+}
+echo implode("\n", dcffCases()), "\n";
+--EXPECT--
+DT 2020-06-15
+DTI 2020-06-15
+false
+2020-01-01 12:00:00
+2021-03-04 00:00:00
+2021-03-04 08:30:00
+--CLEAN--
+<?php


### PR DESCRIPTION
date_create_from_format and date_create_immutable_from_format were missing. They are thin procedural aliases of DateTime::createFromFormat and DateTimeImmutable::createFromFormat, with the same (format, datetime, ?timezone) argument order and returning false on failure, matching php.

The cross-engine test uses "!"-anchored formats so the time-of-day (which php fills from "now" for a date-only format) stays deterministic across the two engine runs.

date_parse, date_parse_from_format and strptime remain unimplemented: they return a broken-down field array (with false for unspecified fields plus warnings/errors), which needs a component-returning parser rather than the timestamp DtParse yields -- recorded in NEWPLAN.

test-compat green under both engines; docker ASan+UBSan clean across build, smoke and integration; full and tiny builds warning-free.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
