### PR TITLE
Match php is_numeric and is_scalar strictness

### DIFF
--- a/src/ph7/builtin.c
+++ b/src/ph7/builtin.c
@@ -236,7 +236,11 @@ static int PH7_builtin_is_numeric(ph7_context *pCtx,int nArg,ph7_value **apArg)
 {
 	int res = 0; /* Assume false by default */
 	if( nArg > 0 ){
-		res = ph7_value_is_numeric(apArg[0]);
+		/* Strict PHP semantics: only int/float and numeric strings are numeric.
+		 * PHL's lenient helper also reports booleans as numeric (they coerce for
+		 * arithmetic), but php's is_numeric() rejects true/false, so exclude
+		 * MEMOBJ_BOOL here. */
+		res = ph7_value_is_numeric(apArg[0]) && !ph7_value_is_bool(apArg[0]);
 	}
 	/* Query result */
 	ph7_result_bool(pCtx,res);
@@ -254,7 +258,10 @@ static int PH7_builtin_is_scalar(ph7_context *pCtx,int nArg,ph7_value **apArg)
 {
 	int res = 0; /* Assume false by default */
 	if( nArg > 0 ){
-		res = ph7_value_is_scalar(apArg[0]);
+		/* Strict PHP semantics: scalars are int/float/string/bool. PHL's
+		 * MEMOBJ_SCALAR bucket also includes NULL, but php's is_scalar(null) is
+		 * false, so exclude the NULL case. */
+		res = ph7_value_is_scalar(apArg[0]) && !ph7_value_is_null(apArg[0]);
 	}
 	/* Query result */
 	ph7_result_bool(pCtx,res);

--- a/tests/ph7/001-smoke/function/is_numeric_is_scalar_php_semantics.phpt
+++ b/tests/ph7/001-smoke/function/is_numeric_is_scalar_php_semantics.phpt
@@ -1,0 +1,24 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: is_numeric rejects booleans, is_scalar rejects null (strict php semantics)
+--FILE--
+<?php
+// is_numeric: booleans are NOT numeric in php (PHL used to accept them because
+// its arithmetic-coercion helper treats bool as numeric); int/float and numeric
+// strings still are.
+$isnvNum = [true, false, null, 0, 1, 3.14, '42', '3.14', '1e3', ' 5', '0x1A', 'x', [], '0'];
+$isnvOut = [];
+foreach ($isnvNum as $isnvV) { $isnvOut[] = var_export(is_numeric($isnvV), true); }
+echo implode(' ', $isnvOut), "\n";
+// is_scalar: int/float/string/bool are scalar; null/array/object are not (PHL's
+// internal scalar bucket wrongly included null).
+$isnvScal = [true, false, null, 0, 0.0, '', 's', [], new stdClass];
+$isnvOut = [];
+foreach ($isnvScal as $isnvV) { $isnvOut[] = var_export(is_scalar($isnvV), true); }
+echo implode(' ', $isnvOut), "\n";
+?>
+--EXPECT--
+false false false true true true true true true true false false false true
+true true false true true true true false false


### PR DESCRIPTION
PHL's shared helpers encode PH7's lenient notion: PH7_MemObjIsNumeric counts booleans (they coerce for arithmetic) and the MEMOBJ_SCALAR bucket includes NULL. php's is_numeric(true) and is_scalar(null) are both false. Fix at the builtin level, like the existing strict is_int, leaving the internal helpers untouched: is_numeric now ANDs !is_bool, is_scalar ANDs !is_null.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
