### PR TITLE
Bind assignment to the immediate lvalue

### DIFF
--- a/src/ph7/parse.c
+++ b/src/ph7/parse.c
@@ -2137,6 +2137,30 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 				 apNode[iLeft] = pSuppress->pLeft;
 			 }
 			 if( ExprIsModifiableValue(apNode[iLeft],FALSE) == FALSE ){
+				 /* php binds `A op $lv = B` as `A op ($lv = B)`: assignment takes the
+				  * immediate lvalue on its left, not the whole binary subtree. When the
+				  * left operand is a (non-lvalue) binary/comparison/logical subtree, walk
+				  * its right spine down to the deepest modifiable lvalue and reparent the
+				  * assignment there, leaving the binary operator as the outer node.
+				  * Covers the very common `while (false !== $p = strpos(...))` idiom. */
+				 if( pSuppress == 0 && apNode[iLeft]->pOp && apNode[iLeft]->pRight ){
+					 ph7_expr_node *pHost = apNode[iLeft];
+					 ph7_expr_node *pParent = pHost;
+					 while( pParent->pRight && pParent->pRight->pOp && pParent->pRight->pRight
+						 && ExprIsModifiableValue(pParent->pRight,FALSE) == FALSE ){
+						 pParent = pParent->pRight;
+					 }
+					 if( pParent->pRight && ExprIsModifiableValue(pParent->pRight,FALSE)
+						 && PH7_ExprContainsNullsafe(pParent->pRight) == 0 ){
+						 pNode->pLeft = apNode[iRight];   /* assignment RHS value */
+						 pNode->pRight = pParent->pRight; /* the extracted lvalue */
+						 pParent->pRight = pNode;         /* assignment becomes the op's right child */
+						 apNode[iCur] = pHost;            /* the binary subtree root is the result */
+						 apNode[iLeft] = apNode[iRight] = 0;
+						 iRight = iCur;
+						 continue;
+					 }
+				 }
 				 if( pNode->pOp->iVmOp != PH7_OP_STORE ||
 					 (apNode[iLeft]->xCode != PH7_CompileList && apNode[iLeft]->xCode != PH7_CompileShortList) ){
 					 /* Left operand must be a modifiable l-value */

--- a/tests/ph7/001-smoke/lang/assign_in_condition/assign_in_condition.phpt
+++ b/tests/ph7/001-smoke/lang/assign_in_condition/assign_in_condition.phpt
@@ -1,0 +1,25 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Assignment binds to the immediate lvalue inside a comparison (false !== $x = f())
+--FILE--
+<?php
+$s = "a\\b\\c"; $out = [];
+if (false !== $pos = strrpos($s, "\\")) { $out[] = "pos=$pos"; }
+$n = 0; $t = "aXbXcX"; while (false !== $i = strpos($t, "X")) { $n++; $t = substr($t, $i + 1); }
+$out[] = "loops=$n";
+$a = 5; $b = $a == 5; $out[] = "b=" . var_export($b, true);
+$c = 3; if ($x = $c + 1) { $out[] = "x=$x"; }
+$o = new stdClass; $o->v = 0; if (0 === $o->v = 9) {} $out[] = "ov={$o->v}";
+$r = true && $y = 7; $out[] = "y=$y r=" . var_export($r, true);
+echo implode("\n", $out), "\n";
+--EXPECT--
+pos=3
+loops=3
+b=true
+x=4
+ov=9
+y=7 r=true
+--CLEAN--
+<?php


### PR DESCRIPTION
The idiom "while (false !== $pos = strpos(...))" -- assignment nested in a comparison, extremely common in real code (Composer's ClassLoader, PDO fetch loops) -- failed with "Left operand must be a modifiable l-value". PHL processed the comparison first, so by the assignment pass the left operand was the whole "false !== $pos" subtree rather than the bare $pos.

php binds "A op $lv = B" as "A op ($lv = B)": the assignment takes the immediate lvalue on its left. The assignment pass now, when its left operand is a non-lvalue binary/comparison/logical subtree, walks that subtree's right spine down to the deepest modifiable lvalue and reparents the assignment there, leaving the binary operator as the outer node. The list()/short-list and @-suppression paths are untouched.

Byte-verified against php across ->, ??, &&, chained and loop forms. Cross-engine test lang/assign_in_condition. test-compat green under both engines; docker ASan+UBSan clean; full and tiny builds warning-free.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
