### PR TITLE
Resolve a qualified name's head through use

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -3633,23 +3633,49 @@ static sxi32 GenStateResolveNamespaceLiteral(ph7_gen_state *pGen)
 			isAbsolute = 1;
 			pGen->pIn++; /* Skip leading backslash */
 		}
-		/* For relative qualified names in a namespace, prepend the NS */
-		if( !isAbsolute && SyBlobLength(&pGen->sNamespace) > 0 ){
-			SyBlobAppend(pWorker,SyBlobData(&pGen->sNamespace),SyBlobLength(&pGen->sNamespace));
-			SyBlobAppend(pWorker,"\\",1);
-		}
-		/* Collect all path components */
-		while( pGen->pIn <= &pGen->pEnd[-1] ){
-			if( pGen->pIn->nType & PH7_TK_NSSEP ){
-				SyBlobAppend(pWorker,"\\",1);
-			}else{
-				SyBlobAppend(pWorker,pGen->pIn->sData.zString,pGen->pIn->sData.nByte);
-			}
-			if( pGen->pIn == &pGen->pEnd[-1] ){
+		/* Collect the raw path (no prefix yet) so its FIRST segment can be resolved
+		 * against use-imports below — php resolves `A\B\C` by mapping the leading
+		 * `A` through the imports (`use X\A;` makes it `X\A\B\C`), and only prepends
+		 * the current namespace when `A` matches no import. Blindly prefixing the
+		 * namespace here produced e.g. `Ns\Ev\Bus` for `use ...\Event as Ev; Ev\Bus`. */
+		{
+			SyBlob sRaw;
+			SyBlobInit(&sRaw,&pGen->pVm->sAllocator);
+			while( pGen->pIn <= &pGen->pEnd[-1] ){
+				if( pGen->pIn->nType & PH7_TK_NSSEP ){
+					SyBlobAppend(&sRaw,"\\",1);
+				}else{
+					SyBlobAppend(&sRaw,pGen->pIn->sData.zString,pGen->pIn->sData.nByte);
+				}
+				if( pGen->pIn == &pGen->pEnd[-1] ){
+					pGen->pIn++;
+					break;
+				}
 				pGen->pIn++;
-				break;
 			}
-			pGen->pIn++;
+			if( isAbsolute ){
+				SyBlobAppend(pWorker,SyBlobData(&sRaw),SyBlobLength(&sRaw)); /* FQN as written */
+			}else{
+				const char *zRaw = (const char *)SyBlobData(&sRaw);
+				sxu32 nRaw = SyBlobLength(&sRaw);
+				sxu32 nFirst = 0;
+				SyHashEntry *pNsImp;
+				while( nFirst < nRaw && zRaw[nFirst] != '\\' ){ nFirst++; }
+				pNsImp = SyHashGet(&pGen->hUseImports,(const void *)zRaw,nFirst);
+				if( pNsImp ){
+					/* Leading segment is an imported alias: substitute its FQN. */
+					const char *zFQN = (const char *)pNsImp->pUserData;
+					SyBlobAppend(pWorker,zFQN,SyStrlen(zFQN));
+					SyBlobAppend(pWorker,zRaw + nFirst,nRaw - nFirst);
+				}else if( SyBlobLength(&pGen->sNamespace) > 0 ){
+					SyBlobAppend(pWorker,SyBlobData(&pGen->sNamespace),SyBlobLength(&pGen->sNamespace));
+					SyBlobAppend(pWorker,"\\",1);
+					SyBlobAppend(pWorker,zRaw,nRaw);
+				}else{
+					SyBlobAppend(pWorker,zRaw,nRaw); /* global scope, no import */
+				}
+			}
+			SyBlobRelease(&sRaw);
 		}
 		if( SyBlobLength(pWorker) > 0 ){
 			ph7_value *pObj;

--- a/tests/ph7/001-smoke/oo/qualified_name_import_resolution.phpt
+++ b/tests/ph7/001-smoke/oo/qualified_name_import_resolution.phpt
@@ -1,0 +1,44 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A qualified name resolves its first segment through use-imports
+--FILE--
+<?php
+namespace Qnir\Event {
+    class Bus { public static function tag(): string { return 'bus'; } }
+    function helper(): string { return 'help'; }
+    const K = 42;
+}
+namespace Qnir\Event\Code {
+    class Builder { public static function tag(): string { return 'builder'; } }
+}
+namespace Qnir\Other {
+    class Bus { public static function tag(): string { return 'OTHER'; } }
+}
+namespace Qnir\Framework {
+    use Qnir\Event;
+    use Qnir\Other as Ot;
+
+    // Leading segment 'Event' maps through `use Qnir\Event;` -> Qnir\Event\...
+    echo Event\Bus::tag(), "\n";
+    echo Event\Code\Builder::tag(), "\n";
+    echo Event\helper(), "\n";
+    echo Event\K, "\n";
+    echo (new Event\Bus() instanceof Event\Bus) ? "isbus\n" : "no\n";
+    // Aliased leading segment.
+    echo Ot\Bus::tag(), "\n";
+    // Absolute name is unaffected.
+    echo \Qnir\Other\Bus::tag(), "\n";
+}
+?>
+--EXPECT--
+bus
+builder
+help
+42
+isbus
+OTHER
+OTHER
+--CLEAN--
+<?php


### PR DESCRIPTION
A multi-segment name like `Event\Code\Foo` was assembled by GenStateResolveNamespaceLiteral by blindly prepending the current namespace (`Ns\Event\Code\Foo`), ignoring `use` imports. php resolves the LEADING segment through the imports first: `use PHPUnit\Event;` makes `Event\Code\Foo` mean `PHPUnit\Event\Code\Foo`, and `use X\Y as Ev;` makes `Ev\Bus` mean `X\Y\Bus`; only when the leading segment matches no import does php fall back to prepending the current namespace.

Collect the raw path, then map its first segment through hUseImports (substituting the alias's FQN and keeping the tail) before falling back to the namespace prefix. Absolute names and the global-scope no-import case are unchanged. Fixes namespaced class references, `new`, static calls, function calls, constants and instanceof alike -- PHPUnit's `Event\Code\TestMethodBuilder` (with `use PHPUnit\Event;`) now resolves, and PHPUnit prints its banner and runtime line.

Test oo/qualified_name_import_resolution. test-compat green on both engines, MODE=tiny builds, docker ASan+UBSan clean.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
