### PR TITLE
Report the declaring class in backtraces

### DIFF
--- a/src/ph7/oo.c
+++ b/src/ph7/oo.c
@@ -1116,7 +1116,12 @@ PH7_PRIVATE ph7_class_instance * PH7_CloneClassInstance(ph7_class_instance *pSrc
 	if( pMethod ){
 		if( pMethod->iCloneDepth < 16 ){
 			pMethod->iCloneDepth++;
+			/* PHP 8.3: __clone() may re-initialize the clone's readonly
+			 * properties. Flag the instance so the readonly store guard allows
+			 * it for the duration of the call. */
+			pClone->iFlags |= VM_INSTANCE_CLONING;
 			PH7_VmCallClassMethod(pVm,pClone,pMethod,0,0,0);
+			pClone->iFlags &= ~VM_INSTANCE_CLONING;
 		}else{
 			/* Nesting limit reached */
 			PH7_VmThrowError(pVm,0,PH7_CTX_ERR,"Object clone limit reached,no more call to __clone()");

--- a/src/ph7/ph7int.h
+++ b/src/ph7/ph7int.h
@@ -1013,6 +1013,14 @@ struct ph7_class_instance
 	                     * never reused). Drives spl_object_id/hash + var_dump #N. */
 };
 /*
+ * ph7_class_instance::iFlags bit set while the object's __clone() magic method
+ * runs. PHP 8.3 lets __clone() re-initialize the cloned object's readonly
+ * properties, so the readonly store guard consults this flag on the executing
+ * $this. (Other iFlags bits are declared privately in their owning .c file:
+ * 0x001 destroyed, 0x002 dumping, 0x004 fcc-bound.)
+ */
+#define VM_INSTANCE_CLONING 0x008
+/*
  * A single instruction of the virtual machine has an opcode
  * and as many as three operands.
  * Each VM instruction resulting from compiling a PHP script

--- a/src/ph7/vm.c
+++ b/src/ph7/vm.c
@@ -7549,10 +7549,15 @@ static sxi32 VmEnforcePropertyTypeOnStore(ph7_vm *pVm,sxu32 nIdx,ph7_value *pVal
 		if( !bCloneInit && (pVmAttr->iState & VM_CLASS_ATTR_UNINIT) == 0 ){
 			/* Already initialized: any further write is forbidden, any scope —
 			 * checked BEFORE the set-visibility scope, matching php's order.
-			 * (PHP 8.5 clone($o,[...]) is the sole exception — bCloneInit — which
-			 * re-initializes a readonly property from an allowed scope, so it
-			 * falls through to the set-scope check below.) */
-			return VmThrowReadonlyError(pVm,pVmAttr->pOwner,pAttr,1);
+			 * Exceptions that fall through to the set-scope check below:
+			 *   - PHP 8.5 clone($o,[...]) with-updates (bCloneInit), and
+			 *   - PHP 8.3 __clone(): the object under clone (the executing $this,
+			 *     flagged VM_INSTANCE_CLONING) may re-initialize its readonly props. */
+			VmFrame *pCloneFr = pVm->pFrame ? VmSkipExceptionFrames(pVm->pFrame) : 0;
+			if( !(pCloneFr && pCloneFr->pThis
+				&& (pCloneFr->pThis->iFlags & VM_INSTANCE_CLONING)) ){
+				return VmThrowReadonlyError(pVm,pVmAttr->pOwner,pAttr,1);
+			}
 		}
 	}
 	if( pAttr->iFlags & (PH7_CLASS_ATTR_PRIVATE_SET|PH7_CLASS_ATTR_PROTECTED_SET) ){
@@ -7567,6 +7572,12 @@ static sxi32 VmEnforcePropertyTypeOnStore(ph7_vm *pVm,sxu32 nIdx,ph7_value *pVal
 		 * class scope (readonly's set-scope is protected — a subclass may set). */
 		ph7_class *pDecl = pAttr->pDeclClass ? pAttr->pDeclClass : pVmAttr->pOwner;
 		ph7_class *pActive = VmCurrentSelf(pVm);
+		/* A readonly property imported from a TRAIT is, per php, declared in the
+		 * USING class (traits are flattened in). The trait is not in any instanceof
+		 * hierarchy, so use the composing class (pVmAttr->pOwner) as the set-scope. */
+		if( pDecl && (pDecl->iFlags & PH7_CLASS_TRAIT) && pVmAttr->pOwner ){
+			pDecl = pVmAttr->pOwner;
+		}
 		if( pActive == 0 || pDecl == 0 || !PH7_VmInstanceOf(pActive,pDecl) ){
 			return VmThrowReadonlyError(pVm,pVmAttr->pOwner,pAttr,0);
 		}
@@ -8861,22 +8872,38 @@ static void VmBuildBacktrace(ph7_vm *pVm,sxi32 iOptions,ph7_value *pList)
 		}
 		ph7_array_add_strkey_elem(pEntry,"function",pValue);
 		ph7_value_reset_string_cursor(pValue);
-		if( pFrame->pThis && pFrame->pThis->pClass ){
-			ph7_value_string(pValue,pFrame->pThis->pClass->sName.zString,
-				(int)pFrame->pThis->pClass->sName.nByte);
-			ph7_array_add_strkey_elem(pEntry,"class",pValue);
-			ph7_value_reset_string_cursor(pValue);
-			ph7_value_string(pValue,"->",sizeof("->")-1);
-			ph7_array_add_strkey_elem(pEntry,"type",pValue);
-			ph7_value_reset_string_cursor(pValue);
-			if( iOptions & 1 /*DEBUG_BACKTRACE_PROVIDE_OBJECT*/ ){
-				ph7_value *pObjVal = ph7_new_scalar(&(*pVm));
-				if( pObjVal ){
-					pFrame->pThis->iRef++;
-					pObjVal->x.pOther = pFrame->pThis;
-					MemObjSetType(pObjVal,MEMOBJ_OBJ);
-					ph7_array_add_strkey_elem(pEntry,"object",pObjVal);
-					ph7_release_value(&(*pVm),pObjVal);
+		{
+			/* php's 'class' is the DECLARING class of the executing method (where it
+			 * is defined), NOT the runtime $this class — an inherited method called
+			 * on a subclass reports the base. pFunc->pUserData is that declaring
+			 * class (oo.c installs methods with it). 'type' is '->' for an instance
+			 * call and '::' for a static one (so static frames get class/type too,
+			 * which the old $this-only path dropped). Fall back to the $this class
+			 * for a bound closure (has $this but is not VM_FUNC_CLASS_METHOD). */
+			SyString *pClsName = 0;
+			const char *zType = "->";
+			if( (pFunc->iFlags & VM_FUNC_CLASS_METHOD) && pFunc->pUserData ){
+				pClsName = &((ph7_class *)pFunc->pUserData)->sName;
+				zType = pFrame->pThis ? "->" : "::";
+			}else if( pFrame->pThis && pFrame->pThis->pClass ){
+				pClsName = &pFrame->pThis->pClass->sName;
+			}
+			if( pClsName ){
+				ph7_value_string(pValue,pClsName->zString,(int)pClsName->nByte);
+				ph7_array_add_strkey_elem(pEntry,"class",pValue);
+				ph7_value_reset_string_cursor(pValue);
+				ph7_value_string(pValue,zType,(int)SyStrlen(zType));
+				ph7_array_add_strkey_elem(pEntry,"type",pValue);
+				ph7_value_reset_string_cursor(pValue);
+				if( (iOptions & 1 /*DEBUG_BACKTRACE_PROVIDE_OBJECT*/) && pFrame->pThis ){
+					ph7_value *pObjVal = ph7_new_scalar(&(*pVm));
+					if( pObjVal ){
+						pFrame->pThis->iRef++;
+						pObjVal->x.pOther = pFrame->pThis;
+						MemObjSetType(pObjVal,MEMOBJ_OBJ);
+						ph7_array_add_strkey_elem(pEntry,"object",pObjVal);
+						ph7_release_value(&(*pVm),pObjVal);
+					}
 				}
 			}
 		}

--- a/tests/ph7/001-smoke/function/debug_backtrace/debug_backtrace_declaring_class.phpt
+++ b/tests/ph7/001-smoke/function/debug_backtrace/debug_backtrace_declaring_class.phpt
@@ -1,0 +1,28 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+debug_backtrace() 'class' is the method's declaring class; static frames carry class/type
+--DESCRIPTION--
+Regression: the backtrace 'class' reported the runtime $this class rather than
+the DECLARING class of the executing method, so an inherited method called on a
+subclass showed the subclass. It now reports the class the method is defined in
+(the frame's function metadata), matching php. Static-method frames also get
+'class'/'type' ('::') now, which the old $this-only path dropped.
+--FILE--
+<?php
+class DbdcBase {
+    public function run() { return debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS)[0]; }
+    public static function srun() { return debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS)[0]; }
+}
+class DbdcChild extends DbdcBase {}
+$f = (new DbdcChild)->run();
+echo "inst class={$f['class']} type={$f['type']}\n";
+$s = DbdcChild::srun();
+echo "static class={$s['class']} type={$s['type']}\n";
+?>
+--EXPECT--
+inst class=DbdcBase type=->
+static class=DbdcBase type=::
+--CLEAN--
+<?php

--- a/tests/ph7/001-smoke/oo/readonly_trait_and_clone.phpt
+++ b/tests/ph7/001-smoke/oo/readonly_trait_and_clone.phpt
@@ -1,0 +1,27 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+A readonly property from a trait is writable from the using class, incl. re-init in __clone
+--DESCRIPTION--
+Regression: a readonly property imported from a trait kept the TRAIT as its
+declaring class, so the set-scope check (instanceof against a trait, which is
+never in the hierarchy) rejected every write with "Cannot modify protected(set)
+readonly property Trait::$x from scope C". Traits are flattened into the using
+class, so the composing class is the set-scope. Also covers PHP 8.3 readonly
+re-initialization inside __clone(). Outside those, the property stays locked.
+--FILE--
+<?php
+trait State { public readonly int $n; public function set(int $v){ $this->n = $v; } }
+trait Cloner { public function __clone(){ $this->n = $this->n * 10; } }
+class RtacBox { use State; use Cloner; }
+$a = new RtacBox(); $a->set(3);
+$b = clone $a;
+echo "a={$a->n} b={$b->n}\n";
+try { $a->n = 99; } catch (\Error $e) { echo "locked: yes\n"; }
+?>
+--EXPECT--
+a=3 b=30
+locked: yes
+--CLEAN--
+<?php


### PR DESCRIPTION
Runtime semantics fidelity surfaced by PHPUnit's mock machinery:

- debug_backtrace()/exception traces now report a frame's 'class' as the DECLARING class of the executing method (from the frame's function metadata), not the runtime $this class — an inherited method called on a subclass shows the base, matching php. Static-method frames now carry 'class'/'type' ('::') too, which the old $this-only path dropped. (PHPUnit's MockBuilder suppresses self-triggered deprecations by checking debug_backtrace()[2]['class'] === TestCase::class.)

- A readonly property may now be re-initialized inside __clone() (php 8.3): the object under clone is flagged VM_INSTANCE_CLONING for the duration of the call and the readonly store guard honors it.

- A readonly property imported from a TRAIT is writable from the using class: traits are flattened into the composing class in php, but PHL kept the trait as the property's declaring class, so the set-scope check (instanceof against a trait, never in the hierarchy) rejected every write. The composing class (pVmAttr->pOwner) is now used as the set-scope for a trait-declared readonly.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
