### PR TITLE
Initialize typed properties set by unserialize

### DIFF
--- a/src/ph7/vm_serialize.c
+++ b/src/ph7/vm_serialize.c
@@ -511,7 +511,19 @@ static ph7_value * VmUnserializeObject(unserialize_data *ud)
 			VmUnstripKey(zKey,nKey,&zName,&nName);
 			SyStringInitFromBuf(&sName,zName,nName);
 			pSlot = PH7_ClassInstanceFetchAttr(pThis,&sName);
-			if( pSlot ){ PH7_MemObjStore(pVal,pSlot); }
+			if( pSlot ){
+				SyHashEntry *pAttrEntry;
+				PH7_MemObjStore(pVal,pSlot);
+				/* php's unserialize() bypasses the property type-check but the
+				 * value IS now set, so a typed property must no longer read as
+				 * "uninitialized" — clear the per-instance UNINIT latch directly
+				 * (routing through VmEnforcePropertyTypeOnStore would wrongly
+				 * apply readonly/scope checks from global scope). */
+				pAttrEntry = SyHashGet(&pThis->hAttr,(const void *)zName,(sxu32)nName);
+				if( pAttrEntry && pAttrEntry->pUserData ){
+					((VmClassAttr *)pAttrEntry->pUserData)->iState &= ~VM_CLASS_ATTR_UNINIT;
+				}
+			}
 		}
 		/* Not released per node (bulk-reclaimed at context teardown) — see the
 		 * O(N^2) note in VmUnserializeArray. */

--- a/tests/ph7/001-smoke/function/unserialize_typed_props.phpt
+++ b/tests/ph7/001-smoke/function/unserialize_typed_props.phpt
@@ -1,0 +1,33 @@
+--TEST--
+unserialize() restores declared/typed properties (public, private, protected, readonly, nested) and leaves never-set typed properties uninitialized
+--FILE--
+<?php
+final class UtpInner { public int $x; public function __construct(int $x){ $this->x = $x; } }
+final class UtpNode {
+    public int $id;
+    public string $name;
+    private array $tags;
+    public readonly ?UtpInner $inner;
+    protected float $ratio;
+    public function __construct(int $id, string $name, array $tags, ?UtpInner $inner, float $ratio) {
+        $this->id = $id; $this->name = $name; $this->tags = $tags; $this->inner = $inner; $this->ratio = $ratio;
+    }
+    public function dump(): string {
+        return $this->id . '|' . $this->name . '|' . implode(',', $this->tags) . '|' .
+               ($this->inner ? $this->inner->x : 'null') . '|' . $this->ratio;
+    }
+}
+$utpN = new UtpNode(7, "node", ["a", "b"], new UtpInner(99), 3.5);
+$utpR = unserialize(serialize($utpN));
+echo $utpR->dump(), "\n";
+// A typed property that was never written round-trips as still-uninitialized
+class UtpU { public int $set; public int $unset; }
+$utpU = new UtpU();
+$utpU->set = 1;
+$utpR2 = unserialize(serialize($utpU));
+echo $utpR2->set, "\n";
+echo isset($utpR2->unset) ? "set" : "unset", "\n";
+--EXPECT--
+7|node|a,b|99|3.5
+1
+unset


### PR DESCRIPTION
unserialize() wrote each declared property's value into its slot but never cleared the per-instance VM_CLASS_ATTR_UNINIT latch, so a typed property restored from a serialized string still read as "must not be accessed before initialization". Clear the latch after the store (bypassing the type/readonly/scope enforcement, which php's unserialize also skips). A never-written typed property still round-trips as uninitialized. This unblocks any round-trip of a modern typed-property object graph, including PHPUnit's process-isolation result passing.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
