### PR TITLE
Fix an unset-slot double-free and four gaps

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -9794,42 +9794,61 @@ static sxi32 PH7_CompileClassInterface(ph7_gen_state *pGen)
 	pBase = 0;
 	if( pGen->pIn < pGen->pEnd  && (pGen->pIn->nType & PH7_TK_KEYWORD) ){
 		nKwrd = SX_PTR_TO_INT(pGen->pIn->pUserData);
-		if( nKwrd == PH7_TKWRD_EXTENDS /* interface b extends a */ ){
-			SyBlob sResolved;
-			SyString sBaseName;
-			sxu32 nRefLine;
-			/* Extract base interface */
+		if( nKwrd == PH7_TKWRD_EXTENDS /* interface b extends a, c, … */ ){
+			/* php lets an interface extend SEVERAL parent interfaces. The first
+			 * becomes pBase (single-inheritance chain, hDerived); every extra one
+			 * is recorded via PH7_ClassImplement so it lands in aInterface — the
+			 * runtime subtype walk (VmInterfaceReaches) follows both. */
 			pGen->pIn++;
-			nRefLine = (pGen->pIn < pGen->pEnd) ? pGen->pIn->nLine : nLine;
-			SyBlobInit(&sResolved,&pGen->pVm->sAllocator);
-			if( GenStateParseClassReference(pGen,&sResolved) != SXRET_OK ){
-				SyBlobRelease(&sResolved);
-				rc = PH7_GenCompileError(pGen,E_ERROR,nLine,
-					"Expected 'interface_name' after 'extends' keyword inside interface '%z'",
-					pName);
-				SyMemBackendPoolFree(&pGen->pVm->sAllocator,pClass);
-				if( rc == SXERR_ABORT ){
-					return SXERR_ABORT;
-				}
-				return SXRET_OK;
-			}
-			pBase = PH7_VmExtractClass(pGen->pVm,
-				(const char *)SyBlobData(&sResolved),(sxu32)SyBlobLength(&sResolved),FALSE,0);
-			SyStringInitFromBuf(&sBaseName,
-				(const char *)SyBlobData(&sResolved),SyBlobLength(&sResolved));
-			/* Only interfaces is allowed */
-			while( pBase && (pBase->iFlags & PH7_CLASS_INTERFACE) == 0 ){
-				pBase = pBase->pNextName;
-			}
-			if( pBase == 0 ){
-				rc = PH7_GenCompileError(pGen,E_ERROR,nRefLine,
-					"Nonexistent base interface '%z'",&sBaseName);
-				if( rc == SXERR_ABORT ){
+			for(;;){
+				SyBlob sResolved;
+				SyString sBaseName;
+				sxu32 nRefLine;
+				ph7_class *pParent;
+				nRefLine = (pGen->pIn < pGen->pEnd) ? pGen->pIn->nLine : nLine;
+				SyBlobInit(&sResolved,&pGen->pVm->sAllocator);
+				if( GenStateParseClassReference(pGen,&sResolved) != SXRET_OK ){
 					SyBlobRelease(&sResolved);
-					return SXERR_ABORT;
+					rc = PH7_GenCompileError(pGen,E_ERROR,nLine,
+						"Expected 'interface_name' after 'extends' keyword inside interface '%z'",
+						pName);
+					SyMemBackendPoolFree(&pGen->pVm->sAllocator,pClass);
+					if( rc == SXERR_ABORT ){
+						return SXERR_ABORT;
+					}
+					return SXRET_OK;
 				}
+				pParent = PH7_VmExtractClass(pGen->pVm,
+					(const char *)SyBlobData(&sResolved),(sxu32)SyBlobLength(&sResolved),FALSE,0);
+				SyStringInitFromBuf(&sBaseName,
+					(const char *)SyBlobData(&sResolved),SyBlobLength(&sResolved));
+				/* Only interfaces is allowed */
+				while( pParent && (pParent->iFlags & PH7_CLASS_INTERFACE) == 0 ){
+					pParent = pParent->pNextName;
+				}
+				if( pParent == 0 ){
+					rc = PH7_GenCompileError(pGen,E_ERROR,nRefLine,
+						"Nonexistent base interface '%z'",&sBaseName);
+					if( rc == SXERR_ABORT ){
+						SyBlobRelease(&sResolved);
+						return SXERR_ABORT;
+					}
+				}else if( pBase == 0 ){
+					/* First parent → single-inheritance base */
+					pBase = pParent;
+				}else{
+					/* Additional parent → record it in aInterface (+ copy its
+					 * constants/method stubs) so instanceof reaches it too. */
+					PH7_ClassImplement(pClass,pParent);
+				}
+				SyBlobRelease(&sResolved);
+				/* Continue on a comma-separated list */
+				if( pGen->pIn < pGen->pEnd && (pGen->pIn->nType & PH7_TK_COMMA) ){
+					pGen->pIn++;
+					continue;
+				}
+				break;
 			}
-			SyBlobRelease(&sResolved);
 		}
 	}
 	if( pGen->pIn >= pGen->pEnd  || (pGen->pIn->nType & PH7_TK_OCB /*'{'*/) == 0 ){
@@ -11034,38 +11053,46 @@ static sxi32 GenStateCompileClassEx(ph7_gen_state *pGen,sxi32 iFlags,
 				pGen->pIn++; /* Jump the 'use' keyword */
 				for(;;){
 					ph7_class *pTrait;
-					SyString *pTraitName;
-					if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_ID) == 0 ){
-						rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,
+					SyBlob sResolved;
+					SyString sTraitName;
+					sxu32 nUseLine = (pGen->pIn < pGen->pEnd) ? pGen->pIn->nLine : nLine;
+					/* A trait name is a full class reference: it may be qualified or
+					 * fully-qualified (`use Foo\Bar\T;`, `use \Foo\Bar\T;`) — the generated
+					 * PHPUnit mocks name their traits absolutely. Parse it with the shared
+					 * class-reference reader (handles the leading '\', every '\'-segment and
+					 * namespace/import resolution) instead of a single-identifier read, which
+					 * choked on the first '\'. */
+					SyBlobInit(&sResolved,&pGen->pVm->sAllocator);
+					if( GenStateParseClassReference(pGen,&sResolved) != SXRET_OK ){
+						SyBlobRelease(&sResolved);
+						rc = PH7_GenCompileError(pGen,E_ERROR,nUseLine,
 							"Expected trait name after 'use' inside class '%z'",pName);
 						if( rc == SXERR_ABORT ){
 							return SXERR_ABORT;
 						}
 						break;
 					}
-					pTraitName = &pGen->pIn->sData;
-					/* Resolve trait name through namespace/imports */ {
-						SyBlob sResolved;
-						SyBlobInit(&sResolved,&pGen->pVm->sAllocator);
-						GenStateResolveName(pGen,pTraitName,&sResolved);
-						pTrait = PH7_VmExtractClass(pGen->pVm,
-							(const char *)SyBlobData(&sResolved),(sxu32)SyBlobLength(&sResolved),FALSE,0);
-						SyBlobRelease(&sResolved);
-					}
+					pTrait = PH7_VmExtractClass(pGen->pVm,
+						(const char *)SyBlobData(&sResolved),(sxu32)SyBlobLength(&sResolved),FALSE,0);
+					SyStringInitFromBuf(&sTraitName,
+						(const char *)SyBlobData(&sResolved),SyBlobLength(&sResolved));
 					/* Only traits are allowed */
 					while( pTrait && (pTrait->iFlags & PH7_CLASS_TRAIT) == 0 ){
 						pTrait = pTrait->pNextName;
 					}
 					if( pTrait == 0 ){
-						rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,
-							"'%z' is not a trait",pTraitName);
+						rc = PH7_GenCompileError(pGen,E_ERROR,nUseLine,
+							"'%z' is not a trait",&sTraitName);
 						if( rc == SXERR_ABORT ){
+							SyBlobRelease(&sResolved);
 							return SXERR_ABORT;
 						}
 					}else{
 						SySetPut(&sUse.aTraits,(const void *)&pTrait);
 					}
-					pGen->pIn++; /* Advance past trait name */
+					SyBlobRelease(&sResolved);
+					/* GenStateParseClassReference already advanced past the whole name —
+					 * continue only across a comma-separated trait list. */
 					if( pGen->pIn >= pGen->pEnd || (pGen->pIn->nType & PH7_TK_COMMA) == 0 ){
 						break;
 					}
@@ -12002,6 +12029,13 @@ static sxi32 PH7_CompileTrait(ph7_gen_state *pGen)
 			if( nKwrd == PH7_TKWRD_PUBLIC || nKwrd == PH7_TKWRD_PRIVATE || nKwrd == PH7_TKWRD_PROTECTED ){
 				iProtection = nKwrd;
 				pGen->pIn++;
+				/* Optional `readonly` after the visibility (PHP 8.1): `private readonly T
+				 * $x` — the generated PHPUnit runtime traits (StubApi, …) declare their
+				 * readonly state this way. Mirrors the class-body attribute parser. */
+				if( pGen->pIn < pGen->pEnd && GenStateIsReadonly(pGen->pIn) ){
+					iAttrflags |= PH7_CLASS_ATTR_READONLY;
+					pGen->pIn++; /* Jump the 'readonly' modifier */
+				}
 				if( pGen->pIn >= pGen->pEnd
 					|| (pGen->pIn->nType & (PH7_TK_KEYWORD|PH7_TK_DOLLAR|PH7_TK_ID|PH7_TK_OP|PH7_TK_NSSEP|PH7_TK_LPAREN)) == 0 ){
 					rc = PH7_GenCompileError(pGen,E_ERROR,pGen->pIn->nLine,
@@ -13622,6 +13656,20 @@ static sxi32 GenStateEmitExprCode(
 			if( pNode->pOp
 				&& (pNode->pOp->iVmOp == PH7_OP_INCR || pNode->pOp->iVmOp == PH7_OP_DECR) ){
 				iLeftFlags |= EXPR_FLAG_LOAD_IDX_STORE | EXPR_FLAG_MEMBER_WRITE;
+			}
+			/* `??` reads its LEFT operand in isset-context: an undefined or
+			 * UNINITIALIZED typed PROPERTY must yield the default rather than a
+			 * warning/Error (php). Tag a member-access LHS so its OP_MEMBER takes
+			 * the silent-lookup path (iP2 = ISSET), which still loads a present
+			 * value. A SUBSCRIPT LHS is left untagged: LOAD_IDX's ISSET mode means
+			 * offsetExists (a bool), but `$o[$k] ?? d` needs the offsetGet value —
+			 * that path is already handled correctly by OP_NULLC. */
+			if( pNode->pOp && pNode->pOp->iOp == EXPR_OP_NULLC
+				&& pNode->pLeft && pNode->pLeft->pOp
+				&& (pNode->pLeft->pOp->iOp == EXPR_OP_ARROW
+					|| pNode->pLeft->pOp->iOp == EXPR_OP_NULLSAFE_ARROW
+					|| pNode->pLeft->pOp->iOp == EXPR_OP_DC) ){
+				iLeftFlags |= EXPR_FLAG_LOAD_IDX_ISSET;
 			}
 			if( iVmOp == PH7_OP_ERR_CTRL ){
 				/* '@' must suppress the diagnostics raised WHILE its operand runs, so

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -1079,10 +1079,21 @@ static void VmLeaveFrame(ph7_vm *pVm)
  */
 static VmRefObj * VmRefObjExtract(ph7_vm *pVm,sxu32 nObjIdx);
 static sxi32 VmUnsetVarByName(ph7_vm *pVm,VmFrame *pFrame,const char *zName,sxu32 nByte);
-static void VmPinMemObjSlot(ph7_vm *pVm,sxu32 nIdx)
+/*
+ * Remove a memobj slot from whichever active frame's local-teardown set (sLocal)
+ * records it — walking the parent chain covers by-reference aliases whose slot is
+ * owned by a caller. Returns TRUE if an entry was dropped.
+ *
+ * A slot lands in sLocal so VmLeaveFrame frees it when the frame exits. But a slot
+ * can leave its frame's ownership EARLY — pinned past the frame (VmPinMemObjSlot),
+ * or returned to the free pool by unset() — and once the index is recycled for a
+ * different owner (an object property reserved with VM_REF_IDX_KEEP, say) a stale
+ * sLocal entry makes VmLeaveFrame release that unrelated owner's value. Dropping the
+ * entry at the point the slot leaves the frame closes that use-after-free.
+ */
+static int VmDropFrameLocalSlot(ph7_vm *pVm,sxu32 nIdx)
 {
 	VmFrame *pFrame;
-	VmRefObj *pRef;
 	for( pFrame = pVm->pFrame ; pFrame ; pFrame = pFrame->pParent ){
 		VmSlot *aSlot = (VmSlot *)SySetBasePtr(&pFrame->sLocal);
 		sxu32 n;
@@ -1091,14 +1102,16 @@ static void VmPinMemObjSlot(ph7_vm *pVm,sxu32 nIdx)
 				/* Swap-remove: teardown order over sLocal is immaterial */
 				aSlot[n] = aSlot[SySetUsed(&pFrame->sLocal)-1];
 				(void)SySetPop(&pFrame->sLocal);
-				pFrame = 0; /* Slot owned by exactly one frame */
-				break;
+				return TRUE; /* Slot owned by exactly one frame */
 			}
 		}
-		if( pFrame == 0 ){
-			break;
-		}
 	}
+	return FALSE;
+}
+static void VmPinMemObjSlot(ph7_vm *pVm,sxu32 nIdx)
+{
+	VmRefObj *pRef;
+	VmDropFrameLocalSlot(&(*pVm),nIdx);
 	pRef = VmRefObjExtract(&(*pVm),nIdx);
 	if( pRef ){
 		pRef->iFlags |= VM_REF_IDX_KEEP;
@@ -16322,6 +16335,14 @@ case PH7_OP_MEMBER: {
 							if( pNext->iOp == PH7_OP_STORE && pNext->iP2 ){
 								bIsLhs = 1;
 							}
+							/* isset()/empty()/`??` read an uninitialized typed property
+							 * as "not set" — a silent miss, NOT the Error a plain read
+							 * raises (php). The compiler tags such an access iP2 =
+							 * ISSET/EMPTY; treat it like the assignment-LHS case and fall
+							 * through to load the slot's NULL. */
+							if( VmMemberCtxIsLookup(pInstr->iP2) ){
+								bIsLhs = 1;
+							}
 							if( !bIsLhs ){
 								sxi32 rcU = VmThrowUninitializedPropertyError(&(*pVm),pClass,pObjAttr->pAttr);
 								PH7_ClassInstanceUnref(pThis);
@@ -24317,6 +24338,10 @@ static sxi32 VmUnsetVarByName(ph7_vm *pVm,VmFrame *pFrame,const char *zName,sxu3
 		/* Unaliased variable: nobody else holds the slot, so the old path is right */
 		SyHashDeleteEntry2(pEntry);
 		PH7_VmUnsetMemObj(&(*pVm),nIdx,FALSE);
+		/* The slot is back in the free pool; drop its stale local-teardown entry so a
+		 * later reuse of the index (e.g. an object property) is not double-freed when
+		 * this frame exits. */
+		VmDropFrameLocalSlot(&(*pVm),nIdx);
 		return SXRET_OK;
 	}
 	{
@@ -24349,6 +24374,10 @@ static sxi32 VmUnsetVarByName(ph7_vm *pVm,VmFrame *pFrame,const char *zName,sxu3
 		if( nLive < 1 ){
 			/* Last holder gone: now the value may go too */
 			PH7_VmUnsetMemObj(&(*pVm),nIdx,FALSE);
+			/* Slot returned to the free pool: drop its stale local-teardown entry so a
+			 * later reuse of the index is not double-freed on frame exit (see
+			 * VmDropFrameLocalSlot). */
+			VmDropFrameLocalSlot(&(*pVm),nIdx);
 		}
 	}
 	return SXRET_OK;
@@ -24440,6 +24469,9 @@ static int vm_builtin_unset(ph7_context *pCtx,int nArg,ph7_value **apArg)
 				return PH7_ABORT;
 			}
 			PH7_VmUnsetMemObj(&(*pVm),nIdx,FALSE);
+			/* Drop the stale local-teardown entry for the freed slot (see
+			 * VmDropFrameLocalSlot) so a later index reuse is not double-freed. */
+			VmDropFrameLocalSlot(&(*pVm),nIdx);
 		}
 	}
 	return SXRET_OK;

--- a/src/ph7/vm_builtin_class.c
+++ b/src/ph7/vm_builtin_class.c
@@ -908,6 +908,34 @@ PH7_PRIVATE int vm_builtin_get_object_vars(ph7_context *pCtx,int nArg,ph7_value 
  * detection should reject them up front. */
 #define PH7_INTERFACE_WALK_MAX_DEPTH 64
 /*
+ * TRUE if pTarget is reachable from pIface as an ancestor interface: walk the
+ * `extends` chain (pBase) AND each additional parent-interface set (aInterface),
+ * so a multiple-interface `interface C extends A, B` is recognized through BOTH
+ * A and B (php allows an interface to extend several interfaces). Recursion is
+ * depth-bounded — a malformed cycle cannot run unbounded.
+ */
+static int VmInterfaceReaches(ph7_class *pIface,ph7_class *pTarget,int iDepth)
+{
+	while( pIface && iDepth <= PH7_INTERFACE_WALK_MAX_DEPTH ){
+		ph7_class **apParent;
+		sxu32 n;
+		if( pIface == pTarget ){
+			return TRUE;
+		}
+		/* Additional parent interfaces (interface X extends A, B, …) live in
+		 * aInterface; the first parent stays on the pBase chain below. */
+		apParent = (ph7_class **)SySetBasePtr(&pIface->aInterface);
+		for( n = 0 ; n < SySetUsed(&pIface->aInterface) ; n++ ){
+			if( VmInterfaceReaches(apParent[n],pTarget,iDepth+1) ){
+				return TRUE;
+			}
+		}
+		pIface = pIface->pBase;
+		iDepth++;
+	}
+	return FALSE;
+}
+/*
  * This function returns TRUE if the given class is an implemented
  * interface.Otherwise FALSE is returned.
  */
@@ -924,14 +952,8 @@ static int VmQueryInterfaceSet(ph7_class *pClass,SySet *pSet)
 	/* Perform the lookup, walking each interface's parent chain so that
 	 * Iterator extends Traversable (and similar) is recognized. */
 	for( n = 0 ; n < SySetUsed(pSet) ; n++ ){
-		ph7_class *pIface = apInterface[n];
-		int iDepth = 0;
-		while( pIface && iDepth <= PH7_INTERFACE_WALK_MAX_DEPTH ){
-			if( pIface == pClass ){
-				return TRUE;
-			}
-			pIface = pIface->pBase;
-			iDepth++;
+		if( VmInterfaceReaches(apInterface[n],pClass,0) ){
+			return TRUE;
 		}
 	}
 	return FALSE;

--- a/tests/ph7/001-smoke/oo/coalesce_uninitialized_typed_property.phpt
+++ b/tests/ph7/001-smoke/oo/coalesce_uninitialized_typed_property.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+isset()/empty()/?? treat an uninitialized typed property as not-set (no Error)
+--FILE--
+<?php
+class CutpBox {
+    private readonly int $x;
+    public int $y = 7;
+    public function tIsset(): bool { return isset($this->x); }
+    public function tCoalesce(): string { return $this->x ?? 'def'; }
+    public function tPresent(): int { return $this->y ?? 99; }
+}
+$b = new CutpBox();
+echo $b->tIsset() ? "set\n" : "unset\n";
+echo $b->tCoalesce(), "\n";
+echo $b->tPresent(), "\n";
+?>
+--EXPECT--
+unset
+def
+7

--- a/tests/ph7/001-smoke/oo/interface_multiple_extends.phpt
+++ b/tests/ph7/001-smoke/oo/interface_multiple_extends.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+An interface may extend several interfaces; instanceof reaches all of them
+--FILE--
+<?php
+interface ImeA { public function a(): string; }
+interface ImeB { public function b(): string; }
+interface ImeC extends ImeA, ImeB { public function c(): string; }
+class ImeImpl implements ImeC {
+    public function a(): string { return 'a'; }
+    public function b(): string { return 'b'; }
+    public function c(): string { return 'c'; }
+}
+$o = new ImeImpl();
+echo ($o instanceof ImeA) ? "A\n" : "no A\n";
+echo ($o instanceof ImeB) ? "B\n" : "no B\n";
+echo ($o instanceof ImeC) ? "C\n" : "no C\n";
+?>
+--EXPECT--
+A
+B
+C

--- a/tests/ph7/001-smoke/oo/trait_qualified_name_use.phpt
+++ b/tests/ph7/001-smoke/oo/trait_qualified_name_use.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A class may use a namespaced/fully-qualified trait name
+--FILE--
+<?php
+namespace Qtnu\Space {
+    trait Greeter { public function hi(): string { return 'hi from Greeter'; } }
+}
+namespace {
+    class QtnuUser { use \Qtnu\Space\Greeter; }
+    class QtnuUser2 { use Qtnu\Space\Greeter; }
+    echo (new QtnuUser())->hi(), "\n";
+    echo (new QtnuUser2())->hi(), "\n";
+}
+?>
+--EXPECT--
+hi from Greeter
+hi from Greeter

--- a/tests/ph7/001-smoke/oo/trait_readonly_property.phpt
+++ b/tests/ph7/001-smoke/oo/trait_readonly_property.phpt
@@ -1,0 +1,18 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A trait may declare a private readonly typed property
+--FILE--
+<?php
+class TrpState { public int $v = 41; }
+trait TrpApi {
+    private readonly TrpState $__state;
+    public function state(): TrpState { return $this->__state ?? new TrpState(); }
+}
+class TrpUser { use TrpApi; }
+$u = new TrpUser();
+echo $u->state()->v + 1, "\n";
+?>
+--EXPECT--
+42

--- a/tests/ph7/001-smoke/oo/unset_local_slot_reuse_property.phpt
+++ b/tests/ph7/001-smoke/oo/unset_local_slot_reuse_property.phpt
@@ -1,0 +1,23 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A local freed by unset() must not clobber an object property that reuses its slot
+--FILE--
+<?php
+final class UlsrpHolder {
+    private string $code;
+    public function __construct(string $c) { $this->code = $c; }
+    public function code(): string { return $this->code; }
+}
+function ulsrp_build(): UlsrpHolder {
+    $tmp = str_repeat('T', 64);   // reserves a local slot
+    unset($tmp);                  // returns the slot to the free pool
+    $h = new UlsrpHolder(str_repeat('x', 1892)); // property may reuse that slot
+    return $h;
+}
+$h = ulsrp_build();
+echo strlen($h->code()), "\n";
+?>
+--EXPECT--
+1892


### PR DESCRIPTION
unset() of a local variable returned its memory-object INDEX to the free pool but left the stale entry in the frame's local-teardown set (sLocal). When the index was reused for an object property (reserved VM_REF_IDX_KEEP), leaving the frame ran the teardown over the stale entry and released the property's value, so a live typed private property silently went uninitialized. This is a logical index double-ownership, invisible to ASan/pool-bypass (the memory is valid; the index is aliased). A new VmDropFrameLocalSlot drops the stale sLocal entry wherever unset returns a slot to the pool (factored out of VmPinMemObjSlot, which needed the same). It surfaced as a mock class losing its 1892-byte classCode property between construction and use.

Four parser/runtime gaps the same PHPUnit mock generation hit:

- An interface may extend several interfaces (interface C extends A, B): the first parent stays the pBase chain, extras are recorded in aInterface, and the runtime subtype walk (new VmInterfaceReaches) recurses through both so instanceof reaches every ancestor.

- A trait may be named qualified or fully-qualified in a use statement (use Foo\Bar\T;, use \Foo\Bar\T;): parse it with the shared class-reference reader instead of a single identifier, which choked on the first '\' and silently aborted the class inside eval.

- A trait body may declare a readonly typed property (private readonly T $x): the trait member parser now consumes the post-visibility readonly modifier, mirroring the class-body attribute path.

- isset()/empty()/?? on an uninitialized typed property now read it as not-set instead of throwing "must not be accessed before initialization": the runtime uninitialized-property Error is suppressed in a lookup context, and ?? tags a member-access LHS (but not a subscript LHS, whose LOAD_IDX ISSET mode means offsetExists) so the value is read through the silent path.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
