### PR TITLE
Preserve the codegen across autoload-in-compile

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -14991,6 +14991,105 @@ PH7_PRIVATE sxi32 PH7_ResetCodeGenerator(
 	return SXRET_OK;
 }
 /*
+ * Save the code generator's compile-position state and hand the live generator a
+ * fresh, empty one for a NESTED compilation unit.
+ *
+ * A require/include normally runs at execution time, when no compile is in flight,
+ * so VmEvalChunk can call PH7_ResetCodeGenerator to wipe the generator. But an
+ * autoload can fire in the MIDDLE of compiling a class: resolving `class Child
+ * extends Base` calls PH7_VmExtractClass, which triggers the autoloader, whose
+ * body `require`s Base's file — a nested compile while the outer one is mid-token.
+ * PH7_ResetCodeGenerator would then blow away the outer compile's cursor
+ * (pIn/pEnd), current block, use-imports, labels, etc.; the outer parse resumes
+ * with pIn == NULL and reports a bogus "Expected '{' after class 'Child'". (Common
+ * in every real framework: Composer autoloads parent classes on demand.)
+ *
+ * This snapshots the position/scope fields into *pSaved (a caller-stack
+ * ph7_gen_state used purely as storage) and re-initializes the live generator's
+ * position containers to FRESH, empty ones WITHOUT releasing the outer's (the
+ * snapshot now owns those). hLiteral/hNumLiteral/hVar are intentionally left LIVE
+ * and shared — compiled bytecode interns names/literals into them and they grow
+ * monotonically (exactly why PH7_ResetCodeGenerator keeps them); restoring an old
+ * copy of those headers after a nested grow would use-after-free the bucket array.
+ */
+PH7_PRIVATE void PH7_CompilerSaveState(ph7_vm *pVm,ph7_gen_state *pSaved,ProcConsumer xErr,void *pErrData)
+{
+	ph7_gen_state *pGen = &pVm->sCodeGen;
+	/* Shallow-copy every field; the position containers below are then replaced
+	 * with fresh ones on the live struct, so *pSaved keeps the outer's memory. */
+	*pSaved = *pGen;
+	SySetInit(&pGen->aLabel,&pVm->sAllocator,sizeof(Label));
+	SySetInit(&pGen->aGoto,&pVm->sAllocator,sizeof(JumpFixup));
+	SySetInit(&pGen->aNullsafeJmp,&pVm->sAllocator,sizeof(sxu32));
+	SySetInit(&pGen->aLoopParent,&pVm->sAllocator,sizeof(sxu32));
+	SySetInit(&pGen->aTrivia,&pVm->sAllocator,sizeof(ph7_trivia));
+	SySetInit(&pGen->aPendingAttrs,&pVm->sAllocator,sizeof(ph7_trivia));
+	SyBlobInit(&pGen->sWorker,&pVm->sAllocator);
+	SyBlobInit(&pGen->sErrBuf,&pVm->sAllocator);
+	SyBlobInit(&pGen->sNamespace,&pVm->sAllocator);
+	SyHashInit(&pGen->hUseImports,&pVm->sAllocator,0,0);
+	SyHashInit(&pGen->hUseFuncImports,&pVm->sAllocator,0,0);
+	SyHashInit(&pGen->hUseConstImports,&pVm->sAllocator,0,0);
+	/* Fresh global scope for the nested unit (address of the embedded sGlobal is
+	 * stable, so any outer block still parented to it stays valid across restore). */
+	GenStateInitBlock(pGen,&pGen->sGlobal,GEN_BLOCK_GLOBAL,PH7_VmInstrLength(pVm),0);
+	pGen->pCurrent = &pGen->sGlobal;
+	pGen->pIn = pGen->pEnd = 0;
+	pGen->pRawIn = pGen->pRawEnd = 0;
+	pGen->pTokenSet = 0;
+	pGen->nErr = 0;
+	pGen->nLoopId = pGen->nCurLoopId = 0;
+	pGen->nCommaExprOk = 0;
+	pGen->bInGenerator = 0;
+	pGen->bStrictTypes = 0;
+	pGen->bStrictTypesLocked = 0;
+	SyStringInitFromBuf(&pGen->sPendingDoc,0,0);
+	pGen->xErr = xErr;
+	pGen->pErrData = pErrData;
+}
+/*
+ * Restore the outer compile-position state saved by PH7_CompilerSaveState,
+ * releasing the nested unit's position containers first. The shared
+ * hLiteral/hNumLiteral/hVar tables (grown by the nested compile) are carried
+ * forward, NOT rolled back to the snapshot's stale headers.
+ */
+PH7_PRIVATE void PH7_CompilerRestoreState(ph7_vm *pVm,ph7_gen_state *pSaved)
+{
+	ph7_gen_state *pGen = &pVm->sCodeGen;
+	GenBlock *pBlock,*pParent;
+	SyHash hVar,hLiteral,hNumLiteral;
+	/* Free any nested blocks left open (e.g. an aborted nested compile), then the
+	 * nested global block's own fixup sets. */
+	pBlock = pGen->pCurrent;
+	while( pBlock && pBlock->pParent != 0 ){
+		pParent = pBlock->pParent;
+		GenStateFreeBlock(pBlock);
+		pBlock = pParent;
+	}
+	GenStateReleaseBlock(&pGen->sGlobal);
+	/* Release the nested unit's position containers. */
+	SySetRelease(&pGen->aLabel);
+	SySetRelease(&pGen->aGoto);
+	SySetRelease(&pGen->aNullsafeJmp);
+	SySetRelease(&pGen->aLoopParent);
+	SySetRelease(&pGen->aTrivia);
+	SySetRelease(&pGen->aPendingAttrs);
+	SyBlobRelease(&pGen->sWorker);
+	SyBlobRelease(&pGen->sErrBuf);
+	SyBlobRelease(&pGen->sNamespace);
+	SyHashRelease(&pGen->hUseImports);
+	SyHashRelease(&pGen->hUseFuncImports);
+	SyHashRelease(&pGen->hUseConstImports);
+	/* Preserve the (possibly grown) shared intern tables across the restore. */
+	hVar = pGen->hVar;
+	hLiteral = pGen->hLiteral;
+	hNumLiteral = pGen->hNumLiteral;
+	*pGen = *pSaved;
+	pGen->hVar = hVar;
+	pGen->hLiteral = hLiteral;
+	pGen->hNumLiteral = hNumLiteral;
+}
+/*
  * Raise php's parse error for an unexpected token: E_PARSE with the exact text
  * php's parser prints, e.g.
  *

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -2396,6 +2396,8 @@ PH7_PRIVATE sxi32 PH7_CompileMatch(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_CompileThrowExpr(ph7_gen_state *pGen,sxi32 iCompileFlag);
 PH7_PRIVATE sxi32 PH7_InitCodeGenerator(ph7_vm *pVm,ProcConsumer xErr,void *pErrData);
 PH7_PRIVATE sxi32 PH7_ResetCodeGenerator(ph7_vm *pVm,ProcConsumer xErr,void *pErrData);
+PH7_PRIVATE void PH7_CompilerSaveState(ph7_vm *pVm,ph7_gen_state *pSaved,ProcConsumer xErr,void *pErrData);
+PH7_PRIVATE void PH7_CompilerRestoreState(ph7_vm *pVm,ph7_gen_state *pSaved);
 PH7_PRIVATE sxi32 PH7_GenCompileError(ph7_gen_state *pGen,sxi32 nErrType,sxu32 nLine,const char *zFormat,...);
 PH7_PRIVATE sxi32 PH7_GenSyntaxError(ph7_gen_state *pGen,SyToken *pTok,const char *zExpecting);
 PH7_PRIVATE sxi32 PH7_CompileScript(ph7_vm *pVm,SyString *pScript,sxi32 iFlags);

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -27020,6 +27020,8 @@ static sxi32 VmEvalChunk(
 	SyBlob sSavedNs;
 	ProcConsumer xErr = 0;
 	void *pErrData = 0;
+	ph7_gen_state sSavedGen;
+	int bNested;
 	/* Initialize bytecode container */
 	SySetInit(&aByteCode,&pVm->sAllocator,sizeof(VmInstr));
 	SySetAlloc(&aByteCode,0x20);
@@ -27029,7 +27031,16 @@ static sxi32 VmEvalChunk(
 		xErr = pVm->pEngine->xConf.xErr;
 		pErrData = pVm->pEngine->xConf.pErrData;
 	}
-	PH7_ResetCodeGenerator(pVm,xErr,pErrData);
+	/* A non-zero cursor means an OUTER compile is in flight — this eval/include
+	 * was reached from inside it (an autoload fired while resolving a base class).
+	 * Wiping the generator would corrupt that outer parse, so snapshot it and hand
+	 * the nested unit a fresh one; a plain runtime eval/include just resets. */
+	bNested = (pVm->sCodeGen.pIn != 0);
+	if( bNested ){
+		PH7_CompilerSaveState(pVm,&sSavedGen,xErr,pErrData);
+	}else{
+		PH7_ResetCodeGenerator(pVm,xErr,pErrData);
+	}
 	/* Save and reset VM namespace state for the new compilation unit.
 	 * Each included file has its own namespace scope; after execution,
 	 * the caller's namespace is restored. */
@@ -27111,6 +27122,10 @@ Cleanup:
 	SyBlobReset(&pVm->sNamespace);
 	SyBlobDup(&sSavedNs,&pVm->sNamespace);
 	SyBlobRelease(&sSavedNs);
+	/* Restore the outer compile's generator state if this was a nested unit. */
+	if( bNested ){
+		PH7_CompilerRestoreState(pVm,&sSavedGen);
+	}
 	return SXRET_OK;
 }
 /*

--- a/tests/ph7/001-smoke/oo/autoload_during_class_compile.phpt
+++ b/tests/ph7/001-smoke/oo/autoload_during_class_compile.phpt
@@ -1,0 +1,49 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Autoloading a base class/interface while compiling the child class
+--FILE--
+<?php
+// Resolving `extends`/`implements` during class compilation triggers the
+// autoloader, whose require compiles another file mid-parse. The nested
+// compile must not clobber the outer class's parse state.
+$dir = sys_get_temp_dir() . '/adc_' . getmypid();
+@mkdir($dir);
+file_put_contents("$dir/AdcBase.php",
+    '<?php class AdcBase { public function b(){ return 7; } }');
+file_put_contents("$dir/AdcIface.php",
+    '<?php interface AdcIface { public function tag(): string; }');
+file_put_contents("$dir/AdcChild.php",
+    '<?php class AdcChild extends AdcBase implements AdcIface, Countable {'
+  . ' const K = [1, 2, 3];'
+  . ' private ?bool $flag = null;'
+  . ' public function tag(): string { return "child"; }'
+  . ' public function count(): int { return count(self::K); } }');
+spl_autoload_register(function ($c) use ($dir) {
+    $f = "$dir/$c.php";
+    if (is_file($f)) { require $f; }
+});
+
+echo class_exists('AdcChild') ? "loaded\n" : "missing\n";
+$o = new AdcChild();
+echo $o->b(), "\n";
+echo $o->tag(), "\n";
+echo count($o), "\n";
+echo ($o instanceof AdcBase) ? "isbase\n" : "no\n";
+echo ($o instanceof AdcIface) ? "isiface\n" : "no\n";
+
+@unlink("$dir/AdcBase.php");
+@unlink("$dir/AdcIface.php");
+@unlink("$dir/AdcChild.php");
+@rmdir($dir);
+?>
+--EXPECT--
+loaded
+7
+child
+3
+isbase
+isiface
+--CLEAN--
+<?php


### PR DESCRIPTION
PHL resolves a class's extends/implements clause at compile time (GenStateCompileClassEx -> PH7_VmExtractClass), which triggers the autoloader when the base class or interface is not yet loaded. The autoload callback's require runs VmEvalChunk, which reset the code generator unconditionally -- wiping the OUTER compile's token cursor (pIn/pEnd), current block, use-imports and labels. Done in the middle of compiling the child class, the outer parse resumed with pIn == NULL and reported a bogus "Expected '{' after class 'X' declaration". This breaks every real autoloaded class hierarchy (e.g. Composer loading PHPUnit's TestCase, whose parent Assert and three interfaces autoload on demand).

The corruption was layout-sensitive -- an unrelated allocation masked it -- but reproduces deterministically under the pool-bypass ASan build, where pIn goes non-null -> (nil) across the PH7_VmExtractClass call.

VmEvalChunk now detects a nested compilation unit (pVm->sCodeGen.pIn is non-zero: an outer compile is mid-stream) and snapshots/restores the generator's compile-position state via new PH7_CompilerSaveState / PH7_CompilerRestoreState instead of resetting it. The nested compile gets fresh, empty position containers; hLiteral/hNumLiteral/hVar stay live and shared (bytecode interns into them and they grow monotonically, so the grown headers are carried forward rather than rolled back -- rolling back would use-after-free the bucket array). A plain runtime eval/include, with no compile in flight, still takes the reset path.

class_exists('PHPUnit\\Framework\\TestCase') now returns true. New cross-engine test oo/autoload_during_class_compile.phpt.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
