### PR TITLE
Make an inaccessible property read catchable

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -16486,17 +16486,37 @@ case PH7_OP_MEMBER: {
 							PH7_ClassInstanceUnref(pThis);
 							break; /* pTos is already the null temp */
 						}
-						/* Throw Error exception (PHP-compatible).
-						 * Build message before unref — pObjAttr belongs to pThis->hAttr. */
+						/* A subclass reading a PARENT's PRIVATE property: php treats it as
+						 * an UNDEFINED property (the base-private is invisible to the
+						 * subclass scope) — a Warning + null, NOT an access Error. Only
+						 * this exact shape warns; every other denied read is the catchable
+						 * "Cannot access" Error below. */
 						{
-						char zMsg[256];
+						ph7_class *pSelf = VmCurrentSelf(&(*pVm));
+						ph7_class *pDecl = pObjAttr->pAttr->pDeclClass;
+						if( pObjAttr->pAttr->iProtection == PH7_CLASS_PROT_PRIVATE
+						 && pSelf && pDecl && pSelf != pDecl && PH7_VmInstanceOf(pSelf,pDecl) ){
+							if( !VmMemberCtxIsLookup(pInstr->iP2) ){
+								VmErrorFormat(&(*pVm),PH7_CTX_WARNING,"Undefined property: %z::$%z",
+									&pClass->sName,&sName);
+							}
+							PH7_ClassInstanceUnref(pThis);
+							break; /* pTos is already the null temp */
+						}
+						}
+						/* Genuinely inaccessible: php's CATCHABLE Error (parked on the
+						 * boundary rail; the fetch-point router lands it — it was an
+						 * uncatchable VmReportUncaughtException+Abort before). */
+						{
+						SyBlob sErrMsg;
 						const char *zVis = pObjAttr->pAttr->iProtection == PH7_CLASS_PROT_PRIVATE ? "private" : "protected";
-						SyBufferFormat(zMsg,sizeof(zMsg),"Cannot access %s property %.*s::$%.*s",
-							zVis,(int)pClass->sName.nByte,pClass->sName.zString,
-							(int)pObjAttr->pAttr->sName.nByte,pObjAttr->pAttr->sName.zString);
+						SyBlobInit(&sErrMsg,&pVm->sAllocator);
+						SyBlobFormat(&sErrMsg,"Cannot access %s property %z::$%z",
+							zVis,&pClass->sName,&sName);
 						PH7_ClassInstanceUnref(pThis);
-						VmReportUncaughtException(&(*pVm),"Error",5,zMsg,(sxu32)SyStrlen(zMsg),0,0);
-						goto Abort;
+						VmBoundaryPark(&(*pVm),VmThrowBuiltinError(&(*pVm),"Error",sizeof("Error")-1,&sErrMsg));
+						SyBlobRelease(&sErrMsg);
+						break;
 						}
 					}
 				}

--- a/tests/ph7/002-integration/oo/private_property_sibling_read.phpt
+++ b/tests/ph7/002-integration/oo/private_property_sibling_read.phpt
@@ -1,0 +1,29 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Reading an inaccessible property: a subclass reading a parent-private yields null (undefined property); every other denied read is a catchable "Cannot access" Error (subprocess: uses @ suppression)
+--FILE--
+<?php
+class PvsA { private $priv = 1; protected $prot = 2; }
+class PvsSub extends PvsA {
+    public function readPriv() { return @$this->priv; }  // parent-private is invisible here -> null
+    public function readProt() { return $this->prot; }   // parent-protected is accessible
+}
+$pvsS = new PvsSub();
+echo "sub-priv="; var_export($pvsS->readPriv()); echo "\n";
+echo "sub-prot=", $pvsS->readProt(), "\n";
+// A genuinely inaccessible read from outside the class is a CATCHABLE Error (not a fatal)
+$pvsA = new PvsA();
+try { $x = $pvsA->priv; echo "no-throw\n"; }
+catch (\Error $e) { echo "caught: ", $e->getMessage(), "\n"; }
+try { $y = $pvsA->prot; echo "no-throw\n"; }
+catch (\Error $e) { echo "caught: ", $e->getMessage(), "\n"; }
+echo "done\n";
+?>
+--EXPECT--
+sub-priv=NULL
+sub-prot=2
+caught: Cannot access private property PvsA::$priv
+caught: Cannot access protected property PvsA::$prot
+done


### PR DESCRIPTION
Reading a private/protected property from a scope that cannot see it raised an UNCATCHABLE fatal (VmReportUncaughtException + Abort) where php throws a catchable Error. Route it through the boundary rail like the other member-access errors so a try/catch works. Additionally, a subclass reading a parent's PRIVATE property now warns "Undefined property" and yields null (php treats the base-private as invisible to the subclass), rather than erroring — every other denied read stays the catchable "Cannot access" Error.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
