### PR TITLE
Fix stack underflow on empty-spread calls

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -16919,9 +16919,17 @@ case PH7_OP_NEW: {
 		 * the wrong scope is php's catchable Error. Reflection's
 		 * newInstance path sets bReflectBypass like method invoke. */
 		if( pCons && pCons->iProtection != PH7_CLASS_PROT_PUBLIC ){
+			/* php binds non-public access by the member's DECLARING class, not the
+			 * instantiated class: a private constructor declared in a base is
+			 * reachable from that base's own methods even when instantiating a
+			 * subclass (`new Child()` inside Base::factory()). __construct is a
+			 * method, so pass its declaring class (sFunc.pUserData) — mirroring the
+			 * method-call visibility check — rather than pClass, whose hAttr lookup
+			 * for a method name always misses and falls to a wrong exact-class test. */
+			ph7_class *pCtorDecl = pCons->sFunc.pUserData ? (ph7_class *)pCons->sFunc.pUserData : pClass;
 			if( pVm->bReflectBypass ){
 				pVm->bReflectBypass = 0;
-			}else if( !PH7_VmClassMemberAccess(&(*pVm),pClass,&pCons->sFunc.sName,pCons->iProtection,FALSE) ){
+			}else if( !PH7_VmClassMemberAccess(&(*pVm),pCtorDecl,&pCons->sFunc.sName,pCons->iProtection,FALSE) ){
 				SyBlob sErrMsg;
 				const char *zVis = pCons->iProtection == PH7_CLASS_PROT_PRIVATE ? "private" : "protected";
 				SyBlobInit(&sErrMsg,&pVm->sAllocator);
@@ -19445,8 +19453,8 @@ SkipFuncBody:
 			/* Exception was caught in place by THIS body's try: pop args and the
 			 * result slot to restore the pre-try stack, then resume. */
 			PH7_MemObjRelease(&sRet);
-			if( pInstr->iP1 > 0 ){
-				VmPopOperand(&pTos,pInstr->iP1);
+			if( nCallArgs > 0 ){
+				VmPopOperand(&pTos,nCallArgs); /* spread-adjusted; see the normal-return path */
 			}
 			VmPopOperand(&pTos,1);
 			pc = iResumePc;
@@ -19460,19 +19468,25 @@ SkipFuncBody:
 			 * and we need to save state here. If it's a nested call (method
 			 * body), the user-function path above will handle re-saving. */
 			PH7_MemObjRelease(&sRet);
-			if( pInstr->iP1 > 0 ){
-				VmPopOperand(&pTos,pInstr->iP1);
+			if( nCallArgs > 0 ){
+				VmPopOperand(&pTos,nCallArgs); /* spread-adjusted; see the normal-return path */
 			}
 			/* Save fiber state: pc+1 is the instruction after this CALL.
 			 * nTos is one below pTos so resume pushes at the return-value slot. */
 			VmSuspendCtx(pVm,pVm->pActiveCtx,pc + 1,(sxi32)(pTos - pStack) - 1);
 			goto Suspend;
 		}
-		if( pInstr->iP1 > 0 ){
-			/* Pop function name and arguments */
-			VmPopOperand(&pTos,pInstr->iP1);
+		if( nCallArgs > 0 ){
+			/* Pop the arguments. nCallArgs (spread-adjusted), NOT iP1: an unpack
+			 * expanded the compile-time arg count on the stack, so popping iP1
+			 * strands the extra elements (or, for an unpack that expanded to fewer
+			 * than iP1 — e.g. array_merge(...[]) — underflows the operand stack,
+			 * reading a bogus value whose stray flags sent MemObjStore into the
+			 * hashmap-release path and hung). Mirrors every other CALL exit. The
+			 * function-name slot (pTos) receives the return value below. */
+			VmPopOperand(&pTos,nCallArgs);
 		}
-		/* Save foreign function return value */
+		/* Save foreign function return value into the (now top) function-name slot */
 		PH7_MemObjStore(&sRet,pTos);
 		PH7_MemObjRelease(&sRet);
 	}

--- a/tests/ph7/001-smoke/lang/spread_empty_builtin_arg.phpt
+++ b/tests/ph7/001-smoke/lang/spread_empty_builtin_arg.phpt
@@ -1,0 +1,39 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Spread of an empty array into a builtin call (operand-stack balance)
+--FILE--
+<?php
+// An unpack expanding to fewer operands than the compile-time arg count once
+// underflowed the operand stack on the builtin-return path.
+$empty = [];
+var_dump(array_merge(...$empty));
+var_dump(array_merge(...[]));
+var_dump(max(1, 2, ...$empty));
+$parts = [[1, 2], [3]];
+var_dump(array_merge(...$parts));
+echo implode(",", [...$empty, 'a', ...$empty]), "\n";
+// In a loop, to exercise the return-slot repeatedly.
+$acc = [];
+for ($i = 0; $i < 3; $i++) { $acc = array_merge($acc, ...[]); }
+var_dump(count($acc));
+?>
+--EXPECT--
+array(0) {
+}
+array(0) {
+}
+int(2)
+array(3) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+}
+a
+int(0)
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/oo/private_ctor_inherited_factory.phpt
+++ b/tests/ph7/001-smoke/oo/private_ctor_inherited_factory.phpt
@@ -1,0 +1,33 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Private constructor reachable from the declaring class when instantiating a subclass
+--FILE--
+<?php
+abstract class PcifStatus {
+    private function __construct() {}
+    public static function unknown(): self { return new PcifUnknown(); }
+    public static function known(): self { return new self(); }
+    abstract public function label(): string;
+}
+final class PcifUnknown extends PcifStatus {
+    public function label(): string { return 'unknown'; }
+}
+echo PcifStatus::unknown()->label(), "\n";
+echo (PcifStatus::unknown() instanceof PcifUnknown) ? "isunknown\n" : "no\n";
+
+// Global-scope instantiation of the private ctor is still rejected.
+try {
+    new PcifUnknown();
+    echo "NOT REACHED\n";
+} catch (\Error $e) {
+    echo "rejected\n";
+}
+?>
+--EXPECT--
+unknown
+isunknown
+rejected
+--CLEAN--
+<?php


### PR DESCRIPTION
Two OP_CALL bugs surfaced running PHPUnit:

- The builtin-function return path popped the compile-time arg count (iP1) instead of the spread-adjusted nCallArgs that every other CALL exit uses. An unpack expanding to FEWER operands than iP1 -- e.g. array_merge(...[]) or f(...$empty) -- underflowed the operand stack; the stale value read below the base carried flags that sent PH7_MemObjStore down the hashmap-release path on a bogus pointer, which spun forever (a hard hang, pinned by ASan as a heap-buffer-overflow in PH7_MemObjStore reading past the operand stack). Fixed on the normal, in-place-catch, and fiber-suspend foreign-return paths.

- `new Child()` from a base method rejected an inherited PRIVATE constructor as "from global scope". The visibility check passed the instantiated class to PH7_VmClassMemberAccess, whose private branch looks the name up in hAttr (properties) -- always missing for the __construct METHOD -- and then required caller == instantiated class, which fails when the private ctor is declared in the base. Pass the constructor's declaring class (sFunc.pUserData) like the method-call visibility check, so a base factory doing `new Child()` is allowed while a global-scope `new Child()` stays rejected.

Tests: lang/spread_empty_builtin_arg, oo/private_ctor_inherited_factory. test-compat green on both engines, MODE=tiny builds, docker ASan+UBSan clean over smoke + integration + a PHPUnit bootstrap.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
