### PR TITLE
Yield '.' and '..' from readdir and scandir

### DIFF
--- a/src/ph7/vfs_unix.c
+++ b/src/ph7/vfs_unix.c
@@ -686,22 +686,16 @@ static int UnixDir_Read(void *pUserData,ph7_context *pCtx)
 {
 	DIR *pDir = (DIR *)pUserData;
 	struct dirent *pEntry;
-	char *zName = 0; /* cc warning */
-	sxu32 n = 0;
-	for(;;){
-		pEntry = readdir(pDir);
-		if( pEntry == 0 ){
-			/* No more entries to process */
-			return -1;
-		}
-		zName = pEntry->d_name;
-		n = SyStrlen(zName);
-		/* Ignore '.' && '..' */
-		if( n > sizeof("..")-1 || zName[0] != '.' || ( n == sizeof("..")-1 && zName[1] != '.') ){
-			break;
-		}
-		/* Next entry */
+	char *zName;
+	sxu32 n;
+	/* php's readdir() yields every entry including '.' and '..' */
+	pEntry = readdir(pDir);
+	if( pEntry == 0 ){
+		/* No more entries to process */
+		return -1;
 	}
+	zName = pEntry->d_name;
+	n = SyStrlen(zName);
 	/* Return the current file name */
 	ph7_result_string(pCtx,zName,(int)n);
 	return PH7_OK;

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -2383,32 +2383,37 @@ static int vm_builtin_Closure_fromCallable(ph7_context *pCtx, int nArg, ph7_valu
 	"  return $aDir;"\
 	"}"\
 	"function glob(string $pattern,int $iFlags = 0){"\
-	"/* Open the target directory */"\
-	"$zDir = dirname($pattern);"\
-	"if(!is_string($zDir) ){ $zDir = './'; }"\
+	"/* php keeps the literal directory portion of the pattern in every result;"\
+	"   split off everything up to and including the last '/' as the prefix. */"\
+	"$slash = strrpos($pattern,'/');"\
+	"if( $slash === false ){ $zDir = '.'; $prefix = ''; $pat = $pattern; }"\
+	"else { $zDir = substr($pattern,0,$slash); if( $zDir === '' ){ $zDir = '/'; } $prefix = substr($pattern,0,$slash+1); $pat = substr($pattern,$slash+1); }"\
 	"$pHandle = opendir($zDir);"\
 	"if( $pHandle == FALSE ){"\
-	"   /* IO error while opening the current directory,return FALSE */"\
+	"   /* IO error while opening the target directory,return FALSE */"\
 	"	return FALSE;"\
 	"}"\
-	"$pattern = basename($pattern);"\
 	"$pArray = array(); /* Empty array */"\
 	"/* Loop throw available entries */"\
 	"while( FALSE !== ($pEntry = readdir($pHandle)) ){"\
+	" /* php's glob() never matches a leading-dot entry (incl. '.' and '..') unless"\
+	"    the pattern itself starts with a dot */"\
+	"	if( strlen($pEntry) > 0 && $pEntry[0] === '.' && (strlen($pat) < 1 || $pat[0] !== '.') ){ continue; }"\
 	" /* Use the built-in strglob function which is a Symisc eXtension for wildcard comparison*/"\
-	"	$rc = strglob($pattern,$pEntry);"\
+	"	$rc = strglob($pat,$pEntry);"\
 	"	if( $rc ){"\
-	"	   if( is_dir($pEntry) ){"\
+	"	   $zFull = $prefix . $pEntry;"\
+	"	   if( is_dir($zDir . '/' . $pEntry) ){"\
 	"	      if( $iFlags & GLOB_MARK ){"\
 	"		     /* Adds a slash to each directory returned */"\
-	"			 $pEntry .= DIRECTORY_SEPARATOR;"\
+	"			 $zFull .= DIRECTORY_SEPARATOR;"\
 	"		  }"\
 	"	   }else if( $iFlags & GLOB_ONLYDIR ){"\
 	"	     /* Not a directory,ignore */"\
 	"		 continue;"\
 	"	   }"\
-	"	   /* Add the entry */"\
-	"	   $pArray[] = $pEntry;"\
+	"	   /* Add the entry (with its literal directory prefix, php-style) */"\
+	"	   $pArray[] = $zFull;"\
 	"	}"\
 	" }"\
 	"/* Close the handle */"\

--- a/tests/ph7/001-smoke/function/readdir_dots_and_glob.phpt
+++ b/tests/ph7/001-smoke/function/readdir_dots_and_glob.phpt
@@ -1,0 +1,40 @@
+--TEST--
+readdir/scandir yield '.' and '..' (php parity); glob returns paths with the pattern's directory prefix, honours GLOB_ONLYDIR and the leading-dot rule
+--FILE--
+<?php
+$rddDir = sys_get_temp_dir() . '/phl_rdd_' . getmypid();
+@mkdir($rddDir);
+@mkdir($rddDir . '/sub');
+file_put_contents($rddDir . '/a.txt', 'a');
+file_put_contents($rddDir . '/b.log', 'bb');
+file_put_contents($rddDir . '/.hidden', 'h');
+// readdir includes . and ..
+$rddH = opendir($rddDir); $rddR = [];
+while (($e = readdir($rddH)) !== false) { $rddR[] = $e; }
+closedir($rddH); sort($rddR);
+echo "readdir: ", implode(',', $rddR), "\n";
+// scandir includes . and .. (sorted)
+echo "scandir: ", implode(',', scandir($rddDir)), "\n";
+// glob returns paths carrying the pattern's directory prefix, no dot-entries
+$rddG = glob($rddDir . '/*');
+echo "glob *: ", implode(',', array_map(fn($p) => substr($p, strlen($rddDir) + 1), $rddG)), "\n";
+// glob GLOB_ONLYDIR
+$rddGd = glob($rddDir . '/*', GLOB_ONLYDIR);
+echo "glob ONLYDIR: ", implode(',', array_map(fn($p) => substr($p, strlen($rddDir) + 1), $rddGd)), "\n";
+// glob '.*' matches dot entries
+$rddGh = glob($rddDir . '/.*');
+echo "glob .*: ", implode(',', array_map(fn($p) => substr($p, strlen($rddDir) + 1), $rddGh)), "\n";
+--EXPECT--
+readdir: .,..,.hidden,a.txt,b.log,sub
+scandir: .,..,.hidden,a.txt,b.log,sub
+glob *: a.txt,b.log,sub
+glob ONLYDIR: sub
+glob .*: .,..,.hidden
+--CLEAN--
+<?php
+$rddDir = sys_get_temp_dir() . '/phl_rdd_' . getmypid();
+@unlink($rddDir . '/a.txt');
+@unlink($rddDir . '/b.log');
+@unlink($rddDir . '/.hidden');
+@rmdir($rddDir . '/sub');
+@rmdir($rddDir);


### PR DESCRIPTION
readdir() (and scandir(), built on it) skipped '.' and '..'; php yields them. Stop filtering in the VFS readdir. glob() returned bare entry names and checked is_dir() against the basename (so GLOB_ONLYDIR always came back empty); it now carries the pattern's literal directory prefix in every result like php, stats the full path, and skips leading-dot entries unless the pattern itself starts with a dot (so the readdir change does not leak '.'/'..' into glob results).

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
