### PR TITLE
Check protected access at the introducing class

### DIFF
--- a/src/ph7/vm_builtin_class.c
+++ b/src/ph7/vm_builtin_class.c
@@ -679,8 +679,35 @@ PH7_PRIVATE int PH7_VmClassMemberAccess(
 		}else{
 			/* Protected */
 			ph7_class *pBase = pCallerScope;
-			/* Must be in the same class hierarchy */
-			if( !PH7_VmInstanceOf(pClass,pBase) && !PH7_VmInstanceOf(pBase,pClass) ){
+			/* php checks the hierarchy against the class that INTRODUCES the member,
+			 * not the one that (re)declares the override we resolved. A protected
+			 * member declared in a common ancestor B and overridden in a child C is
+			 * still reachable from a SIBLING scope S (also extending B) — S and C both
+			 * descend from B. Walk pClass up to the top-most ancestor that genuinely
+			 * declares a member of this name (a method via sFunc.pUserData, or an attr
+			 * via pDeclClass — hMethod/hAttr also carry inherited copies, so match on the
+			 * true declaring class) and test the hierarchy against that introducing
+			 * class. `child_only` (declared solely in C) keeps pClass and stays denied
+			 * from a sibling, matching php. */
+			ph7_class *pIntro = pClass;
+			ph7_class *pAnc;
+			for( pAnc = pClass ; pAnc ; pAnc = pAnc->pBase ){
+				ph7_class_method *pAncMeth = PH7_ClassExtractMethod(pAnc,pAttrName->zString,pAttrName->nByte);
+				SyHashEntry *pAncAttrE = SyHashGet(&pAnc->hAttr,(const void *)pAttrName->zString,pAttrName->nByte);
+				ph7_class_attr *pAncAttr = pAncAttrE ? (ph7_class_attr *)pAncAttrE->pUserData : 0;
+				int bHere = 0;
+				if( pAncMeth && (ph7_class *)pAncMeth->sFunc.pUserData == pAnc ){
+					bHere = 1;
+				}
+				if( pAncAttr && (pAncAttr->pDeclClass == pAnc || pAncAttr->pDeclClass == 0) ){
+					bHere = 1;
+				}
+				if( bHere ){
+					pIntro = pAnc; /* keep climbing: the LAST (highest) match wins */
+				}
+			}
+			/* Must be in the same class hierarchy as the introducing class */
+			if( !PH7_VmInstanceOf(pIntro,pBase) && !PH7_VmInstanceOf(pBase,pIntro) ){
 				int bTraitGrant = 0;
 				if( (pClass->iFlags & PH7_CLASS_TRAIT) != 0 ){
 					/* Same trait-target rule as the private branch above */

--- a/tests/ph7/001-smoke/oo/protected_sibling_introduced_in_base.phpt
+++ b/tests/ph7/001-smoke/oo/protected_sibling_introduced_in_base.phpt
@@ -1,0 +1,46 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+a protected member introduced in a common base is reachable from a sibling scope even when overridden in the target
+--FILE--
+<?php
+/* php checks protected access against the class that INTRODUCES the member, not
+ * the one that re-declares the override that was resolved. So a sibling scope S
+ * (extends B) may touch a protected member declared in B and overridden in a
+ * sibling C (also extends B). PHL checked against C's override class and denied
+ * it — the PHPUnit Constraint\Operator failure-description path
+ * (`$constraint->failureDescription($other)` between sibling constraints).
+ * A member declared ONLY in the target (not the shared base) stays denied. */
+abstract class NpsBase {
+    protected function shared(mixed $o): string { return "base:" . $o; }
+    protected $tag = "B";
+}
+class NpsChild extends NpsBase {
+    protected function shared(mixed $o): string { return "child:" . $o; } // override
+    protected $tag = "C";
+    protected function childOnly(): string { return "co"; }                // NOT in the base
+}
+class NpsSibling extends NpsBase {
+    public function __construct(private NpsBase $c) {}
+    public function callShared(mixed $o): string { $x = $this->c; return $x->shared($o); }
+    public function readTag(): string { $x = $this->c; return $x->tag; }
+    public function callChildOnly(): string {
+        $x = $this->c;
+        return $x instanceof NpsChild ? $x->childOnly() : "n/a";
+    }
+}
+$s = new NpsSibling(new NpsChild());
+echo $s->callShared(1), "\n";   // introduced in base, overridden in child -> child:1
+echo $s->readTag(), "\n";        // protected prop introduced in base -> C
+/* childOnly() is declared only in NpsChild, not the shared base: a sibling scope
+ * has no access, which is a catchable Error. */
+try { echo $s->callChildOnly(), "\n"; }
+catch (\Error $e) { echo "denied\n"; }
+?>
+--EXPECT--
+child:1
+C
+denied
+--CLEAN--
+<?php


### PR DESCRIPTION
php grants access to a protected member from a scope that shares the class HIERARCHY IN WHICH THE MEMBER IS INTRODUCED, not the class of the override that happened to be resolved. A protected method or property declared in a common base B and overridden in a child C is therefore reachable from a sibling scope S (also extending B): S and C both descend from B.

PH7_VmClassMemberAccess tested the sibling hierarchy against the resolved override's declaring class (C), so `$sibling->member()` was wrongly denied whenever the target overrode a base-introduced protected member — reported as the misleading "Call to protected method ... from global scope", and in a deeper call chain it also corrupted the reported argument count ("0 passed"). A member declared ONLY in the target (not the shared base) correctly stays denied.

Walk the target's declaring class up to the top-most ancestor that genuinely declares a member of this name (a method via sFunc.pUserData or an attribute via pDeclClass — hMethod/hAttr also carry inherited copies) and test the hierarchy against that introducing class.

Fixes the bulk of PHPUnit's Framework/Assert suite, whose failing- assertion path runs Constraint\Operator::failureDescription() -> `$constraint->failureDescription($other)` between sibling constraints.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
