### PR TITLE
Resolve self:: in attribute arguments

### DIFF
--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -2238,6 +2238,7 @@ PH7_PRIVATE int vm_builtin_xml_error_string(ph7_context *pCtx,int nArg,ph7_value
 PH7_PRIVATE int vm_builtin_utf8_encode(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE int vm_builtin_utf8_decode(ph7_context *pCtx,int nArg,ph7_value **apArg);
 PH7_PRIVATE sxi32 VmLocalExec(ph7_vm *pVm,SySet *pByteCode,ph7_value *pResult,int bReturnPropagates);
+PH7_PRIVATE sxi32 PH7_VmExecAttrArg(ph7_vm *pVm,SySet *pByteCode,ph7_class *pDeclCls,ph7_value *pResult);
 PH7_PRIVATE sxi32 VmErrorFormat(ph7_vm *pVm,sxi32 iErr,const char *zFormat,...);
 /* vm_builtin_class.c function prototypes */
 PH7_PRIVATE int PH7_VmInstanceOf(ph7_class *pThis,ph7_class *pClass);

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -19791,6 +19791,27 @@ PH7_PRIVATE sxi32 VmLocalExec(ph7_vm *pVm,SySet *pByteCode,ph7_value *pResult,in
 	return rc;
 }
 /*
+ * Evaluate an attribute-argument bytecode with the attribute's DECLARING class
+ * installed as the const-eval scope, so `self::`/`parent::`/`self::CONST` inside
+ * the argument resolve against that class (like php) rather than the reflection
+ * machinery's scope. pDeclCls == 0 (a free function or global constant) leaves
+ * the ambient scope untouched. Mirrors the property/const-initializer path.
+ */
+PH7_PRIVATE sxi32 PH7_VmExecAttrArg(ph7_vm *pVm,SySet *pByteCode,ph7_class *pDeclCls,ph7_value *pResult)
+{
+	ph7_class *pSaveCtx = pVm->pConstEvalClass;
+	void *pSaveFrame = pVm->pConstEvalFrame;
+	sxi32 rc;
+	if( pDeclCls ){
+		pVm->pConstEvalClass = pDeclCls;
+		pVm->pConstEvalFrame = (void *)VmSkipExceptionFrames(pVm->pFrame);
+	}
+	rc = VmLocalExec(&(*pVm),pByteCode,pResult,FALSE);
+	pVm->pConstEvalClass = pSaveCtx;
+	pVm->pConstEvalFrame = pSaveFrame;
+	return rc;
+}
+/*
  * Invoke any installed shutdown callbacks.
  * Flush every still-open output buffer to the real output consumer at the end
  * of execution. php implicitly ends+flushes all ob_start() levels on shutdown

--- a/src/ph7/vm_builtin_reflection.c
+++ b/src/ph7/vm_builtin_reflection.c
@@ -1648,6 +1648,7 @@ static int vm_builtin_reflect_attr_args(ph7_context *pCtx, int nArg, ph7_value *
 {
 	ph7_vm *pVm = pCtx->pVm;
 	SySet *pAttrs = 0;
+	ph7_class *pDeclCls = 0; /* class an attribute is declared on: scope for self:: in its args */
 	ph7_attribute *pAttrRec;
 	ph7_value *pOut;
 	const char *zKind;
@@ -1661,14 +1662,14 @@ static int vm_builtin_reflect_attr_args(ph7_context *pCtx, int nArg, ph7_value *
 	nAttrIdx = (sxu32)ph7_value_to_int(apArg[4]);
 	if( nKind == 5 && SyMemcmp(zKind, "class", 5) == 0 ){
 		ph7_class *pClass = ReflectResolveClass(pVm, apArg[1]);
-		if( pClass ){ pAttrs = &pClass->aAttrs; }
+		if( pClass ){ pAttrs = &pClass->aAttrs; pDeclCls = pClass; }
 	}else if( nKind == 4 && SyMemcmp(zKind, "attr", 4) == 0 ){
 		ph7_class *pClass = ReflectResolveClass(pVm, apArg[1]);
 		ph7_class_attr *pMember = pClass ? ReflectFetchAttr(pClass, apArg[2]) : 0;
-		if( pMember ){ pAttrs = &pMember->aAttrs; }
+		if( pMember ){ pAttrs = &pMember->aAttrs; pDeclCls = pClass; }
 	}else if( nKind == 6 && SyMemcmp(zKind, "method", 6) == 0 ){
 		ph7_vm_func *pFunc = ReflectResolveCallable(pCtx, apArg[1], apArg[2], 0, 0, 0, 0);
-		if( pFunc ){ pAttrs = &pFunc->aAttrs; }
+		if( pFunc ){ pAttrs = &pFunc->aAttrs; pDeclCls = (ph7_class *)pFunc->pUserData; }
 	}else if( nKind == 2 && SyMemcmp(zKind, "fn", 2) == 0 ){
 		ph7_vm_func *pFunc = ReflectResolveCallable(pCtx, apArg[1], 0, 0, 0, 0, 0);
 		if( pFunc ){ pAttrs = &pFunc->aAttrs; }
@@ -1676,7 +1677,7 @@ static int vm_builtin_reflect_attr_args(ph7_context *pCtx, int nArg, ph7_value *
 		ph7_vm_func *pFunc = ReflectResolveCallable(pCtx, apArg[1], apArg[2], 0, 0, 0, 0);
 		ph7_vm_func_arg *pParam = pFunc
 			? (ph7_vm_func_arg *)SySetAt(&pFunc->aArgs, (sxu32)ph7_value_to_int(apArg[3])) : 0;
-		if( pParam ){ pAttrs = &pParam->aAttrs; }
+		if( pParam ){ pAttrs = &pParam->aAttrs; pDeclCls = (ph7_class *)pFunc->pUserData; }
 	}else if( nKind == 5 && SyMemcmp(zKind, "const", 5) == 0 ){
 		/* Global constant (php 8.5 attributes on `const` statements) */
 		const char *zCName;
@@ -1696,7 +1697,10 @@ static int vm_builtin_reflect_attr_args(ph7_context *pCtx, int nArg, ph7_value *
 		ph7_value sValue;
 		PH7_MemObjInit(pVm, &sValue);
 		if( SySetUsed(&pArgRec->aByteCode) > 0 ){
-			VmLocalExec(pVm, &pArgRec->aByteCode, &sValue, FALSE);
+			/* Evaluate under the attribute's declaring-class scope so `self::class`
+			 * / `self::CONST` / `parent::` resolve like php (else self:: would bind
+			 * to the reflection machinery's own class). */
+			PH7_VmExecAttrArg(pVm, &pArgRec->aByteCode, pDeclCls, &sValue);
 		}
 		if( SyStringLength(&pArgRec->sName) > 0 ){
 			ReflectMapAddDyn(pCtx, pOut, &pArgRec->sName, &sValue);

--- a/tests/ph7/001-smoke/attribute_self_scope_args.phpt
+++ b/tests/ph7/001-smoke/attribute_self_scope_args.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Attribute arguments resolve self::/parent::/self::CONST against the attribute's declaring class (not the reflection scope)
+--FILE--
+<?php
+#[Attribute]
+class AaMark { public $v; public function __construct($v){ $this->v = $v; } }
+class AaBase { const BC = 'bc'; }
+#[AaMark(self::class)]
+class AaChild extends AaBase {
+    const MC = 'mc';
+    #[AaMark(self::MC)]
+    public function withSelfConst() {}
+    #[AaMark(parent::class)]
+    public function withParent() {}
+    #[AaMark('lit')]
+    public function withLiteral() {}
+}
+echo (new ReflectionClass(AaChild::class))->getAttributes()[0]->newInstance()->v, "\n";
+foreach (['withSelfConst', 'withParent', 'withLiteral'] as $aaM) {
+    echo $aaM, ': ', (new ReflectionMethod(AaChild::class, $aaM))->getAttributes()[0]->newInstance()->v, "\n";
+}
+--EXPECT--
+AaChild
+withSelfConst: mc
+withParent: AaBase
+withLiteral: lit


### PR DESCRIPTION
An attribute argument like #[A(self::class)] or #[A(self::CONST)] is stored as bytecode and re-evaluated by the Reflection machinery via VmLocalExec, so self:: resolved against that machinery's scope and yielded 'ReflectionAttribute'. Evaluate the argument bytecode with the attribute's declaring class installed as the const-eval scope (new PH7_VmExecAttrArg helper, mirroring the property/const-initializer path), so self::/parent::/self::CONST resolve like php. Flips PHPUnit's Metadata/Parser/AttributeParserTest.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
