### PR TITLE
Advance PHPUnit boot: const self::, octal 0o

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -721,6 +721,21 @@ static int GenStateIntLiteralOverflows(const SyString *pNum, ph7_real *pReal, in
 		  *pReal = dv;
 		}
 		return TRUE;
+	}else if( z[0] == '0' && (z + 1) < zEnd && (z[1] == 'o' || z[1] == 'O') ){
+		/* PHP 8.1 explicit octal 0o/0O: 21 significant octal digits fit in int64. */
+		p = z + 2;
+		while( p < zEnd && p[0] == '0' ){ p++; }
+		for( q = p, n = 0; q < zEnd && q[0] >= '0' && q[0] <= '7'; q++ ){ n++; }
+		if( n <= 21 ){
+			return FALSE;
+		}
+		{ ph7_real dv = 0;
+		  for( q = p; q < zEnd && q[0] >= '0' && q[0] <= '7'; q++ ){
+			dv = dv * 8 + (ph7_real)(q[0] - '0');
+		  }
+		  *pReal = dv;
+		}
+		return TRUE;
 	}else if( z[0] == '0' ){
 		/* Octal: INT64_MAX == 0o777...7 (21 significant octal digits). Skip the
 		 * leading zeros (incl. the base '0'); a non-octal char such as the 8.1
@@ -7029,6 +7044,30 @@ struct PhlTypeAtom {
  * is advanced past the atom. The previous nullable `?` prefix must
  * already be consumed by the caller.
  */
+/*
+ * TRUE if pName is a reserved PHP type keyword (never a class name), so a type
+ * hint that spells it must not be namespace-qualified. Only the words that can
+ * reach GenStateParseOneTypeAtom's identifier branch as a bare name matter here
+ * (bool/int/float/string/array/object/self/static/parent arrive as keywords, and
+ * null/void/never are matched before the class path), but the full set is listed
+ * so the guard is robust to lexer changes.
+ */
+static int GenStateIsReservedTypeWord(const SyString *pName)
+{
+	static const char *azWords[] = {
+		"false","true","mixed","iterable","callable","null","void","never",
+		"bool","boolean","int","integer","float","double","string","array",
+		"object","self","static","parent"
+	};
+	sxu32 i;
+	for( i = 0 ; i < SX_ARRAYSIZE(azWords) ; i++ ){
+		sxu32 n = (sxu32)SyStrlen(azWords[i]);
+		if( pName->nByte == n && SyStrnicmp(pName->zString,azWords[i],n) == 0 ){
+			return 1;
+		}
+	}
+	return 0;
+}
 static sxi32 GenStateParseOneTypeAtom(ph7_gen_state *pGen, PhlTypeAtom *pOut)
 {
 	SyToken *pIn = pGen->pIn;
@@ -7107,7 +7146,10 @@ static sxi32 GenStateParseOneTypeAtom(ph7_gen_state *pGen, PhlTypeAtom *pOut)
 			 * `use` alias) at type-check time instead of the global \Base — mirrors
 			 * the NEW/CALL/instanceof qualification. Absolute (\Base) and already-
 			 * qualified (A\B) names are left as written, matching GenStateNsQualifyName. */
-			if( !bAbsolute && pLast == pFirst ){
+			/* Reserved type words that reach this identifier branch (false, true,
+			 * mixed, iterable, callable) are NOT classes and must not be qualified
+			 * (else `false|string` becomes `Ns\false|string`). */
+			if( !bAbsolute && pLast == pFirst && !GenStateIsReservedTypeWord(&pOut->sClass) ){
 				SyBlob sFqn;
 				SyBlobInit(&sFqn,&pGen->pVm->sAllocator);
 				GenStateResolveName(pGen,&pOut->sClass,&sFqn);

--- a/src/ph7/lex.c
+++ b/src/ph7/lex.c
@@ -341,6 +341,18 @@ static sxi32 TokenizePHP(SyStream *pStream,SyToken *pToken,void *pUserData,void 
 							pStream->zText++;
 						}
 					}
+				}else if( c == 'o' || c == 'O' ){
+					/* PHP 8.1 explicit octal 0o/0O (underscore separator allowed between two digits) */
+					pStream->zText++;
+					while( pStream->zText < pStream->zEnd && pStream->zText[0] >= '0' && pStream->zText[0] <= '7' ){
+						pStream->zText++;
+						if( pStream->zText < pStream->zEnd
+							&& pStream->zText[0] == '_'
+							&& pStream->zText + 1 < pStream->zEnd
+							&& pStream->zText[1] >= '0' && pStream->zText[1] <= '7' ){
+							pStream->zText++;
+						}
+					}
 				}
 			}
 			/* PHP 7.4: absorb a trailing malformed underscore run into the

--- a/src/ph7/memobj.c
+++ b/src/ph7/memobj.c
@@ -144,8 +144,14 @@ PH7_PRIVATE sxi64 PH7_TokenValueToInt64(SyString *pVal)
 		}else if( c == 'b' || c == 'B' ){
 			/* Binary digit stream */
 			SyBinaryStrToInt64(pVal->zString,pVal->nByte,(void *)&iVal,0);
+		}else if( c == 'o' || c == 'O' ){
+			/* PHP 8.1 explicit octal 0o/0O: skip the two-char prefix and parse the
+			 * remaining octal digits (SyOctalStrToInt64 expects no letter prefix). */
+			if( pVal->nByte > 2 ){
+				SyOctalStrToInt64(pVal->zString + 2,pVal->nByte - 2,(void *)&iVal,0);
+			}
 		}else{
-			/* Octal digit stream */
+			/* Legacy octal digit stream (leading 0) */
 			SyOctalStrToInt64(pVal->zString,pVal->nByte,(void *)&iVal,0);
 		}
 	}else{

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1375,6 +1375,13 @@ struct ph7_vm
 	                             * being evaluated (VmLocalExec has no method frame, so self::/parent::
 	                             * inside an initializer resolve through this fallback — consulted by
 	                             * PH7_VmPeekDeclaringClass/PH7_VmPeekTopClass when no frame matches). */
+	void *pConstEvalFrame;      /* The VmFrame that was current when an ON-DEMAND const initializer
+	                             * eval began (VmLocalExec pushes no frame). While the current frame
+	                             * still equals it, self::/parent:: resolve to pConstEvalClass even
+	                             * though an outer method frame exists (e.g. Base::CONST accessed from
+	                             * Sub::method() must NOT resolve self to Sub). A method call inside the
+	                             * initializer pushes a new frame, so the marker no longer matches and
+	                             * that method's own declaring class wins. NULL outside on-demand eval. */
 	sxi32 nConstEvalDepth;      /* Nesting depth of constant/enum-case initializer evaluations. A
 	                             * cycle detected at an inner level (pConstCycleAttr) is thrown only
 	                             * when depth returns to 0 — a throw INSIDE an initializer mini-exec

--- a/src/ph7/vfs.c
+++ b/src/ph7/vfs.c
@@ -7175,6 +7175,40 @@ static int is_data_stream(const ph7_io_stream *pStream)
 	return 0;
 #endif /* PH7_DISABLE_DISK_IO */
 }
+/*
+ * bool stream_isatty(resource $stream)
+ *  TRUE when the stream is an interactive terminal. PHL answers this for the
+ *  php:// standard streams (STDIN/STDOUT/STDERR carry their fd) via the
+ *  platform isatty()/GetFileType(); file and memory streams are never a
+ *  terminal, so they answer FALSE (php-exact for those).
+ */
+static int PH7_builtin_stream_isatty(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	int bTty = 0;
+	if( nArg < 1 || !ph7_value_is_resource(apArg[0]) ){
+		ph7_result_bool(pCtx,0);
+		return PH7_OK;
+	}
+#ifndef PH7_DISABLE_DISK_IO
+	{
+		io_private *pDev = (io_private *)ph7_value_to_resource(apArg[0]);
+		if( !IO_PRIVATE_INVALID(pDev) && is_php_stream(pDev->pStream) ){
+			ph7_stream_data *pData = (ph7_stream_data *)pDev->pHandle;
+			if( pData && (pData->iType == PH7_IO_STREAM_STDIN
+				|| pData->iType == PH7_IO_STREAM_STDOUT
+				|| pData->iType == PH7_IO_STREAM_STDERR) ){
+#ifdef __WINNT__
+				bTty = (GetFileType((HANDLE)pData->x.pHandle) == FILE_TYPE_CHAR) ? 1 : 0;
+#else
+				bTty = isatty(SX_PTR_TO_INT(pData->x.pHandle)) ? 1 : 0;
+#endif
+			}
+		}
+	}
+#endif /* PH7_DISABLE_DISK_IO */
+	ph7_result_bool(pCtx,bTty);
+	return PH7_OK;
+}
 
 #endif /* PH7_DISABLE_BUILTIN_FUNC */
 /*
@@ -7267,6 +7301,7 @@ PH7_PRIVATE sxi32 PH7_RegisterIORoutine(ph7_vm *pVm)
 		{"file",      PH7_builtin_file   },
 		{"copy",      PH7_builtin_copy   },
 		{"fstat",     PH7_builtin_fstat  },
+		{"stream_isatty", PH7_builtin_stream_isatty },
 		{"fwrite",    PH7_builtin_fwrite },
 		{"fputs",     PH7_builtin_fwrite },
 		{"flock",     PH7_builtin_flock  },

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -6863,13 +6863,19 @@ static sxi32 VmClassConstEvalOnDemand(ph7_vm *pVm,ph7_class *pClass,ph7_class_at
 	}
 	if( SySetUsed(&pAttr->aByteCode) > 0 ){
 		ph7_class *pSaveCtx = pVm->pConstEvalClass;
+		void *pSaveFrame = pVm->pConstEvalFrame;
 		sxi32 rcExec;
 		pAttr->iFlags |= PH7_CLASS_ATTR_EVALING;
 		pVm->pConstEvalClass = pAttr->pDeclClass ? pAttr->pDeclClass : pClass;
+		/* Mark the frame current at eval start: while it stays current, self::/
+		 * parent:: in the initializer resolve to pConstEvalClass rather than the
+		 * enclosing method's class (VmLocalExec pushes no frame of its own). */
+		pVm->pConstEvalFrame = (void *)VmSkipExceptionFrames(pVm->pFrame);
 		pVm->nConstEvalDepth++;
 		rcExec = VmLocalExecIntoObj(&(*pVm),&pAttr->aByteCode,&pMemObj,FALSE);
 		pVm->nConstEvalDepth--;
 		pVm->pConstEvalClass = pSaveCtx;
+		pVm->pConstEvalFrame = pSaveFrame;
 		pAttr->iFlags &= ~PH7_CLASS_ATTR_EVALING;
 		/* Memoize before any throw so re-access doesn't loop. */
 		pAttr->nIdx = pMemObj->nIdx;
@@ -22623,6 +22629,17 @@ PH7_PRIVATE ph7_class * PH7_VmPeekDeclaringClass(ph7_vm *pVm)
 
 	/* Skip exception frames to find the actual method frame */
 	pFrame = VmSkipExceptionFrames(pFrame);
+
+	/* An on-demand constant/property initializer is evaluated via VmLocalExec,
+	 * which pushes no frame — so the enclosing method's frame is still current.
+	 * While that frame is the one the eval started in, self::/parent:: inside the
+	 * initializer must resolve to the class whose constant is being evaluated
+	 * (pConstEvalClass), NOT the enclosing method's class. Once the initializer
+	 * calls a method (a new frame), the marker no longer matches and the normal
+	 * frame walk below picks that method's declaring class. */
+	if( pVm->pConstEvalClass && pVm->pConstEvalFrame == (void *)pFrame ){
+		return pVm->pConstEvalClass;
+	}
 
 	/* Check if we're in a method context */
 	if( pFrame->pParent ){

--- a/tests/ph7/001-smoke/function/stream_isatty.phpt
+++ b/tests/ph7/001-smoke/function/stream_isatty.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+stream_isatty() on redirected/file streams is false
+--FILE--
+<?php
+// Under the test harness stdout/stderr are redirected (not a terminal), and a
+// regular file is never a terminal, so all of these are false on both engines.
+var_dump(stream_isatty(STDOUT));
+var_dump(stream_isatty(STDERR));
+$f = fopen(tempnam(sys_get_temp_dir(), 'sia'), 'w');
+var_dump(stream_isatty($f));
+fclose($f);
+?>
+--EXPECT--
+bool(false)
+bool(false)
+bool(false)
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/lang/octal_prefix_literal.phpt
+++ b/tests/ph7/001-smoke/lang/octal_prefix_literal.phpt
@@ -1,0 +1,28 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PHP 8.1 explicit octal literal 0o / 0O
+--FILE--
+<?php
+echo 0o17000, "\n";
+echo 0O777, "\n";
+echo 0o1_7000, "\n";
+echo 0o0, "\n";
+// Coexists with the legacy and other bases.
+echo 017, " ", 0x1F, " ", 0b101, "\n";
+// Used in a bitmask, like real code (fstat mode bits).
+$mode = 0o0100644;
+echo ($mode & 0o170000) === 0o100000 ? "regfile\n" : "other\n";
+var_dump(0o755);
+?>
+--EXPECT--
+7680
+511
+7680
+0
+15 31 5
+regfile
+int(493)
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/oo/const_self_ref_from_subclass_method.phpt
+++ b/tests/ph7/001-smoke/oo/const_self_ref_from_subclass_method.phpt
@@ -1,0 +1,36 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+self:: in a base const initializer resolves to the declaring class, not the caller
+--FILE--
+<?php
+// A constant whose initializer references a sibling constant via self:: must
+// resolve self:: to the class that DECLARES the constant, even when the access
+// happens from inside a subclass method (whose frame is the current one while
+// the on-demand initializer eval runs).
+abstract class CsrfBase {
+    public const COLOR_NEVER   = 'never';
+    public const COLOR_DEFAULT = self::COLOR_NEVER;
+}
+abstract class CsrfMiddle extends CsrfBase {}
+final class CsrfLeaf extends CsrfMiddle {
+    public static function make(): string {
+        return CsrfBase::COLOR_DEFAULT;
+    }
+    public static function viaSelf(): string {
+        return self::COLOR_DEFAULT;
+    }
+}
+echo CsrfLeaf::make(), "\n";
+echo CsrfLeaf::viaSelf(), "\n";
+echo CsrfBase::COLOR_DEFAULT, "\n";
+echo CsrfLeaf::COLOR_NEVER, "\n";
+?>
+--EXPECT--
+never
+never
+never
+never
+--CLEAN--
+<?php


### PR DESCRIPTION
Continuing the PHPUnit 11.5.56 bring-up (it now fully initializes: "PHPUnit Started / Test Runner Configured / Event Facade Sealed"). Fixes:

- self:: in a constant initializer resolved to the wrong class. An on-demand constant eval (VmClassConstEvalOnDemand) runs via VmLocalExec, which pushes no frame, so PH7_VmPeekDeclaringClass found the enclosing method's frame: Base::COLOR_DEFAULT (= self::COLOR_NEVER) accessed from Sub::method() resolved self to Sub and failed to find the inherited constant ("Access to undeclared static property Sub::$COLOR_NEVER"). A new pConstEvalFrame marks the frame current when the eval began; while it is still current, self::/ parent:: resolve to pConstEvalClass, and a method call inside the initializer (a new frame) correctly reverts to that method's declaring class.

- Reserved type words false/true/mixed/iterable/callable reaching the type parser's identifier branch were namespace-qualified by the previous type-hint fix, so `false|string` in a namespace became `Ns\false|string`. They are not classes; GenStateIsReservedTypeWord now excludes them (self/static/parent and null/void/never were already handled).

- PHP 8.1 explicit octal literals 0o / 0O (lexer, PH7_TokenValueToInt64, and the int-overflow-to-float classifier).

- stream_isatty(): answered via isatty()/GetFileType() for the php:// standard streams; file and memory streams are never a terminal (php-exact there).

Tests: oo/const_self_ref_from_subclass_method, lang/octal_prefix_literal, function/stream_isatty. test-compat green on both engines, MODE=tiny builds, docker ASan+UBSan clean.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
