### PR TITLE
Add phl.stub_extensions for gated software

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -2493,16 +2493,32 @@ static int vm_builtin_Closure_fromCallable(ph7_context *pCtx, int nArg, ph7_valu
    "  }"\
    "  return null;"\
    "}"\
+   "/* phl.stub_extensions (a -d/php.ini list, comma-separated) declares extensions"\
+   " * PHL does not implement as LOADED, backed by no-op behaviour, so software that"\
+   " * only GATES on extension_loaded() (e.g. PHPUnit's dom/xmlwriter check) runs"\
+   " * unmodified. It does NOT synthesize the extension's classes/functions. */"\
+   "function __phl_stub_exts(){"\
+   "  $s = ini_get('phl.stub_extensions');"\
+   "  if( $s === false || $s === '' ){ return array(); }"\
+   "  $out = array();"\
+   "  foreach( explode(',', (string)$s) as $e ){ $e = trim($e); if( $e !== '' ){ $out[strtolower($e)] = $e; } }"\
+   "  return $out;"\
+   "}"\
    "function extension_loaded($name){"\
    "  static $ext = array('core' => 1, 'standard' => 1, 'pcre' => 1, 'json' => 1,"\
    "   'ctype' => 1, 'date' => 1, 'spl' => 1, 'reflection' => 1, 'mbstring' => 1,"\
    "   'hash' => 1, 'filter' => 1, 'session' => 1, 'libxml' => 1, 'xml' => 1);"\
-   "  return isset($ext[strtolower((string)$name)]);"\
+   "  $n = strtolower((string)$name);"\
+   "  if( isset($ext[$n]) ){ return true; }"\
+   "  $stub = __phl_stub_exts();"\
+   "  return isset($stub[$n]);"\
    "}"\
    "function get_loaded_extensions($zend_extensions = false){"\
    "  if( $zend_extensions ){ return array(); }"\
-   "  return array('Core','date','libxml','pcre','SPL','json','standard',"\
+   "  $base = array('Core','date','libxml','pcre','SPL','json','standard',"\
    "   'ctype','filter','hash','Reflection','session','mbstring','xml');"\
+   "  foreach( __phl_stub_exts() as $e ){ $base[] = $e; }"\
+   "  return $base;"\
    "}"\
    "/* Inverse of bin2hex() */"\
    "function hex2bin($str){"\

--- a/tests/ph7/002-integration/function/stub_extensions_ini.phpt
+++ b/tests/ph7/002-integration/function/stub_extensions_ini.phpt
@@ -1,0 +1,27 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+phl.stub_extensions (-d/php.ini) makes extension_loaded() report the listed extensions
+--SKIPIF--
+<?php if (function_exists('zend_version')) echo 'skip PHL-specific phl.stub_extensions directive';
+--INI--
+phl.stub_extensions=phlfakeext, another_fake
+--FILE--
+<?php
+var_dump(extension_loaded('phlfakeext'));
+var_dump(extension_loaded('another_fake'));
+var_dump(extension_loaded('ANOTHER_FAKE'));      // case-insensitive
+var_dump(extension_loaded('definitely_not_here'));
+var_dump(extension_loaded('json'));              // built-in stays true
+var_dump(in_array('phlfakeext', get_loaded_extensions(), true));
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+--CLEAN--
+<?php

--- a/tests/phpt.php
+++ b/tests/phpt.php
@@ -11,7 +11,7 @@
 $phpt_valid_sections = array('test', 'description', 'credits', 'skipif', 'file', 'expect', 'expectf', 'expectregex', 'clean', 'post', 'post_raw', 'get', 'cookie', 'stdin', 'ini', 'args', 'env');
 
 // Unimplemented section types
-$phpt_not_implemented = array('post', 'post_raw', 'get', 'cookie', 'stdin', 'ini', 'args', 'expectregex');
+$phpt_not_implemented = array('post', 'post_raw', 'get', 'cookie', 'stdin', 'args', 'expectregex');
 
 // Default values
 $phpt_target_executable = "";
@@ -373,13 +373,24 @@ function build_env_prefix($phpt_env) {
 
 // Run a PHPT section file through an external target executable
 // Returns the combined stdout/stderr output as string, or false if popen() failed
-function run_file_with_target($phpt_target_executable, $phpt_file, $phpt_env = array()) {
+function run_file_with_target($phpt_target_executable, $phpt_file, $phpt_env = array(), $phpt_ini = array()) {
     // Export PHPT_TARGET_EXECUTABLE through the same per-OS, value-quoting path as
     // the --ENV-- vars (build_env_prefix) so a target path containing a space is
     // quoted too. The '+' keeps PHPT_TARGET_EXECUTABLE ahead of any --ENV-- vars.
     $phpt_full_env = array('PHPT_TARGET_EXECUTABLE' => $phpt_target_executable) + $phpt_env;
     $cmd = build_env_prefix($phpt_full_env);
-    $cmd .= '"' . $phpt_target_executable . '" "' . $phpt_file . '" 2>&1';
+    $cmd .= '"' . $phpt_target_executable . '"';
+    // --INI-- directives: pass each as a `-d name=value` CLI flag to the fresh
+    // child (mirrors php run-tests). Quote the whole token per-OS like the env.
+    foreach ($phpt_ini as $phpt_ini_key => $phpt_ini_val) {
+        $phpt_ini_tok = $phpt_ini_key . '=' . $phpt_ini_val;
+        if (PHP_OS === 'WINNT') {
+            $cmd .= ' -d "' . str_replace('"', '\\"', $phpt_ini_tok) . '"';
+        } else {
+            $cmd .= ' -d ' . "'" . str_replace("'", "'\\''", $phpt_ini_tok) . "'";
+        }
+    }
+    $cmd .= ' "' . $phpt_file . '" 2>&1';
     $fp = popen($cmd, 'r');
     if ($fp === false) {
         // piped execution failed
@@ -436,6 +447,13 @@ foreach ($phpt_files as $phpt_file) {
     $phpt_env = isset($phpt_sections['env']) ? parse_env_section($phpt_sections['env']) : array();
     $phpt_env_unsupported = (!empty($phpt_env) && empty($phpt_target_executable));
 
+    // Optional --INI-- section: php.ini directives (name=value lines) passed to the
+    // target CHILD as `-d name=value`. Like --ENV--, only meaningful with a fresh
+    // child process; the in-process (@include) runner shares the runner's own VM
+    // (started without those -d flags), so such tests are skipped there.
+    $phpt_ini = isset($phpt_sections['ini']) ? parse_env_section($phpt_sections['ini']) : array();
+    $phpt_ini_unsupported = (!empty($phpt_ini) && empty($phpt_target_executable));
+
     // Write sections to disk
     if (isset($phpt_sections['file'])) {
         $phpt_file_path = $phpt_file . '.file';
@@ -461,10 +479,14 @@ foreach ($phpt_files as $phpt_file) {
         // skip rather than run in-process with the env silently dropped.
         $phpt_skip = true;
         $phpt_skip_reason = '--ENV-- requires --target-executable';
+    } elseif ($phpt_ini_unsupported) {
+        // --INI-- is applied as -d flags to a fresh child; skip in-process runs.
+        $phpt_skip = true;
+        $phpt_skip_reason = '--INI-- requires --target-executable';
     } elseif (isset($phpt_sections['skipif'])) {
         $phpt_skipif_path = $phpt_file . '.skipif';
         if (!empty($phpt_target_executable)) {
-            $phpt_skip_output = run_file_with_target($phpt_target_executable, $phpt_skipif_path, $phpt_env);
+            $phpt_skip_output = run_file_with_target($phpt_target_executable, $phpt_skipif_path, $phpt_env, $phpt_ini);
             if ($phpt_skip_output === false) {
                 echo "# ERROR: Failed to spawn skipif for $phpt_skipif_path\n";
                 $phpt_skip_output = '';
@@ -533,7 +555,7 @@ foreach ($phpt_files as $phpt_file) {
             // Test execution
             $phpt_file_path = $phpt_file . '.file';
             if (!empty($phpt_target_executable)) {
-                $phpt_output = run_file_with_target($phpt_target_executable, $phpt_file_path, $phpt_env);
+                $phpt_output = run_file_with_target($phpt_target_executable, $phpt_file_path, $phpt_env, $phpt_ini);
                 if ($phpt_output === false) {
                     echo "# ERROR: Failed to spawn test for $phpt_file_path\n";
                     $phpt_output = "";
@@ -597,7 +619,7 @@ foreach ($phpt_files as $phpt_file) {
     if (isset($phpt_sections['clean']) && $phpt_skip === false) {
         $phpt_clean_path = $phpt_file . '.clean';
         if (!empty($phpt_target_executable)) {
-            $phpt_clean_output = run_file_with_target($phpt_target_executable, $phpt_clean_path, $phpt_env);
+            $phpt_clean_output = run_file_with_target($phpt_target_executable, $phpt_clean_path, $phpt_env, $phpt_ini);
             if ($phpt_clean_output === false) {
                 echo "# ERROR: Failed to spawn clean for $phpt_clean_path\n";
             }


### PR DESCRIPTION
Real software often GATES on extension_loaded()/get_loaded_extensions() for extensions PHL does not implement (PHPUnit hard-checks dom, libxml, mbstring, xml, xmlwriter and dies if any is missing), even when a given run never actually uses them (`--no-configuration` never touches DOM). Rather than editing the third-party source, a php.ini directive `phl.stub_extensions` (comma-separated, set via -d or -c) now makes extension_loaded() report those names as loaded and adds them to get_loaded_extensions(). It is a pure gate bypass: it does NOT synthesize the extension's classes/functions, so code that actually calls into them still fails loudly.

    phl -d phl.stub_extensions=dom,xmlwriter vendor/.../phpunit test.php

runs the UNMODIFIED PHPUnit and reports tests normally.

Also implement the standard phpt `--INI--` section in the test runner (was recognized-but-unimplemented): each `name=value` line is passed to the target child as `-d name=value`. Like `--ENV--`, it only applies to `--target-executable` (subprocess) runs; in-process smoke tests share the runner's VM and are skipped with a reason. New integration test function/stub_extensions_ini exercises it.

test-compat green on both engines, MODE=tiny builds, docker ASan+UBSan clean (incl. an unmodified-PHPUnit run behind the stub).

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
