### PR TITLE
Treat a reserved word after :: as a member name

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -3469,8 +3469,13 @@ static sxi32 GenStateLoadLiteral(ph7_gen_state *pGen)
 	sxu32 nIdx;
 	/* Extract token value */
 	pStr = &pToken->sData;
-	/* Deal with the reserved literals [i.e: null,false,true,...] first */
-	if( pStr->nByte == sizeof("NULL") - 1 ){
+	/* Deal with the reserved literals [i.e: null,false,true,...] first. A reserved
+	 * word used as a member NAME (Enum::Null, C::Array, $o->list()) is a plain
+	 * identifier — the parser flagged its token so the whole value-folding chain is
+	 * skipped and it falls through to the ordinary string-literal emit below. */
+	if( pToken->nType & PH7_TK_MEMBER_NAME ){
+		/* fall through to the plain-string literal path */
+	}else if( pStr->nByte == sizeof("NULL") - 1 ){
 		if( SyStrnicmp(pStr->zString,"null",sizeof("NULL")-1) == 0 ){
 			/* NULL constant are always indexed at 0 */
 			PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOADC,0,0,0,0);

--- a/src/ph7/parse.c
+++ b/src/ph7/parse.c
@@ -1014,7 +1014,11 @@ static sxi32 ExprExtractNode(ph7_gen_state *pGen,ph7_expr_node **ppNode,int iLas
 			 /* A keyword immediately after a member operator (->, ?->, ::) is a
 			  * method/property NAME, not a language construct — PHP allows any
 			  * keyword there (e.g. $g->throw(), $o->list(), $o->print()). Treat it
-			  * as a plain literal like an ordinary identifier member name. */
+			  * as a plain literal like an ordinary identifier member name. Flag the
+			  * token so GenStateLoadLiteral does not fold a reserved VALUE word
+			  * (Enum::Null, C::Array, C::True) into its literal — the member name is
+			  * the word itself. */
+			 pCur->nType |= PH7_TK_MEMBER_NAME;
 			 ExprAssembleLiteral(&pCur,pGen->pEnd);
 			 pNode->xCode = PH7_CompileLiteral;
 		 }else if( nKeyword == PH7_TKWRD_ARRAY ||  nKeyword == PH7_TKWRD_LIST ){
@@ -1132,6 +1136,13 @@ static sxi32 ExprExtractNode(ph7_gen_state *pGen,ph7_expr_node **ppNode,int iLas
 		 }
 	 }else if( pCur->nType & (PH7_TK_NSSEP|PH7_TK_ID) ){
 		 /* Constants,function name,namespace path,class name... */
+		 if( bAfterMemberOp ){
+			 /* An identifier used as a member NAME right after -> / ?-> / :: is the
+			  * name itself. null/true/false are lexed as PH7_TK_ID (not keywords), so
+			  * `Enum::Null` / `C::True` would otherwise be folded to the literal VALUE
+			  * by GenStateLoadLiteral, leaving an empty member name. Flag the token. */
+			 pCur->nType |= PH7_TK_MEMBER_NAME;
+		 }
 		 ExprAssembleLiteral(&pCur,pGen->pEnd);
 		 pNode->xCode = PH7_CompileLiteral;
 	 }else{

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1818,6 +1818,9 @@ enum ph7_expr_id {
 #define PH7_TK_ARRAY_OP  0x0800000 /* Array operator '=>' */
 #define PH7_TK_ELLIPSIS  0x1000000 /* Ellipsis '...' */
 #define PH7_TK_OTHER     0x2000000 /* Other symbols */
+#define PH7_TK_MEMBER_NAME 0x4000000 /* Reserved word used as a member NAME right after -> / ?-> / ::
+                                      * (Enum::Null, C::Array, $o->list()): a plain identifier, never
+                                      * the literal value — GenStateLoadLiteral skips its value conversion. */
 /*
  * PHP keyword.
  * These words have special meaning in PHP. Some of them represent things which look like

--- a/tests/ph7/001-smoke/oo/reserved_word_member_names.phpt
+++ b/tests/ph7/001-smoke/oo/reserved_word_member_names.phpt
@@ -1,0 +1,50 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+reserved words (null/true/false/array/...) are valid member names after :: and ->
+--FILE--
+<?php
+/* php allows any reserved word as a class constant, enum case, or method name,
+ * accessed after :: / ->. null/true/false are lexed as bare identifiers, so
+ * `Enum::Null` used to fold to the literal VALUE (null) and left an empty member
+ * name ("Access to undeclared static property Enum::$"). Regression for PHPUnit's
+ * NativeType enum (cases Null, Array, Object, String, Iterable, ...). */
+enum NrwType: string {
+    case Null     = 'null';
+    case Array    = 'array';
+    case Object   = 'object';
+    case String   = 'string';
+    case Iterable = 'iterable';
+    case True     = 'true';
+}
+echo NrwType::Null->value, ",", NrwType::Array->value, ",", NrwType::Object->value, "\n";
+echo NrwType::from('string')->name, "\n";
+var_dump(NrwType::True instanceof NrwType);
+
+class NrwMethods {
+    public function list(): string  { return "L"; }
+    public function print(): string { return "P"; }
+    public function throw(): string { return "T"; }
+    public function and(): string   { return "A"; }
+}
+$m = new NrwMethods;
+echo $m->list(), $m->print(), $m->throw(), $m->and(), "\n";
+
+/* Plain null/true/false/array must still evaluate as VALUES, not names. */
+$n = null; $t = true; $f = false;
+var_dump($n === null, $t, $f);
+$arr = array(1, 2, 3);
+echo count($arr), "\n";
+?>
+--EXPECT--
+null,array,object
+String
+bool(true)
+LPTA
+bool(true)
+bool(true)
+bool(false)
+3
+--CLEAN--
+<?php


### PR DESCRIPTION
php allows any reserved word as a class constant, enum case, or method name accessed after `::` / `->` / `?->`. null/true/false are lexed as plain identifiers (PH7_TK_ID, not keywords), so GenStateLoadLiteral folded them to their literal VALUE even in member-name position: `Enum::Null` loaded null as the member name and failed with "Access to undeclared static property Enum::$" (empty name); `C::True` / `C::Array` likewise.

The expression parser already knows when a node follows a member operator (bAfterMemberOp). Flag that node's token PH7_TK_MEMBER_NAME and skip the whole reserved-literal value-folding chain in GenStateLoadLiteral for it, so the identifier is emitted as the plain string the OP_MEMBER name path expects. Plain null/true/false/array in value position are untouched.

Fixes access to PHPUnit's NativeType enum (cases Null, Array, Object, String, Iterable, ...), unblocking the assertContainsOnly*/NotOnly* tests.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
