### PR TITLE
Make strict array comparison order-sensitive

### DIFF
--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -1152,6 +1152,42 @@ PH7_PRIVATE sxi32 PH7_HashmapCmp(
 		/* Must have the same number of entries */
 		return pLeft->nEntry > pRight->nEntry ? 1 : -1;
 	}
+	if( bStrict ){
+		/* PHP's '===' on arrays is ORDER-SENSITIVE: the two maps must hold the
+		 * same key/value pairs, with identical key types, in the same insertion
+		 * order. Walk both in insertion order (pFirst, then the pPrev chain, per
+		 * this file's forward-iteration convention) in lockstep and compare each
+		 * position's key then value. (Loose '==' below stays order-insensitive,
+		 * matching each left key by lookup into the right map.) */
+		ph7_hashmap_node *pLs = pLeft->pFirst;
+		ph7_hashmap_node *pRs = pRight->pFirst;
+		for( n = pLeft->nEntry ; n > 0 ; n-- ){
+			/* Keys must match in type and value at this position */
+			if( pLs->iType != pRs->iType ){
+				return 1;
+			}
+			if( pLs->iType == HASHMAP_INT_NODE ){
+				if( pLs->xKey.iKey != pRs->xKey.iKey ){
+					return 1;
+				}
+			}else{
+				SyBlob *pLk = &pLs->xKey.sKey;
+				SyBlob *pRk = &pRs->xKey.sKey;
+				if( SyBlobLength(pLk) != SyBlobLength(pRk)
+				 || (SyBlobLength(pLk) > 0
+				  && SyMemcmp(SyBlobData(pLk),SyBlobData(pRk),SyBlobLength(pLk)) != 0) ){
+					return 1;
+				}
+			}
+			/* Values must be strictly identical */
+			if( HashmapNodeCmp(pLs,pRs,TRUE) != 0 ){
+				return 1;
+			}
+			pLs = pLs->pPrev; /* Reverse link = insertion order */
+			pRs = pRs->pPrev;
+		}
+		return 0; /* Same pairs, same order */
+	}
 	/* Point to the first inserted entry of the left hashmap */
 	pLe = pLeft->pFirst;
 	pRe = 0; /* cc warning */

--- a/tests/ph7/001-smoke/lang/array_strict_identity_order_sensitive.phpt
+++ b/tests/ph7/001-smoke/lang/array_strict_identity_order_sensitive.phpt
@@ -1,0 +1,43 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: array === is order-sensitive (== stays order-insensitive)
+--FILE--
+<?php
+// PHP's '===' on arrays requires the same key/value pairs in the SAME order;
+// PHL's hashmap comparison used to match keys by lookup for both === and ==,
+// making === wrongly order-insensitive.
+$aiA = ['a' => 1, 'b' => 2];
+$aiB = ['b' => 2, 'a' => 1];
+echo var_export($aiA === $aiB, true), " ", var_export($aiA == $aiB, true), "\n";
+// identical order is identical
+echo var_export(['x'=>1,'y'=>2] === ['x'=>1,'y'=>2], true), "\n";
+// nested reorder is not identical
+echo var_export(['p'=>['q'=>1,'r'=>2]] === ['p'=>['r'=>2,'q'=>1]], true), "\n";
+// int keys reordered
+echo var_export([0=>1,1=>2] === [1=>2,0=>1], true), "\n";
+// a numeric-string key normalizes to int, so these ARE identical
+echo var_export([1=>'a'] === ['1'=>'a'], true), "\n";
+// value type strictness under ===
+echo var_export(['k'=>1] === ['k'=>'1'], true), "\n";
+// in_array / array_search strict membership stays order-independent (=== per element)
+$aiHay = ['1', 1, true];
+echo var_export(in_array(1, $aiHay, true), true), " ", var_export(array_search('1', $aiHay, true), true), "\n";
+// match() compares with === : a reordered subject only hits an identical arm
+$aiSubj = ['b'=>2, 'a'=>1];
+echo match($aiSubj) {
+    ['a'=>1, 'b'=>2] => "ordered",
+    ['b'=>2, 'a'=>1] => "asis",
+    default => "none",
+}, "\n";
+?>
+--EXPECT--
+false true
+true
+false
+false
+true
+false
+true 0
+asis


### PR DESCRIPTION
PH7_HashmapCmp matched each left key by lookup into the right map for both == and ===, so array === was wrongly order-insensitive: ['a'=>1,'b'=>2] === ['b'=>2,'a'=>1] returned true where php returns false (=== requires the same pairs in the same insertion order; only == ignores order). This also backs match, strict switch, in_array(...,true) and array_search(...,true). Add a strict lockstep branch that walks both maps in insertion order comparing each position's key type/value then value; the loose path is unchanged.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
