### PR TITLE
Namespace-qualify named class type hints

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -7032,6 +7032,7 @@ struct PhlTypeAtom {
 static sxi32 GenStateParseOneTypeAtom(ph7_gen_state *pGen, PhlTypeAtom *pOut)
 {
 	SyToken *pIn = pGen->pIn;
+	int bAbsolute = 0;
 	SyZero(pOut, sizeof(*pOut));
 	SyStringInitFromBuf(&pOut->sClass, 0, 0);
 	if( pIn >= pGen->pEnd ){
@@ -7039,6 +7040,7 @@ static sxi32 GenStateParseOneTypeAtom(ph7_gen_state *pGen, PhlTypeAtom *pOut)
 	}
 	/* Optional leading namespace separator '\' on FQN class types */
 	if( pIn->nType & PH7_TK_NSSEP ){
+		bAbsolute = 1; /* fully-qualified: never prefix the current namespace */
 		pIn++;
 		if( pIn >= pGen->pEnd ){
 			return SXERR_SYNTAX;
@@ -7099,6 +7101,25 @@ static sxi32 GenStateParseOneTypeAtom(ph7_gen_state *pGen, PhlTypeAtom *pOut)
 				const char *zEnd = pLast->sData.zString + pLast->sData.nByte;
 				pOut->sClass.zString = zFirst;
 				pOut->sClass.nByte = (sxu32)(zEnd - zFirst);
+			}
+			/* Namespace-qualify a bare (single-segment, non-absolute) class type so
+			 * a `: Base` / `Base $x` hint in namespace N resolves to N\Base (or a
+			 * `use` alias) at type-check time instead of the global \Base — mirrors
+			 * the NEW/CALL/instanceof qualification. Absolute (\Base) and already-
+			 * qualified (A\B) names are left as written, matching GenStateNsQualifyName. */
+			if( !bAbsolute && pLast == pFirst ){
+				SyBlob sFqn;
+				SyBlobInit(&sFqn,&pGen->pVm->sAllocator);
+				GenStateResolveName(pGen,&pOut->sClass,&sFqn);
+				if( SyBlobLength(&sFqn) != pOut->sClass.nByte
+				 || SyMemcmp(SyBlobData(&sFqn),(const void *)pOut->sClass.zString,pOut->sClass.nByte) != 0 ){
+					char *zDup = SyMemBackendStrDup(&pGen->pVm->sAllocator,
+						(const char *)SyBlobData(&sFqn),SyBlobLength(&sFqn));
+					if( zDup ){
+						SyStringInitFromBuf(&pOut->sClass,zDup,SyBlobLength(&sFqn));
+					}
+				}
+				SyBlobRelease(&sFqn);
 			}
 		}
 	}

--- a/tests/ph7/001-smoke/oo/type_hint_namespace_qualified.phpt
+++ b/tests/ph7/001-smoke/oo/type_hint_namespace_qualified.phpt
@@ -1,0 +1,43 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Named return/param type hints resolve against the current namespace
+--FILE--
+<?php
+namespace RtnqOther {
+    class Widget { public string $w = 'other-widget'; }
+}
+namespace {
+    class RtnqBase { public string $g = 'global'; }
+    class RtnqWidget { public string $g = 'global-widget'; }
+}
+namespace RtnqApp {
+    use RtnqOther\Widget as AliasedWidget;
+
+    class RtnqBase { public string $n = 'ns'; }
+
+    class Service {
+        // Bare name must resolve to RtnqApp\RtnqBase, not the global \RtnqBase.
+        public function ret(): RtnqBase { return new RtnqBase(); }
+        public function param(RtnqBase $b): string { return $b->n; }
+        // Absolute name keeps the global class.
+        public function abs(\RtnqBase $b): string { return $b->g; }
+        // `use` alias resolves to the imported FQN.
+        public function alias(AliasedWidget $w): string { return $w->w; }
+    }
+
+    $s = new Service();
+    echo \get_class($s->ret()), "\n";
+    echo $s->param(new RtnqBase()), "\n";
+    echo $s->abs(new \RtnqBase()), "\n";
+    echo $s->alias(new \RtnqOther\Widget()), "\n";
+}
+?>
+--EXPECT--
+RtnqApp\RtnqBase
+ns
+global
+other-widget
+--CLEAN--
+<?php


### PR DESCRIPTION
A named return/parameter type hint was captured verbatim from its tokens and never namespace-qualified, so inside `namespace N` a `function f(): Base` (or `f(Base $x)`) hint resolved `Base` to the global \Base when one existed instead of N\Base -- php resolves it to N\Base. The mismatch was masked whenever no global collision existed; it surfaced as a spurious "Return value must be of type Base, N\Base returned" TypeError.

GenStateParseOneTypeAtom now qualifies a bare (single-segment, non-absolute) class type through GenStateResolveName, applying `use` aliases and the current namespace exactly like the NEW/CALL/instanceof paths. self/static/parent (the keyword branch) and the scalar/void/never/ null words are untouched; absolute \Base and already-qualified A\B names are left as written. This also corrects the reflection type text and the TypeError message to php's fully-qualified form.

Test oo/type_hint_namespace_qualified.phpt. test-compat green on both engines, MODE=tiny builds, docker ASan+UBSan clean.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
