### PR TITLE
Support \callables and dynamic static calls

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -13687,6 +13687,19 @@ static sxi32 GenStateEmitExprCode(
 				}else if( pInstr->iOp == PH7_OP_MEMBER /* $a->b(1,2,3) */ || pInstr->iOp == PH7_OP_NEW ){
 					/* Method call,flag that */
 					pInstr->iP2 = 1;
+					/* A static call with a DYNAMIC method name (`C::$m(...)`): the
+					 * static-`::` codegen folded the variable NAME into OP_MEMBER->p3
+					 * as if it were a static-PROPERTY read (`C::$m`), but in a CALL the
+					 * method name is the variable's VALUE. Rebuild the sequence
+					 * [class, OP_LOAD $m -> value, OP_MEMBER(static, method)] so the
+					 * dynamic name is read off the stack, matching the instance
+					 * (`$o->$m()`) path. iP1==1 marks a static member. */
+					if( pInstr->iOp == PH7_OP_MEMBER && pInstr->iP1 == 1 && pInstr->p3 ){
+						void *pDynName = pInstr->p3;
+						(void)PH7_VmPopInstr(pGen->pVm);
+						PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOAD,0,0,pDynName,0);
+						PH7_VmEmitInstr(pGen->pVm,PH7_OP_MEMBER,1,PH7_MEMBER_METHOD,0,0);
+					}
 				}
 			}
 		}else if( iVmOp == PH7_OP_LOAD_IDX ){

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -17857,6 +17857,13 @@ case PH7_OP_CALL: {
 		break;
 	}
 	SyStringInitFromBuf(&sName,SyBlobData(&pTos->sBlob),SyBlobLength(&pTos->sBlob));
+	/* php: a leading '\\' on a callable string name ("\\trim", "\\Foo\\bar") just
+	 * anchors it to the global namespace — strip it before resolving so a
+	 * dynamic call `$f()` / array_map('\\trim', …) finds the function. */
+	if( sName.nByte > 0 && sName.zString[0] == '\\' ){
+		sName.zString++;
+		sName.nByte--;
+	}
 	/* Check for a compiled function first.
 	 * Static names are already namespace-qualified by the compiler.
 	 * Dynamic names (from variables) use exact match only, matching PHP behavior. */
@@ -22383,6 +22390,8 @@ static int vm_builtin_func_exists(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	pVm = pCtx->pVm;
 	/* Extract the function name */
 	zName = ph7_value_to_string(apArg[0],&nLen);
+	/* php: a leading '\' anchors the name to the global namespace; strip it. */
+	if( nLen > 0 && zName[0] == '\\' ){ zName++; nLen--; }
 	/* Assume the function is not defined */
 	res = 0;
 	/* Perform the lookup */
@@ -22444,6 +22453,9 @@ PH7_PRIVATE int PH7_VmIsCallable(ph7_vm *pVm,ph7_value *pValue,int CallInvoke)
 		int nLen;
 		/* Extract the name */
 		zName = ph7_value_to_string(pValue,&nLen);
+		/* php: a leading '\' just anchors the callable to the global namespace
+		 * ("\trim", "\Foo::bar"); strip it before the lookup. */
+		if( nLen > 0 && zName[0] == '\\' ){ zName++; nLen--; }
 		/* Perform the lookup */
 		if( SyHashGet(&pVm->hFunction,(const void *)zName,(sxu32)nLen) != 0 ||
 			SyHashGet(&pVm->hHostFunction,(const void *)zName,(sxu32)nLen) != 0 ){
@@ -25491,6 +25503,9 @@ static int vm_builtin_debug_backtrace(ph7_context *pCtx,int nArg,ph7_value **apA
 	ph7_value *pValue;
 	SyString *pFile;
 	VmFrame *pFrame;
+	/* $options (php default DEBUG_BACKTRACE_PROVIDE_OBJECT): bit 1 attaches the
+	 * frame's $this as 'object', bit 2 (IGNORE_ARGS) suppresses the 'args' list. */
+	sxi32 iOptions = (nArg > 0 && apArg[0]) ? ph7_value_to_int(apArg[0]) : 1 /*PROVIDE_OBJECT*/;
 	/* php returns a LIST of frames, innermost first -- one entry per ACTIVE call, each
 	 * describing the callee (function/class) and the position of the CALL SITE. PH7
 	 * returned a single flat map of the innermost frame only, so a caller could never
@@ -25541,18 +25556,34 @@ static int vm_builtin_debug_backtrace(ph7_context *pCtx,int nArg,ph7_value **apA
 			ph7_value_string(pValue,"->",sizeof("->")-1);
 			ph7_array_add_strkey_elem(pEntry,"type",pValue);
 			ph7_value_reset_string_cursor(pValue);
-		}
-		pArg = ph7_context_new_array(pCtx);
-		if( pArg ){
-			VmSlot *aSlot = (VmSlot *)SySetBasePtr(&pFrame->sArg);
-			sxu32 n;
-			for( n = 0 ; n < SySetUsed(&pFrame->sArg) ; ++n ){
-				ph7_value *pObj = (ph7_value *)SySetAt(&pVm->aMemObj,aSlot[n].nIdx);
-				if( pObj ){
-					ph7_array_add_elem(pArg,0/* Automatic index assign*/,pObj);
+			/* DEBUG_BACKTRACE_PROVIDE_OBJECT: attach the executing $this instance as
+			 * 'object' (php uses this for e.g. finding the current object on the
+			 * call stack). ph7_array_add_strkey_elem stores a refcounted copy, so
+			 * balance our transient reference with the matching iRef++. */
+			if( iOptions & 1 /*DEBUG_BACKTRACE_PROVIDE_OBJECT*/ ){
+				ph7_value *pObjVal = ph7_context_new_scalar(pCtx);
+				if( pObjVal ){
+					pFrame->pThis->iRef++;
+					pObjVal->x.pOther = pFrame->pThis;
+					MemObjSetType(pObjVal,MEMOBJ_OBJ);
+					ph7_array_add_strkey_elem(pEntry,"object",pObjVal);
+					ph7_context_release_value(pCtx,pObjVal);
 				}
 			}
-			ph7_array_add_strkey_elem(pEntry,"args",pArg);
+		}
+		if( (iOptions & 2 /*DEBUG_BACKTRACE_IGNORE_ARGS*/) == 0 ){
+			pArg = ph7_context_new_array(pCtx);
+			if( pArg ){
+				VmSlot *aSlot = (VmSlot *)SySetBasePtr(&pFrame->sArg);
+				sxu32 n;
+				for( n = 0 ; n < SySetUsed(&pFrame->sArg) ; ++n ){
+					ph7_value *pObj = (ph7_value *)SySetAt(&pVm->aMemObj,aSlot[n].nIdx);
+					if( pObj ){
+						ph7_array_add_elem(pArg,0/* Automatic index assign*/,pObj);
+					}
+				}
+				ph7_array_add_strkey_elem(pEntry,"args",pArg);
+			}
 		}
 		ph7_array_add_elem(pList,0/* Automatic index assign*/,pEntry);
 		pFrame = pFrame->pParent ? VmSkipExceptionFrames(pFrame->pParent) : 0;

--- a/tests/ph7/001-smoke/function/callable_leading_backslash.phpt
+++ b/tests/ph7/001-smoke/function/callable_leading_backslash.phpt
@@ -1,0 +1,34 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A callable string with a leading backslash resolves to the global function
+--FILE--
+<?php
+var_dump(array_map('\trim', [' a ', ' b ']));
+var_dump(call_user_func('\strlen', 'hello'));
+var_dump(is_callable('\trim'));
+var_dump(function_exists('\strtoupper'));
+$f = '\strtoupper';
+var_dump($f('hi'));
+var_dump(array_map('\intval', ['7', '8']));
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  string(1) "a"
+  [1]=>
+  string(1) "b"
+}
+int(5)
+bool(true)
+bool(true)
+string(2) "HI"
+array(2) {
+  [0]=>
+  int(7)
+  [1]=>
+  int(8)
+}
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/function/debug_backtrace_object.phpt
+++ b/tests/ph7/001-smoke/function/debug_backtrace_object.phpt
@@ -1,0 +1,38 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+debug_backtrace() attaches 'object' (PROVIDE_OBJECT) and honors IGNORE_ARGS
+--FILE--
+<?php
+class DboOuter {
+    public function run(): array { return (new DboInner())->go(7); }
+}
+class DboInner {
+    public function go(int $n): array {
+        return [
+            'default' => debug_backtrace(),
+            'ignore'  => debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS),
+        ];
+    }
+}
+$bt = (new DboOuter())->run();
+// Frame 0 = DboInner::go (its object is the DboInner instance).
+echo $bt['default'][0]['class'], $bt['default'][0]['type'], $bt['default'][0]['function'], "\n";
+echo ($bt['default'][0]['object'] instanceof DboInner) ? "obj-inner\n" : "no\n";
+// Frame 1 = DboOuter::run (object is the DboOuter instance).
+echo ($bt['default'][1]['object'] instanceof DboOuter) ? "obj-outer\n" : "no\n";
+// Default keeps args; IGNORE_ARGS drops them but keeps the object.
+echo isset($bt['default'][0]['args']) ? "has-args\n" : "no-args\n";
+echo isset($bt['ignore'][0]['args']) ? "has-args\n" : "no-args\n";
+echo isset($bt['ignore'][0]['object']) ? "has-object\n" : "no-object\n";
+?>
+--EXPECT--
+DboInner->go
+obj-inner
+obj-outer
+has-args
+no-args
+has-object
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/oo/dynamic_static_method_call.phpt
+++ b/tests/ph7/001-smoke/oo/dynamic_static_method_call.phpt
@@ -1,0 +1,35 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Dynamic static method call Class::$var() uses the variable's value as the method name
+--FILE--
+<?php
+class DsmcCalc {
+    public static function add(int $a, int $b): int { return $a + $b; }
+    public static function mul(int $a, int $b): int { return $a * $b; }
+    public static $store = 'a static property';
+}
+$op = 'add';
+echo DsmcCalc::$op(2, 3), "\n";              // -> add
+$op = 'mul';
+echo DsmcCalc::$op(2, 3), "\n";              // -> mul
+
+$cls = 'DsmcCalc';
+$m = 'add';
+echo $cls::$m(10, 20), "\n";                 // dynamic class + dynamic method
+
+$obj = new DsmcCalc();
+echo $obj::$m(1, 1), "\n";                    // dynamic method via instance
+
+// A same-named static property is unaffected (no call).
+echo DsmcCalc::$store, "\n";                  // static property access
+?>
+--EXPECT--
+5
+6
+30
+2
+a static property
+--CLEAN--
+<?php


### PR DESCRIPTION
A callable string with a leading '\' ("\trim", "\Foo\bar") anchors the name to the global namespace; strip it before resolving so dynamic calls, array_map('\trim', ...) and func_exists/is_callable find the function (OP_CALL name resolution, vm_builtin_func_exists, PH7_VmIsCallable).

A static call with a DYNAMIC method name (C::$m(...)) now uses the variable's VALUE as the method name instead of the literal "m" (OP_MEMBER rebuild in the method-call codegen).

debug_backtrace() honors its $options argument: DEBUG_BACKTRACE_PROVIDE_OBJECT (default) attaches the executing $this as the frame's 'object', and DEBUG_BACKTRACE_IGNORE_ARGS drops the 'args' entry. PHPUnit's mock invocation handler reads frame['object'].

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
