### PR TITLE
Implement set_include_path()

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -27636,6 +27636,60 @@ static int vm_builtin_get_include_path(ph7_context *pCtx,int nArg,ph7_value **ap
 	return PH7_OK;
 }
 /*
+ * string|false set_include_path(string $include_path)
+ *  Sets the include_path configuration option for the duration of the script,
+ *  returning the OLD value (php contract).
+ */
+static int vm_builtin_set_include_path(ph7_context *pCtx,int nArg,ph7_value **apArg)
+{
+	ph7_vm *pVm = pCtx->pVm;
+	SyString *aEntry;
+	const char *zNew, *z, *zEnd;
+	int dir_sep, nLen;
+	sxu32 n;
+#ifdef __WINNT__
+	dir_sep = ';';
+#else
+	dir_sep = ':';
+#endif
+	/* Build the OLD include_path first: it is this call's return value */
+	aEntry = (SyString *)SySetBasePtr(&pVm->aPaths);
+	for( n = 0 ; n < SySetUsed(&pVm->aPaths) ; n++ ){
+		if( n > 0 ){ ph7_result_string(pCtx,(const char *)&dir_sep,sizeof(char)); }
+		ph7_result_string(pCtx,aEntry[n].zString,(int)aEntry[n].nByte);
+	}
+	if( nArg < 1 ){
+		return PH7_OK;
+	}
+	/* Replace the path set with the separated segments of the new value.
+	 * Segments are duped into the VM allocator (reclaimed at VM teardown) so
+	 * the SyString entries stay valid, mirroring the config-time literals. */
+	zNew = ph7_value_to_string(apArg[0],&nLen);
+	SySetReset(&pVm->aPaths);
+	z = zNew; zEnd = &zNew[nLen];
+	while( z < zEnd ){
+		const char *zStart = z;
+		SyString sPath;
+		while( z < zEnd && (int)z[0] != dir_sep ){ z++; }
+		if( z > zStart ){
+			char *zDup = (char *)SyMemBackendDup(&pVm->sAllocator,zStart,(sxu32)(z-zStart));
+			if( zDup ){
+				SyStringInitFromBuf(&sPath,zDup,(sxu32)(z-zStart));
+#ifdef __WINNT__
+				SyStringTrimTrailingChar(&sPath,'\\');
+#endif
+				SyStringTrimTrailingChar(&sPath,'/');
+				SyStringFullTrim(&sPath);
+				if( sPath.nByte > 0 ){
+					SySetPut(&pVm->aPaths,(const void *)&sPath);
+				}
+			}
+		}
+		if( z < zEnd ){ z++; } /* skip the separator */
+	}
+	return PH7_OK;
+}
+/*
  * string get_get_included_files(void)
  *  Gets the current include_path configuration option.
  * Parameter
@@ -28366,6 +28420,7 @@ static const ph7_builtin_func aVmFunc[] = {
 	{"unserialize",    vm_builtin_unserialize },
 	   /* Files/URI inclusion facility */
 	{ "get_include_path",  vm_builtin_get_include_path },
+	{ "set_include_path",  vm_builtin_set_include_path },
 	{ "get_included_files",vm_builtin_get_included_files},
 	{ "include",      vm_builtin_include          },
 	{ "include_once", vm_builtin_include_once     },

--- a/tests/ph7/002-integration/function/set_include_path.phpt
+++ b/tests/ph7/002-integration/function/set_include_path.phpt
@@ -1,0 +1,26 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+set_include_path() replaces the include_path and returns the previous value (subprocess: mutates global state)
+--FILE--
+<?php
+// Normalize a known baseline first (the default include_path differs per engine/ini).
+set_include_path('.');
+echo "base=", get_include_path(), "\n";
+$sipOld = set_include_path('/foo:/bar/baz');
+echo "old=", $sipOld, "\n";
+echo "new=", get_include_path(), "\n";
+$sipOld2 = set_include_path('/single');
+echo "old2=", $sipOld2, "\n";
+echo "cur=", get_include_path(), "\n";
+?>
+--EXPECT--
+base=.
+old=.
+new=/foo:/bar/baz
+old2=/foo:/bar/baz
+cur=/single
+--CLEAN--
+<?php
+unset($sipOld, $sipOld2);


### PR DESCRIPTION
get_include_path() existed but its setter did not. set_include_path() returns the previous include_path (php contract) and replaces the VM path set with the separated segments of its argument, duped into the VM allocator. restore_include_path() is intentionally omitted: it was removed from PHP in 8.0. PHPUnit's isolation template sets the child's include_path through this.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
