### PR TITLE
Key escaped single-quoted literals in the cache

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -850,6 +850,7 @@ PH7_PRIVATE sxi32 PH7_CompileSimpleString(ph7_gen_state *pGen,sxi32 iCompileFlag
 	const char *zIn,*zCur,*zEnd;
 	ph7_value *pObj;
 	sxu32 nIdx;
+	sxi32 bHasEsc;
 	nIdx = 0; /* Prevent compiler warning */
 	/* Delimit the string */
 	zIn  = pStr->zString;
@@ -860,7 +861,21 @@ PH7_PRIVATE sxi32 PH7_CompileSimpleString(ph7_gen_state *pGen,sxi32 iCompileFlag
 		PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOADC,0,pGen->pVm->nEmptyStringIdx,0,0);
 		return SXRET_OK;
 	}
-	if( SXRET_OK == GenStateFindLiteral(&(*pGen),pStr,&nIdx) ){
+	/* A single-quoted literal whose raw source holds a backslash unescapes to a
+	 * value that differs from that source (\\ -> \, \' -> '). The literal cache
+	 * keys FIND on the raw source text but INSTALL on the unescaped value, so
+	 * caching such a literal lets an unrelated one collide with it — e.g. '\\'
+	 * (raw \\, value \) would find the entry installed for '\\\\' (raw \\\\,
+	 * value \\) and load two backslashes. Only cache literals whose value equals
+	 * their source, i.e. those with no backslash to unescape. */
+	bHasEsc = 0;
+	{
+		const char *zScan;
+		for( zScan = zIn ; zScan < zEnd ; zScan++ ){
+			if( zScan[0] == '\\' ){ bHasEsc = 1; break; }
+		}
+	}
+	if( !bHasEsc && SXRET_OK == GenStateFindLiteral(&(*pGen),pStr,&nIdx) ){
 		/* Already processed,emit the load constant instruction
 		 * and return.
 		 */
@@ -909,8 +924,8 @@ PH7_PRIVATE sxi32 PH7_CompileSimpleString(ph7_gen_state *pGen,sxi32 iCompileFlag
 	}
 	/* Emit the load constant instruction */
 	PH7_VmEmitInstr(pGen->pVm,PH7_OP_LOADC,0,nIdx,0,0);
-	if( pStr->nByte < 1024 ){
-		/* Install in the literal table */
+	if( !bHasEsc && pStr->nByte < 1024 ){
+		/* Install in the literal table (only when value == source; see above) */
 		GenStateInstallLiteral(pGen,pObj,nIdx);
 	}
 	/* Node successfully compiled */

--- a/tests/ph7/001-smoke/lang/single_quote_escape_literal_dedup.phpt
+++ b/tests/ph7/001-smoke/lang/single_quote_escape_literal_dedup.phpt
@@ -1,0 +1,42 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: an escaped single-quoted literal is not aliased by the literal cache
+--FILE--
+<?php
+// The compiler dedups string literals, but keyed FIND on the raw source and
+// INSTALL on the unescaped value. For escaped literals those differ, so '\\'
+// (raw \\, value \) could wrongly reuse the entry installed for '\\\\' (raw
+// \\\\, value \\) and load two backslashes. Both orders must stay distinct.
+$sqdTwo = '\\\\';
+$sqdOne = '\\';
+echo strlen($sqdTwo), strlen($sqdOne), "\n";
+echo bin2hex($sqdTwo), " ", bin2hex($sqdOne), "\n";
+echo ($sqdOne === $sqdTwo ? "SAME" : "DIFF"), "\n";
+// reverse declaration order (single before double)
+$sqdOneR = '\\';
+$sqdTwoR = '\\\\';
+echo strlen($sqdOneR), strlen($sqdTwoR), "\n";
+// escaped single quote vs backslash-then-quote
+$sqdQ  = '\'';
+$sqdBq = '\\\'';
+echo bin2hex($sqdQ), " ", bin2hex($sqdBq), "\n";
+// a backslash mid-literal must not collide with a namespace-shaped literal
+$sqdNs  = 'Foo\\Bar';
+$sqdNs2 = 'Foo\\\\Bar';
+echo strlen($sqdNs), strlen($sqdNs2), "\n";
+// the regex round-trip that first exposed the bug
+$sqdRe = '/^' . preg_quote('\\', '/') . '$/s';
+var_export(preg_match($sqdRe, '\\'));   echo "\n";
+var_export(preg_match($sqdRe, '\\\\')); echo "\n";
+?>
+--EXPECT--
+21
+5c5c 5c
+DIFF
+12
+27 5c27
+78
+1
+0


### PR DESCRIPTION
The codegen literal cache keyed its lookup on the raw source token text but its install on the unescaped value. For a literal with no backslash the two are equal, so dedup was safe; for an escaped one they differ, letting an unrelated literal collide. '\\' (raw \\, value \) found the entry installed for '\\\\' (raw \\\\, value \\) and loaded two backslashes where the source has one. Skip the cache for any single-quoted literal whose source contains a backslash, i.e. dedup only when the value equals the source.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
