### PR TITLE
Give a no-capture static closure its class scope

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -12048,7 +12048,13 @@ case PH7_OP_LOAD_CLOSURE:{
 	 * copy for a real closure (built below), or the shared lambda function itself for a
 	 * plain anonymous function with no captured environment. */
 	ph7_vm_func *pTarget = pFunc;
-	if( pFunc->iFlags & VM_FUNC_CLOSURE ){
+	/* A no-capture lambda declared inside a class method is not VM_FUNC_CLOSURE
+	 * (its env is empty), yet php still binds the creation-site class as its scope
+	 * so `self::`/private access inside the body works. Detect the enclosing class
+	 * here and route such a lambda through the per-instance closure path (a global
+	 * no-capture lambda peeks NULL and stays a shared function). */
+	ph7_class *pLoadScope = (pFunc->iFlags & VM_FUNC_CLOSURE) ? 0 : PH7_VmPeekDeclaringClass(pVm);
+	if( (pFunc->iFlags & VM_FUNC_CLOSURE) || pLoadScope ){
 		ph7_vm_func_closure_env *aEnv,*pEnv,sEnv;
 		ph7_vm_func *pClosure;
 		char *zName;
@@ -12073,6 +12079,9 @@ case PH7_OP_LOAD_CLOSURE:{
 		pClosure->aByteCode = pFunc->aByteCode;
 		pClosure->aStatic = pFunc->aStatic;
 		pClosure->iFlags = pFunc->iFlags;
+		/* An in-class no-capture lambda routed here (pLoadScope set) must be a
+		 * real closure so PH7_VmClassMemberAccess honors its pUserData scope. */
+		pClosure->iFlags |= VM_FUNC_CLOSURE;
 		pClosure->pUserData = pFunc->pUserData;
 		pClosure->sSignature = pFunc->sSignature;
 		pClosure->nReturnType = pFunc->nReturnType;

--- a/tests/ph7/001-smoke/oo/static_closure_class_scope.phpt
+++ b/tests/ph7/001-smoke/oo/static_closure_class_scope.phpt
@@ -1,0 +1,26 @@
+--TEST--
+A no-capture long-form static closure declared in a method carries its class scope (self::, private property/method); global and free-function lambdas are unaffected
+--FILE--
+<?php
+class Ncs {
+    private static $s = 'PS';
+    private $i = 'PI';
+    const C = 'CC';
+    private function priv() { return 'PRIV'; }
+    public function selfRef() { return static function() { return self::$s . '|' . self::C; }; }
+    public function instRef() { return static function(Ncs $p) { return $p->i . '|' . $p->priv(); }; }
+}
+$ncsP = new Ncs();
+echo ($ncsP->selfRef())(), "\n";          // PS|CC
+echo ($ncsP->instRef())(new Ncs()), "\n"; // PI|PRIV
+// A global no-capture static lambda needs no scope and is unchanged
+$ncsG = static function ($x) { return $x * 2; };
+echo $ncsG(21), "\n";                     // 42
+// A no-capture static closure in a free function has no class scope but must not crash
+function ncsMk() { return static function () { return 'freefn'; }; }
+echo (ncsMk())(), "\n";                   // freefn
+--EXPECT--
+PS|CC
+PI|PRIV
+42
+freefn


### PR DESCRIPTION
A long-form static closure with no captures compiled inside a method was registered as a scope-less shared lambda (only closures with a non-empty environment — captures, or the auto-bound $this of a non-static closure — were flagged VM_FUNC_CLOSURE), so self:: and private member access from its body were wrongly denied. OP_LOAD_CLOSURE now detects the enclosing class via the executing frame and routes such a lambda through the per-instance closure path, stamping the creation-site class as its scope. A global or free-function no-capture lambda peeks no class and stays a shared function.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
