### PR TITLE
Stop warning on a redeclared private property

### DIFF
--- a/src/ph7/oo.c
+++ b/src/ph7/oo.c
@@ -494,14 +494,10 @@ PH7_PRIVATE sxi32 PH7_ClassInherit(ph7_gen_state *pGen,ph7_class *pSub,ph7_class
 					return SXERR_ABORT;
 				}
 			}
-			if( pAttr->iProtection == PH7_CLASS_PROT_PRIVATE &&
-				((ph7_class_attr *)pEntry->pUserData)->iProtection != PH7_CLASS_PROT_PUBLIC ){
-					/* Cannot redeclare private attribute */
-					PH7_GenCompileError(&(*pGen),E_WARNING,((ph7_class_attr *)pEntry->pUserData)->nLine,
-						"Private attribute '%z::%z' redeclared inside child class '%z'",
-						&pBase->sName,pName,&pSub->sName);
-
-			}
+			/* A child MAY redeclare a base's private property: php treats the two
+			 * as independent members (each private to its declaring class), with no
+			 * diagnostic. PH7 warned here, which is wrong — the child's entry simply
+			 * shadows the base's in the by-name attribute table. */
 			continue;
 		}
 		/* Install the attribute. php: a base class's private INSTANCE property

--- a/tests/ph7/002-integration/oo/private_attr_redeclare.phpt
+++ b/tests/ph7/002-integration/oo/private_attr_redeclare.phpt
@@ -2,20 +2,27 @@
 SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
 SPDX-License-Identifier: BSD-3-Clause
 --TEST--
-PHL: Private attribute redeclared in subclass
---SKIPIF--
-<?php if (function_exists('zend_version')) echo 'skip'; ?>
+A subclass may redeclare a base private attribute with no diagnostic
 --FILE--
 <?php
+// php emits NO diagnostic when a child redeclares a base private property;
+// the child instantiates and its own method reads its own value. (PHL cannot
+// yet keep the base's shadowed same-named private as a distinct member — see
+// NEWPLAN — so this checks only the child-visible value, which both engines
+// agree on, plus the absence of a warning.)
 class A {
     private $attr = 1;
 }
 class B extends A {
     private $attr = 2;
+    public function bVal() { return $this->attr; }
 }
+$b = new B();
+echo $b->bVal(), "\n";
+echo "done\n";
 ?>
---EXPECTF--
-%s Warning:  Private attribute 'A::attr' redeclared inside child class 'B' %s
+--EXPECT--
+2
+done
 --CLEAN--
 <?php
-


### PR DESCRIPTION
php treats a child's private property with the same name as a base private as an independent member and emits no diagnostic; PH7 printed a spurious "Private attribute 'A::x' redeclared inside child class 'B'" warning (which, among other things, PHPUnit tripped declaring DataProviderTestSuite::$providedTests). Drop the warning; the child's entry simply shadows the base's in the by-name attribute table.

The former PHL-only test (SKIPIF on real php) that codified the warning is rewritten as a cross-engine test of the silent, working redeclaration. (The deeper limitation — keeping the base's shadowed same-named private as a distinct member so A's own method still reads A's value — is recorded in NEWPLAN as a follow-up.)

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
