### PR TITLE
Honor JSON_THROW_ON_ERROR; reject Inf/NaN

### DIFF
--- a/src/ph7/constant.c
+++ b/src/ph7/constant.c
@@ -1951,6 +1951,15 @@ static void PH7_JSON_UNESCAPED_UNICODE_Const(ph7_value *pVal,void *pUserData)
 	ph7_value_int(pVal,JSON_UNESCAPED_UNICODE);
 }
 /*
+ * JSON_THROW_ON_ERROR.
+ *   Expand the value of JSON_THROW_ON_ERROR defined in ph7Int.h.
+ */
+static void PH7_JSON_THROW_ON_ERROR_Const(ph7_value *pVal,void *pUserData)
+{
+	SXUNUSED(pUserData); /* cc warning */
+	ph7_value_int(pVal,JSON_THROW_ON_ERROR);
+}
+/*
  * JSON_ERROR_NONE.
  *   Expand the value of JSON_ERROR_NONE defined in ph7Int.h.
  */
@@ -2012,6 +2021,15 @@ static void PH7_JSON_ERROR_NON_BACKED_ENUM_Const(ph7_value *pVal,void *pUserData
 {
 	SXUNUSED(pUserData); /* cc warning */
 	ph7_value_int(pVal,JSON_ERROR_NON_BACKED_ENUM);
+}
+/*
+ * JSON_ERROR_INF_OR_NAN.
+ *   Expand the value of JSON_ERROR_INF_OR_NAN defined in ph7Int.h.
+ */
+static void PH7_JSON_ERROR_INF_OR_NAN_Const(ph7_value *pVal,void *pUserData)
+{
+	SXUNUSED(pUserData); /* cc warning */
+	ph7_value_int(pVal,JSON_ERROR_INF_OR_NAN);
 }
 /*
  * __CLASS__
@@ -2370,6 +2388,7 @@ static const ph7_builtin_constant aBuiltIn[] = {
 	{"JSON_PRETTY_PRINT",      PH7_JSON_PRETTY_PRINT_Const},
 	{"JSON_UNESCAPED_SLASHES", PH7_JSON_UNESCAPED_SLASHES_Const},
 	{"JSON_UNESCAPED_UNICODE", PH7_JSON_UNESCAPED_UNICODE_Const},
+	{"JSON_THROW_ON_ERROR",    PH7_JSON_THROW_ON_ERROR_Const},
 	{"JSON_ERROR_NONE",        PH7_JSON_ERROR_NONE_Const},
 	{"JSON_ERROR_DEPTH",       PH7_JSON_ERROR_DEPTH_Const},
 	{"JSON_ERROR_STATE_MISMATCH", PH7_JSON_ERROR_STATE_MISMATCH_Const},
@@ -2377,6 +2396,7 @@ static const ph7_builtin_constant aBuiltIn[] = {
 	{"JSON_ERROR_SYNTAX",    PH7_JSON_ERROR_SYNTAX_Const},
 	{"JSON_ERROR_UTF8",      PH7_JSON_ERROR_UTF8_Const},
 	{"JSON_ERROR_NON_BACKED_ENUM", PH7_JSON_ERROR_NON_BACKED_ENUM_Const},
+	{"JSON_ERROR_INF_OR_NAN", PH7_JSON_ERROR_INF_OR_NAN_Const},
 	/* `self`, `parent` and `static` are KEYWORDS in php, not constants: using one as a bare
 	 * word is an "Undefined constant" Error (or a parse error for `static`). PH7 registered
 	 * them as constants that quietly expanded to the class name / NULL, so a typo'd bare

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1933,6 +1933,7 @@ enum json_err_code{
 	JSON_ERROR_CTRL_CHAR, /* Control character error, possibly incorrectly encoded.  */
 	JSON_ERROR_SYNTAX,    /* Syntax error. */
 	JSON_ERROR_UTF8,      /* Malformed UTF-8 characters */
+	JSON_ERROR_INF_OR_NAN = 7, /* Inf or NaN given to json_encode (php value) */
 	JSON_ERROR_NON_BACKED_ENUM = 11 /* Non-backed enum given to json_encode (php 8.1 value) */
 };
 /* The following constants can be combined to form options for json_encode(). */
@@ -1946,6 +1947,7 @@ enum json_err_code{
 #define JSON_PRETTY_PRINT      0x80  /* Use whitespace in returned data to format it.*/
 #define JSON_UNESCAPED_SLASHES 0x100 /* Don't escape '/' */
 #define JSON_UNESCAPED_UNICODE 0x200 /* Not used */
+#define JSON_THROW_ON_ERROR    0x400000 /* Throw JsonException on encode/decode error */
 /*
  * Each parsed URI is recorded and stored in an instance of the following structure.
  */

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -2250,6 +2250,7 @@ static int vm_builtin_Closure_fromCallable(ph7_context *pCtx, int nArg, ph7_valu
 	"class RangeException extends RuntimeException { }"\
 	"class UnderflowException extends RuntimeException { }"\
 	"class UnexpectedValueException extends RuntimeException { }"\
+	"class JsonException extends Exception { }"\
 	"interface Iterator extends Traversable {"\
 	"public function current();"\
 	"public function key();"\

--- a/src/ph7/vm_json.c
+++ b/src/ph7/vm_json.c
@@ -27,8 +27,10 @@ struct json_private_data
 	int nRecCount;     /* Recursion count */
 	int exc;           /* True if a jsonSerialize() callback threw an exception */
 	int oom;           /* True if a result append ran out of memory (raises a fatal) */
-	int fail;          /* True if the value is unencodable (php 8.1: a non-backed
-	                    * enum case) — json_encode returns FALSE */
+	int fail;          /* True if the value is unencodable — json_encode returns
+	                    * FALSE (or throws under JSON_THROW_ON_ERROR) */
+	int failRc;        /* json_rc to report for a ->fail (INF_OR_NAN vs
+	                    * NON_BACKED_ENUM) */
 };
 /*
  * Emit into the JSON result, flagging OOM on the shared data and bailing out
@@ -100,12 +102,21 @@ static sxi32 VmJsonEncode(
 			JSON_EMIT(pData,ph7_result_string(pCtx,iBool ? "true" : "false",iLen-1));
 		}else if(  ph7_value_is_numeric(pIn) && !ph7_value_is_string(pIn) ){
 			if( ph7_value_is_float(pIn) ){
+				double rVal = ph7_value_to_double(pIn);
+				/* php rejects Inf/NaN: json_encode returns FALSE with
+				 * json_last_error() == JSON_ERROR_INF_OR_NAN (they have no JSON
+				 * representation), instead of emitting the invalid bare token. */
+				if( PH7_IS_NAN(rVal) || PH7_IS_INF(rVal) ){
+					pData->fail = 1;
+					pData->failRc = JSON_ERROR_INF_OR_NAN;
+					return PH7_OK;
+				}
 				/* php's json float output follows serialize_precision
 				 * (shortest round-trip, like serialize/var_export), NOT the
 				 * echo/cast precision of 14 — with a lowercase exponent
 				 * marker: 1/3 -> 0.3333333333333333, 1e17 -> 1.0e+17,
 				 * 1.0 -> 1, -0.0 -> -0. */
-				JSON_EMIT(pData,VmJsonEmitReal(pCtx,ph7_value_to_double(pIn)));
+				JSON_EMIT(pData,VmJsonEmitReal(pCtx,rVal));
 			}else{
 				const char *zNum;
 				/* Get a string representation of the number */
@@ -233,6 +244,7 @@ static sxi32 VmJsonEncode(
 					pData->nRecCount--;
 				}else{
 					pData->fail = 1;
+					pData->failRc = JSON_ERROR_NON_BACKED_ENUM;
 				}
 				return PH7_OK;
 			}
@@ -427,6 +439,7 @@ static int VmJsonObjectEncode(const char *zAttr,ph7_value *pValue,void *pUserDat
  * Return
  *  Returns a JSON encoded string on success. FALSE otherwise
  */
+static const char * JsonErrorMsg(int rc); /* defined below, near json_last_error_msg */
 PH7_PRIVATE int vm_builtin_json_encode(ph7_context *pCtx,int nArg,ph7_value **apArg)
 {
 	json_private_data sJson;
@@ -444,6 +457,7 @@ PH7_PRIVATE int vm_builtin_json_encode(ph7_context *pCtx,int nArg,ph7_value **ap
 	sJson.exc = 0;
 	sJson.oom = 0;
 	sJson.fail = 0;
+	sJson.failRc = JSON_ERROR_NON_BACKED_ENUM;
 	if( nArg > 1 && ph7_value_is_int(apArg[1]) ){
 		/* Extract option flags */
 		sJson.iFlags = ph7_value_to_int(apArg[1]);
@@ -461,9 +475,15 @@ PH7_PRIVATE int vm_builtin_json_encode(ph7_context *pCtx,int nArg,ph7_value **ap
 		return PH7_EXCEPTION;
 	}
 	if( sJson.fail ){
-		/* Unencodable value (php 8.1: non-backed enum case): the whole encode
-		 * fails — discard whatever was emitted and return FALSE. */
-		pCtx->pVm->json_rc = JSON_ERROR_NON_BACKED_ENUM;
+		/* Unencodable value (Inf/NaN, or a php 8.1 non-backed enum case): the
+		 * whole encode fails — discard whatever was emitted and return FALSE. */
+		pCtx->pVm->json_rc = sJson.failRc;
+		if( sJson.iFlags & JSON_THROW_ON_ERROR ){
+			/* php: raise a JsonException carrying json_last_error_msg() instead
+			 * of returning FALSE. */
+			return PH7_VmThrowException(pCtx,"JsonException","%s",
+				JsonErrorMsg(pCtx->pVm->json_rc));
+		}
 		ph7_result_bool(pCtx,0);
 		return PH7_OK;
 	}
@@ -503,37 +523,26 @@ PH7_PRIVATE int vm_builtin_json_last_error(ph7_context *pCtx,int nArg,ph7_value 
  *  Returns the human-readable message corresponding to the last json_last_error()
  *  code, or "No error" if no error has occurred.
  */
+/* Human-readable message for a json_rc code. Shared by json_last_error_msg()
+ * and the JSON_THROW_ON_ERROR path (php's JsonException message is exactly this
+ * text). */
+static const char * JsonErrorMsg(int rc)
+{
+	switch( rc ){
+	case JSON_ERROR_NONE:            return "No error";
+	case JSON_ERROR_DEPTH:           return "Maximum stack depth exceeded";
+	case JSON_ERROR_STATE_MISMATCH:  return "State mismatch (invalid or malformed JSON)";
+	case JSON_ERROR_CTRL_CHAR:       return "Control character error, possibly incorrectly encoded";
+	case JSON_ERROR_SYNTAX:          return "Syntax error";
+	case JSON_ERROR_UTF8:            return "Malformed UTF-8 characters, possibly incorrectly encoded";
+	case JSON_ERROR_INF_OR_NAN:     return "Inf and NaN cannot be JSON encoded";
+	case JSON_ERROR_NON_BACKED_ENUM: return "Non-backed enums have no default serialization";
+	default:                         return "Unknown error";
+	}
+}
 PH7_PRIVATE int vm_builtin_json_last_error_msg(ph7_context *pCtx,int nArg,ph7_value **apArg)
 {
-	ph7_vm *pVm = pCtx->pVm;
-	const char *zMsg;
-	switch( pVm->json_rc ){
-	case JSON_ERROR_NONE:
-		zMsg = "No error";
-		break;
-	case JSON_ERROR_DEPTH:
-		zMsg = "Maximum stack depth exceeded";
-		break;
-	case JSON_ERROR_STATE_MISMATCH:
-		zMsg = "State mismatch (invalid or malformed JSON)";
-		break;
-	case JSON_ERROR_CTRL_CHAR:
-		zMsg = "Control character error, possibly incorrectly encoded";
-		break;
-	case JSON_ERROR_SYNTAX:
-		zMsg = "Syntax error";
-		break;
-	case JSON_ERROR_UTF8:
-		zMsg = "Malformed UTF-8 characters, possibly incorrectly encoded";
-		break;
-	case JSON_ERROR_NON_BACKED_ENUM:
-		zMsg = "Non-backed enums have no default serialization";
-		break;
-	default:
-		zMsg = "Unknown error";
-		break;
-	}
-	ph7_result_string(pCtx,zMsg,-1/* Compute length automatically */);
+	ph7_result_string(pCtx,JsonErrorMsg(pCtx->pVm->json_rc),-1/* auto length */);
 	SXUNUSED(nArg); /* cc warning */
 	SXUNUSED(apArg);
 	return PH7_OK;
@@ -1066,6 +1075,7 @@ PH7_PRIVATE int vm_builtin_json_decode(ph7_context *pCtx,int nArg,ph7_value **ap
 	int nByte;
 	int iAssoc = 0;
 	int nDepth = 32;
+	int iFlags = 0;
 	/* php coerces a scalar argument to string here (weak mode); the shared ZPP
 	 * screen in vm.c has already rejected the values that cannot coerce. */
 	if( nArg < 1 ){
@@ -1073,10 +1083,21 @@ PH7_PRIVATE int vm_builtin_json_decode(ph7_context *pCtx,int nArg,ph7_value **ap
 		ph7_result_null(pCtx);
 		return PH7_OK;
 	}
+	if( nArg > 3 && ph7_value_is_int(apArg[3]) ){
+		/* $flags — only JSON_THROW_ON_ERROR is honored (see NEWPLAN §5). */
+		iFlags = ph7_value_to_int(apArg[3]);
+	}
 	/* Extract the JSON string */
 	zIn = ph7_value_to_string(apArg[0],&nByte);
 	if( nByte < 1 ){
-		/* Empty string,return NULL */
+		/* Empty string: php records a syntax error. Without the throw flag it
+		 * returns NULL (leaving json_last_error untouched, as PHL always has);
+		 * with JSON_THROW_ON_ERROR it raises a JsonException. */
+		if( iFlags & JSON_THROW_ON_ERROR ){
+			pCtx->pVm->json_rc = JSON_ERROR_SYNTAX;
+			return PH7_VmThrowException(pCtx,"JsonException","%s",
+				JsonErrorMsg(JSON_ERROR_SYNTAX));
+		}
 		ph7_result_null(pCtx);
 		return PH7_OK;
 	}
@@ -1102,9 +1123,14 @@ PH7_PRIVATE int vm_builtin_json_decode(ph7_context *pCtx,int nArg,ph7_value **ap
 		nDepth = (int)nWant;
 	}
 	/* Decode the raw JSON input.The default consumer sets the decoded value as the
-	 * call-context result; on failure we replace it with NULL. */
+	 * call-context result; on failure we replace it with NULL (or throw). */
 	if( VmJsonDecodeInput(pCtx,zIn,nByte,iAssoc,nDepth) != JSON_ERROR_NONE ){
-		/* Something goes wrong while decoding JSON input.Return NULL. */
+		/* Something goes wrong while decoding JSON input. */
+		if( iFlags & JSON_THROW_ON_ERROR ){
+			/* php: raise a JsonException carrying json_last_error_msg() text. */
+			return PH7_VmThrowException(pCtx,"JsonException","%s",
+				JsonErrorMsg(pCtx->pVm->json_rc));
+		}
 		ph7_result_null(pCtx);
 	}
 	/* All done */

--- a/tests/ph7/001-smoke/function/json_throw_on_error.phpt
+++ b/tests/ph7/001-smoke/function/json_throw_on_error.phpt
@@ -1,0 +1,35 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: JSON_THROW_ON_ERROR + JsonException, and Inf/NaN encode rejection
+--FILE--
+<?php
+echo JSON_THROW_ON_ERROR, " ", JSON_ERROR_INF_OR_NAN, "\n";
+echo get_parent_class(new JsonException('x')), "\n";
+// a valid decode with the flag is unaffected
+echo json_encode(json_decode('[1,2,3]', true, 512, JSON_THROW_ON_ERROR)), "\n";
+// malformed decode WITHOUT the flag: NULL, error recorded, no throw
+var_export(json_decode('{bad')); echo " ", json_last_error(), " ", json_last_error_msg(), "\n";
+// malformed decode WITH the flag: a JsonException (catchable as Exception)
+try { json_decode('{bad', true, 512, JSON_THROW_ON_ERROR); }
+catch (JsonException $jseE) { echo "decode: ", get_class($jseE), " ", $jseE->getMessage(), "\n"; }
+// Inf/NaN encode WITHOUT the flag: false + JSON_ERROR_INF_OR_NAN (no invalid token)
+var_export(json_encode(NAN)); echo " ", json_last_error(), "\n";
+var_export(json_encode([1.5, INF, 3])); echo " ", json_last_error(), "\n";
+// Inf/NaN encode WITH the flag: throws
+try { json_encode(INF, JSON_THROW_ON_ERROR); }
+catch (Exception $jseE) { echo "encode: ", get_class($jseE), " ", $jseE->getMessage(), "\n"; }
+// finite floats still encode fine
+echo json_encode([1.5, -0.0, 2.0]), "\n";
+?>
+--EXPECT--
+4194304 7
+Exception
+[1,2,3]
+NULL 4 Syntax error
+decode: JsonException Syntax error
+false 7
+false 7
+encode: JsonException Inf and NaN cannot be JSON encoded
+[1.5,-0,2]


### PR DESCRIPTION
JSON_THROW_ON_ERROR was an undefined constant and PHL had no JsonException; json_decode ignored its $flags argument, so malformed input silently returned null instead of throwing; and json_encode(NAN/INF) emitted the bare NAN/INF token (invalid JSON) where php returns false with JSON_ERROR_INF_OR_NAN. Add the JSON_THROW_ON_ERROR (4194304) and JSON_ERROR_INF_OR_NAN (7) constants, a JsonException class, an Inf/NaN guard in the float-encode path, and honor JSON_THROW_ON_ERROR in both directions: a decode syntax/depth error and an encode Inf-NaN / non-backed-enum now raise a JsonException carrying the json_last_error_msg() text.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
