### PR TITLE
Resolve __FILE__ and __DIR__ at compile time

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -3482,6 +3482,41 @@ static sxi32 GenStateLoadLiteral(ph7_gen_state *pGen)
 			/* Emit the load constant instruction */
 			PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOADC,0,nIdx,0,0);
 			return SXRET_OK;
+	}else if( (pStr->nByte == sizeof("__FILE__") - 1 &&
+		SyMemcmp(pStr->zString,"__FILE__",sizeof("__FILE__")-1) == 0) ||
+		(pStr->nByte == sizeof("__DIR__") - 1 &&
+		SyMemcmp(pStr->zString,"__DIR__",sizeof("__DIR__")-1) == 0) ){
+			/* __FILE__ / __DIR__ are magic constants resolved at COMPILE time to the
+			 * file being compiled (where the token is written), NOT the runtime
+			 * execution file. A function defined in a.php reporting __FILE__ must say
+			 * a.php even when called from b.php — php semantics, and what Composer's
+			 * autoloader (loadClassLoader's `require __DIR__ . '/ClassLoader.php'`)
+			 * relies on. The runtime-constant path returned the caller's file. */
+			int bDir = (pStr->zString[2] == 'D'); /* __DIR__ vs __FILE__ */
+			SyString *pFile = (SyString *)SySetPeek(&pGen->pVm->aFiles);
+			pObj = PH7_ReserveConstObj(pGen->pVm,&nIdx);
+			if( pObj == 0 ){
+				PH7_GenCompileError(pGen,E_ERROR,pToken->nLine,"Fatal, PH7 engine is running out of memory");
+				return SXERR_ABORT;
+			}
+			if( pFile && pFile->nByte > 0 ){
+				if( bDir ){
+					const char *zDir;
+					int nLen;
+					SyString sDir;
+					zDir = PH7_ExtractDirName(pFile->zString,(int)pFile->nByte,&nLen);
+					SyStringInitFromBuf(&sDir,zDir,nLen);
+					PH7_MemObjInitFromString(pGen->pVm,pObj,&sDir);
+				}else{
+					PH7_MemObjInitFromString(pGen->pVm,pObj,pFile);
+				}
+			}else{
+				SyString sMem;
+				SyStringInitFromBuf(&sMem,":MEMORY:",sizeof(":MEMORY:")-1);
+				PH7_MemObjInitFromString(pGen->pVm,pObj,&sMem);
+			}
+			PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOADC,0,nIdx,0,0);
+			return SXRET_OK;
 	}else if( pStr->nByte == sizeof("__NAMESPACE__") - 1 &&
 		SyMemcmp(pStr->zString,"__NAMESPACE__",sizeof("__NAMESPACE__")-1) == 0 ){
 			/* __NAMESPACE__ magic constant: resolved at compile time */

--- a/tests/ph7/001-smoke/constants/magic_file_dir.phpt
+++ b/tests/ph7/001-smoke/constants/magic_file_dir.phpt
@@ -1,0 +1,29 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: __FILE__ and __DIR__ are compile-time and mutually consistent
+--FILE--
+<?php
+// __DIR__ is the directory part of __FILE__, resolved at compile time.
+echo (int)(__DIR__ === dirname(__FILE__)), "\n";
+echo (int)(__FILE__ === __DIR__ . DIRECTORY_SEPARATOR . basename(__FILE__)), "\n";
+// Same holds inside a function body (still the compiling file).
+function mfd_check() { return (int)(__DIR__ === dirname(__FILE__)); }
+echo mfd_check(), "\n";
+// Inside an included file, __FILE__/__DIR__ reflect that file, not the includer.
+$inc = tempnam(sys_get_temp_dir(), 'mfd');
+file_put_contents($inc, '<?php return [__FILE__, __DIR__];');
+$r = include $inc;
+echo (int)($r[1] === dirname($r[0])), "\n";
+echo (int)(basename($r[0]) === basename($inc)), "\n";
+unlink($inc);
+?>
+--EXPECT--
+1
+1
+1
+1
+1
+--CLEAN--
+<?php


### PR DESCRIPTION
Both were runtime constants (constant.c), so they reported the executing file rather than the file where the token is written. A function defined in a.php that echoes __FILE__ must say a.php even when called from b.php, and __DIR__ in a constant expression must resolve to the compiling file's directory -- which is what Composer's autoloader relies on for its `require __DIR__ . '/ClassLoader.php'`.

GenStateLoadLiteral now intercepts __FILE__/__DIR__ and emits a literal LOADC of the compiling file (SySetPeek of aFiles), using PH7_ExtractDirName for __DIR__; falls back to :MEMORY: with no source file. Cross-engine test asserts the compile-time identities (__DIR__===dirname(__FILE__), consistency inside functions and included files) path-agnostically.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
