### PR TITLE
Reflect fromCallable's underlying method

### DIFF
--- a/src/ph7/vm_builtin_reflection.c
+++ b/src/ph7/vm_builtin_reflection.c
@@ -1000,6 +1000,33 @@ static ph7_vm_func * ReflectResolveCallable(ph7_context *pCtx, ph7_value *pTarge
 			if( pFn == 0 || (pFn->iFlags & MEMOBJ_STRING) == 0 || SyBlobLength(&pFn->sBlob) < 1 ){
 				return 0;
 			}
+			/* A closure over an object method or __invoke object
+			 * (Closure::fromCallable([$obj,'m']) / fromCallable($invokeObj)) stores the
+			 * bare method name in $__fn and the class in $__scope. Resolve it as a METHOD
+			 * of $__scope FIRST — before the global function table — so a same-named
+			 * global function does not shadow the method (the bug: $__fn "add" hitting a
+			 * global add()). A plain anonymous closure's $__fn is its unique lambda name,
+			 * which is not a method, so this falls through cleanly. */
+			{
+				SyString sScope;
+				ph7_value *pScope;
+				SyStringInitFromBuf(&sScope, "__scope", 7);
+				pScope = PH7_ClassInstanceFetchAttr(pClo, &sScope);
+				if( pScope && (pScope->iFlags & MEMOBJ_STRING) && SyBlobLength(&pScope->sBlob) > 0 ){
+					ph7_class *pScopeCls = PH7_VmExtractClass(pVm,
+						(const char *)SyBlobData(&pScope->sBlob), SyBlobLength(&pScope->sBlob), FALSE, 0);
+					if( pScopeCls ){
+						ph7_class_method *pScopeMeth = PH7_ClassExtractMethod(pScopeCls,
+							(const char *)SyBlobData(&pFn->sBlob), SyBlobLength(&pFn->sBlob));
+						if( pScopeMeth ){
+							if( ppClass ){ *ppClass = pScopeCls; }
+							if( ppMeth ){ *ppMeth = pScopeMeth; }
+							if( ppClosure ){ *ppClosure = pClo; }
+							return &pScopeMeth->sFunc;
+						}
+					}
+				}
+			}
 			pEntry = SyHashGet(&pVm->hFunction, SyBlobData(&pFn->sBlob), SyBlobLength(&pFn->sBlob));
 			if( pEntry == 0 ){
 				/* A Closure over a host function (Closure::fromCallable('strlen')) */

--- a/tests/ph7/001-smoke/reflection_fromcallable_signature.phpt
+++ b/tests/ph7/001-smoke/reflection_fromcallable_signature.phpt
@@ -1,0 +1,19 @@
+--TEST--
+ReflectionFunction over a Closure::fromCallable([obj,'m']) / fromCallable($invokeObj) resolves the underlying method signature (variadic, params)
+--FILE--
+<?php
+class RvCalc {
+    public function add(int $a, int $b = 5): int { return $a + $b; }
+    public function __invoke(string $s, int ...$n) { return $s . array_sum($n); }
+}
+$rvO = new RvCalc();
+$rvR1 = new ReflectionFunction(Closure::fromCallable([$rvO, 'add']));
+echo var_export($rvR1->isVariadic(), true), '|', $rvR1->getNumberOfParameters(), '|', $rvR1->getNumberOfRequiredParameters(), "\n";
+$rvR2 = new ReflectionFunction(Closure::fromCallable($rvO));
+echo var_export($rvR2->isVariadic(), true), '|', $rvR2->getNumberOfParameters(), "\n";
+$rvNames = array_map(fn($p) => $p->getName(), $rvR1->getParameters());
+echo implode(',', $rvNames), "\n";
+--EXPECT--
+false|2|1
+true|2
+a,b


### PR DESCRIPTION
ReflectionFunction over a closure made from [obj,'method'] or an __invoke object returned null (Trying to access array offset on null): such a closure stores the bare method name in $__fn and the class in $__scope, and the resolver only looked $__fn up in the global function table. Resolve $__fn as a method of $__scope first — before the global lookup, so a same-named global function cannot shadow the method — so isVariadic()/getParameters()/etc. see the real signature. Flips PHPUnit's Constraint/CallbackTest.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
