### PR TITLE
Return "" from file_get_contents on empty

### DIFF
--- a/src/ph7/vfs.c
+++ b/src/ph7/vfs.c
@@ -3897,10 +3897,11 @@ static int PH7_builtin_file_get_contents(ph7_context *pCtx,int nArg,ph7_value **
 	}
 	/* Close the stream */
 	PH7_StreamCloseHandle(pStream,pHandle);
-	/* Check if we have read something */
+	/* A successfully opened but empty file yields "" in php (FALSE is only for an
+	 * open failure, handled above); the read loop never set a string result, so
+	 * force an empty string rather than leaving a null/FALSE result. */
 	if( ph7_context_result_buf_length(pCtx) < 1 ){
-		/* Nothing read,return FALSE */
-		ph7_result_bool(pCtx,0);
+		ph7_result_string(pCtx,"",0);
 	}
 	return PH7_OK;
 }

--- a/tests/ph7/002-integration/function/file_get_contents_empty.phpt
+++ b/tests/ph7/002-integration/function/file_get_contents_empty.phpt
@@ -1,0 +1,19 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+file_get_contents() of a successfully opened empty file returns "" (FALSE only on open failure)
+--FILE--
+<?php
+$tmp = tempnam(sys_get_temp_dir(), 'fgc');
+file_put_contents($tmp, '');
+$r = file_get_contents($tmp);
+echo var_export($r, true), " len=", strlen($r), "\n";
+file_put_contents($tmp, 'data');
+echo var_export(file_get_contents($tmp), true), "\n";
+unlink($tmp);
+echo var_export(@file_get_contents($tmp), true), "\n";
+--EXPECT--
+'' len=0
+'data'
+false


### PR DESCRIPTION
The read loop returned FALSE whenever nothing was read, but php returns FALSE only when the file cannot be opened; a successfully opened empty file yields "". Force an empty-string result instead of leaving the FALSE.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
