### PR TITLE
Implement version_compare and extension_loaded

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -2413,6 +2413,61 @@ static int vm_builtin_Closure_fromCallable(ph7_context *pCtx, int nArg, ph7_valu
    "function is_nan($v){ $v = (float)$v; return $v != $v; }"\
    "function is_infinite($v){ $v = (float)$v; return $v == INF || $v == -INF; }"\
    "function is_finite($v){ $v = (float)$v; return !is_nan($v) && !is_infinite($v); }"\
+   "/* php's version_compare: canonicalise (separators + digit/alpha boundaries all"\
+   " * become '.'), then compare parts with the special dev<alpha<beta<RC<#<pl ordering. */"\
+   "function __phl_vcanon($v){"\
+   "  $v = (string)$v; $len = strlen($v); $out = '';"\
+   "  for( $i = 0; $i < $len; $i++ ){"\
+   "   $c = $v[$i]; $rp = $i + 1 < $len ? $v[$i + 1] : '';"\
+   "   $cd = ($c >= '0' && $c <= '9');"\
+   "   $ca = $cd || ($c >= 'a' && $c <= 'z') || ($c >= 'A' && $c <= 'Z');"\
+   "   if( !$ca ){"\
+   "    /* any non-alphanumeric (., -, _, +, ...) is a separator: emit one '.' */"\
+   "    if( $out !== '' && substr($out, -1) !== '.' ){ $out .= '.'; }"\
+   "   }else{"\
+   "    $out .= $c;"\
+   "    $rd = ($rp >= '0' && $rp <= '9');"\
+   "    $ra = $rd || ($rp >= 'a' && $rp <= 'z') || ($rp >= 'A' && $rp <= 'Z');"\
+   "    if( $rp !== '' && $ra && ($cd !== $rd) ){ $out .= '.'; }"\
+   "   }"\
+   "  }"\
+   "  return explode('.', $out);"\
+   "}"\
+   "function __phl_vform($s){"\
+   "  if( $s === '' ){ return -1; }"\
+   "  if( ctype_digit($s) ){ return 4; }"\
+   "  $f = array('dev' => 0, 'alpha' => 1, 'a' => 1, 'beta' => 2, 'b' => 2, 'RC' => 3, 'rc' => 3, 'pl' => 5, 'p' => 5);"\
+   "  foreach( $f as $name => $ord ){ if( strncmp($s, $name, strlen($name)) === 0 ){ return $ord; } }"\
+   "  return -1;"\
+   "}"\
+   "function version_compare($version1, $version2, $operator = null){"\
+   "  $v1 = __phl_vcanon($version1); $v2 = __phl_vcanon($version2);"\
+   "  $n1 = count($v1); $n2 = count($v2); $n = $n1 > $n2 ? $n1 : $n2; $cmp = 0;"\
+   "  for( $i = 0; $i < $n; $i++ ){"\
+   "   $a = $i < $n1 ? $v1[$i] : null; $b = $i < $n2 ? $v2[$i] : null;"\
+   "   if( $a === null ){ $cmp = ctype_digit($b) ? -1 : (4 <=> __phl_vform($b)); }"\
+   "   elseif( $b === null ){ $cmp = ctype_digit($a) ? 1 : (__phl_vform($a) <=> 4); }"\
+   "   elseif( ctype_digit($a) && ctype_digit($b) ){ $cmp = (int)$a <=> (int)$b; }"\
+   "   else{ $cmp = __phl_vform($a) <=> __phl_vform($b); }"\
+   "   if( $cmp !== 0 ){ break; }"\
+   "  }"\
+   "  if( $operator === null ){ return $cmp; }"\
+   "  switch( (string)$operator ){"\
+   "   case '<': case 'lt': return $cmp < 0;"\
+   "   case '<=': case 'le': return $cmp <= 0;"\
+   "   case '>': case 'gt': return $cmp > 0;"\
+   "   case '>=': case 'ge': return $cmp >= 0;"\
+   "   case '==': case '=': case 'eq': return $cmp === 0;"\
+   "   case '!=': case '<>': case 'ne': return $cmp !== 0;"\
+   "  }"\
+   "  return null;"\
+   "}"\
+   "function extension_loaded($name){"\
+   "  static $ext = array('core' => 1, 'standard' => 1, 'pcre' => 1, 'json' => 1,"\
+   "   'ctype' => 1, 'date' => 1, 'spl' => 1, 'reflection' => 1, 'mbstring' => 1,"\
+   "   'hash' => 1, 'filter' => 1, 'session' => 1, 'libxml' => 1, 'xml' => 1);"\
+   "  return isset($ext[strtolower((string)$name)]);"\
+   "}"\
    "/* Inverse of bin2hex() */"\
    "function hex2bin($str){"\
    "  $str = (string)$str;"\

--- a/tests/ph7/001-smoke/function/version_compare/version_compare.phpt
+++ b/tests/ph7/001-smoke/function/version_compare/version_compare.phpt
@@ -1,0 +1,38 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+version_compare canonicalizes and orders versions (dev<alpha<beta<RC<release<pl)
+--FILE--
+<?php
+$pairs = [["1.0.0","1.0.0"],["1.0","1.0.0"],["1.0","1.0.1"],["8.2.0","8.5.7"],
+  ["1.0.0-dev","1.0.0"],["1.0.0-alpha","1.0.0-beta"],["1.0.0-rc1","1.0.0"],
+  ["1.0.0pl1","1.0.0"],["2.0","1.9.9"],["1.0a","1.0b"],["1.0RC1","1.0RC2"],
+  ["7.4","8.0"],["","1.0"],["1","1.0.0"],["1.0.0beta2","1.0.0beta10"]];
+$out = [];
+foreach ($pairs as [$a, $b]) {
+    $out[] = "$a|$b=" . var_export(version_compare($a, $b), true)
+        . "," . var_export(version_compare($a, $b, ">="), true)
+        . "," . var_export(version_compare($a, $b, "lt"), true);
+}
+$out[] = "ext:" . (extension_loaded("json") ? "1" : "0") . (extension_loaded("pcre") ? "1" : "0") . (extension_loaded("SPL") ? "1" : "0");
+echo implode("\n", $out), "\n";
+--EXPECT--
+1.0.0|1.0.0=0,true,false
+1.0|1.0.0=-1,false,true
+1.0|1.0.1=-1,false,true
+8.2.0|8.5.7=-1,false,true
+1.0.0-dev|1.0.0=-1,false,true
+1.0.0-alpha|1.0.0-beta=-1,false,true
+1.0.0-rc1|1.0.0=-1,false,true
+1.0.0pl1|1.0.0=1,true,false
+2.0|1.9.9=1,true,false
+1.0a|1.0b=-1,false,true
+1.0RC1|1.0RC2=-1,false,true
+7.4|8.0=-1,false,true
+|1.0=-1,false,true
+1|1.0.0=-1,false,true
+1.0.0beta2|1.0.0beta10=-1,false,true
+ext:111
+--CLEAN--
+<?php


### PR DESCRIPTION
Both were missing and blocked real-world scripts (PHPUnit's entry point). version_compare canonicalises each version -- separators (- _ +) and digit/alpha boundaries all become '.' -- then compares parts with php's special ordering (dev < alpha/a < beta/b < RC/rc < numeric < pl/p), byte-verified against php across a wide matrix including pre-release tags and length mismatches, and supporting every comparison operator form. extension_loaded reports the set of extensions PHL provides (false for the ones it lacks, e.g. dom/tokenizer/xmlwriter).

Cross-engine test function/version_compare. test-compat green under both engines; docker ASan+UBSan clean; full and tiny builds warning-free.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
