### PR TITLE
Unwind dead callee frames after an outer catch

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -1175,23 +1175,30 @@ static int VmRecordedResume(ph7_vm *pVm,sxi32 *pResumePc,VmFrame *pEntryFrame,Vm
 		 * never match a real frame. */
 		return FALSE;
 	}
-	/* The catch may have run at an OUTER try, several try-levels above the throw.
-	 * Each intervening try pushed its own VM_FRAME_EXCEPTION frame (at
-	 * OP_LOAD_EXCEPTION) that its OWN OP_POP_EXCEPTION would tear down — but we are
-	 * about to jump straight to the catching try's landing pad, skipping those inner
-	 * OP_POP_EXCEPTIONs. Pop the intermediate exception frames here so exactly one
-	 * frame (the catching try's) is left for the OP_POP_EXCEPTION we land on; without
-	 * this each skipped inner try leaks a frame, corrupting the stack for later code.
-	 * Their handlers/finally already ran in place during VmThrowException. The loop
-	 * stops on any of three terms, all load-bearing: the catching try is reached (its
-	 * iExceptionJump == the recorded landing); a non-exception (body) frame is reached
-	 * (structural floor — never pop a real body); or this exec's entry is reached.
-	 * Landing pads are unique per try within one bytecode array, and the function guard
-	 * above pins (frame,array) to this exec, so the iExceptionJump match cannot stop at
-	 * the wrong try. */
-	while( (pVm->pFrame->iFlags & VM_FRAME_EXCEPTION)
-	    && pVm->pFrame->iExceptionJump != pVm->iResumePc
-	    && pVm->pFrame != pEntryFrame ){
+	/* The catch may have run at an OUTER try, several call-levels above the throw.
+	 * VmThrowException runs the catch in place and then leaves pVm->pFrame at the
+	 * THROW SITE (its pThrowSite restore), so between here and the catching try's
+	 * landing pad the chain can hold: the intermediate try's own VM_FRAME_EXCEPTION
+	 * frames (each normally torn down by its OWN OP_POP_EXCEPTION, which we are about
+	 * to skip), AND — when the throw was raised in a DEEPER call than the one that
+	 * declared the catching try — the dead body frames of those abandoned callees
+	 * (the exception unwound past them, but the in-place-catch resume short-circuits
+	 * the per-record VmCallFinish that would otherwise have popped them). Pop them ALL
+	 * so exactly one frame (the catching try's exception frame) is left for the
+	 * OP_POP_EXCEPTION we land on; without this the skipped inner tries and the
+	 * dangling callee frames leak, and — worse — the landing code runs with pVm->pFrame
+	 * pointing at a dead callee, so its locals resolve against the wrong scope (a live
+	 * caller variable reads as an uninitialised fresh one). Their handlers/finally
+	 * already ran in place during VmThrowException. The loop stops on either term, both
+	 * load-bearing: the catching try's exception frame is reached (its iExceptionJump ==
+	 * the recorded landing); or this exec's entry is reached (structural floor). Landing
+	 * pads are unique per try within one bytecode array, and the function guard above
+	 * pins (frame,array) to this exec, so the iExceptionJump match cannot stop at the
+	 * wrong try. OP_POP_EXCEPTION's frame-leave is guarded on VM_FRAME_EXCEPTION, so
+	 * leaving the catching exception frame here (rather than the body) lands cleanly. */
+	while( pVm->pFrame != pEntryFrame
+	    && !((pVm->pFrame->iFlags & VM_FRAME_EXCEPTION)
+	         && pVm->pFrame->iExceptionJump == pVm->iResumePc) ){
 		VmLeaveFrame(&(*pVm));
 	}
 	*pResumePc = (sxi32)pVm->iResumePc - 1;

--- a/tests/ph7/001-smoke/lang/resume_deep_catch_scope.phpt
+++ b/tests/ph7/001-smoke/lang/resume_deep_catch_scope.phpt
@@ -1,0 +1,61 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+after an outer try catches a throw raised several calls deep, the continuation runs in the catching frame's own scope (outer locals stay live)
+--FILE--
+<?php
+/* Regression: VmRecordedResume used to leave pVm->pFrame pointing at a dead
+ * callee frame when a DEEP throw was caught by an OUTER try, so code after the
+ * try resolved the catching function's own locals against the wrong scope and
+ * read them as fresh nulls. This is the PHPUnit "member function ... on null"
+ * blocker distilled: $emitter (a pre-try local) went null after runBare caught
+ * a constraint failure raised deep inside runTest. */
+class NwpResumeObj {
+    public function ping(): string { return "pong"; }
+}
+function nwpResumeDeep(): void {
+    throw new RuntimeException("deep");
+}
+function nwpResumeMid(): void {
+    /* an inner try that does NOT match the thrown type: it pushes its own
+     * exception frame and re-propagates, reproducing the intermediate frames
+     * the resume path has to tear down. */
+    try {
+        nwpResumeDeep();
+    } catch (LogicException $bad) {
+        echo "unexpected-inner-catch";
+    }
+}
+function nwpResumeOuter(): string {
+    $emitter = new NwpResumeObj();   // pre-try outer local (the $emitter analogue)
+    $marker  = "kept";
+    try {
+        nwpResumeMid();              // throws two calls deep; caught right here
+    } catch (Throwable $e) {
+        $caught = $e->getMessage();  // written in the catch, must persist
+    }
+    /* All three must resolve in THIS frame after the catch. */
+    return $emitter->ping() . "/" . $marker . "/" . $caught;
+}
+echo nwpResumeOuter(), "\n";
+
+/* And the non-exception continuation guard must see the right scope too: with a
+ * successful (non-throwing) call the same tail runs, and isset() reflects it. */
+function nwpResumeNoThrow(): void {}
+function nwpResumeGuard(): string {
+    $emitter = new NwpResumeObj();
+    try {
+        nwpResumeNoThrow();
+    } catch (Throwable $e) {
+        return "threw";
+    }
+    return !isset($e) ? ("clean/" . $emitter->ping()) : "stale-e";
+}
+echo nwpResumeGuard(), "\n";
+?>
+--EXPECT--
+pong/kept/deep
+clean/pong
+--CLEAN--
+<?php


### PR DESCRIPTION
A throw raised several calls deep and caught by an OUTER try left the resume machinery pointing at the wrong frame. VmThrowException runs the catch in place, records the resume target, then restores pVm->pFrame to the deep throw site. VmRecordedResume only tore down VM_FRAME_EXCEPTION frames, stopping at the first body frame ("never pop a real body" — an assumption that only holds for a same-frame throw), so the post-catch continuation ran with pVm->pFrame pointing at a dead callee. Every local in the catching function then resolved (VmExtractMemObj skips only exception frames) against that wrong scope as a fresh, never-assigned null.

This surfaced as PHPUnit's own suite erroring at finalization with "Call to a member function testPassed() on null": TestCase::runBare's $emitter, a live local, read as null after runBare caught a constraint failure raised deep inside runTest.

Extend VmRecordedResume's pop loop to also tear down the dangling dead body frames, stopping at the catching try's own exception frame (iExceptionJump == iResumePc) or the exec entry. Safe because OP_POP_EXCEPTION's frame-leave is guarded on VM_FRAME_EXCEPTION and VmCallFinish's trailing VmLeaveFrame lands cleanly on either the exception frame or the body.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
