### PR TITLE
Boot PHPUnit: catch(), new self, gc builtins

### DIFF
--- a/src/ph7/api.c
+++ b/src/ph7/api.c
@@ -42,7 +42,7 @@ static struct Global_Data
 	ph7 *pEngines;                          /* List of active engine */
 	sxu32 nMagic;                           /* Sanity check against library misuse */
 }sMPGlobal = {
-	{0,0,0,0,0,0,0,0,0,{0}},
+	{0,0,0,0,0,0,0,0,0,0,0,{0}},
 #if defined(PH7_ENABLE_THREADS)
 	0,
 	0,

--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -9538,7 +9538,110 @@ static int PH7_builtin_urldecode(ph7_context *pCtx,int nArg,ph7_value **apArg)
 }
 #endif /* PH7_NEED_BUILTIN_REG */
 /* Table of the built-in functions */
+/*
+ * int memory_get_usage([bool $real_usage = false])
+ *  Amount of memory, in bytes, currently allocated to the script through PHL's
+ *  memory backend. PHL tracks the backend's real allocated bytes, so the
+ *  $real_usage flag has no effect here (php's non-real figure would be smaller,
+ *  reflecting Zend's emalloc bookkeeping — recorded divergence).
+ */
+static int PH7_builtin_memory_get_usage(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	SXUNUSED(nArg);
+	SXUNUSED(apArg);
+	ph7_result_int64(pCtx,(ph7_int64)pCtx->pVm->sAllocator.nMemUsed);
+	return PH7_OK;
+}
+/*
+ * int memory_get_peak_usage([bool $real_usage = false])
+ *  High-water mark of memory_get_usage() over the script's lifetime.
+ */
+static int PH7_builtin_memory_get_peak_usage(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	SXUNUSED(nArg);
+	SXUNUSED(apArg);
+	ph7_result_int64(pCtx,(ph7_int64)pCtx->pVm->sAllocator.nMemPeak);
+	return PH7_OK;
+}
+/*
+ * PHL frees values by reference count as they go out of scope, so there is no
+ * mark-and-sweep cycle collector to drive. The gc_* family is provided for
+ * source compatibility (real frameworks call it around test runs): the state is
+ * observational and collection is a no-op. Recorded divergence from php, whose
+ * collector actually reclaims reference cycles.
+ */
+static int PH7_builtin_gc_enable(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	SXUNUSED(nArg); SXUNUSED(apArg);
+	pCtx->pVm->bGcEnabled = 1;
+	return PH7_OK;
+}
+static int PH7_builtin_gc_disable(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	SXUNUSED(nArg); SXUNUSED(apArg);
+	pCtx->pVm->bGcEnabled = 0;
+	return PH7_OK;
+}
+static int PH7_builtin_gc_enabled(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	SXUNUSED(nArg); SXUNUSED(apArg);
+	ph7_result_bool(pCtx,pCtx->pVm->bGcEnabled);
+	return PH7_OK;
+}
+static int PH7_builtin_gc_collect_cycles(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	/* No cycle collector: nothing to reclaim. Returns the count collected (0). */
+	SXUNUSED(nArg); SXUNUSED(apArg);
+	ph7_result_int(pCtx,0);
+	return PH7_OK;
+}
+static int PH7_builtin_gc_mem_caches(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	SXUNUSED(nArg); SXUNUSED(apArg);
+	ph7_result_int(pCtx,0);
+	return PH7_OK;
+}
+/*
+ * array gc_status(void)
+ *  php 8.3 shape. PHL never runs a collection, so every counter is zero and the
+ *  timing fields are 0.0; 'running' reflects gc_enable()/gc_disable().
+ */
+static int PH7_builtin_gc_status(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	ph7_value *pArray,*pVal;
+	SXUNUSED(nArg); SXUNUSED(apArg);
+	pArray = ph7_context_new_array(pCtx);
+	pVal = ph7_context_new_scalar(pCtx);
+	if( pArray == 0 || pVal == 0 ){
+		ph7_result_null(pCtx);
+		return PH7_OK;
+	}
+	/* Key order matches php 8.3's gc_status(). */
+	ph7_value_bool(pVal,pCtx->pVm->bGcEnabled); ph7_array_add_strkey_elem(pArray,"running",pVal);
+	ph7_value_bool(pVal,0);      ph7_array_add_strkey_elem(pArray,"protected",pVal);
+	ph7_value_bool(pVal,0);      ph7_array_add_strkey_elem(pArray,"full",pVal);
+	ph7_value_int(pVal,0);       ph7_array_add_strkey_elem(pArray,"runs",pVal);
+	ph7_value_int(pVal,0);       ph7_array_add_strkey_elem(pArray,"collected",pVal);
+	ph7_value_int(pVal,1000);    ph7_array_add_strkey_elem(pArray,"threshold",pVal);
+	ph7_value_int(pVal,0);       ph7_array_add_strkey_elem(pArray,"buffer_size",pVal);
+	ph7_value_int(pVal,0);       ph7_array_add_strkey_elem(pArray,"roots",pVal);
+	ph7_value_double(pVal,0.0);  ph7_array_add_strkey_elem(pArray,"application_time",pVal);
+	ph7_value_double(pVal,0.0);  ph7_array_add_strkey_elem(pArray,"collector_time",pVal);
+	ph7_value_double(pVal,0.0);  ph7_array_add_strkey_elem(pArray,"destructor_time",pVal);
+	ph7_value_double(pVal,0.0);  ph7_array_add_strkey_elem(pArray,"free_time",pVal);
+	ph7_context_release_value(pCtx,pVal);
+	ph7_result_value(pCtx,pArray);
+	return PH7_OK;
+}
 static const ph7_builtin_func aBuiltInFunc[] = {
+	{ "memory_get_usage"     , PH7_builtin_memory_get_usage      },
+	{ "memory_get_peak_usage", PH7_builtin_memory_get_peak_usage },
+	{ "gc_enable"            , PH7_builtin_gc_enable             },
+	{ "gc_disable"           , PH7_builtin_gc_disable            },
+	{ "gc_enabled"           , PH7_builtin_gc_enabled            },
+	{ "gc_collect_cycles"    , PH7_builtin_gc_collect_cycles     },
+	{ "gc_mem_caches"        , PH7_builtin_gc_mem_caches         },
+	{ "gc_status"            , PH7_builtin_gc_status             },
 	   /* Variable handling functions */
 	{ "is_bool"    , PH7_builtin_is_bool     },
 	{ "is_float"   , PH7_builtin_is_float    },

--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -12293,6 +12293,12 @@ static sxi32 GenStateParseCatchHeader(ph7_gen_state *pGen, ph7_exception_block *
 		}
 		break;
 	}
+	/* PHP 8.0 non-capturing catch: `catch (Type)` / `catch (A|B)` with no
+	 * variable. sThis stays empty (SyZero'd above) so the runtime skips binding. */
+	if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_RPAREN) ){
+		pGen->pIn++; /* ')' */
+		return SXRET_OK;
+	}
 	if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_DOLLAR) == 0 ||
 		&pGen->pIn[1] >= pGen->pEnd || (pGen->pIn[1].nType & (PH7_TK_ID|PH7_TK_KEYWORD)) == 0 ){
 		pToken = pGen->pIn; if( pToken >= pGen->pEnd ){ pToken--; }
@@ -12510,6 +12516,12 @@ static sxi32 PH7_CompileCatch(ph7_gen_state *pGen,ph7_exception *pException)
 		}
 		break;
 	}
+	/* PHP 8.0 non-capturing catch: `catch (Type)` / `catch (A|B)` with no
+	 * variable. sThis stays empty (SyZero'd above) so the runtime skips binding;
+	 * jump straight to compiling the block below. */
+	if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_RPAREN) /*)*/ ){
+		goto CatchBody;
+	}
 	if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_DOLLAR) == 0 /*$*/ ||
 		&pGen->pIn[1] >= pGen->pEnd || (pGen->pIn[1].nType & (PH7_TK_ID|PH7_TK_KEYWORD)) == 0 ){
 			/* Unexpected token,break immediately */
@@ -12534,6 +12546,7 @@ static sxi32 PH7_CompileCatch(ph7_gen_state *pGen,ph7_exception *pException)
 	}
 	SyStringInitFromBuf(&sCatch.sThis,zDup,pName->nByte);
 	pGen->pIn++;
+CatchBody:
 	if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_RPAREN) == 0 /*)*/ ){
 		/* Unexpected token,break immediately */
 		pToken = pGen->pIn;
@@ -13786,7 +13799,26 @@ static sxi32 GenStateEmitExprCode(
 					}
 					pPeek->iP1 = 0;
 					if( !bAbsolute ){
-						pPeek->iP2 = (sxi32)GenStateNsQualifyName(pGen,nLitForClass,&pGen->hUseImports,0);
+						/* self/static/parent are resolved at runtime against the
+						 * current class — never namespace-qualify them (else
+						 * `new self` in namespace N becomes "N\self"). Mirrors the
+						 * instanceof (IS_A) guard below. */
+						ph7_value *pLitChk = (ph7_value *)SySetAt(&pGen->pVm->aLitObj,nLitForClass);
+						int isSpecialNew = 0;
+						if( pLitChk && (pLitChk->iFlags & MEMOBJ_STRING) ){
+							const char *z = (const char *)SyBlobData(&pLitChk->sBlob);
+							sxu32 n = (sxu32)SyBlobLength(&pLitChk->sBlob);
+							if( (n == 4 && SyMemcmp(z,"self",4) == 0) ||
+								(n == 6 && SyMemcmp(z,"static",6) == 0) ||
+								(n == 6 && SyMemcmp(z,"parent",6) == 0) ){
+								isSpecialNew = 1;
+							}
+						}
+						if( isSpecialNew ){
+							pPeek->iP2 = (sxi32)nLitForClass;
+						}else{
+							pPeek->iP2 = (sxi32)GenStateNsQualifyName(pGen,nLitForClass,&pGen->hUseImports,0);
+						}
 					}else{
 						pPeek->iP2 = (sxi32)nLitForClass;
 					}

--- a/src/ph7/constant.c
+++ b/src/ph7/constant.c
@@ -77,6 +77,56 @@ static void PH7_OS_Const(ph7_value *pVal,void *pUnused)
 	SXUNUSED(pUnused);
 }
 /*
+ * PHP_OS_FAMILY (php 7.2)
+ *  One of 'Windows', 'BSD', 'Darwin', 'Solaris', 'Linux' or 'Unknown', derived
+ *  from the host's uname sysname (php maps the same set at build time).
+ */
+static void PH7_OS_FAMILY_Const(ph7_value *pVal,void *pUnused)
+{
+	SXUNUSED(pUnused);
+#if defined(__WINNT__)
+	ph7_value_string(pVal,"Windows",(int)sizeof("Windows")-1);
+#elif defined(__UNIXES__)
+	struct utsname sInfo;
+	const char *zFamily = "Unknown";
+	if( uname(&sInfo) == 0 ){
+		const char *z = sInfo.sysname;
+		if( SyStrnicmp(z,"Darwin",sizeof("Darwin")-1) == 0 ){
+			zFamily = "Darwin";
+		}else if( SyStrnicmp(z,"Linux",sizeof("Linux")-1) == 0 ){
+			zFamily = "Linux";
+		}else if( SyStrnicmp(z,"SunOS",sizeof("SunOS")-1) == 0 ){
+			zFamily = "Solaris";
+		}else{
+			/* FreeBSD/OpenBSD/NetBSD/DragonFly -> 'BSD' (scan for "BSD"). */
+			const char *p = z;
+			while( p[0] && p[1] && p[2] ){
+				if( (p[0]=='B'||p[0]=='b') && (p[1]=='S'||p[1]=='s') && (p[2]=='D'||p[2]=='d') ){
+					zFamily = "BSD";
+					break;
+				}
+				p++;
+			}
+		}
+	}
+	ph7_value_string(pVal,zFamily,-1);
+#else
+	ph7_value_string(pVal,"Unknown",(int)sizeof("Unknown")-1);
+#endif
+}
+/*
+ * PHP_SAPI
+ *  The interface between the interpreter and the host. PHL's host binary is a
+ *  command-line interpreter, so this is "cli" (matching the CLI default of
+ *  php_sapi_name(); the built-in -S server's per-request "cli-server" flavour is
+ *  only surfaced by php_sapi_name(), not this compile-time constant).
+ */
+static void PH7_SAPI_Const(ph7_value *pVal,void *pUnused)
+{
+	SXUNUSED(pUnused);
+	ph7_value_string(pVal,"cli",(int)sizeof("cli")-1);
+}
+/*
  * PHP_EOL
  *  Expand the correct 'End Of Line' symbol for this platform.
  */
@@ -2065,6 +2115,8 @@ static const ph7_builtin_constant aBuiltIn[] = {
 	{"PHP_EXTRA_VERSION",    PH7_PHPExtraConst  },
 	{"PHP_VERSION_ID",       PH7_PHPVerIdConst  },
 	{"PHP_OS",               PH7_OS_Const       },
+	{"PHP_OS_FAMILY",        PH7_OS_FAMILY_Const},
+	{"PHP_SAPI",             PH7_SAPI_Const     },
 	{"PHP_EOL",              PH7_EOL_Const      },
 	{"PHP_SESSION_DISABLED", PH7_PHP_SESSION_DISABLED_Const },
 	{"PHP_SESSION_NONE",     PH7_PHP_SESSION_NONE_Const },

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1400,6 +1400,9 @@ struct ph7_vm
 	void *pStdout;             /* STDOUT IO stream */
 	void *pStderr;             /* STDERR IO stream */
 	int bErrReport;            /* TRUE to report all runtime Error/Warning/Notice */
+	int bGcEnabled;            /* gc_enable()/gc_disable() state reported by gc_enabled()/
+	                            * gc_status(); PHL frees by refcount, so the cycle collector
+	                            * is a no-op and this flag is purely observational. */
 	sxi32 iErrMask;      /* error_reporting() level. PH7 collapsed it to the bErrReport
 	                      * boolean, so E_ALL & ~E_DEPRECATED still printed every
 	                      * deprecation — any non-zero level meant "report all". */

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -2499,6 +2499,11 @@ static int vm_builtin_Closure_fromCallable(ph7_context *pCtx, int nArg, ph7_valu
    "   'hash' => 1, 'filter' => 1, 'session' => 1, 'libxml' => 1, 'xml' => 1);"\
    "  return isset($ext[strtolower((string)$name)]);"\
    "}"\
+   "function get_loaded_extensions($zend_extensions = false){"\
+   "  if( $zend_extensions ){ return array(); }"\
+   "  return array('Core','date','libxml','pcre','SPL','json','standard',"\
+   "   'ctype','filter','hash','Reflection','session','mbstring','xml');"\
+   "}"\
    "/* Inverse of bin2hex() */"\
    "function hex2bin($str){"\
    "  $str = (string)$str;"\
@@ -3015,6 +3020,7 @@ PH7_PRIVATE sxi32 PH7_VmInit(
 	SyZero(pVm,sizeof(ph7_vm));
 	/* Initialize VM fields */
 	pVm->pEngine = &(*pEngine);
+	pVm->bGcEnabled = 1; /* php default: the cycle collector is enabled */
 	SyMemBackendInitFromParent(&pVm->sAllocator,&pEngine->sAllocator);
 	/* Instructions containers */
 	SySetInit(&pVm->aByteCode,&pVm->sAllocator,sizeof(VmInstr));
@@ -3794,6 +3800,12 @@ static const struct VmBuiltinSig {
 	{ "func_num_args", "", "int" },
 	{ "function_exists", "string $function", "bool" },
 	{ "fwrite", "$stream, string $data, ?int $length = NULL", "int|false" },
+	{ "gc_collect_cycles", "", "int" },
+	{ "gc_disable", "", "void" },
+	{ "gc_enable", "", "void" },
+	{ "gc_enabled", "", "bool" },
+	{ "gc_mem_caches", "", "int" },
+	{ "gc_status", "", "array" },
 	{ "get_called_class", "", "string" },
 	{ "get_class", "object $object = ?", "string" },
 	{ "get_class_methods", "object|string $object_or_class", "array" },
@@ -3893,6 +3905,8 @@ static const struct VmBuiltinSig {
 	{ "md5", "string $string, bool $binary = false", "string" },
 	{ "md5_file", "string $filename, bool $binary = false", "string|false" },
 	{ "method_exists", "$object_or_class, string $method", "bool" },
+	{ "memory_get_peak_usage", "bool $real_usage = false", "int" },
+	{ "memory_get_usage", "bool $real_usage = false", "int" },
 	{ "microtime", "bool $as_float = false", "string|float" },
 	{ "min", "mixed $value, mixed ...$values = ?", "mixed" },
 	{ "mkdir", "string $directory, int $permissions = 511, bool $recursive = false, $context = NULL", "bool" },
@@ -14924,7 +14938,9 @@ case PH7_OP_CATCH: {
 	ph7_class_instance *pBind = pExc ? pExc->pInflight : 0;
 	VmFrame *pBody = VmSkipExceptionFrames(pVm->pFrame);
 	pBody->iFlags &= ~VM_FRAME_THROW;
-	if( pCatch && pBind ){
+	if( pCatch && pBind && pCatch->sThis.nByte > 0 ){
+		/* sThis empty => PHP 8.0 non-capturing catch (catch (Type) {}): the
+		 * exception is caught but not bound to any variable. */
 		ph7_value *pObj = VmExtractMemObj(&(*pVm),&pCatch->sThis,FALSE,TRUE);
 		if( pObj ){
 			/* Overwrite-then-release (mirrors PH7_MemObjStore): pin the new instance,
@@ -26052,7 +26068,9 @@ Rethrow:
 			 * stays 0, so the try-frame-only paths (all guarded by iExceptionJump>0)
 			 * are unaffected. Must be set BEFORE binding $e below. */
 			pFrame->iFlags |= VM_FRAME_CATCH | VM_FRAME_EXCEPTION;
-			pObj = VmExtractMemObj(&(*pVm),&pCatch->sThis,FALSE,TRUE);
+			/* sThis empty => PHP 8.0 non-capturing catch: caught, not bound. */
+			pObj = (pCatch->sThis.nByte > 0)
+				? VmExtractMemObj(&(*pVm),&pCatch->sThis,FALSE,TRUE) : 0;
 			if( pObj ){
 				/* The catch variable now resolves in the (shared) enclosing frame,
 				 * so it may already hold a value from a prior catch or assignment.

--- a/src/sx/sxmem.c
+++ b/src/sx/sxmem.c
@@ -175,6 +175,11 @@ static void * MemBackendAlloc(SyMemBackend *pBackend,sxu32 nByte)
 #if defined(UNTRUST)
 	pBlock->nGuard = SXMEM_BACKEND_MAGIC;
 #endif
+	pBlock->nSize = nByte;
+	pBackend->nMemUsed += nByte;
+	if( pBackend->nMemUsed > pBackend->nMemPeak ){
+		pBackend->nMemPeak = pBackend->nMemUsed;
+	}
 	pBackend->nBlock++;
 	return (void *)&pBlock[1];
 }
@@ -216,6 +221,10 @@ static void * MemBackendRealloc(SyMemBackend *pBackend,void * pOld,sxu32 nByte)
 	}
 	pPrev = pBlock->pPrev;
 	pNext = pBlock->pNext;
+	{
+		/* Old size, captured before realloc may move/free the block; the
+		 * live-byte counter is adjusted by the delta only on success below. */
+		sxu32 nOld = pBlock->nSize;
 	for(;;){
 		pNew = (SyMemBlock *)pBackend->pMethods->xRealloc(pBlock,nByte);
 		if( pNew != 0 || pBackend->xMemError == 0 || nRetry > SXMEM_BACKEND_RETRY ||
@@ -240,7 +249,15 @@ static void * MemBackendRealloc(SyMemBackend *pBackend,void * pOld,sxu32 nByte)
 		pNew->nGuard = SXMEM_BACKEND_MAGIC;
 #endif
 	}
+	/* Apply the size delta to the live-byte counter (underflow-guarded). */
+	pBackend->nMemUsed = (pBackend->nMemUsed >= nOld) ? (pBackend->nMemUsed - nOld) : 0;
+	pBackend->nMemUsed += nByte;
+	if( pBackend->nMemUsed > pBackend->nMemPeak ){
+		pBackend->nMemPeak = pBackend->nMemUsed;
+	}
+	pNew->nSize = nByte;
 	return (void *)&pNew[1];
+	}
 }
 PH7_PRIVATE void * SyMemBackendRealloc(SyMemBackend *pBackend,void * pOld,sxu32 nByte)
 {
@@ -277,6 +294,8 @@ static sxi32 MemBackendFree(SyMemBackend *pBackend,void * pChunk)
 #endif
 		MACRO_LD_REMOVE(pBackend->pBlocks,pBlock);
 		pBackend->nBlock--;
+		pBackend->nMemUsed = (pBackend->nMemUsed >= pBlock->nSize)
+			? (pBackend->nMemUsed - pBlock->nSize) : 0;
 		pBackend->pMethods->xFree(pBlock);
 	}
 	return SXRET_OK;

--- a/src/sx/sxmem.h
+++ b/src/sx/sxmem.h
@@ -22,6 +22,9 @@ typedef struct SyMemBlock SyMemBlock;
 struct SyMemBlock
 {
 	SyMemBlock *pNext,*pPrev; /* Chain of allocated memory blocks */
+	sxu32 nSize;              /* Total bytes of this block (incl. this header), so the
+	                           * backend's live-byte counter can be decremented on free
+	                           * (feeds memory_get_usage()). */
 #ifdef UNTRUST
 	sxu32 nGuard;             /* magic number associated with each valid block,so we
 	                           * can detect misuse.
@@ -44,6 +47,10 @@ struct SyMemBackend
 	const SyMemMethods *pMethods;  /* Memory allocation methods */
 	SyMemBlock *pBlocks;           /* List of valid memory blocks */
 	sxu32 nBlock;                  /* Total number of memory blocks allocated so far */
+	sxu32 nMemUsed;                /* Live bytes currently allocated through this backend
+	                                * (direct + pool buckets; pool sub-allocations are
+	                                * covered by their bucket). Feeds memory_get_usage(). */
+	sxu32 nMemPeak;                /* High-water mark of nMemUsed (memory_get_peak_usage()). */
 	ProcMemError xMemError;        /* Out-of memory callback */
 	void *pUserData;               /* First arg to xMemError() */
 	SyMutex *pMutex;               /* Per instance mutex */

--- a/tests/ph7/001-smoke/lang/catch_non_capturing.phpt
+++ b/tests/ph7/001-smoke/lang/catch_non_capturing.phpt
@@ -1,0 +1,47 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Non-capturing catch (PHP 8.0): catch (Type) / catch (A|B) with no variable
+--FILE--
+<?php
+// Single type, no variable.
+try {
+    throw new RuntimeException('boom');
+} catch (RuntimeException) {
+    echo "caught single\n";
+}
+
+// Union type, no variable.
+try {
+    throw new LogicException('x');
+} catch (RuntimeException|LogicException) {
+    echo "caught union\n";
+}
+
+// Capturing catch still works and binds the variable.
+try {
+    throw new Exception('msg');
+} catch (Exception $e) {
+    echo "caught var: ", $e->getMessage(), "\n";
+}
+
+// Non-capturing inside a generator body (inline try/catch path).
+function ncgen() {
+    try {
+        throw new Exception('g');
+    } catch (Exception) {
+        yield "gen caught\n";
+    }
+}
+foreach (ncgen() as $line) {
+    echo $line;
+}
+?>
+--EXPECT--
+caught single
+caught union
+caught var: msg
+gen caught
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/oo/new_self_static_parent_namespaced.phpt
+++ b/tests/ph7/001-smoke/oo/new_self_static_parent_namespaced.phpt
@@ -1,0 +1,37 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+new self / new static / new parent are not namespace-qualified
+--FILE--
+<?php
+namespace Nsspc\App;
+
+class Base {
+    public function who(): string { return 'base'; }
+    public static function make(): static { return new static(); }
+    private static ?self $inst = null;
+    public static function singleton(): self { return self::$inst ??= new self(); }
+}
+
+class Child extends Base {
+    public function who(): string { return 'child'; }
+    // No return type hint here: this test is about `new parent()`, and a `: Base`
+    // hint would tangle with the separate return-type namespace-qualification issue.
+    public function makeParent() { return new parent(); }
+}
+
+echo (new Child())->who(), "\n";          // child
+echo Child::make()->who(), "\n";          // child (new static)
+echo (new Child())->makeParent()->who(), "\n"; // base (new parent)
+echo Base::singleton()->who(), "\n";      // base (new self)
+echo \get_class(Base::singleton()), "\n"; // Nsspc\App\Base
+?>
+--EXPECT--
+child
+child
+base
+base
+Nsspc\App\Base
+--CLEAN--
+<?php


### PR DESCRIPTION
Getting PHPUnit 11.5.56's runner to start under PHL (`phpunit --version` now prints its banner) surfaced a batch of real, common gaps, fixed here:

- Non-capturing catch (PHP 8.0): `catch (Type)` / `catch (A|B)` with no variable. Both catch header parsers (the generator-inline GenStateParseCatchHeader and the legacy PH7_CompileCatch) now accept a missing `$var`; sThis stays empty and the two runtime bind sites skip the bind. Test lang/catch_non_capturing.phpt.

- `new self` / `new static` / `new parent` were namespace-qualified (e.g. `new self` in namespace N became "N\self"). The OP_NEW class-name path lacked the self/static/parent guard the instanceof path already had; added it. Test oo/new_self_static_parent_namespaced.phpt.

- memory_get_usage() / memory_get_peak_usage(): backed by a new real live-byte counter on SyMemBackend (nMemUsed / nMemPeak, maintained in MemBackendAlloc/Realloc/Free via a per-block nSize). Reports real backend bytes; php's non-real emalloc figure is smaller (recorded divergence).

- gc_enable/gc_disable/gc_enabled/gc_collect_cycles/gc_mem_caches/gc_status: PHL frees by reference count with no cycle collector, so these are observational no-ops (gc_status() matches php 8.3's key order).

- get_loaded_extensions(), and the PHP_OS_FAMILY and PHP_SAPI ("cli") constants.

Verified: make (full + MODE=tiny), test-compat green on both engines, docker ASan+UBSan clean over smoke + integration (the SyMemBlock layout change is memory-safe).

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
