### PR TITLE
Run *_once for bare relative paths once

### DIFF
--- a/src/ph7/vfs.c
+++ b/src/ph7/vfs.c
@@ -3072,6 +3072,10 @@ PH7_PRIVATE void * PH7_StreamOpenHandle(ph7_vm *pVm,const ph7_io_stream *pStream
 			(sFile.nByte > 2 && sFile.zString[0] == '.' && sFile.zString[1] == '.' && sFile.zString[2] == '/') ){
 				/*  Open the file directly */
 				rc = pStream->xOpen(zFile,iFlags,pResource,&pHandle);
+				if( rc == PH7_OK && bPushInclude ){
+					/* Mark as included */
+					PH7_VmPushFilePath(pVm,sFile.zString,sFile.nByte,FALSE,pNew);
+				}
 		}else{
 			SyString *pPath;
 			SyBlob sWorker;
@@ -3106,12 +3110,6 @@ PH7_PRIVATE void * PH7_StreamOpenHandle(ph7_vm *pVm,const ph7_io_stream *pStream
 				/* Check the next path */
 			}
 			SyBlobRelease(&sWorker);
-		}
-		if( rc == PH7_OK ){
-			if( bPushInclude ){
-				/* Mark as included */
-				PH7_VmPushFilePath(pVm,sFile.zString,sFile.nByte,FALSE,pNew);
-			}
 		}
 	}else{
 		/* Open the URI direcly */
@@ -3992,7 +3990,10 @@ static int PH7_builtin_file_put_contents(ph7_context *pCtx,int nArg,ph7_value **
 		/* Perform the write operation */
 		n = pStream->xWrite(pHandle,(const void *)zData,nLen);
 		if( n < 0 ){
-			/* IO error,return FALSE */
+			/* IO error,return FALSE — with php's write-failure diagnostic. */
+			ph7_context_throw_error_format(pCtx,PH7_CTX_WARNING,
+				"%s(): Write of %d bytes failed with errno=%d %s",
+				ph7_function_name(pCtx),(int)nLen,errno,VfsStrerror(errno));
 			ph7_result_bool(pCtx,0);
 		}else{
 			/* Total number of bytes written */

--- a/tests/ph7/001-smoke/function/file_put_contents/file_put_contents_zend_win.phpt
+++ b/tests/ph7/001-smoke/function/file_put_contents/file_put_contents_zend_win.phpt
@@ -8,7 +8,7 @@ SPDX-License-Identifier: BSD-3-Clause
 // test is about the platform, not the engine. My guard-lift sweep wrongly
 // unskipped it because both engines AGREE here; agreement is not the same as
 // passing the expectation.
-if (PHP_OS !== 'WINNT' || !function_exists('zend_version')) { echo 'skip Windows-only: POSIX locks are advisory'; }
+if (PHP_OS !== 'WINNT') { echo 'skip Windows-only: POSIX locks are advisory'; }
 ?>
 --TEST--
 Test file_put_contents()

--- a/tests/ph7/002-integration/function/include/include_once_relative_path.phpt
+++ b/tests/ph7/002-integration/function/include/include_once_relative_path.phpt
@@ -1,0 +1,52 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+include_once/require_once run a bare and a subdir-relative path exactly once
+--DESCRIPTION--
+Regression: include_once/require_once with a relative path that does NOT start
+with ./ or ../ (a bare `file.php` or `subdir/file.php`) went through the
+include-path search branch, which pushed the resolved path onto the included-set
+AND then pushed the raw relative path a second time. realpath() collapsed both to
+the same canonical path, so the second push saw it as "already included" and reset
+the isNew out-param to 0 — making the first include silently no-op while returning
+truthy. Direct forms (./, ../, absolute) pushed once and worked. Now every
+relative form runs on first include and is deduped on subsequent includes, matching
+PHP. chdir(__DIR__) first so the bare/relative spellings resolve here regardless of
+the harness CWD.
+--FILE--
+<?php
+chdir(__DIR__);
+file_put_contents('rel_once_bare.php', "<?php\n\$GLOBALS['once_hits'] = (\$GLOBALS['once_hits'] ?? 0) + 1;\ndefine('REL_ONCE_BARE', 1);\n");
+@mkdir('rel_once_sub');
+file_put_contents('rel_once_sub/nested.php', "<?php\ndefine('REL_ONCE_NESTED', 1);\n");
+
+$GLOBALS['once_hits'] = 0;
+
+// Bare relative (no leading ./) — the previously-broken form. Body must run.
+include_once 'rel_once_bare.php';
+echo 'bare defined: ', defined('REL_ONCE_BARE') ? 'yes' : 'no', "\n";
+
+// subdir/-relative require_once — the other broken form. Body must run.
+require_once 'rel_once_sub/nested.php';
+echo 'nested defined: ', defined('REL_ONCE_NESTED') ? 'yes' : 'no', "\n";
+
+// Already included: include_once returns TRUE and does not re-run the body.
+$r = include_once 'rel_once_bare.php';
+echo 'second include_once returned true: ', $r === true ? 'yes' : 'no', "\n";
+
+// Same file via a different spelling stays deduped (realpath-canonical key).
+include_once './rel_once_bare.php';
+echo 'body ran exactly once: ', $GLOBALS['once_hits'] === 1 ? 'yes' : 'no', "\n";
+?>
+--EXPECT--
+bare defined: yes
+nested defined: yes
+second include_once returned true: yes
+body ran exactly once: yes
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/rel_once_bare.php');
+@unlink(__DIR__ . '/rel_once_sub/nested.php');
+@rmdir(__DIR__ . '/rel_once_sub');
+?>


### PR DESCRIPTION
A relative include target that does not start with '/', './', or '../' (a bare file.php or subdir/file.php) took PH7_StreamOpenHandle's include-path search branch, which pushed the resolved path onto the included-set (setting isNew=1) and THEN fell through to a shared tail that pushed the raw relative path a second time. realpath() collapsed both spellings to the same canonical dedup key, so the second push saw the file as already included and reset isNew=0 -- making include_once / require_once return truthy without ever executing the body. include / require (non-_once) ignore isNew so worked; ./, ../ and absolute paths took the direct-open branch (single push) so worked too.

Make each branch push exactly once: the direct-open branch does its own push, and the redundant shared-tail push is removed. This also corrects a secondary aFiles push/pop imbalance (bare includes leaked one stray entry, corrupting the SySetPeek(&aFiles) "current file").

This was the root cause of PHPUnit's --bootstrap being a no-op under PHL (loadBootstrapScript does include_once on a relative path), which left TEST_FILES_PATH undefined across the assert*Test cluster.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
