### PR TITLE
Preserve late static binding on forwarding calls

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -16546,6 +16546,14 @@ case PH7_OP_MEMBER: {
 		}
 		if( pNos->iFlags & (MEMOBJ_STRING|MEMOBJ_OBJ) ){
 			ph7_class *pClass = 0;
+			/* A FORWARDING static call — self::/parent::/static:: — preserves the
+			 * caller's late-static-binding class (php); a non-forwarding C::m() resets
+			 * it to C. The receiver slot below keeps the literal keyword, which OP_CALL
+			 * can't resolve, so it would fall back to the callee's DECLARING class and
+			 * lose LSB. Remember the live LSB class here and stamp it onto the receiver
+			 * after the method name is pushed. */
+			int bForwardingCall = 0;
+			ph7_class *pForwardLsb = 0;
 			if( pNos->iFlags & MEMOBJ_OBJ ){
 				/* Class already instantiated */
 				pThis = (ph7_class_instance *)pNos->x.pOther;
@@ -16563,13 +16571,19 @@ case PH7_OP_MEMBER: {
 							/* In a trait method, self:: resolves to the using class */
 							pClass = PH7_VmPeekTopClass(&(*pVm));
 						}
+						bForwardingCall = 1;
+						pForwardLsb = PH7_VmPeekTopClass(&(*pVm));
 					}else if( nCls == 6 && SyMemcmp(zCls,"static",6) == 0 ){
 						pClass = PH7_VmPeekTopClass(&(*pVm));
+						bForwardingCall = 1;
+						pForwardLsb = pClass;
 					}else if( nCls == 6 && SyMemcmp(zCls,"parent",6) == 0 ){
 						ph7_class *pSelf = PH7_VmPeekDeclaringClass(&(*pVm));
 						if( pSelf && pSelf->pBase ){
 							pClass = pSelf->pBase;
 						}
+						bForwardingCall = 1;
+						pForwardLsb = PH7_VmPeekTopClass(&(*pVm));
 					}else{
 						pClass = PH7_VmExtractClass(&(*pVm),zCls,nCls,FALSE,0);
 					}
@@ -16670,6 +16684,16 @@ case PH7_OP_MEMBER: {
 						MemObjSetType(pTos,MEMOBJ_STRING);
 					}
 					pTos->nIdx = SXU32_HIGH;
+					/* Forwarding call (self::/parent::/static::): overwrite the receiver
+					 * slot (pNos, one below the method name) with the live LSB class name
+					 * so OP_CALL pushes THAT onto aSelf — preserving `static::` inside the
+					 * callee. Without this the literal keyword falls through to the
+					 * callee's declaring class. Only when an LSB class is actually in
+					 * scope (a static call from global scope has none). */
+					if( bForwardingCall && pForwardLsb && (pNos->iFlags & MEMOBJ_STRING) ){
+						SyBlobReset(&pNos->sBlob);
+						SyBlobAppend(&pNos->sBlob,pForwardLsb->sName.zString,pForwardLsb->sName.nByte);
+					}
 				}else{
 					/* Attribute access */
 					ph7_class_attr *pAttr = 0;

--- a/tests/ph7/001-smoke/oo/late_static_binding_forwarding.phpt
+++ b/tests/ph7/001-smoke/oo/late_static_binding_forwarding.phpt
@@ -1,0 +1,41 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+forwarding static calls (self::/parent::/static::) preserve the late-static-binding class
+--FILE--
+<?php
+/* php: a FORWARDING static call — self::m(), parent::m(), static::m() — keeps the
+ * caller's late-static-binding class, so `static::` inside the callee still refers
+ * to the runtime class. A non-forwarding C::m() resets it to C. PHL pushed the
+ * callee's DECLARING class instead, so `static::class` reached through self:: /
+ * parent:: reported the wrong class — which broke PHPUnit's
+ * `self::generateReturnValuesForTestDoubles()` (static::class -> the wrong test
+ * class -> attribute metadata missed). */
+class NlsA {
+    public function who(): string { return static::class; }             // direct
+    public function viaSelf(): string { return self::sm(); }             // forwarding
+    public static function sm(): string { return static::class; }
+    public static function nonForward(): string { return NlsA::sm(); }   // non-forwarding
+}
+class NlsB extends NlsA {
+    public function viaParent(): string { return parent::sm(); }         // forwarding
+    public static function make(): static { return new static(); }
+}
+$b = new NlsB();
+echo "direct: ", $b->who(), "\n";                 // NlsB
+echo "viaSelf: ", $b->viaSelf(), "\n";            // NlsB (LSB preserved through self::)
+echo "viaParent: ", $b->viaParent(), "\n";        // NlsB (LSB preserved through parent::)
+echo "newStatic: ", get_class(NlsB::make()), "\n"; // NlsB
+echo "nonForward: ", NlsB::nonForward(), "\n";    // NlsA (reset by NlsA::)
+echo "staticCall: ", NlsB::sm(), "\n";            // NlsB
+?>
+--EXPECT--
+direct: NlsB
+viaSelf: NlsB
+viaParent: NlsB
+newStatic: NlsB
+nonForward: NlsA
+staticCall: NlsB
+--CLEAN--
+<?php


### PR DESCRIPTION
A forwarding static call — self::m(), parent::m(), static::m() — keeps the caller's late-static-binding class in php, so `static::` inside the callee still names the runtime class. A non-forwarding C::m() resets it to C.

OP_MEMBER left the literal self/parent/static keyword in the receiver slot. OP_CALL cannot resolve those to a class, so it fell back to the callee's DECLARING class for the aSelf/LSB push, and `static::class` reached through self:: / parent:: reported the wrong class.

Stamp the live LSB class (PH7_VmPeekTopClass) onto the receiver slot when the static call is forwarding, so OP_CALL pushes that class onto aSelf. Non-forwarding C::m() keeps resolving the receiver to C as before.

This fixes PHPUnit's self::generateReturnValuesForTestDoubles(): its `static::class` mis-resolved to TestCase, so the class-level #[DisableReturnValueGenerationForTestDoubles] attribute was read for the wrong class and return-value generation was never disabled.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
