### PR TITLE
Make the sort family stable

### DIFF
--- a/src/ph7/hashmap.c
+++ b/src/ph7/hashmap.c
@@ -2169,7 +2169,13 @@ static sxi32 HashmapMergeSort(ph7_hashmap *pMap,ProcNodeCmp xCmp,void *pCmpData)
 	}
 	p = a[0];
 	for(i=1; i<N_SORT_BUCKET; i++){
-		p = HashmapNodeMerge(p,a[i],xCmp,pCmpData);
+		/* Higher-index buckets hold EARLIER-inserted (and larger) runs, so the
+		 * bucket must be the LEFT operand: HashmapNodeMerge favors its left arg on
+		 * a tie (cmp <= 0), and php's sorts are stable (PHP 8.0+) — equal elements
+		 * keep their original order. Passing p (the later elements) on the left
+		 * reversed equal runs (e.g. usort of five tie-keyed items moved the last to
+		 * the front). */
+		p = HashmapNodeMerge(a[i],p,xCmp,pCmpData);
 	}
 	p->pNext = 0;
 	/* Reflect the change */

--- a/tests/ph7/001-smoke/function/usort/usort_stable.phpt
+++ b/tests/ph7/001-smoke/function/usort/usort_stable.phpt
@@ -1,0 +1,34 @@
+--CREDITS--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+SPDX-License-Identifier: BSD-3-Clause
+--TEST--
+usort/uasort are stable: equal elements keep their original order (PHP 8.0+)
+--DESCRIPTION--
+Regression: the linked-list merge sort combined its accumulator buckets with the
+later run as the LEFT operand, and the merge favors its left operand on a tie, so
+equal-keyed elements were reversed (five tie-keyed items sorted to
+last,first,second,third,fourth). Higher buckets hold earlier-inserted runs, so
+they must be the left operand — restoring php's guaranteed sort stability across
+the usort/uasort/sort family.
+--FILE--
+<?php
+$data = [];
+foreach (['first','second','third','fourth','fifth'] as $name) $data[] = ['prio' => 0, 'name' => $name];
+usort($data, fn($a, $b) => $a['prio'] <=> $b['prio']);
+echo implode(',', array_map(fn($r) => $r['name'], $data)), "\n";
+
+$m = ['k1' => 1, 'k2' => 1, 'k3' => 1, 'k4' => 0];
+uasort($m, fn($a, $b) => $a <=> $b);
+echo implode(',', array_keys($m)), "\n";
+
+$p = [];
+foreach (['a','b','c','d','e','f'] as $i => $x) $p[] = [$i % 2, $x];
+usort($p, fn($a, $b) => $a[0] <=> $b[0]);
+echo implode(',', array_map(fn($r) => $r[1], $p)), "\n";
+?>
+--EXPECT--
+first,second,third,fourth,fifth
+k4,k1,k2,k3
+a,c,e,b,d,f
+--CLEAN--
+<?php


### PR DESCRIPTION
PHP 8.0+ guarantees stable sorts, but PHL's linked-list merge sort reversed equal-keyed elements: the final pass combined the accumulator buckets with the running result as the LEFT operand of HashmapNodeMerge, which favors its left arg on a tie. Since higher-index buckets hold the EARLIER-inserted (larger) runs, the bucket must be the left operand instead. Without this, usort() of five items that all compare equal returned them as last,first,second,third,fourth.

Affects the whole comparison-sort family (sort/asort/ksort/usort/uasort/uksort/…). Surfaced by PHPUnit's HookMethodCollection, which usorts hook methods by priority and relies on equal-priority methods keeping declaration order.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the documentation accordingly
