### PR TITLE
Autoload the class of an array callable

### DIFF
--- a/src/ph7/vm_builtin_class.c
+++ b/src/ph7/vm_builtin_class.c
@@ -121,14 +121,16 @@ PH7_PRIVATE ph7_class * PH7_VmExtractClassFromValue(ph7_vm *pVm,ph7_value *pArg)
 		int nLen;
 		/* Extract class name */
 		zClass = ph7_value_to_string(pArg,&nLen);
+		/* php: a leading '\' anchors the name to the global namespace. */
+		if( nLen > 0 && zClass[0] == '\\' ){ zClass++; nLen--; }
 		if( nLen > 0 ){
-			SyHashEntry *pEntry;
-			/* Perform a lookup */
-			pEntry = SyHashGet(&pVm->hClass,(const void *)zClass,(sxu32)nLen);
-			if( pEntry ){
-				/* Point to the desired class */
-				pClass = (ph7_class *)pEntry->pUserData;
-			}
+			/* Resolve through PH7_VmExtractClass so a class named by STRING is
+			 * autoloaded on a miss — php autoloads the class of a [class,method]
+			 * callable (is_callable/array_map/call_user_func), and of the class
+			 * argument to method_exists()/property_exists(). iLoadable=FALSE keeps
+			 * abstract classes and interfaces (a static method on an abstract class
+			 * is a valid callable). */
+			pClass = PH7_VmExtractClass(pVm,zClass,(sxu32)nLen,FALSE,0);
 		}
 	}
 	return pClass;

--- a/tests/ph7/002-integration/function/array_callback_autoload.phpt
+++ b/tests/ph7/002-integration/function/array_callback_autoload.phpt
@@ -1,0 +1,20 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A [ClassName, staticMethod] callback autoloads the class (array_map/is_callable)
+--FILE--
+<?php
+spl_autoload_register(function ($c) {
+    if ($c === 'AcaLazyHelper') {
+        eval('class AcaLazyHelper { public static function fmt($v) { return "<$v>"; } }');
+    }
+});
+// class not yet loaded; the array callable must autoload it
+var_dump(is_callable(['AcaLazyHelper', 'fmt']));
+$r = array_map(['AcaLazyHelper', 'fmt'], ['a', 'b']);
+echo implode(',', $r), "\n";
+?>
+--EXPECT--
+bool(true)
+<a>,<b>


### PR DESCRIPTION
PH7_VmExtractClassFromValue resolved a string class name with a bare hClass lookup and no autoload, so a [ClassName, method] array callable whose class was not yet loaded was rejected as "not a valid callback" (array_map, is_callable, call_user_func) — where php autoloads the class. It also affected method_exists() and property_exists() with an unloaded class-name string.

Resolve the string through PH7_VmExtractClass, which autoloads on a miss (the string "Class::method" callable path already did). Also strip a leading '\'. This unblocked PHPUnit's mock argument matching: Invocation::toString() maps array_map([Util\Exporter::class, 'shortenedExport'], ...) over the arguments before the Exporter class is otherwise referenced.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
