### PR TITLE
Resolve static:: inside closures

### DIFF
--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -845,6 +845,9 @@ struct ph7_vm_func
 	sxu32 nLine;         /* Line of the 'function'/'fn' keyword (Reflection getStartLine) */
 	sxu32 nEndLine;      /* Line of the closing brace of the body (Reflection getEndLine) */
 	void *pUserData;     /* Upper layer private data associated with this instance */
+	void *pLsbClass;     /* For a closure: the late-static-binding class captured at its
+	                      * creation site (ph7_class*), so `static::` inside the body
+	                      * resolves like php. NULL for a plain function/method. */
 	ph7_vm_func *pNextName; /* Next VM function with the same name as this one */
 };
 /* Forward reference */

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -12096,6 +12096,11 @@ case PH7_OP_LOAD_CLOSURE:{
 			 * the peek reads — resolves self::/parent:: against it like php. */
 			pClosure->pUserData = (void *)PH7_VmPeekDeclaringClass(pVm);
 		}
+		/* Capture the creation-site late-static-binding class so `static::` inside
+		 * the closure body resolves like php (the "called class", which may differ
+		 * from the declaring scope stamped above — e.g. a closure made in an
+		 * inherited method). A closure made outside any class captures NULL. */
+		pClosure->pLsbClass = (void *)PH7_VmPeekTopClass(pVm);
 		/* Reflection descriptor fields (getDocComment/getAttributes/getStartLine/
 		 * getEndLine/getFileName read the INSTANTIATED copy via $__fn) */
 		pClosure->aAttrs = pFunc->aAttrs;
@@ -18160,6 +18165,19 @@ case PH7_OP_CALL: {
 			ph7_class *pDecl = (ph7_class *)pVmFunc->pUserData;
 			if( pDecl && (pDecl->iFlags & PH7_CLASS_TRAIT) == 0 ){
 				pSelfHint = pDecl;
+			}
+		}
+		if( pSelf == 0 && (pVmFunc->iFlags & VM_FUNC_CLOSURE) ){
+			/* Push the closure's called-class as this frame's LSB class so
+			 * `static::` inside the body resolves like php. An explicit
+			 * Closure::bind/bindTo scope rebinds the called-class; otherwise use
+			 * the class captured at the closure's creation site. self::/parent::
+			 * still use the declaring-class scope (PH7_VmPeekDeclaringClass); done
+			 * after pSelfHint so a `self`-typed param is unaffected. */
+			if( pClosureScope ){
+				pSelf = pClosureScope;
+			}else if( pVmFunc->pLsbClass ){
+				pSelf = (ph7_class *)pVmFunc->pLsbClass;
 			}
 		}
 		if( SySetUsed(&pVmFunc->aAttrs) > 0 ){

--- a/tests/ph7/001-smoke/oo/static_lsb_in_closures.phpt
+++ b/tests/ph7/001-smoke/oo/static_lsb_in_closures.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Late static binding (static::) resolves inside closures, static closures, and arrow functions; Closure::bind rebinds the called-class
+--FILE--
+<?php
+class LsbBase {
+    public static function who() { return static::class; }
+    public function makeClosure() { return function() { return static::who() . '|' . static::class; }; }
+    public function makeStatic()  { return static function() { return static::who(); }; }
+    public function makeArrow()   { return fn() => static::who(); }
+    public function makeNew()     { return static function() { return get_class(new static()); }; }
+}
+class LsbDerived extends LsbBase {
+    public static function who() { return 'D:' . static::class; }
+}
+$lsbD = new LsbDerived();
+echo ($lsbD->makeClosure())(), "\n";  // D:LsbDerived|LsbDerived
+echo ($lsbD->makeStatic())(), "\n";   // D:LsbDerived
+echo ($lsbD->makeArrow())(), "\n";    // D:LsbDerived
+echo ($lsbD->makeNew())(), "\n";      // LsbDerived
+// Closure::bind rebinds the called-class used by static::
+$lsbC = (new LsbBase())->makeClosure();
+echo Closure::bind($lsbC, null, LsbDerived::class)(), "\n"; // D:LsbDerived|LsbDerived
+--EXPECT--
+D:LsbDerived|LsbDerived
+D:LsbDerived
+D:LsbDerived
+LsbDerived
+D:LsbDerived|LsbDerived


### PR DESCRIPTION
static::class / static::method() inside a closure raised Class "static" not found: a closure invocation pushed no called-class onto the LSB stack, so static:: had nothing to resolve against. Closures now capture the creation-site LSB class (PH7_VmPeekTopClass) into a new ph7_vm_func field and push it as the frame's called-class when invoked, so static:: resolves like php across plain, static, and arrow closures. An explicit Closure::bind/bindTo scope rebinds the called-class; self::/parent:: keep using the declaring-class scope.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
