### PR TITLE
Populate named capture groups in preg_match

### DIFF
--- a/src/ph7/vm_pcre.c
+++ b/src/ph7/vm_pcre.c
@@ -294,81 +294,60 @@ static void PcrePopulateMatches(
 	if( iFlags & PHP_PREG_OFFSET_CAPTURE ){
 		pSub = ph7_context_new_array(pCtx);
 	}
+	/* Read the name table up front so each group's named key can be emitted
+	 * INTERLEAVED with its numbered key, in group order — php stores
+	 * `0, name, 1, value, 2` (named entry immediately before its number), not
+	 * every number followed by every name. Code that iterates $matches or
+	 * var_dumps it (PHPUnit's annotation parser) depends on this order. */
+	pcre2_pattern_info(pCode, PCRE2_INFO_NAMECOUNT, &namecount);
+	if( namecount > 0 ){
+		pcre2_pattern_info(pCode, PCRE2_INFO_NAMETABLE, &nametable);
+		pcre2_pattern_info(pCode, PCRE2_INFO_NAMEENTRYSIZE, &nameentrysize);
+	}
 	for( i = 0; i < nGroups; i++ ){
 		PCRE2_SIZE start = ovector[2 * i];
 		PCRE2_SIZE end   = ovector[2 * i + 1];
+		const char *zName = 0;
+		/* Does group i carry a (?<name>...) label? namecount is tiny in practice. */
+		if( namecount > 0 ){
+			uint32_t k;
+			for( k = 0; k < namecount; k++ ){
+				PCRE2_SPTR entry = nametable + k * nameentrysize;
+				if( (((entry[0] << 8) | entry[1])) == i ){
+					zName = (const char *)(entry + 2);
+					break;
+				}
+			}
+		}
 		if( start == PCRE2_UNSET ){
 			if( iFlags & PHP_PREG_UNMATCHED_AS_NULL ){
 				ph7_value_null(pVal);
 			}else{
 				ph7_value_string(pVal, "", 0);
 			}
-			if( iFlags & PHP_PREG_OFFSET_CAPTURE ){
-				ph7_value *pOff = ph7_context_new_scalar(pCtx);
-				ph7_array_add_intkey_elem(pSub, 0, pVal);
-				ph7_value_int(pOff, -1);
-				ph7_array_add_intkey_elem(pSub, 1, pOff);
-				ph7_array_add_intkey_elem(pArray, i, pSub);
-				/* Reset sub-array for reuse */
-				ph7_context_release_value(pCtx, pOff);
-				ph7_context_release_value(pCtx, pSub);
-				pSub = ph7_context_new_array(pCtx);
-			}else{
-				ph7_array_add_intkey_elem(pArray, i, pVal);
-			}
 		}else{
 			ph7_value_string(pVal, &zSubject[start], (int)(end - start));
-			if( iFlags & PHP_PREG_OFFSET_CAPTURE ){
-				ph7_value *pOff = ph7_context_new_scalar(pCtx);
-				ph7_array_add_intkey_elem(pSub, 0, pVal);
-				ph7_value_int(pOff, (int)start);
-				ph7_array_add_intkey_elem(pSub, 1, pOff);
-				ph7_array_add_intkey_elem(pArray, i, pSub);
-				ph7_context_release_value(pCtx, pOff);
-				ph7_context_release_value(pCtx, pSub);
-				pSub = ph7_context_new_array(pCtx);
-			}else{
-				ph7_array_add_intkey_elem(pArray, i, pVal);
-			}
 		}
-		ph7_value_reset_string_cursor(pVal);
-	}
-	/* Named groups */
-	pcre2_pattern_info(pCode, PCRE2_INFO_NAMECOUNT, &namecount);
-	if( namecount > 0 ){
-		pcre2_pattern_info(pCode, PCRE2_INFO_NAMETABLE, &nametable);
-		pcre2_pattern_info(pCode, PCRE2_INFO_NAMEENTRYSIZE, &nameentrysize);
-		for( i = 0; (uint32_t)i < namecount; i++ ){
-			PCRE2_SPTR entry = nametable + i * nameentrysize;
-			int groupNum = (entry[0] << 8) | entry[1];
-			const char *zName = (const char *)(entry + 2);
-			PCRE2_SIZE start, end;
-			if( groupNum >= nGroups ) continue;
-			start = ovector[2 * groupNum];
-			end   = ovector[2 * groupNum + 1];
-			if( start == PCRE2_UNSET ){
-				if( iFlags & PHP_PREG_UNMATCHED_AS_NULL ){
-					ph7_value_null(pVal);
-				}else{
-					ph7_value_string(pVal, "", 0);
-				}
-			}else{
-				ph7_value_string(pVal, &zSubject[start], (int)(end - start));
-			}
-			if( iFlags & PHP_PREG_OFFSET_CAPTURE ){
-				ph7_value *pOff = ph7_context_new_scalar(pCtx);
-				ph7_array_add_intkey_elem(pSub, 0, pVal);
-				ph7_value_int(pOff, start == PCRE2_UNSET ? -1 : (int)start);
-				ph7_array_add_intkey_elem(pSub, 1, pOff);
+		if( iFlags & PHP_PREG_OFFSET_CAPTURE ){
+			ph7_value *pOff = ph7_context_new_scalar(pCtx);
+			ph7_array_add_intkey_elem(pSub, 0, pVal);
+			ph7_value_int(pOff, start == PCRE2_UNSET ? -1 : (int)start);
+			ph7_array_add_intkey_elem(pSub, 1, pOff);
+			/* php: the named key comes first, then the numbered key (same value). */
+			if( zName ){
 				ph7_array_add_strkey_elem(pArray, zName, pSub);
-				ph7_context_release_value(pCtx, pOff);
-				ph7_context_release_value(pCtx, pSub);
-				pSub = ph7_context_new_array(pCtx);
-			}else{
+			}
+			ph7_array_add_intkey_elem(pArray, i, pSub);
+			ph7_context_release_value(pCtx, pOff);
+			ph7_context_release_value(pCtx, pSub);
+			pSub = ph7_context_new_array(pCtx);
+		}else{
+			if( zName ){
 				ph7_array_add_strkey_elem(pArray, zName, pVal);
 			}
-			ph7_value_reset_string_cursor(pVal);
+			ph7_array_add_intkey_elem(pArray, i, pVal);
 		}
+		ph7_value_reset_string_cursor(pVal);
 	}
 	ph7_context_release_value(pCtx, pVal);
 	if( pSub ){
@@ -607,7 +586,32 @@ static int PH7_builtin_preg_match_all(ph7_context *pCtx, int nArg, ph7_value **a
 				totalMatches++;
 			}
 			if( apGroupArrays ){
+				/* Attach the per-group match arrays. php's PREG_PATTERN_ORDER stores a
+				 * named group under BOTH its name and its number, interleaved
+				 * (`0, name, 1, value, 2`) — the same value under each key. Read the
+				 * name table so each numbered group can emit its named alias first. */
+				uint32_t namecount = 0, nameentrysize = 0;
+				PCRE2_SPTR nametable = 0;
+				pcre2_pattern_info(pCode, PCRE2_INFO_NAMECOUNT, &namecount);
+				if( namecount > 0 ){
+					pcre2_pattern_info(pCode, PCRE2_INFO_NAMETABLE, &nametable);
+					pcre2_pattern_info(pCode, PCRE2_INFO_NAMEENTRYSIZE, &nameentrysize);
+				}
 				for( g = 0; g < nGroups; g++ ){
+					const char *zName = 0;
+					if( namecount > 0 ){
+						uint32_t k;
+						for( k = 0; k < namecount; k++ ){
+							PCRE2_SPTR entry = nametable + k * nameentrysize;
+							if( (uint32_t)(((entry[0] << 8) | entry[1])) == g ){
+								zName = (const char *)(entry + 2);
+								break;
+							}
+						}
+					}
+					if( zName ){
+						ph7_array_add_strkey_elem(pOutArray, zName, apGroupArrays[g]);
+					}
 					ph7_array_add_intkey_elem(pOutArray, (int)g, apGroupArrays[g]);
 					ph7_context_release_value(pCtx, apGroupArrays[g]);
 				}

--- a/tests/ph7/001-smoke/function/preg_match_all/preg_match_all_named_groups.phpt
+++ b/tests/ph7/001-smoke/function/preg_match_all/preg_match_all_named_groups.phpt
@@ -1,0 +1,37 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+preg_match_all PREG_PATTERN_ORDER stores named groups under their name, interleaved with the numbered keys
+--FILE--
+<?php
+/* PREG_PATTERN_ORDER (the default) used to omit named-group keys entirely, so
+ * $m['name'] / $m['value'] were undefined — breaking code that reads them
+ * (PHPUnit's DocBlock annotation parser: $matches['name'][$i] /
+ * $matches['value'][$i]). php stores each named group under BOTH its name and
+ * its number, and interleaves them per group: 0, name, 1, value, 2. An optional
+ * named group that does not participate contributes an empty string. */
+$doc = "@covers Foo\n@small\n@dataProvider bar";
+$n = preg_match_all('/@(?P<name>[A-Za-z_-]+)(?:[ \t]+(?P<value>.*?))?[ \t]*\r?$/m', $doc, $m);
+echo $n, "\n";
+/* keys present in insertion order */
+echo implode(",", array_keys($m)), "\n";
+/* named arrays are the same as their numbered twins */
+echo implode("|", $m['name']), "\n";
+echo implode("|", $m['value']), "\n";   // @small -> "" in the middle
+var_dump($m['name'] === $m[1]);
+var_dump($m['value'] === $m[2]);
+/* PREG_SET_ORDER also carries the named keys per set. */
+preg_match_all('/(?P<k>\w)(?P<v>\d)/', 'a1b2', $s, PREG_SET_ORDER);
+echo $s[0]['k'], $s[0]['v'], " ", $s[1]['k'], $s[1]['v'], "\n";
+?>
+--EXPECT--
+3
+0,name,1,value,2
+covers|small|dataProvider
+Foo||bar
+bool(true)
+bool(true)
+a1 b2
+--CLEAN--
+<?php


### PR DESCRIPTION
Two named-group gaps versus php:

- preg_match appended every named key AFTER all the numbered ones (`0, 1, 2, name, value`). php interleaves them per group (`0, name, 1, value, 2`), storing the named alias immediately before its number. Code that iterates or var_dumps $matches depends on that order.

- preg_match_all's default PREG_PATTERN_ORDER omitted named-group keys entirely: $matches['name'] / $matches['value'] were never created, so reading them warned ("Undefined array key") and indexing the (null) result warned again ("Trying to access array offset on null").

Read the pattern's name table and emit each group's named key interleaved with its numbered key in both paths (PREG_SET_ORDER already routed through the shared populate helper and was correct). An optional named group that does not participate contributes an empty string, like php.

Clears the annotation-parser warnings across PHPUnit's Framework/Assert suite (Metadata\Parser\Annotation\DocBlock reads
$matches['name'][$i] / $matches['value'][$i] from a preg_match_all).

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
