### PR TITLE
Stop the lexer splitting at ?> inside a string

### DIFF
--- a/src/ph7/lex.c
+++ b/src/ph7/lex.c
@@ -1295,32 +1295,61 @@ PH7_PRIVATE sxi32 PH7_TokenizeRawText(const char *zInput,sxu32 nLen,SySet *pOut,
 			if( SyMemcmp(zIn,sCtag.zString,sCtag.nByte) == 0 && iNest < 1 ){
 				break;
 			}
-			for(;;){
-				if( zIn[0] != '/' || (zIn[1] != '*' && zIn[1] != '/') /* && sCtag.nByte >= 2 */ ){
-					break;
+			/* Line comment ('#' or '//', but not the '#[' attribute opener): php
+			 * ends it at a newline OR at the closing tag, so a '?>' inside a line
+			 * comment DOES close the PHP block. Skipping the comment here also
+			 * stops the string skip below from treating a quote inside the
+			 * comment as a string. Only outside a heredoc body (iNest < 1). */
+			if( iNest < 1 &&
+				( (zIn[0] == '#' && !(zIn+1 < zEnd && zIn[1] == '[')) ||
+				  (zIn[0] == '/' && zIn+1 < zEnd && zIn[1] == '/') ) ){
+				zIn += (zIn[0] == '#') ? 1 : 2;
+				while( zIn < zEnd && zIn[0] != '\n' ){
+					if( (sxu32)(zEnd - zIn) >= sCtag.nByte
+						&& SyMemcmp(zIn,sCtag.zString,sCtag.nByte) == 0 ){
+						break; /* the closing tag terminates the line comment */
+					}
+					zIn++;
 				}
+				continue;
+			}
+			/* Block comment: spans everything, including '?>', up to its close. */
+			if( iNest < 1 && zIn[0] == '/' && zIn+1 < zEnd && zIn[1] == '*' ){
 				zIn += 2;
-				if( zIn[-1] == '/' ){
-					/* Inline comment */
-					while( zIn < zEnd && zIn[0] != '\n' ){
-						zIn++;
+				while( (sxu32)(zEnd-zIn) >= sizeof("*/") - 1 ){
+					if( zIn[0] == '*' && zIn[1] == '/' ){
+						zIn += 2;
+						break;
 					}
-					if( zIn >= zEnd ){
-						zIn--;
+					if( zIn[0] == '\n' ){
+						nLine++;
 					}
-				}else{
-					/* Block comment */
-					while( (sxu32)(zEnd-zIn) >= sizeof("*/") - 1 ){
-						if( zIn[0] == '*' && zIn[1] == '/' ){
-							zIn += 2;
-							break;
-						}
-						if( zIn[0] == '\n' ){
-							nLine++;
-						}
-						zIn++;
-					}
+					zIn++;
 				}
+				continue;
+			}
+			/* Skip over a single/double-quoted or backtick string literal so a
+			 * '?>' sequence inside it is not mistaken for the closing tag. Only
+			 * outside a heredoc body (iNest < 1); heredocs are delimited by the
+			 * label-matching logic above. Escapes (\" \' \\ and a line-continuing
+			 * backslash-newline) are honoured. Same-quote nesting inside "{$...}"
+			 * interpolation is not tracked, but that can only end the skip early
+			 * on a string that has no '?>' anyway, which stays a PHP chunk either
+			 * way — it never mis-splits code that works today. */
+			if( iNest < 1 && (zIn[0] == '\'' || zIn[0] == '"' || zIn[0] == '`') ){
+				int qch = zIn[0];
+				zIn++;
+				while( zIn < zEnd ){
+					if( zIn[0] == '\\' && zIn + 1 < zEnd ){
+						if( zIn[1] == '\n' ){ nLine++; }
+						zIn += 2;
+						continue;
+					}
+					if( zIn[0] == qch ){ zIn++; break; }
+					if( zIn[0] == '\n' ){ nLine++; }
+					zIn++;
+				}
+				continue;
 			}
 			if( zIn[0] == '\n' ){
 				nLine++;

--- a/tests/ph7/002-integration/lang/closetag_in_line_comment.phpt
+++ b/tests/ph7/002-integration/lang/closetag_in_line_comment.phpt
@@ -1,0 +1,10 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Compile lexer: a line comment ('//' or '#') ends at '?>', which closes the PHP tag
+--FILE--
+<?php echo "A"; // trailing note it's here ?>
+INLINE<?php echo "B\n";
+--EXPECT--
+AINLINEB

--- a/tests/ph7/002-integration/lang/closetag_in_string.phpt
+++ b/tests/ph7/002-integration/lang/closetag_in_string.phpt
@@ -1,0 +1,35 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+Compile lexer: a '?>' inside a string literal, block comment, attribute string, or heredoc/nowdoc body is not a close tag
+--FILE--
+<?php
+// close-tag sequence inside string literals is not a real close tag
+$dq = "a ?" . ">" . " b";
+$dq2 = "lit ?".">";
+$sq = 'c ?> d';
+$re = "/x?>y/";
+echo strlen($sq), "|", $sq, "\n";
+echo $re, "\n";
+echo $dq2, "\n";
+$obj = new #[Attr("p?>q")] class { public $v = 7; };
+echo $obj->v, "\n";
+/* a block comment spans the close-tag bytes and stays a comment */
+$h = <<<EOT
+here ?> there
+EOT;
+echo $h, "\n";
+$n = <<<'NOW'
+raw ?> text
+NOW;
+echo $n, "\n";
+echo "END\n";
+--EXPECT--
+6|c ?> d
+/x?>y/
+lit ?>
+7
+here ?> there
+raw ?> text
+END


### PR DESCRIPTION
PH7_TokenizeRawText's PHP-chunk delimiter scanned for the closing tag while skipping only comments and heredocs, so a ?> inside a quoted string (e.g. the regex '{__HALT_COMPILER…\?>…}') was mistaken for the close tag and the string's tail was emitted as inline HTML — a miscompile. Skip string literals in the delimiter (escape-aware, only outside a heredoc body).

Also recognise line comments there: '#' (but not the '#[' attribute opener) and '//' now end at the closing tag like php, so "echo 1; // note ?>" closes the tag, and a quote inside a line comment no longer starts a bogus string skip. Block comments still span ?>.

Old-vs-new lint over the full 4258-file corpus changes exactly one result (255->0, the regex file); full compat stays green. Regressions in tests/ph7/002-integration/lang/closetag_in_{string,line_comment}.phpt.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
