### PR TITLE
Invoke a parenthesised member access value

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -13732,8 +13732,16 @@ static sxi32 GenStateEmitExprCode(
 							}
 						}
 					}
-				}else if( pInstr->iOp == PH7_OP_MEMBER /* $a->b(1,2,3) */ || pInstr->iOp == PH7_OP_NEW ){
-					/* Method call,flag that */
+				}else if( (pInstr->iOp == PH7_OP_MEMBER /* $a->b(1,2,3) */
+						&& !(pNode->pLeft && (pNode->pLeft->iFlags & EXPR_NODE_PARENS)))
+					|| pInstr->iOp == PH7_OP_NEW ){
+					/* Method call,flag that. But NOT when the callee was an explicitly
+					 * PARENTHESISED member access: `($o->p)(...)` / `($o::$p)(...)` invokes
+					 * the VALUE of the property (php's variable-invocation), so the OP_MEMBER
+					 * must stay a plain property READ (leaving the callable on the stack for
+					 * OP_CALL to invoke) rather than being rewritten into a method-name
+					 * resolution — the parens are exactly what distinguishes `($o->p)()` from
+					 * the method call `$o->p()`. */
 					pInstr->iP2 = 1;
 					/* A static call with a DYNAMIC method name (`C::$m(...)`): the
 					 * static-`::` codegen folded the variable NAME into OP_MEMBER->p3

--- a/tests/ph7/001-smoke/lang/paren_callable_invoke.phpt
+++ b/tests/ph7/001-smoke/lang/paren_callable_invoke.phpt
@@ -1,0 +1,40 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+a parenthesised member access invoked as a call runs the property VALUE, not a method of that name
+--FILE--
+<?php
+/* `($o->p)(...)` / `($o::$p)(...)` invoke the callable VALUE of the property
+ * (php's variable-invocation), which is distinct from the method call `$o->p()`.
+ * PHL used to compile the parenthesised form as a method call, failing with
+ * "Call to undefined method". Regression for the PHPUnit Callback constraint's
+ * `($this->callback)($other)`. */
+class NpcInvoke {
+    public $cb;
+    public static $scb;
+    public function __construct() {
+        $this->cb  = fn ($n) => $n * 2;
+        self::$scb = fn ($n) => $n + 100;
+    }
+    /* A real method of the same name must still win for the UNparenthesised call. */
+    public function cb($n) { return "method:$n"; }
+    public function callProp($n)   { return ($this->cb)($n); }
+    public function callStatic($n) { return (self::$scb)($n); }
+    public function callMethod($n) { return $this->cb($n); }
+}
+$o = new NpcInvoke();
+echo $o->callProp(21), "\n";    // property closure -> 42
+echo $o->callStatic(1), "\n";   // static property closure -> 101
+echo $o->callMethod(5), "\n";   // real method -> method:5
+/* Also outside a class: parenthesised element/variable invocation. */
+$arr = ['f' => fn () => "elem"];
+echo ($arr['f'])(), "\n";
+?>
+--EXPECT--
+42
+101
+method:5
+elem
+--CLEAN--
+<?php


### PR DESCRIPTION
`($o->p)(...)` and `($o::$p)(...)` invoke the callable VALUE of the property — php's variable-invocation — which is distinct from the method call `$o->p()`. The call codegen unconditionally rewrote a preceding OP_MEMBER into a method-name resolution whenever a call followed, so the parenthesised form compiled as `$o->p(...)` and failed with "Call to undefined method".

Skip that rewrite when the callee node carries EXPR_NODE_PARENS: the OP_MEMBER stays a plain property read, leaving the callable on the stack for OP_CALL to invoke. The parentheses are exactly what distinguishes the two forms, so an unparenthesised `$o->p()` still resolves as a method.

Fixes PHPUnit's Constraint\Callback::matches(), which calls `($this->callback)($other)`.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
