### PR TITLE
Fix use-after-free in large array defaults

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -1473,6 +1473,37 @@ static sxi32 VmEnforceConstantType(ph7_vm *pVm,ph7_class *pClass,ph7_class_attr 
 static void VmBoundaryPark(ph7_vm *pVm,sxi32 rc);
 static sxi32 VmConstCycleThrow(ph7_vm *pVm);
 /*
+ * Evaluate a constant/default initializer bytecode into a pool memory-object slot,
+ * safely across a pool reallocation.
+ *
+ * VmLocalExec writes its result through the caller's pResult pointer at
+ * end-of-exec. When pResult is a slot in the growable aMemObj pool AND the
+ * initializer allocates pool memobjs — a large array literal grows aMemObj via
+ * PH7_ReserveMemObj (per element), reallocating and FREEING the pool buffer —
+ * the reserved pResult pointer dangles and the final store is a heap
+ * use-after-free (confirmed via ASan on a >=~227-element class-const array; it
+ * is what blocked Composer's autoload class-map). Evaluate into a stable local
+ * instead, then store into the slot re-fetched by its (stable) index. On return
+ * *ppMemObj points at the valid post-eval slot. PH7_MemObjStore preserves the
+ * destination slot's nIdx (excluded from its memcpy), so the slot identity is
+ * kept. Mirrors the enum-case backing path, which already evaluates into a local.
+ */
+static sxi32 VmLocalExecIntoObj(ph7_vm *pVm,SySet *pByteCode,ph7_value **ppMemObj,int bReturnPropagates)
+{
+	ph7_value sVal;
+	sxu32 nIdx = (*ppMemObj)->nIdx;
+	sxi32 rc;
+	PH7_MemObjInit(&(*pVm),&sVal);
+	rc = VmLocalExec(&(*pVm),pByteCode,&sVal,bReturnPropagates);
+	/* aMemObj may have moved during the eval — re-fetch by the reserved index. */
+	*ppMemObj = (ph7_value *)SySetAt(&pVm->aMemObj,nIdx);
+	if( *ppMemObj ){
+		PH7_MemObjStore(&sVal,*ppMemObj);
+	}
+	PH7_MemObjRelease(&sVal);
+	return rc;
+}
+/*
  * Mount a compiled class into the freshly created vitual machine so that
  * it can be instanciated from the executed PHP script.
  */
@@ -1538,7 +1569,7 @@ static sxi32 VmMountUserClassAttrs(
 				pVm->pConstEvalClass = pAttr->pDeclClass ? pAttr->pDeclClass : pClass;
 				pAttr->iFlags |= PH7_CLASS_ATTR_EVALING; /* cycle guard, shared with the on-demand path */
 				pVm->nConstEvalDepth++;
-				rcExec = VmLocalExec(&(*pVm),&pAttr->aByteCode,pMemObj,FALSE);
+				rcExec = VmLocalExecIntoObj(&(*pVm),&pAttr->aByteCode,&pMemObj,FALSE);
 				pVm->nConstEvalDepth--;
 				pAttr->iFlags &= ~PH7_CLASS_ATTR_EVALING;
 				pVm->pConstEvalClass = pSaveCtx;
@@ -1683,7 +1714,7 @@ PH7_PRIVATE sxi32 PH7_VmCreateClassInstanceFrame(
 				 * against the declaring class (no method frame here). */
 				ph7_class *pSaveCtx = pVm->pConstEvalClass;
 				pVm->pConstEvalClass = pAttr->pDeclClass ? pAttr->pDeclClass : pClass;
-				VmLocalExec(&(*pVm),&pAttr->aByteCode,pMemObj,FALSE);
+				VmLocalExecIntoObj(&(*pVm),&pAttr->aByteCode,&pMemObj,FALSE);
 				pVm->pConstEvalClass = pSaveCtx;
 			}else if( pAttr->iFlags & PH7_CLASS_ATTR_TYPED ){
 				/* Typed property without a default: mark uninitialized. Reading
@@ -6822,7 +6853,7 @@ static sxi32 VmClassConstEvalOnDemand(ph7_vm *pVm,ph7_class *pClass,ph7_class_at
 		pAttr->iFlags |= PH7_CLASS_ATTR_EVALING;
 		pVm->pConstEvalClass = pAttr->pDeclClass ? pAttr->pDeclClass : pClass;
 		pVm->nConstEvalDepth++;
-		rcExec = VmLocalExec(&(*pVm),&pAttr->aByteCode,pMemObj,FALSE);
+		rcExec = VmLocalExecIntoObj(&(*pVm),&pAttr->aByteCode,&pMemObj,FALSE);
 		pVm->nConstEvalDepth--;
 		pVm->pConstEvalClass = pSaveCtx;
 		pAttr->iFlags &= ~PH7_CLASS_ATTR_EVALING;

--- a/tests/ph7/001-smoke/constants/large_const_array_default.phpt
+++ b/tests/ph7/001-smoke/constants/large_const_array_default.phpt
@@ -1,0 +1,35 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Large array literal as a class const / static / instance default (pool-realloc safe)
+--FILE--
+<?php
+// A big array literal in a constant-expression init once triggered a
+// heap use-after-free: the result slot was a pointer into the growable
+// memobj pool, and building the array reallocated that pool mid-eval.
+// Well past the ~227-element pool-realloc boundary here.
+$n = 1000;
+$parts = [];
+for ($i = 0; $i < $n; $i++) { $parts[] = (string)$i; }
+$src = implode(',', $parts);
+
+eval("class LcadConst  { const M = [$src]; }");
+eval("class LcadStatic { public static \$p = [$src]; }");
+eval("class LcadInst   { public \$p = [$src]; }");
+
+echo count(LcadConst::M), "\n";
+echo LcadConst::M[0], ' ', LcadConst::M[$n - 1], "\n";
+echo count(LcadStatic::$p), "\n";
+$obj = new LcadInst();
+echo count($obj->p), "\n";
+echo array_sum(LcadConst::M), "\n";
+?>
+--EXPECT--
+1000
+0 999
+1000
+1000
+499500
+--CLEAN--
+<?php


### PR DESCRIPTION
The class const, static-property, instance-property, and on-demand class-constant init paths reserved their result slot with PH7_ReserveMemObj -- a pointer into the growable aMemObj pool -- and passed it straight to VmLocalExec. Evaluating a large array literal allocates one pool memobj per element (LOAD_MAP -> PH7_HashmapInsert -> HashmapInsertIntKey -> PH7_ReserveMemObj), so aMemObj reallocates and frees the buffer the reserved slot pointed at; the end-of-exec PH7_MemObjStore then writes through the dangling pointer.

The pool allocator masked it below ~227 elements (no realloc yet); past that the slot moved, producing a silent NULL constant (mount time) or corrupted operand state and a hang/empty result at larger sizes -- the same root cause behind all three regimes, and what blocked Composer's autoload_static.php class-map. Pinned with docker ASan (heap-use-after-free in PH7_MemObjStore, freed by SySetPut via VmReserveMemObj).

New VmLocalExecIntoObj helper evaluates into a stable C-stack ph7_value and stores into the slot re-fetched by its stable index after the eval, applied to all three vulnerable call sites (the enum-case backing path already evaluated into a local and is unaffected). Class const/static/ instance array defaults are now correct and fast to N>=3000, and Composer's autoloader loads fully.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
