### PR TITLE
Scope a closure to its defining class

### DIFF
--- a/src/ph7/vm_builtin_class.c
+++ b/src/ph7/vm_builtin_class.c
@@ -601,6 +601,15 @@ PH7_PRIVATE int PH7_VmClassMemberAccess(
 			pCallerScope = pFrame->pBoundScope;
 		}else if( pVmFunc && (pVmFunc->iFlags & VM_FUNC_CLASS_METHOD) ){
 			pCallerScope = (ph7_class *)pVmFunc->pUserData;
+		}else if( pVmFunc && (pVmFunc->iFlags & VM_FUNC_CLOSURE) && pVmFunc->pUserData ){
+			/* A closure/arrow-fn defined inside a class carries its creation-site
+			 * class in pUserData (stamped by OP_LOAD_CLOSURE via
+			 * PH7_VmPeekDeclaringClass, the same scope `self::`/`parent::` resolve
+			 * against inside the body). php binds that class as the closure's scope,
+			 * so `$this->privateMethod()` / `self::$private` inside the closure are
+			 * allowed — an explicit Closure::bindTo/bind rebind still wins above via
+			 * pBoundScope. */
+			pCallerScope = (ph7_class *)pVmFunc->pUserData;
 		}else if( pVm->pConstEvalClass ){
 			/* Constant/property initializer bytecode runs without a method
 			 * frame; its scope is the class being initialized (php: a private

--- a/tests/ph7/001-smoke/oo/closure_class_scope.phpt
+++ b/tests/ph7/001-smoke/oo/closure_class_scope.phpt
@@ -1,0 +1,58 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+a closure/arrow-fn defined in a class carries that class as its scope, so it may touch private/protected members
+--FILE--
+<?php
+/* php binds a closure's scope to its defining class: `$this->privateMethod()`,
+ * `self::CONST`, and a private member of ANY same-class instance passed in are
+ * all reachable from inside the closure body. PHL stamped the creation-site
+ * class on the closure (for self:: resolution) but the visibility check ignored
+ * it for VM_FUNC_CLOSURE frames, so every such access raised "from global
+ * scope". Regression for PHPUnit's Operator constraints
+ * (`array_map(fn($c) => $this->checkConstraint($c), $constraints)`). */
+class NcsBase { const K = 7; }
+class NcsScope extends NcsBase {
+    private $secret = "S";
+    private function priv() { return "P"; }
+    protected function prot() { return "R"; }
+    /* arrow fn capturing $this */
+    public function aThis() { $f = fn () => $this->priv() . $this->secret; return $f(); }
+    /* self:: inside the arrow */
+    public function aSelf() { $f = fn () => self::K; return $f(); }
+    /* long-form closure capturing $this, protected method */
+    public function cThis() { $f = function () { return $this->prot(); }; return $f(); }
+    /* via array_map callback (the PHPUnit shape) */
+    public function mapped(array $xs) {
+        return array_map(fn ($x) => $this->twice($x), $xs);
+    }
+    private function twice($x) { return $x * 2; }
+    /* passed same-class instance (not $this): scope still grants access */
+    public function passed(NcsScope $o) { $f = fn () => $o->priv(); return $f(); }
+    /* static arrow reaching a passed object's private */
+    public function staticPassed(NcsScope $o) { $f = static fn () => $o->priv(); return $f(); }
+}
+$o = new NcsScope();
+echo $o->aThis(), "\n";                       // PS
+echo $o->aSelf(), "\n";                        // 7
+echo $o->cThis(), "\n";                        // R
+echo implode(",", $o->mapped([1, 2, 3])), "\n"; // 2,4,6
+echo $o->passed(new NcsScope()), "\n";          // P
+echo $o->staticPassed(new NcsScope()), "\n";    // P
+
+/* A closure defined OUTSIDE the class gets no such scope. */
+$outsider = fn ($x) => $x->priv();
+try { $outsider($o); echo "LEAK\n"; }
+catch (\Error $e) { echo "denied\n"; }
+?>
+--EXPECT--
+PS
+7
+R
+2,4,6
+P
+P
+denied
+--CLEAN--
+<?php


### PR DESCRIPTION
A closure or arrow function defined inside a class stamps its creation-site class onto its VmFunc (OP_LOAD_CLOSURE via PH7_VmPeekDeclaringClass) so `self::`/`parent::` resolve against it. But PH7_VmClassMemberAccess only consulted that pUserData for frames flagged VM_FUNC_CLASS_METHOD, so a closure frame (VM_FUNC_CLOSURE) fell through to the global-scope denial: `fn() => $this->privateMethod()` and `self::$private` inside the body raised "from global scope".

Resolve a VM_FUNC_CLOSURE frame's calling scope to its stamped declaring class the same way a method resolves to its own. An explicit Closure::bindTo/bind scope still wins (it is applied earlier via the frame's pBoundScope).

Clears the four Logical* Operator-constraint hard crashes in PHPUnit's own suite, whose constructor runs
`array_map(fn($c) => $this->checkConstraint($c), $constraints)`.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
