### PR TITLE
Scope get_defined_vars() to the frame locals

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -24485,6 +24485,12 @@ static sxi32 VmHashVarWalker(SyHashEntry *pEntry,void *pUserData)
 	ph7_vm *pVm = pArray->pVm;
 	ph7_value *pObj;
 	sxu32 nIdx;
+	/* php excludes $this from get_defined_vars() (it is bound implicitly, not a
+	 * declared local). PHL keeps it in the frame's hVar, so skip it here. */
+	if( pEntry->nKeyLen == sizeof("this")-1
+	 && SyMemcmp(pEntry->pKey,"this",sizeof("this")-1) == 0 ){
+		return SXRET_OK;
+	}
 	/* Extract the memory object */
 	nIdx = SX_PTR_TO_INT(pEntry->pUserData);
 	pObj = (ph7_value *)SySetAt(&pVm->aMemObj,nIdx);
@@ -24526,8 +24532,14 @@ static int vm_builtin_get_defined_vars(ph7_context *pCtx,int nArg,ph7_value **ap
 		ph7_result_null(pCtx);
 		return SXRET_OK;
 	}
-	/* Superglobals first */
-	SyHashForEach(&pVm->hSuper,VmHashVarWalker,pArray);
+	/* Superglobals appear in get_defined_vars() ONLY at the global scope (php).
+	 * Inside a function the result is the local symbol table alone — a leak of
+	 * $argv/$_SERVER/... into every function's scope breaks callers that treat the
+	 * keys as real locals (e.g. PHPUnit's doubled-method template reflects each
+	 * get_defined_vars() name as a ReflectionParameter). */
+	if( pVm->pFrame->pParent == 0 ){
+		SyHashForEach(&pVm->hSuper,VmHashVarWalker,pArray);
+	}
 	/* Then variable defined in the current frame */
 	SyHashForEach(&pVm->pFrame->hVar,VmHashVarWalker,pArray);
 	/* Finally,return the created array */

--- a/tests/ph7/001-smoke/function/get_defined_vars_scope.phpt
+++ b/tests/ph7/001-smoke/function/get_defined_vars_scope.phpt
@@ -1,0 +1,27 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+get_defined_vars() returns only locals in a function/method (no superglobals, no $this)
+--FILE--
+<?php
+function gdvs_fn(int $a, int $b) {
+    $c = $a + $b;
+    $k = array_keys(get_defined_vars());
+    sort($k);
+    return implode(',', $k);
+}
+class GdvsK {
+    public function m(int $x) {
+        $y = 1;
+        $k = array_keys(get_defined_vars());
+        sort($k);
+        return implode(',', $k);
+    }
+}
+echo gdvs_fn(1, 2), "\n";
+echo (new GdvsK())->m(5), "\n";
+?>
+--EXPECT--
+a,b,c
+x,y


### PR DESCRIPTION
get_defined_vars() walked the superglobals table unconditionally and never excluded $this, so inside a function/method it returned $argv, $_SERVER, $_GET, ... and $this alongside the real locals. php includes superglobals only at the global scope and never lists $this.

The leak broke PHPUnit's generated test-double methods: the doubled-method template calls new ReflectionParameter([__CLASS__, __FUNCTION__], $name) for every get_defined_vars() key, so the phantom argv/this (not parameters of the mocked method) threw "The parameter specified by its name could not be found". With this fixed, createMock()/->method()->willReturn() and the assertion pass.

Walk the superglobals only at the global frame (pFrame->pParent == 0) and skip the 'this' entry in the frame walker.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
