### PR TITLE
Lower error_reporting() inside @

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -25277,6 +25277,14 @@ static int vm_builtin_error_reporting(ph7_context *pCtx,int nArg,ph7_value **apA
 	int nOld;
 	/* Extract the old reporting level */
 	nOld = pVm->bErrReport ? (int)pVm->iErrMask : 0;
+	if( pVm->nErrSuppress > 0 ){
+		/* Inside the '@' silence operator php reports the level masked down to
+		 * the errors '@' cannot suppress: E_ERROR|E_PARSE|E_CORE_ERROR|
+		 * E_COMPILE_ERROR|E_USER_ERROR|E_RECOVERABLE_ERROR (== 4437). A custom
+		 * error handler (e.g. PHPUnit's) consults error_reporting() to honor
+		 * '@', so a suppressed warning must fall outside the returned mask. */
+		nOld &= 4437;
+	}
 	if( nArg > 0 ){
 		int nNew;
 		/* Keep the LEVEL, not just an on/off bit: php masks per-severity. */

--- a/tests/ph7/002-integration/error/at_operator_error_reporting_level.phpt
+++ b/tests/ph7/002-integration/error/at_operator_error_reporting_level.phpt
@@ -1,0 +1,33 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+PH7 / PHP: the @ operator lowers error_reporting() so a handler can honor it
+--FILE--
+<?php
+error_reporting(E_ALL);
+$atSeen = [];
+set_error_handler(function($no, $str) use (&$atSeen) {
+    if (!(error_reporting() & $no)) { return false; } // respect the @ operator
+    $atSeen[] = $str;
+    return true;
+});
+echo "outside=", error_reporting(), "\n";
+$atInside = null;
+@(function() use (&$atInside) { $atInside = error_reporting(); })();
+echo "inside=", $atInside, "\n";
+// a suppressed warning must not reach a handler that honors error_reporting()
+@file('no-such-file-atrep.php');
+echo "seen-after-suppressed=", count($atSeen), "\n";
+// an unsuppressed one is counted
+@file('no-such-file-atrep.php') ?: file('no-such-file-atrep.php');
+echo "seen-after-plain=", count($atSeen), "\n";
+echo "outside-again=", error_reporting(), "\n";
+restore_error_handler();
+?>
+--EXPECT--
+outside=30719
+inside=4437
+seen-after-suppressed=0
+seen-after-plain=1
+outside-again=30719


### PR DESCRIPTION
Inside @, php reports the level masked down to the errors @ cannot suppress (E_ERROR|E_PARSE|E_CORE_ERROR|E_COMPILE_ERROR|E_USER_ERROR|E_RECOVERABLE_ERROR == 4437), but PHL's error_reporting() returned the full mask regardless of the @ counter. A custom error handler consults error_reporting() & $errno to honor @, so a @-silenced warning was still handled and counted (e.g. PHPUnit counted the file() warning from Issue::calculateHash's @file($missing)). Mask the returned level with 4437 while nErrSuppress > 0.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
