### PR TITLE
Bind instanceof tighter than logical NOT

### DIFF
--- a/src/ph7/parse.c
+++ b/src/ph7/parse.c
@@ -1832,6 +1832,38 @@ static sxi32 ExprProcessFuncArguments(ph7_gen_state *pGen,ph7_expr_node *pOp,ph7
 		  }
 		 iLeft = iCur;
 	 }
+	 /* Link `instanceof` BEFORE the unary(prec 4) pass. PHP gives instanceof a
+	  * HIGHER precedence than logical NOT, so `!$x instanceof C` parses as
+	  * `!($x instanceof C)`. instanceof lives in the generic binary pass (prec
+	  * 7-16) which runs AFTER unary — leaving it there lets `!` capture $x first
+	  * and yields the wrong `(!$x) instanceof C`. Collapse each `$obj instanceof
+	  * Class` into a term here (left = object expr, right = class-name term) so a
+	  * preceding `!`/`~`/cast then operates on the whole subtree. The generic
+	  * pass below skips it (pLeft != 0). */
+	 iLeft = -1;
+	 for( iCur = 0 ; iCur < nToken ; ++iCur ){
+		 if( apNode[iCur] == 0 ){
+			 continue;
+		 }
+		 pNode = apNode[iCur];
+		 if( pNode->pOp && pNode->pOp->iOp == EXPR_OP_INSTOF && pNode->pLeft == 0 ){
+			 iRight = iCur + 1;
+			 while( iRight < nToken && apNode[iRight] == 0 ){
+				 iRight++;
+			 }
+			 if( iRight >= nToken || iLeft < 0 || !NODE_ISTERM(iRight) || !NODE_ISTERM(iLeft) ){
+				 rc = PH7_GenSyntaxError(pGen,0,0);
+				 if( rc != SXERR_ABORT ){
+					 rc = SXERR_SYNTAX;
+				 }
+				 return rc;
+			 }
+			 pNode->pLeft = apNode[iLeft];
+			 pNode->pRight = apNode[iRight];
+			 apNode[iLeft] = apNode[iRight] = 0;
+		 }
+		 iLeft = iCur;
+	 }
 	 /* Handle right associative unary and cast operators [i.e: !,(string),~...]  with precedence 4*/
 	  iLeft = 0;
 	  for( iCur = nToken -  1 ; iCur >= 0 ; iCur-- ){

--- a/tests/ph7/001-smoke/lang/instanceof_precedence_not.phpt
+++ b/tests/ph7/001-smoke/lang/instanceof_precedence_not.phpt
@@ -1,0 +1,28 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+instanceof binds tighter than logical NOT: !$x instanceof C is !($x instanceof C)
+--FILE--
+<?php
+class IopnWrap {}
+$s = 'hello';
+// Without parens, php parses !$s instanceof C as !($s instanceof C) = !false = true
+if (!$s instanceof IopnWrap) { $s = 'CHANGED'; }
+echo $s, "\n";
+// The PHPUnit constructor shape: wrap non-objects
+$out = [];
+foreach (['a', new IopnWrap()] as $item) {
+    if (!$item instanceof IopnWrap) { $item = new IopnWrap(); }
+    $out[] = get_class($item);
+}
+echo implode(',', $out), "\n";
+// Assignment form
+$obj = new IopnWrap();
+$cond = !$obj instanceof IopnWrap;
+echo $cond ? "true\n" : "false\n";
+?>
+--EXPECT--
+CHANGED
+IopnWrap,IopnWrap
+false


### PR DESCRIPTION
The precedence parser processed the unary prec-4 pass (!, ~, casts) before the generic binary pass (prec 7-16) that handled instanceof, so `!$x instanceof C` collapsed as `(!$x) instanceof C` instead of php's `!($x instanceof C)` — instanceof has higher precedence than !. On a string $x this flipped the condition (`(!$x) instanceof C` is always false), so a guarded reassignment like PHPUnit's `if (!$p instanceof Constraint) { $p = new IsEqual($p); }` never ran and the raw value was used where a Constraint object was expected ("Call to a member function evaluate() on string" during ->with() matching).

Add a dedicated instanceof-linking pass before the unary pass so `$obj instanceof Class` collapses to a term first; a preceding !/~/cast then operates on the whole subtree.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
