### PR TITLE
Apply TOKEN_PARSE re-tagging in token_get_all

### DIFF
--- a/src/ph7/vm_builtin_tokenizer.c
+++ b/src/ph7/vm_builtin_tokenizer.c
@@ -323,7 +323,9 @@ struct tok_state {
 	const unsigned char *z;      /* cursor */
 	const unsigned char *zEnd;   /* one past end */
 	int          iLine;    /* current 1-based line at the cursor */
-	int          bProp;    /* one-shot: next identifier is a property -> T_STRING */
+	int          bProp;    /* one-shot: next identifier is a member name -> T_STRING */
+	int          bCaseName;/* one-shot: next identifier may be an enum case name (after 'case') */
+	int          bParse;   /* TOKEN_PARSE flag: apply php's semi-reserved re-tagging */
 	int          bStop;    /* __halt_compiler seen: stop scanning entirely */
 	int          bOOM;     /* memory failure flag */
 };
@@ -778,6 +780,7 @@ static int tok_lex_one(tok_state *ts){
 	const unsigned char *z = ts->z;
 	int c;
 	int bWasProp;
+	int bWasCase;
 	if( z >= ts->zEnd ){ return -1; }
 	c = *z;
 	/* Whitespace run (preserves property state). */
@@ -829,9 +832,11 @@ static int tok_lex_one(tok_state *ts){
 		tok_tok(ts,bDoc ? T_DOC_COMMENT : T_COMMENT,(const char *)z0,(int)(ts->z-z0),iLine);
 		return 0;
 	}
-	/* From here the token consumes property state. */
+	/* From here the token consumes property/case state. */
 	bWasProp = ts->bProp;
+	bWasCase = ts->bCaseName;
 	ts->bProp = 0;
+	ts->bCaseName = 0;
 	/* Close tag. */
 	if( c=='?' && z+1 < ts->zEnd && z[1]=='>' ){
 		const unsigned char *z0 = z;
@@ -921,6 +926,19 @@ static int tok_lex_one(tok_state *ts){
 					}
 				}
 			}
+			/* Under TOKEN_PARSE, a reserved word right after 'case' that names an
+			 * enum case (followed by ';' or '=') is T_STRING; a switch 'case
+			 * array(...)'/'case expr:' keeps the keyword. */
+			if( bWasCase && id != T_STRING ){
+				const unsigned char *q = firstLabelEnd;
+				while( q < ts->zEnd && tok_is_ws(*q) ){ q++; }
+				/* ';' ends a pure case, a lone '=' (not '=='/'=>') starts a backed
+				 * case value; both mark an enum case name. */
+				if( q < ts->zEnd && (*q==';' ||
+					(*q=='=' && (q+1>=ts->zEnd || (q[1]!='=' && q[1]!='>')))) ){
+					id = T_STRING;
+				}
+			}
 			if( id == T_STRING ){
 				tok_tok(ts,T_STRING,(const char *)z,n,ts->iLine);
 			}else{
@@ -930,6 +948,16 @@ static int tok_lex_one(tok_state *ts){
 			if( id == T_HALT_COMPILER ){
 				tok_halt_tail(ts);
 				return -1;
+			}
+			/* Under TOKEN_PARSE, a reserved word naming a function/method or a
+			 * class constant becomes T_STRING (semi-reserved words); force the
+			 * next identifier to T_STRING like a member name. 'case' arms a
+			 * conditional retag (enum case names only — see the identifier path). */
+			if( ts->bParse && (id == T_FUNCTION || id == T_CONST) ){
+				ts->bProp = 1;
+			}
+			if( ts->bParse && id == T_CASE ){
+				ts->bCaseName = 1;
 			}
 			return 0;
 		}
@@ -1043,6 +1071,14 @@ static int tok_lex_one(tok_state *ts){
 		ts->bProp = 1;
 		return 0;
 	}
+	/* Under TOKEN_PARSE, php re-tags a reserved word used as a member name after
+	 * "::" as T_STRING (e.g. Foo::class, Foo::empty). Mirror that with bProp. */
+	if( c==':' && z+1 < ts->zEnd && z[1]==':' ){
+		tok_tok(ts,T_DOUBLE_COLON,"::",2,ts->iLine);
+		ts->z += 2;
+		if( ts->bParse ){ ts->bProp = 1; }
+		return 0;
+	}
 	/* Multi-char and single-char operators (longest match first). */
 	{
 		const unsigned char *e = ts->zEnd;
@@ -1070,7 +1106,6 @@ static int tok_lex_one(tok_state *ts){
 		TK2('+','+',T_INC)
 		TK2('-','-',T_DEC)
 		TK2('=','>',T_DOUBLE_ARROW)
-		TK2(':',':',T_DOUBLE_COLON)
 		TK2('<','<',T_SL)
 		TK2('>','>',T_SR)
 		TK2('*','*',T_POW)
@@ -1211,6 +1246,9 @@ static int PH7_builtin_token_get_all(ph7_context *pCtx,int nArg,ph7_value **apAr
 	ts.z    = (const unsigned char *)zSrc;
 	ts.zEnd = ts.z + (nSrc > 0 ? (sxu32)nSrc : 0);
 	ts.iLine = 1;
+	if( nArg > 1 && (ph7_value_to_int(apArg[1]) & TOK_TOKEN_PARSE) ){
+		ts.bParse = 1;
+	}
 	tok_run(&ts);
 	if( ts.bOOM ){
 		return PH7_ContextMemoryError(pCtx);

--- a/tests/ph7/001-smoke/tokenizer.phpt
+++ b/tests/ph7/001-smoke/tokenizer.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Tokenizer: token_get_all/token_name/T_* constants/PhpToken php-parity
+Tokenizer: token_get_all/token_name/T_* constants/PhpToken/TOKEN_PARSE php-parity
 --SKIPIF--
 skip: flaky
 --FILE--
@@ -35,6 +35,11 @@ foreach(PhpToken::tokenize('<?php $x=1;') as $tkP){
 }
 $tkV = PhpToken::tokenize('<?php $x;')[1];
 echo ($tkV->is(T_VARIABLE)?"1":"0"),($tkV->is("T_VARIABLE")?"1":"0"),"\n";
+echo "== token_parse ==\n";
+$tkPsrc = '<?php class C { public function list(){} const IF=1; } Foo::class; Foo::empty; enum E { case array; } switch($x){ case array($y): break; }';
+foreach(token_get_all($tkPsrc, TOKEN_PARSE) as $tkT){
+  echo is_array($tkT) ? token_name($tkT[0])."|".$tkT[1]."|".$tkT[2]."\n" : "S:$tkT\n";
+}
 echo TOKEN_PARSE,"\n";
 --EXPECT--
 == basic ==
@@ -300,4 +305,72 @@ T_VARIABLE,T_VARIABLE,T_DOUBLE_COLON,UNKNOWN,UNKNOWN
 260|1|1|9|-|T_LNUMBER
 59|;|1|10|-|;
 10
+== token_parse ==
+T_OPEN_TAG|<?php |1
+T_CLASS|class|1
+T_WHITESPACE| |1
+T_STRING|C|1
+T_WHITESPACE| |1
+S:{
+T_WHITESPACE| |1
+T_PUBLIC|public|1
+T_WHITESPACE| |1
+T_FUNCTION|function|1
+T_WHITESPACE| |1
+T_STRING|list|1
+S:(
+S:)
+S:{
+S:}
+T_WHITESPACE| |1
+T_CONST|const|1
+T_WHITESPACE| |1
+T_STRING|IF|1
+S:=
+T_LNUMBER|1|1
+S:;
+T_WHITESPACE| |1
+S:}
+T_WHITESPACE| |1
+T_STRING|Foo|1
+T_DOUBLE_COLON|::|1
+T_STRING|class|1
+S:;
+T_WHITESPACE| |1
+T_STRING|Foo|1
+T_DOUBLE_COLON|::|1
+T_STRING|empty|1
+S:;
+T_WHITESPACE| |1
+T_ENUM|enum|1
+T_WHITESPACE| |1
+T_STRING|E|1
+T_WHITESPACE| |1
+S:{
+T_WHITESPACE| |1
+T_CASE|case|1
+T_WHITESPACE| |1
+T_STRING|array|1
+S:;
+T_WHITESPACE| |1
+S:}
+T_WHITESPACE| |1
+T_SWITCH|switch|1
+S:(
+T_VARIABLE|$x|1
+S:)
+S:{
+T_WHITESPACE| |1
+T_CASE|case|1
+T_WHITESPACE| |1
+T_ARRAY|array|1
+S:(
+T_VARIABLE|$y|1
+S:)
+S::
+T_WHITESPACE| |1
+T_BREAK|break|1
+S:;
+T_WHITESPACE| |1
+S:}
 1


### PR DESCRIPTION
php's TOKEN_PARSE mode re-tags reserved words used as identifiers (semi-reserved words) as T_STRING, which does change the token stream — measured on 51 of 935 real files. Handle the three naming contexts that account for it: a reserved word after :: (Foo::class, Foo::empty), after function/const (method and class constant names), and after case (enum case names, guarded by a lookahead so a switch "case array($y):" keeps T_ARRAY). Reuse the one-shot member-name flag for the first two and add a lookahead-guarded flag for case.

token_get_all($src, TOKEN_PARSE) is now byte-identical to php across the full 1.9M-token, 4258-file sweep, so PhpToken::tokenize (which always passes the flag) is correct. Being lexer-only, PHL still does not raise php's parse errors on invalid code under TOKEN_PARSE; valid code is exact.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
