### PR TITLE
Implement mb_detect_encoding for ASCII/UTF-8

### DIFF
--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -9777,6 +9777,7 @@ static const ph7_builtin_func aBuiltInFunc[] = {
 	{ "mb_strwidth",  PH7_builtin_mb_strwidth_f },
 	{ "mb_chr",       PH7_builtin_mb_chr_f   },
 	{ "mb_ord",       PH7_builtin_mb_ord_f   },
+	{ "mb_detect_encoding", PH7_builtin_mb_detect_encoding_f },
 	{ "ucfirst",      PH7_builtin_ucfirst    },
 	{ "lcfirst",      PH7_builtin_lcfirst    },
 	{ "ord",          PH7_builtin_ord        },

--- a/src/ph7/builtin_mb.c
+++ b/src/ph7/builtin_mb.c
@@ -574,6 +574,155 @@ static int PH7_builtin_mb_ord(ph7_context *pCtx,int nArg,ph7_value **apArg)
 	return PH7_OK;
 }
 /*
+ * mb_detect_encoding(string $string, array|string|null $encodings = null,
+ *                    bool $strict = false): string|false
+ *
+ * PHL's encoding scope is ASCII and UTF-8 (NEWPLAN §10 scope cut). php's
+ * default detect order is exactly ASCII,UTF-8, so the null/default path is
+ * byte-identical. A candidate encoding php supports but PHL does not (e.g.
+ * SJIS) raises the same ValueError php uses for a truly invalid name — a
+ * recorded scope divergence, not silent.
+ *
+ * Detection scores each candidate by its count of undecodable bytes and keeps
+ * the smallest, earliest-in-order on a tie. In strict mode a non-zero best
+ * score means "no candidate fully matched" -> false. This reproduces php's
+ * ASCII/UTF-8 outcomes for every probed case, strict and non-strict alike.
+ */
+static int MbAsciiErrors(const unsigned char *z,int n)
+{
+	int i,e = 0;
+	for( i = 0 ; i < n ; i++ ){
+		if( z[i] >= 0x80 ){ e++; }
+	}
+	return e;
+}
+static int MbUtf8Errors(const unsigned char *z,int n)
+{
+	sxu32 i = 0,nLen;
+	int e = 0;
+	while( i < (sxu32)n ){
+		MbUtf8Decode(&z[i],(sxu32)n - i,&nLen);
+		if( nLen == 1 && z[i] >= 0x80 ){ e++; i++; }
+		else{ i += nLen; }
+	}
+	return e;
+}
+/* Map an encoding name to PHL's supported set: 0 = ASCII, 1 = UTF-8, -1 = out
+ * of scope. Surrounding ASCII whitespace is trimmed (php accepts "ASCII, UTF-8"). */
+static int MbDetectEncId(const char *z,int n)
+{
+	while( n > 0 && (z[0]==' '||z[0]=='\t'||z[0]=='\n'||z[0]=='\r') ){ z++; n--; }
+	while( n > 0 && (z[n-1]==' '||z[n-1]=='\t'||z[n-1]=='\n'||z[n-1]=='\r') ){ n--; }
+	if( (n == 5 && SyStrnicmp(z,"ASCII",5) == 0)
+	 || (n == 8 && SyStrnicmp(z,"US-ASCII",8) == 0) ){
+		return 0;
+	}
+	if( (n == 5 && SyStrnicmp(z,"UTF-8",5) == 0)
+	 || (n == 4 && SyStrnicmp(z,"UTF8",4) == 0) ){
+		return 1;
+	}
+	return -1;
+}
+/* Per-detection running state, shared by the array walker and the string path. */
+typedef struct mb_detect_state mb_detect_state;
+struct mb_detect_state {
+	ph7_context *pCtx;
+	int aErr[2];      /* precomputed [ASCII], [UTF-8] error counts */
+	int iBestEnc;     /* winning encoding id, -1 until the first candidate */
+	int iBestErr;     /* its error count */
+	int nSeen;        /* candidates considered (0 -> "must specify at least one") */
+	int bError;       /* an out-of-scope name threw -> abort */
+	int rc;           /* the throw's propagation code (PH7_ABORT/PH7_EXCEPTION) */
+};
+/* Fold one candidate encoding name into the running best. Returns SXERR_ABORT
+ * (and throws) when the name is outside PHL's ASCII/UTF-8 scope. */
+static int MbDetectConsider(mb_detect_state *pState,const char *zName,int nName)
+{
+	int enc = MbDetectEncId(zName,nName);
+	if( enc < 0 ){
+		pState->bError = 1;
+		pState->rc = PH7_VmThrowException(pState->pCtx,"ValueError",
+			"mb_detect_encoding(): Argument #2 ($encodings) contains invalid encoding \"%.*s\"",
+			nName,zName);
+		return SXERR_ABORT;
+	}
+	pState->nSeen++;
+	if( pState->iBestEnc < 0 || pState->aErr[enc] < pState->iBestErr ){
+		pState->iBestEnc = enc;
+		pState->iBestErr = pState->aErr[enc];
+	}
+	return PH7_OK;
+}
+/* ph7_array_walk() callback over the $encodings array. */
+static int MbDetectWalker(ph7_value *pKey,ph7_value *pData,void *pUserData)
+{
+	mb_detect_state *pState = (mb_detect_state *)pUserData;
+	const char *zName;
+	int nName;
+	SXUNUSED(pKey);
+	zName = ph7_value_to_string(pData,&nName);
+	return MbDetectConsider(pState,zName,nName);
+}
+static int PH7_builtin_mb_detect_encoding(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	const char *zIn;
+	int nByte,bStrict = 0;
+	mb_detect_state sState;
+	if( nArg < 1 ){
+		ph7_result_bool(pCtx,0);
+		return PH7_OK;
+	}
+	zIn = ph7_value_to_string(apArg[0],&nByte);
+	if( nArg > 2 ){ bStrict = ph7_value_to_bool(apArg[2]); }
+	sState.pCtx = pCtx;
+	sState.aErr[0] = MbAsciiErrors((const unsigned char *)zIn,nByte);
+	sState.aErr[1] = MbUtf8Errors((const unsigned char *)zIn,nByte);
+	sState.iBestEnc = -1;
+	sState.iBestErr = 0;
+	sState.nSeen = 0;
+	sState.bError = 0;
+	sState.rc = PH7_OK;
+	if( nArg < 2 || ph7_value_is_null(apArg[1]) ){
+		/* php's default detect order is exactly ASCII, then UTF-8 */
+		MbDetectConsider(&sState,"ASCII",5);
+		MbDetectConsider(&sState,"UTF-8",5);
+	}else if( ph7_value_is_array(apArg[1]) ){
+		if( ph7_array_count(apArg[1]) == 0 ){
+			return PH7_VmThrowException(pCtx,"ValueError",
+				"mb_detect_encoding(): Argument #2 ($encodings) must specify at least one encoding");
+		}
+		ph7_array_walk(apArg[1],MbDetectWalker,&sState);
+		if( sState.bError ){ return sState.rc; }
+	}else{
+		/* comma-separated list, e.g. "ASCII, UTF-8" */
+		const char *z2;
+		int n2,i,iStart = 0;
+		z2 = ph7_value_to_string(apArg[1],&n2);
+		for( i = 0 ; i <= n2 ; i++ ){
+			if( i == n2 || z2[i] == ',' ){
+				const char *zTok = &z2[iStart];
+				int nTok = i - iStart,t = nTok;
+				/* ignore an empty / all-whitespace token */
+				while( t > 0 && (zTok[0]==' '||zTok[0]=='\t'||zTok[0]=='\n'||zTok[0]=='\r') ){ zTok++; t--; }
+				if( t > 0 && MbDetectConsider(&sState,&z2[iStart],nTok) == SXERR_ABORT ){
+					return sState.rc;
+				}
+				iStart = i + 1;
+			}
+		}
+	}
+	if( sState.nSeen == 0 ){
+		return PH7_VmThrowException(pCtx,"ValueError",
+			"mb_detect_encoding(): Argument #2 ($encodings) must specify at least one encoding");
+	}
+	if( bStrict && sState.iBestErr > 0 ){
+		ph7_result_bool(pCtx,0);
+		return PH7_OK;
+	}
+	ph7_result_string(pCtx,sState.iBestEnc == 0 ? "ASCII" : "UTF-8",5);
+	return PH7_OK;
+}
+/*
  * Install the mb_* functions (called from PH7_RegisterBuiltInFunction's
  * table in builtin.c via these PH7_PRIVATE symbols).
  */
@@ -588,5 +737,6 @@ PH7_PRIVATE int PH7_builtin_mb_check_encoding_f(ph7_context *pCtx,int nArg,ph7_v
 PH7_PRIVATE int PH7_builtin_mb_strwidth_f(ph7_context *pCtx,int nArg,ph7_value **apArg){ return PH7_builtin_mb_strwidth(pCtx,nArg,apArg); }
 PH7_PRIVATE int PH7_builtin_mb_chr_f(ph7_context *pCtx,int nArg,ph7_value **apArg){ return PH7_builtin_mb_chr(pCtx,nArg,apArg); }
 PH7_PRIVATE int PH7_builtin_mb_ord_f(ph7_context *pCtx,int nArg,ph7_value **apArg){ return PH7_builtin_mb_ord(pCtx,nArg,apArg); }
+PH7_PRIVATE int PH7_builtin_mb_detect_encoding_f(ph7_context *pCtx,int nArg,ph7_value **apArg){ return PH7_builtin_mb_detect_encoding(pCtx,nArg,apArg); }
 
 #endif /* PH7_DISABLE_BUILTIN_FUNC */

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -2347,6 +2347,7 @@ PH7_PRIVATE int PH7_builtin_mb_check_encoding_f(ph7_context *pCtx,int nArg,ph7_v
 PH7_PRIVATE int PH7_builtin_mb_strwidth_f(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE int PH7_builtin_mb_chr_f(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE int PH7_builtin_mb_ord_f(ph7_context *pCtx,int nArg,ph7_value **apArg);
+PH7_PRIVATE int PH7_builtin_mb_detect_encoding_f(ph7_context *pCtx,int nArg,ph7_value **apArg);
 /* vm_builtin_spl.c */
 PH7_PRIVATE sxi32 PH7_VmInstallSpl(ph7_vm *pVm);
 /* vm_builtin_session.c */

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -419,6 +419,7 @@ static const struct VmBuiltinArity {
 	{ "mb_check_encoding",         1, 0 },
 	{ "mb_chr",                    1, 1 },
 	{ "mb_convert_case",           2, 1 },
+	{ "mb_detect_encoding",        1, 1 },
 	{ "mb_ord",                    1, 1 },
 	{ "mb_str_split",              1, 1 },
 	{ "mb_stripos",                2, 1 },

--- a/tests/ph7/001-smoke/function/mb/mb_detect_encoding.phpt
+++ b/tests/ph7/001-smoke/function/mb/mb_detect_encoding.phpt
@@ -1,0 +1,35 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: mb_detect_encoding, ASCII/UTF-8 scope (strict + non-strict, list forms)
+--FILE--
+<?php
+// default detect order is exactly ASCII, then UTF-8
+echo mb_detect_encoding("hello"), "|", mb_detect_encoding("héllo"), "\n";
+// strict: no candidate fully matches -> false; empty string is valid ASCII
+echo var_export(mb_detect_encoding("\xff\xfe", null, true), true), "|", mb_detect_encoding("", null, true), "\n";
+// explicit array list, and list order picks the earliest fully-valid candidate
+echo mb_detect_encoding("héllo", ["ASCII","UTF-8"], true), "|", mb_detect_encoding("hello", ["UTF-8","ASCII"], true), "\n";
+// comma-separated string list, whitespace around names tolerated
+echo mb_detect_encoding("héllo", "ASCII, UTF-8", true), "\n";
+// non-strict scores by fewest undecodable bytes, earliest on a tie
+echo mb_detect_encoding("\xff\xfe"), "|", mb_detect_encoding("héllo\xff"), "\n";
+// same input, strict -> false (the trailing byte breaks UTF-8, ASCII already out)
+echo var_export(mb_detect_encoding("héllo\xff", null, true), true), "\n";
+// encoding names are matched case-insensitively and returned canonicalised
+echo mb_detect_encoding("hello", "ascii", true), "|", mb_detect_encoding("héllo", "utf8", true), "\n";
+// an empty list and an out-of-scope name each raise php's ValueError
+try { mb_detect_encoding("hi", [], true); } catch (ValueError $mbdeE) { echo $mbdeE->getMessage(), "\n"; }
+try { mb_detect_encoding("hi", ["ASCII","BOGUS"], true); } catch (ValueError $mbdeE) { echo $mbdeE->getMessage(), "\n"; }
+?>
+--EXPECT--
+ASCII|UTF-8
+false|ASCII
+UTF-8|UTF-8
+UTF-8
+ASCII|UTF-8
+false
+ASCII|UTF-8
+mb_detect_encoding(): Argument #2 ($encodings) must specify at least one encoding
+mb_detect_encoding(): Argument #2 ($encodings) contains invalid encoding "BOGUS"


### PR DESCRIPTION
Adds mb_detect_encoding(string, array|string|null, bool) over the existing UTF-8 codec. php's default detect order is exactly ASCII,UTF-8, so the null/default path is byte-identical; each candidate is scored by its count of undecodable bytes, keeping the smallest (earliest-in-order on a tie), and strict mode returns false when the best score is non-zero. The encodings argument accepts null, a comma-string, or an array; an empty list and an out-of-scope name each raise php's ValueError. Only ASCII and UTF-8 are recognised (recorded scope cut): a candidate php supports but PHL does not raises the same "invalid encoding" ValueError php reserves for a bad name.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
