### PR TITLE
Populate $_SERVER argv and argc on the CLI

### DIFF
--- a/src/ph7/ph7.h
+++ b/src/ph7/ph7.h
@@ -222,6 +222,7 @@ typedef int (*ph7_clock)(void *pUserData, ph7_int64 *pSec, ph7_int64 *pUsec);
 #define PH7_VM_CONFIG_RESPONSE_HEADERS 23  /* TWO ARGUMENTS: int (*xCallback)(const char *zName,unsigned int nName,const char *zValue,unsigned int nValue,void *pUserData), void *pUserData */
 #define PH7_VM_CONFIG_NATIVE_DEPTH    24  /* ONE ARGUMENT: int nMaxNativeDepth (native VmByteCodeExec nesting: eval/include, callbacks, coroutine resume; default 256 host / 16 embedded) */
 #define PH7_VM_CONFIG_INI_ENTRY       25  /* TWO ARGUMENTS: const char *zName,const char *zValue (a php.ini directive from -d/-c) */
+#define PH7_VM_CONFIG_SERVER_ARGV     26  /* NO ARGUMENTS: mirror $argv/$argc into $_SERVER['argv']/$_SERVER['argc'] */
 /*
  * Global Library Configuration Commands.
  *

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -5817,6 +5817,46 @@ PH7_PRIVATE sxi32 PH7_VmConfigure(
 		}
 		break;
 								  }
+	case PH7_VM_CONFIG_SERVER_ARGV: {
+		/* php CLI exposes the script arguments in $_SERVER['argv'] and their
+		 * count in $_SERVER['argc'], in addition to the top-level $argv/$argc.
+		 * Mirror the already-populated $argv array into $_SERVER once, after
+		 * all PH7_VM_CONFIG_ARGV_ENTRY calls are done. */
+		ph7_value *pArgv,*pServer;
+		ph7_hashmap *pServerMap,*pArgvMap,*pDup;
+		ph7_value sArgvVal,sKey,sCount;
+		pArgv   = PH7_VmExtractSuper(&(*pVm),"argv",sizeof("argv")-1);
+		pServer = PH7_VmExtractSuper(&(*pVm),"_SERVER",sizeof("_SERVER")-1);
+		if( pArgv == 0 || (pArgv->iFlags & MEMOBJ_HASHMAP) == 0
+		 || pServer == 0 || (pServer->iFlags & MEMOBJ_HASHMAP) == 0 ){
+			rc = SXERR_NOTFOUND;
+			break;
+		}
+		pArgvMap   = (ph7_hashmap *)pArgv->x.pOther;
+		pServerMap = (ph7_hashmap *)pServer->x.pOther;
+		/* Deep-copy $argv so $_SERVER['argv'] is an independent array. */
+		pDup = PH7_NewHashmap(&(*pVm),0,0);
+		if( pDup == 0 ){
+			rc = SXERR_MEM;
+			break;
+		}
+		PH7_HashmapDup(pArgvMap,pDup);
+		PH7_MemObjInitFromArray(&(*pVm),&sArgvVal,pDup);
+		PH7_MemObjInitFromString(&(*pVm),&sKey,0);
+		PH7_MemObjStringAppend(&sKey,"argv",sizeof("argv")-1);
+		PH7_HashmapInsert(pServerMap,&sKey,&sArgvVal);
+		PH7_MemObjRelease(&sArgvVal); /* drops the duplicated array */
+		PH7_MemObjRelease(&sKey);
+		/* $_SERVER['argc'] = count($argv). */
+		PH7_MemObjInitFromInt(&(*pVm),&sCount,(sxi64)pArgvMap->nEntry);
+		PH7_MemObjInitFromString(&(*pVm),&sKey,0);
+		PH7_MemObjStringAppend(&sKey,"argc",sizeof("argc")-1);
+		PH7_HashmapInsert(pServerMap,&sKey,&sCount);
+		PH7_MemObjRelease(&sCount);
+		PH7_MemObjRelease(&sKey);
+		rc = SXRET_OK;
+		break;
+								  }
 	case PH7_VM_CONFIG_INI_ENTRY: {
 		/* A php.ini directive from the CLI (-d name=value or a -c file line).
 		 * Copies are queued for the INI chunk's lazy seed; engine-level knobs

--- a/src/phl/phl.c
+++ b/src/phl/phl.c
@@ -658,6 +658,8 @@ int main(int argc,char **argv)
 			ph7_vm_config(pVm,PH7_VM_CONFIG_CREATE_VAR,"argc",pArgc);
 			ph7_release_value(pVm,pArgc);
 		}
+		/* Mirror $argv/$argc into $_SERVER['argv']/$_SERVER['argc'] (php CLI). */
+		ph7_vm_config(pVm,PH7_VM_CONFIG_SERVER_ARGV);
 		/* $_SERVER entries frameworks read at CLI bootstrap. SCRIPT_FILENAME is
 		 * already set to the script path by PH7_HashmapCreateSuper. */
 		ph7_vm_config(pVm,PH7_VM_CONFIG_SERVER_ATTR,"SCRIPT_NAME",zScriptName,-1);


### PR DESCRIPTION
Only the top-level $argv/$argc were set; php CLI also mirrors them into $_SERVER, which framework bootstraps (PHPUnit's CLI entry among them) read. A new PH7_VM_CONFIG_SERVER_ARGV op deep-copies the already-built $argv array into $_SERVER['argv'] and sets $_SERVER['argc'] to its count; phl.c invokes it right after the PH7_VM_CONFIG_ARGV_ENTRY loop.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
