### PR TITLE
Record a realpath'd absolute __FILE__

### DIFF
--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -27531,9 +27531,6 @@ PH7_PRIVATE sxi32 PH7_VmPushFilePath(ph7_vm *pVm,const char *zPath,int nLen,sxu8
 {
 	SyString sPath;
 	char *zDup;
-#ifdef __WINNT__
-	char *zCur;
-#endif
 	sxi32 rc;
 	if( nLen < 0 ){
 		nLen = SyStrlen(zPath);
@@ -27543,22 +27540,47 @@ PH7_PRIVATE sxi32 PH7_VmPushFilePath(ph7_vm *pVm,const char *zPath,int nLen,sxu8
 	if( zDup == 0 ){
 		return SXERR_MEM;
 	}
-#ifdef __WINNT__
-	/* Normalize path on windows
-	 * Example:
-	 *    Path/To/File.php
-	 * becomes
-	 *   path\to\file.php
-	 */
-	zCur = zDup;
-	while( zCur[0] != 0 ){
-		if( zCur[0] == '/' ){
-			zCur[0] = '\\';
-		}else if( (unsigned char)zCur[0] < 0xc0 && SyisUpper(zCur[0]) ){
-			int c = SyToLower(zCur[0]);
-			zCur[0] = (char)c; /* MSVC stupidity */
+#ifdef __UNIXES__
+	/* php records the REALPATH'd absolute path for __FILE__/__DIR__/getFileName
+	 * and include-once dedup: realpath() resolves '.', '..' and symlinks (e.g.
+	 * macOS /tmp -> /private/tmp). It needs an existing file, so on failure keep
+	 * the raw path (eval'd code, php:///data:// wrappers, a missing include that
+	 * errors elsewhere). */
+	{
+		char *zReal = realpath(zDup,0); /* POSIX: malloc'd result */
+		if( zReal ){
+			sxu32 nReal = SyStrlen(zReal);
+			char *zRealDup = SyMemBackendStrDup(&pVm->sAllocator,zReal,nReal);
+			free(zReal);
+			if( zRealDup ){
+				SyMemBackendFree(&pVm->sAllocator,zDup);
+				zDup = zRealDup;
+				nLen = (int)nReal;
+			}
 		}
-		zCur++;
+	}
+#endif
+#ifdef __WINNT__
+	/* Windows counterpart of the realpath() above: canonicalize to an absolute
+	 * path (resolves '.'/'..' , '/' -> '\'), case-preserved to match php — NOT
+	 * lowercased as the legacy PH7 code did. Like the POSIX branch, keep the raw
+	 * path when it does not name an existing file (the "Command line code" marker,
+	 * eval'd code, stream wrappers). _fullpath() is lexical, so pair it with a VFS
+	 * existence check. */
+	{
+		char *zFull = _fullpath(0,zDup,0); /* MSVC CRT: malloc'd absolute path */
+		if( zFull ){
+			if( pVm->pEngine->pVfs && pVm->pEngine->pVfs->xFileExists && pVm->pEngine->pVfs->xFileExists(zFull) == PH7_OK ){
+				sxu32 nFull = SyStrlen(zFull);
+				char *zFullDup = SyMemBackendStrDup(&pVm->sAllocator,zFull,nFull);
+				if( zFullDup ){
+					SyMemBackendFree(&pVm->sAllocator,zDup);
+					zDup = zFullDup;
+					nLen = (int)nFull;
+				}
+			}
+			free(zFull);
+		}
 	}
 #endif
 	/* Install the file path */

--- a/tests/ph7/002-integration/constants/__file_memory__.phpt
+++ b/tests/ph7/002-integration/constants/__file_memory__.phpt
@@ -1,0 +1,21 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+__FILE__ constant reports php's "Command line code" for inline (-r) code
+--FILE--
+<?php
+$phl = getenv('PHPT_TARGET_EXECUTABLE');
+$fp = popen("\"$phl\" -r \"echo \\\"__FILE__=\\\" . __FILE__ . \\\"\\n\\\";\"", "r");
+$out = '';
+while (!feof($fp)) {
+    $out .= fgets($fp);
+}
+fclose($fp);
+echo $out;
+?>
+--EXPECT--
+__FILE__=Command line code
+--CLEAN--
+<?php
+unset($phl, $fp, $out);

--- a/tests/ph7/002-integration/constants/file_realpath_canonical.phpt
+++ b/tests/ph7/002-integration/constants/file_realpath_canonical.phpt
@@ -1,0 +1,28 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+__FILE__ / ReflectionClass::getFileName() report the realpath'd absolute path (symlinks and '..' resolved), matching php
+--FILE--
+<?php
+$cnDir = sys_get_temp_dir() . '/phl_canon_' . getmypid();
+@mkdir($cnDir);
+@mkdir($cnDir . '/sub');
+file_put_contents($cnDir . '/inc.php', "<?php function cnf() { return __FILE__; } class CnClass {}\n");
+// Include through a non-canonical path (…/sub/../inc.php)
+require $cnDir . '/sub/../inc.php';
+$cnDirect = realpath($cnDir . '/inc.php');
+var_dump(cnf() === $cnDirect);
+var_dump((new ReflectionClass('CnClass'))->getFileName() === $cnDirect);
+var_dump(strpos(cnf(), '/../') === false);
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+--CLEAN--
+<?php
+$cnDir = sys_get_temp_dir() . '/phl_canon_' . getmypid();
+@unlink($cnDir . '/inc.php');
+@rmdir($cnDir . '/sub');
+@rmdir($cnDir);


### PR DESCRIPTION
PHL kept the raw path passed to the CLI or to include/require, so __FILE__, __DIR__, and ReflectionClass::getFileName() reported non-canonical paths (unresolved '..', and /tmp instead of the symlink-resolved /private/tmp on macOS) where php reports the realpath. PH7_VmPushFilePath now realpath()s the path before recording it on the file stack (also tightening include-once dedup), falling back to the raw path when realpath fails (eval'd code, stream wrappers). Flips PHPUnit's Util/ExcludeListTest, whose ExcludeList discovers directories via getFileName().

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
