### PR TITLE
Fix use-segment name resolution

### DIFF
--- a/src/ph7/compile.c
+++ b/src/ph7/compile.c
@@ -5845,11 +5845,22 @@ static sxu32 GenStateNsQualifyName(ph7_gen_state *pGen,sxu32 nOrigIdx,SyHash *pI
 static void GenStateResolveName(ph7_gen_state *pGen,const SyString *pName,SyBlob *pOut)
 {
 	SyHashEntry *pImport;
-	/* Check use imports first */
-	pImport = SyHashGet(&pGen->hUseImports,(const void *)pName->zString,pName->nByte);
+	const char *zName = pName->zString;
+	sxu32 nName = pName->nByte;
+	sxu32 nFirst = 0;
+	/* php resolves a name through use-imports on its LEADING segment: an
+	 * unqualified `C` maps the whole name (`use X\C;` -> X\C), while a QUALIFIED
+	 * `A\B\C` maps just `A` (`use X\A;` -> X\A\B\C) and keeps the `\B\C` tail.
+	 * The old code looked up the whole qualified string (which never matches a
+	 * single-segment import alias) and then blindly prefixed the current
+	 * namespace, so `use PHPUnit\Framework; extends Framework\TestCase` resolved
+	 * to Ns\Framework\TestCase. Mirror GenStateResolveNamespaceLiteral here. */
+	while( nFirst < nName && zName[nFirst] != '\\' ){ nFirst++; }
+	pImport = SyHashGet(&pGen->hUseImports,(const void *)zName,nFirst);
 	if( pImport ){
 		const char *zFQN = (const char *)pImport->pUserData;
 		SyBlobAppend(pOut,zFQN,SyStrlen(zFQN));
+		SyBlobAppend(pOut,zName + nFirst,nName - nFirst); /* the \B\C tail, if any */
 		return;
 	}
 	/* Prepend current namespace if active */
@@ -5857,7 +5868,7 @@ static void GenStateResolveName(ph7_gen_state *pGen,const SyString *pName,SyBlob
 		SyBlobAppend(pOut,SyBlobData(&pGen->sNamespace),SyBlobLength(&pGen->sNamespace));
 		SyBlobAppend(pOut,"\\",1);
 	}
-	SyBlobAppend(pOut,pName->zString,pName->nByte);
+	SyBlobAppend(pOut,zName,nName);
 }
 /*
  * Build a fully-qualified name by prepending the current namespace to a short name.
@@ -6627,8 +6638,12 @@ static sxi32 GenStateCollectFuncArgs(ph7_vm_func *pFunc,ph7_gen_state *pGen,SyTo
 					/* php 8.4: the implicit form is deprecated at COMPILE time —
 					 * `f(): Implicitly marking parameter $x as nullable …`
 					 * (methods carry the Class:: prefix when the class link is
-					 * already up at this point). */
-					{
+					 * already up at this point). But NOT when the declared type
+					 * already accepts null: `mixed $x = null` is fine because mixed
+					 * includes null (explicit ?T / T|null are already excluded via
+					 * VM_FUNC_ARG_NULLABLE above). */
+					if( !(sArg.sClass.nByte == sizeof("mixed")-1
+						&& SyStrnicmp(SyStringData(&sArg.sClass),"mixed",sizeof("mixed")-1) == 0) ){
 						const char *zSep = "";
 						SyString sCls = { "", 0 };
 						if( (pFunc->iFlags & VM_FUNC_CLASS_METHOD) && pFunc->pUserData ){

--- a/tests/ph7/001-smoke/lang/use_namespace_segment_import.phpt
+++ b/tests/ph7/001-smoke/lang/use_namespace_segment_import.phpt
@@ -1,0 +1,36 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A `use X\Y;` segment import resolves the leading segment of a qualified name Y\Z
+--DESCRIPTION--
+Regression: `use App\Lib;` imports the segment `Lib` (alias -> App\Lib). A later
+qualified reference `Lib\Base` must map its LEADING segment through that import
+(-> App\Lib\Base), not prepend the current namespace (which produced
+App\Run\Lib\Base -> "Nonexistent base class"). The literal path already did this;
+the class-reference resolver used by extends/implements/new/instanceof/::class did
+not. Exercises every construct that flows through GenStateResolveName.
+--FILE--
+<?php
+namespace App\Lib {
+    class Base { public function who() { return 'Base'; } }
+    interface Iface {}
+    class Helper {}
+}
+namespace App\Run {
+    use App\Lib;
+    class Impl extends Lib\Base implements Lib\Iface {}
+    $o = new Impl();
+    echo 'parent=', get_parent_class($o), "\n";
+    echo 'impl=', ($o instanceof Lib\Iface ? '1' : '0'), "\n";
+    echo 'new=', get_class(new Lib\Helper()), "\n";
+    echo 'static=', Lib\Base::class, "\n";
+}
+?>
+--EXPECT--
+parent=App\Lib\Base
+impl=1
+new=App\Lib\Helper
+static=App\Lib\Base
+--CLEAN--
+<?php

--- a/tests/ph7/002-integration/lang/implicit_nullable_mixed_no_deprecation.phpt
+++ b/tests/ph7/002-integration/lang/implicit_nullable_mixed_no_deprecation.phpt
@@ -1,0 +1,22 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+mixed $x = null does NOT trigger the php 8.4 implicit-nullable deprecation
+--DESCRIPTION--
+Regression: PHL emitted the implicit-nullable deprecation for `mixed $x = null`,
+but php does not — `mixed` already includes null, so the default is not
+"implicitly" marking the parameter nullable. Exact --EXPECT-- (no %A): a spurious
+"Deprecated:" line printed to stderr would break the match. The int case (which
+DOES deprecate) is covered by implicit_nullable_deprecation.phpt.
+--FILE--
+<?php
+function mf(mixed $m = null) { return $m; }
+echo mf() === null ? "mixed-ok" : "bad", "\n";
+echo "done\n";
+?>
+--EXPECT--
+mixed-ok
+done
+--CLEAN--
+<?php


### PR DESCRIPTION
Two compile-time name/type resolution divergences:

- A `use X\Y;` import (which aliases the segment `Y` -> `X\Y`) was not consulted when resolving the LEADING segment of a qualified class reference `Y\Z`. GenStateResolveName looked up the whole qualified string (never matching a single-segment alias) and then blindly prepended the current namespace, so `use PHPUnit\Framework; class T extends Framework\TestCase` resolved to Ns\Framework\TestCase -> "Nonexistent base class". It now maps the leading segment through imports and keeps the tail, mirroring the literal path (GenStateResolveNamespaceLiteral) — fixing extends/implements/new/instanceof/ ::class.

- `mixed $x = null` no longer emits php 8.4's implicit-nullable deprecation: `mixed` already includes null, so the null default is not "implicitly" marking the parameter nullable (php is silent). `int`/`object` still deprecate; `?T` was already excluded.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
