### PR TITLE
Treat an abstract trait method as a requirement

### DIFF
--- a/src/ph7/oo.c
+++ b/src/ph7/oo.c
@@ -629,19 +629,39 @@ PH7_PRIVATE sxi32 PH7_ClassUseTrait(ph7_gen_state *pGen,ph7_class *pClass,ph7_cl
 	/* Copy methods from the trait */
 	SyHashResetLoopCursor(&pTrait->hMethod);
 	while((pEntry = SyHashGetNextEntry(&pTrait->hMethod)) != 0 ){
+		SyHashEntry *pClassMethEntry;
 		pMeth = (ph7_class_method *)pEntry->pUserData;
 		pName = &pMeth->sFunc.sName;
-		if( SyHashGet(&pClass->hMethod,(const void *)pName->zString,pName->nByte) != 0 ){
-			/* Method already exists in the class. Check if it came from another trait
-			 * (unresolved conflict) vs being defined by the class itself.
-			 */
+		pClassMethEntry = SyHashGet(&pClass->hMethod,(const void *)pName->zString,pName->nByte);
+		if( pClassMethEntry != 0 ){
+			/* Method already exists in the class. An ABSTRACT trait method is a
+			 * REQUIREMENT, not an implementation: php satisfies it with any concrete
+			 * method of the same name (from the class body or another trait) — no
+			 * collision. Only two CONCRETE trait methods actually conflict. */
+			ph7_class_method *pExistingMeth = (ph7_class_method *)pClassMethEntry->pUserData;
+			int bIncomingAbstract = (pMeth->iFlags & PH7_CLASS_ATTR_ABSTRACT) != 0;
+			int bExistingAbstract = (pExistingMeth->iFlags & PH7_CLASS_ATTR_ABSTRACT) != 0;
 			ph7_class **apUsedTraits;
 			sxu32 nUsed,k;
+			if( bIncomingAbstract ){
+				/* Incoming abstract requirement: the existing (concrete or abstract)
+				 * method already covers this name — keep it. */
+				continue;
+			}
+			if( bExistingAbstract ){
+				/* Existing entry is only an abstract requirement (from an earlier
+				 * trait): the incoming concrete method satisfies and replaces it. */
+				pClassMethEntry->pUserData = (void *)pMeth;
+				continue;
+			}
+			/* Both concrete: a genuine collision only when the OTHER definition came
+			 * from another trait (a concrete one). A class-body method wins silently. */
 			apUsedTraits = (ph7_class **)SySetBasePtr(&pClass->aTrait);
 			nUsed = SySetUsed(&pClass->aTrait);
 			for(k = 0; k < nUsed; k++){
-				if( PH7_ClassExtractMethod(apUsedTraits[k],pName->zString,pName->nByte) != 0 ){
-					/* Two different traits define the same method with no resolution */
+				ph7_class_method *pOtherMeth = PH7_ClassExtractMethod(apUsedTraits[k],pName->zString,pName->nByte);
+				if( pOtherMeth != 0 && (pOtherMeth->iFlags & PH7_CLASS_ATTR_ABSTRACT) == 0 ){
+					/* Two different traits define the same CONCRETE method with no resolution */
 					rc = PH7_GenCompileError(pGen,E_ERROR,pTrait->nLine,
 						"Trait method %z::%z has not been applied as %z::%z, "
 						"because of collision with %z::%z",

--- a/tests/ph7/001-smoke/oo/trait_abstract_method_requirement.phpt
+++ b/tests/ph7/001-smoke/oo/trait_abstract_method_requirement.phpt
@@ -1,0 +1,38 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+an abstract trait method is a requirement satisfied by a concrete one, not a collision
+--FILE--
+<?php
+/* php treats an abstract method declared in a trait as a REQUIREMENT: any concrete
+ * method of the same name — from the class body or another trait — satisfies it
+ * with no conflict. PHL wrongly flagged abstract-vs-concrete as an unresolved trait
+ * collision, refused to apply the concrete method, then declared the whole class
+ * abstract, which cascaded into "Call to undefined function" for UNRELATED class
+ * methods. Regression for PHPUnit's mock traits (the Method trait declares
+ * `abstract __phpunit_getInvocationHandler()`, StubApi provides it). */
+trait NtaRequires {
+    abstract public function handler(): string;
+    public function useHandler(): string { return $this->handler() . "!"; }
+}
+trait NtaProvides {
+    public function handler(): string { return "H"; }
+}
+/* concrete-from-trait satisfies the abstract, in BOTH use orders */
+class NtaA { use NtaProvides; use NtaRequires; public function ping(): string { return "a"; } }
+class NtaB { use NtaRequires; use NtaProvides; public function ping(): string { return "b"; } }
+/* concrete-from-class-body satisfies the abstract */
+class NtaC { use NtaRequires; public function handler(): string { return "C"; } public function ping(): string { return "c"; } }
+
+foreach (['NtaA', 'NtaB', 'NtaC'] as $c) {
+    $o = new $c;
+    echo $c, ": ", $o->ping(), " ", $o->handler(), " ", $o->useHandler(), "\n";
+}
+?>
+--EXPECT--
+NtaA: a H H!
+NtaB: b H H!
+NtaC: c C C!
+--CLEAN--
+<?php


### PR DESCRIPTION
php treats a method declared `abstract` in a trait as a REQUIREMENT that any concrete method of the same name satisfies — whether that concrete method comes from the class body or from another used trait. It is never a conflict.

PH7's trait-merge flagged abstract-vs-concrete as an unresolved trait collision, refused to apply the concrete method, and left the class with an unsatisfied abstract — which then made the whole class malformed and cascaded into "Call to undefined function [__Class@method_salt]()" for UNRELATED methods on instances of that class.

Skip an incoming abstract trait method when the name already exists; replace an existing abstract entry when a concrete method arrives; and raise the collision error only when the other definition is itself a CONCRETE trait method.

Fixes PHPUnit's intersection-of-interfaces mocks (and the wider mock machinery): the `Method` trait declares
`abstract __phpunit_getInvocationHandler()` and `StubApi` provides it.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
