### PR TITLE
Skip a #! shebang; fix \Class:: names

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -13613,8 +13613,17 @@ static sxi32 GenStateEmitExprCode(
 				}
 			}
 			pInstr->iP1 = 0;
-			if( !isSpecial ){
-				pInstr->iP2 = (sxi32)GenStateNsQualifyName(pGen,(sxu32)pInstr->iP2,&pGen->hUseImports,0);
+			/* A leading `\` (NSSEP) makes the class name ABSOLUTE: it names the
+			 * global class, so it must NOT be re-qualified with the current namespace.
+			 * `\Closure::bind(...)` inside `namespace X` is Closure, not X\Closure.
+			 * (Multi-component `\A\B::m` already resolves absolutely because its
+			 * literal keeps a backslash; the single-component `\Closure` lost it.) */
+			{
+				int bAbsolute = (pNode->pLeft && pNode->pLeft->pStart
+					&& (pNode->pLeft->pStart->nType & PH7_TK_NSSEP));
+				if( !isSpecial && !bAbsolute ){
+					pInstr->iP2 = (sxi32)GenStateNsQualifyName(pGen,(sxu32)pInstr->iP2,&pGen->hUseImports,0);
+				}
 			}
 			/* Foo::class — resolve at compile time. The LOADC already holds the
 			 * namespace-qualified name. self/static/parent need runtime resolution. */
@@ -14742,9 +14751,25 @@ PH7_PRIVATE sxi32 PH7_CompileScript(
 	sxi8 bSavedStrictLocked;
 	SyToken *pSavedIn,*pSavedEnd;
 	sxi32 rc;
+	sxu32 nBaseLine = 1;
 	if( pScript->nByte < 1 ){
 		/* Nothing to compile */
 		return PH7_OK;
+	}
+	/* php skips a "#!" shebang on the first line of a CLI script: consume it
+	 * (including its newline) so it is not echoed as inline text, and bump the
+	 * base line to 2 so the code below still reports php-matching line numbers. */
+	if( pScript->nByte >= 2 && pScript->zString[0]=='#' && pScript->zString[1]=='!' ){
+		const char *z = pScript->zString;
+		const char *zEnd = &z[pScript->nByte];
+		while( z < zEnd && z[0] != '\n' ){ z++; }
+		if( z < zEnd ){ z++; } /* consume the newline too */
+		pScript->nByte -= (sxu32)(z - pScript->zString);
+		pScript->zString = z;
+		nBaseLine = 2;
+		if( pScript->nByte < 1 ){
+			return PH7_OK;
+		}
 	}
 	/* Each compiled file has its own strict_types scope. Save the outer
 	 * file's flags so include/require restore them on return. */
@@ -14781,7 +14806,7 @@ PH7_PRIVATE sxi32 PH7_CompileScript(
 	}else{
 		/* Tokenize raw text */
 		SySetAlloc(&aRawToken,32);
-		PH7_TokenizeRawText(pScript->zString,pScript->nByte,&aRawToken);
+		PH7_TokenizeRawText(pScript->zString,pScript->nByte,&aRawToken,nBaseLine);
 	}
 	/* Process high-level tokens */
 	pCodeGen->pRawIn = (SyToken *)SySetBasePtr(&aRawToken);

--- a/src/ph7/lex.c
+++ b/src/ph7/lex.c
@@ -1204,7 +1204,7 @@ PH7_PRIVATE sxi32 PH7_TokenizePHP(const char *zInput,sxu32 nLen,sxu32 nLineStart
  * 3.  <? echo 'this is the simplest, an SGML processing instruction'; ?>
  *   <?= expression ?> This is a shortcut for "<? echo expression ?>"
  */
-PH7_PRIVATE sxi32 PH7_TokenizeRawText(const char *zInput,sxu32 nLen,SySet *pOut)
+PH7_PRIVATE sxi32 PH7_TokenizeRawText(const char *zInput,sxu32 nLen,SySet *pOut,sxu32 nBaseLine)
 {
 	const char *zEnd = &zInput[nLen];
 	const char *zIn  = zInput;
@@ -1215,8 +1215,9 @@ PH7_PRIVATE sxi32 PH7_TokenizeRawText(const char *zInput,sxu32 nLen,SySet *pOut)
 	sxu32 nLine;
 	sxi32 iNest;
 	sxi32 rc;
-	/* Tokenize the input into PHP tokens and raw tokens */
-	nLine = 1;
+	/* Tokenize the input into PHP tokens and raw tokens. nBaseLine is normally 1,
+	 * but 2 when a "#!" shebang line was stripped so error lines still match php. */
+	nLine = nBaseLine;
 	zCur = zCurEnd   = 0; /* Prevent compiler warning */
 	sToken.pUserData = 0;
 	iNest = 0;

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -2045,7 +2045,7 @@ PH7_PRIVATE sxi32 PH7_MemObjToInteger(ph7_value *pObj);
 PH7_PRIVATE sxi32 PH7_MemObjToBool(ph7_value *pObj);
 PH7_PRIVATE sxi64 PH7_TokenValueToInt64(SyString *pData);
 /* lex.c function prototypes */
-PH7_PRIVATE sxi32 PH7_TokenizeRawText(const char *zInput,sxu32 nLen,SySet *pOut);
+PH7_PRIVATE sxi32 PH7_TokenizeRawText(const char *zInput,sxu32 nLen,SySet *pOut,sxu32 nBaseLine);
 PH7_PRIVATE sxi32 PH7_TokenizePHP(const char *zInput,sxu32 nLen,sxu32 nLineStart,SySet *pOut,SySet *pTrivia);
 /* vm.c function prototypes */
 PH7_PRIVATE void PH7_VmReleaseContextValue(ph7_context *pCtx,ph7_value *pValue);

--- a/tests/ph7/001-smoke/oo/absolute_class_static/absolute_class_static.phpt
+++ b/tests/ph7/001-smoke/oo/absolute_class_static/absolute_class_static.phpt
@@ -1,0 +1,30 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A leading-backslash class name in :: is absolute inside a namespace (\Closure::bind)
+--FILE--
+<?php
+namespace AbsNsTest\Deep;
+class AbsHelper { public static function tag() { return "ns-helper"; } }
+$out = [];
+$out[] = \Closure::fromCallable('strlen')("hello");
+$out[] = \Closure::bind(static function ($a, $b) { return $a * $b; }, null)(4, 5);
+$out[] = \stdClass::class;
+$out[] = \Exception::class;
+$out[] = \Closure::class;
+$out[] = AbsHelper::class;
+$out[] = AbsHelper::tag();
+$out[] = \strlen("abc");
+echo implode("\n", array_map(fn($x) => (string)$x, $out)), "\n";
+--EXPECT--
+5
+20
+stdClass
+Exception
+Closure
+AbsNsTest\Deep\AbsHelper
+ns-helper
+3
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/shebang/shebang.phpt
+++ b/tests/ph7/002-integration/lang/shebang/shebang.phpt
@@ -1,0 +1,15 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A #! shebang on line 1 is skipped (not echoed) and line numbering continues at 2
+--FILE--
+#!/usr/bin/env php
+<?php
+echo "no shebang echoed\n";
+echo __LINE__, "\n";
+--EXPECT--
+no shebang echoed
+4
+--CLEAN--
+<?php


### PR DESCRIPTION
Two compiler fixes surfaced by running real-world code (PHPUnit's entry point and Composer's autoloader) under PHL; both are in compile.c.

Shebang: php ignores a "#!" line on the first line of a script (CLI entry points such as vendor/bin/phpunit); PHL echoed it as inline text. PH7_CompileScript now consumes the shebang line including its trailing newline before tokenizing, so it produces no output, and bumps the tokenizer's base line to 2 (a new PH7_TokenizeRawText parameter) so diagnostics still report php-matching line numbers. Applies to include()d files too, matching php.

Absolute ::: inside a namespace, "\Closure::bind(...)" / "\Global::class" was re-qualified with the current namespace (e.g. Composer\Autoload\Closure) and failed. A single-component absolute name lost its leading backslash before the :: class-name re-qualification, so the qualifier could not tell it was absolute and prepended the namespace. The :: resolution now checks the original left-operand token for a leading NSSEP and skips qualification when present, so an absolute name resolves to the global class. (new \Class and multi-component \A\B:: already worked.)

Cross-engine tests integration/lang/shebang and oo/absolute_class_static. test-compat green under both engines; docker ASan+UBSan clean; full and tiny builds warning-free.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
